### PR TITLE
fix: distinguish LinkedIn Content vs Ads connections

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -197,38 +197,49 @@ function SettingsContent() {
                 <Linkedin className="h-5 w-5" />
               </div>
               <div>
-                <p className="text-sm font-medium">LinkedIn Ads</p>
-                {orgDetails?.adPlatforms?.linkedin?.connected ? (
-                  <p className="text-xs text-muted-foreground">
-                    {orgDetails.adPlatforms.linkedin.adAccountName ||
-                      orgDetails.adPlatforms.linkedin.linkedInProfileName ||
-                      "Connected"}
-                  </p>
-                ) : (
-                  <p className="text-xs text-muted-foreground">
-                    Not connected
-                  </p>
-                )}
+                <p className="text-sm font-medium">LinkedIn Content</p>
+                <p className="text-xs text-muted-foreground">
+                  Publish posts to your LinkedIn profile
+                </p>
               </div>
             </div>
-            {orgDetails?.adPlatforms?.linkedin?.connected ? (
-              <Badge className="bg-green-600 gap-1">
-                <CheckCircle2 className="h-3 w-3" />
-                Connected
-              </Badge>
-            ) : (
-              <Button
-                size="sm"
-                variant="outline"
-                className="gap-1.5"
-                onClick={() => {
-                  window.location.href = `${API_BASE_URL}/v1/integrations/linkedin_ads/authorize`;
-                }}
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                Connect
-              </Button>
-            )}
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => {
+                window.location.href = `${API_BASE_URL}/v1/integrations/linkedin_content/authorize`;
+              }}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Connect
+            </Button>
+          </div>
+
+          {/* LinkedIn Ads */}
+          <div className="flex items-center justify-between rounded-lg border p-4 transition-colors hover:bg-muted/50">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#0A66C2] text-white">
+                <Linkedin className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">LinkedIn Ads</p>
+                <p className="text-xs text-muted-foreground">
+                  Run ad campaigns on LinkedIn
+                </p>
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => {
+                window.location.href = `${API_BASE_URL}/v1/integrations/linkedin_ads/authorize`;
+              }}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Connect
+            </Button>
           </div>
 
           <Separator />

--- a/src/app/onboarding/connect-platforms/page.tsx
+++ b/src/app/onboarding/connect-platforms/page.tsx
@@ -36,7 +36,7 @@ export default function ConnectPlatformsPage() {
 
   function handleConnectLinkedIn() {
     // Redirect to LinkedIn OAuth flow
-    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/v1/integrations/linkedin_ads/authorize`;
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/v1/integrations/linkedin_content/authorize`;
   }
 
   return (


### PR DESCRIPTION
## **User description**
Onboarding uses linkedin_content. Settings shows both Content and Ads.


___

## **CodeAnt-AI Description**
Distinguish LinkedIn Content vs Ads in onboarding and settings

### What Changed
- Onboarding now starts the LinkedIn Content OAuth flow so users connect post-publishing capability (previously started the Ads flow)
- Settings shows two separate LinkedIn tiles: "LinkedIn Content" (publish posts) with a Connect button, and "LinkedIn Ads" (run ad campaigns) with its own Connect button
- The Ads tile no longer displays a connected badge or account name by default; both integrations must be connected independently

### Impact
`✅ Can connect LinkedIn Content during onboarding`
`✅ Clearer separation between posting and ads in Settings`
`✅ Fewer incorrect LinkedIn connections from onboarding`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
