### PR TITLE
fix: onboarding uses LinkedIn Ads app until content app approved

### DIFF
--- a/src/app/onboarding/connect-platforms/page.tsx
+++ b/src/app/onboarding/connect-platforms/page.tsx
@@ -36,7 +36,8 @@ export default function ConnectPlatformsPage() {
 
   function handleConnectLinkedIn() {
     // Redirect to LinkedIn OAuth flow
-    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/v1/integrations/linkedin_content/authorize`;
+    // Use ads app (has Share on LinkedIn + Advertising API) until content app is approved
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/v1/integrations/linkedin_ads/authorize`;
   }
 
   return (


### PR DESCRIPTION
## **User description**
Ads app has all needed products approved. Content app is under LinkedIn review.


___

## **CodeAnt-AI Description**
**Use LinkedIn Ads app for onboarding until the Content app is approved**

### What Changed
- Onboarding's "Connect LinkedIn" now starts OAuth with the LinkedIn Ads app instead of the LinkedIn Content app
- This uses the Ads app because it already has "Share on LinkedIn" and Advertising API permissions while the Content app remains under review
- No other onboarding UI behavior changed; the redirect targets a different working integration endpoint

### Impact
`✅ Can connect LinkedIn during onboarding`
`✅ Fewer failed LinkedIn OAuth attempts`
`✅ Clearer, working onboarding flow for ad account connections`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
