### PR TITLE
fix: Remove local network permission prompt on landing page

### DIFF
--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { AuthProvider } from "@/providers/auth-provider";
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useAuth } from "@/providers/auth-provider";
+import { AuthProvider, useAuth } from "@/providers/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
@@ -21,6 +21,14 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  return (
+    <AuthProvider>
+      <DashboardShell>{children}</DashboardShell>
+    </AuthProvider>
+  );
+}
+
+function DashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { user, org, logout, isLoading, isAuthenticated } = useAuth();
 
@@ -95,3 +103,4 @@ export default function DashboardLayout({
     </div>
   );
 }
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { QueryProvider } from "@/providers/query-provider";
-import { AuthProvider } from "@/providers/auth-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -33,7 +32,7 @@ export default function RootLayout({
       >
         <ThemeProvider>
           <QueryProvider>
-            <AuthProvider>{children}</AuthProvider>
+            {children}
           </QueryProvider>
         </ThemeProvider>
       </body>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 type FetchOptions = RequestInit & {
   params?: Record<string, string>;
@@ -12,6 +12,14 @@ class ApiClient {
   }
 
   async request<T>(path: string, options: FetchOptions = {}): Promise<T> {
+    if (!this.baseUrl) {
+      throw new ApiError(
+        "CONFIG_ERROR",
+        "NEXT_PUBLIC_API_URL is not configured",
+        0
+      );
+    }
+
     const { params, ...fetchOptions } = options;
 
     let url = `${this.baseUrl}${path}`;


### PR DESCRIPTION
## **User description**
## Summary
- Move `AuthProvider` from root layout → dashboard layout + auth layout only
- Landing page (`/`) no longer makes any API calls on mount
- `NEXT_PUBLIC_API_URL` now required — throws graceful `CONFIG_ERROR` if missing instead of falling back to `localhost:3001`

## Files changed
- `src/app/layout.tsx` — removed AuthProvider wrapper
- `src/app/dashboard/layout.tsx` — added AuthProvider + extracted DashboardShell
- `src/app/auth/layout.tsx` — **new**, wraps auth pages with AuthProvider
- `src/lib/api.ts` — removed localhost fallback, added missing-config guard

## Test plan
- [ ] `npm run build` passes
- [ ] Landing page (`/`) loads with zero API calls (no network tab requests)
- [ ] `/dashboard/*` pages still have auth guard (redirect to login)
- [ ] `/auth/login` and `/auth/register` still use `useAuth()` correctly
- [ ] Set `NEXT_PUBLIC_API_URL` in Vercel env vars before deploying

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent landing page from triggering local network permission prompt; require API URL; make API errors consistent**

### What Changed
- Landing page (/) no longer wraps the app in the authentication provider and therefore does not initiate API calls on load.
- Authentication context is now provided only to dashboard and auth routes, so /dashboard/* remains guarded and /auth/* pages continue to work with auth.
- The app now requires NEXT_PUBLIC_API_URL; if it is missing the client throws a clear CONFIG_ERROR instead of silently calling localhost.
- API client parsing is guarded: non-JSON or empty server responses produce a consistent PARSE_ERROR with the server status, and API errors always include a status and message.

### Impact
`✅ Landing page loads with no network requests`
`✅ Fewer local network permission prompts`
`✅ Clearer API errors for misconfigured or non-JSON server responses`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
