### PR TITLE
fix: auto-refresh access_token on 401

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ type FetchOptions = RequestInit & {
 
 let csrfToken: string | null = null;
 let csrfFetchPromise: Promise<string | null> | null = null;
+let refreshPromise: Promise<boolean> | null = null;
 
 class ApiClient {
   private baseUrl: string;
@@ -135,6 +136,27 @@ class ApiClient {
         }
       }
 
+      // Auto-refresh on 401: call /auth/refresh to renew access_token, then retry once
+      if (res.status === 401 && !path.includes("/auth/refresh") && !path.includes("/auth/me")) {
+        const refreshed = await this.tryRefresh();
+        if (refreshed) {
+          // Retry the original request with fresh access_token cookie
+          const retryRes = await fetch(url, {
+            credentials: "include",
+            ...fetchOptions,
+            headers,
+          });
+          try {
+            const retryJson = (await retryRes.json()) as Record<string, unknown>;
+            if (retryRes.ok && retryJson.ok) {
+              return retryJson.data as T;
+            }
+          } catch {
+            // Fall through to original error
+          }
+        }
+      }
+
       throw new ApiError(
         error.code || "UNKNOWN",
         error.message || "Request failed",
@@ -143,6 +165,27 @@ class ApiClient {
     }
 
     return json.data as T;
+  }
+
+  /** Attempt to refresh the access_token using the refresh_token cookie. Deduped. */
+  private async tryRefresh(): Promise<boolean> {
+    if (!refreshPromise) {
+      refreshPromise = (async () => {
+        try {
+          const res = await fetch(`${this.baseUrl}/v1/auth/refresh`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+          });
+          return res.ok;
+        } catch {
+          return false;
+        } finally {
+          refreshPromise = null;
+        }
+      })();
+    }
+    return refreshPromise;
   }
 
   get<T>(path: string, params?: Record<string, string>) {


### PR DESCRIPTION
## **User description**
## Summary
- API client auto-refreshes expired access_token on 401 response
- Calls `POST /auth/refresh` (uses refresh_token cookie, valid 30 days)
- Retries original request once after successful refresh
- Deduped: concurrent 401s share a single refresh call
- Skips refresh for `/auth/refresh` and `/auth/me` to avoid loops

## Test plan
- [ ] Sign in, wait >15 min, make a request → auto-refreshes and succeeds
- [ ] Multiple concurrent 401s → single refresh call, all retry
- [ ] Expired refresh_token → throws 401, redirects to sign in

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Automatically renew expired session and retry failed requests on 401**

### What Changed
- When an API request returns 401, the client calls the server's refresh endpoint to renew the session and then retries the original request once; if refresh fails the original 401 is returned
- Concurrent 401 responses share a single refresh attempt so only one refresh call happens for simultaneous failures
- Refresh attempts are skipped for the refresh and current-user endpoints to avoid retry loops

### Impact
`✅ Fewer forced sign-outs when session expires`
`✅ Fewer failed requests after users are idle`
`✅ Fewer duplicate refresh calls during concurrent 401s`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
