### PR TITLE
feat: editable business details and sectors in settings

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -3,8 +3,9 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/providers/auth-provider";
-import { api, API_BASE_URL } from "@/lib/api";
+import { api, ApiError, API_BASE_URL } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import {
   Card,
   CardContent,
@@ -25,6 +26,10 @@ import {
   Tags,
   ExternalLink,
   CheckCircle2,
+  Pencil,
+  X,
+  Check,
+  Plus,
 } from "lucide-react";
 
 interface OrgDetails {
@@ -89,6 +94,45 @@ function SettingsContent() {
   const [error, setError] = useState("");
   const [linkedInJustConnected, setLinkedInJustConnected] = useState(false);
 
+  // Edit state
+  const [editingBusiness, setEditingBusiness] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [editType, setEditType] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+  const [editSectors, setEditSectors] = useState<string[]>([]);
+
+  async function handleSaveBusinessDetails() {
+    setSaving(true);
+    setError("");
+    try {
+      const updates: Record<string, any> = {};
+      if (editName && editName !== orgDetails?.name) updates.name = editName;
+      if (editType !== (orgDetails?.businessType || "")) updates.businessType = editType;
+      if (editUrl !== (orgDetails?.websiteUrl || "")) updates.websiteUrl = editUrl;
+      if (JSON.stringify(editSectors) !== JSON.stringify(orgDetails?.taxonomy?.sectors || [])) {
+        updates.taxonomy = { sectors: editSectors };
+      }
+
+      if (Object.keys(updates).length === 0) {
+        setEditingBusiness(false);
+        return;
+      }
+
+      await api.put("/v1/dashboard/org", updates);
+
+      // Refresh data
+      const updated = await api.get<OrgDetails>("/v1/dashboard/org");
+      setOrgDetails(updated);
+      setEditingBusiness(false);
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.message);
+      else setError("Failed to save. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   useEffect(() => {
     if (searchParams?.get("linkedin") === "connected") {
       setLinkedInJustConnected(true);
@@ -136,44 +180,104 @@ function SettingsContent() {
       {/* Business Details */}
       <Card>
         <CardHeader>
-          <div className="flex items-center gap-2">
-            <Building2 className="h-5 w-5 text-muted-foreground" />
-            <CardTitle>Business Details</CardTitle>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Building2 className="h-5 w-5 text-muted-foreground" />
+              <CardTitle>Business Details</CardTitle>
+            </div>
+            {!editingBusiness ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-1.5 text-muted-foreground"
+                onClick={() => {
+                  setEditingBusiness(true);
+                  setEditName(orgDetails?.name || "");
+                  setEditType(orgDetails?.businessType || "");
+                  setEditUrl(orgDetails?.websiteUrl || "");
+                  setEditSectors(orgDetails?.taxonomy?.sectors || []);
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                Edit
+              </Button>
+            ) : (
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setEditingBusiness(false)}
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={saving}
+                  onClick={handleSaveBusinessDetails}
+                >
+                  <Check className="h-3.5 w-3.5" />
+                  {saving ? "Saving..." : "Save"}
+                </Button>
+              </div>
+            )}
           </div>
           <CardDescription>
             Your business information used by the AI engine
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <SettingRow label="Business name" value={orgDetails?.name} />
-          <SettingRow label="Slug" value={orgDetails?.slug} />
-          <SettingRow label="Category" value={orgDetails?.businessCategory} />
-          <SettingRow label="Type" value={orgDetails?.businessType} />
-          <SettingRow label="Website" value={orgDetails?.websiteUrl} />
-          <SettingRow
-            label="Plan"
-            value={
-              <Badge variant="outline" className="capitalize">
-                {orgDetails?.billing?.plan || "free"}
-              </Badge>
-            }
-          />
-          {orgDetails?.taxonomy?.sectors && (
-            <div>
-              <div className="flex items-center gap-1.5 mb-2">
-                <Tags className="h-3.5 w-3.5 text-muted-foreground" />
-                <p className="text-sm font-medium text-muted-foreground">
-                  AI-discovered sectors
-                </p>
-              </div>
-              <div className="flex flex-wrap gap-1.5">
-                {orgDetails.taxonomy.sectors.map((s) => (
-                  <Badge key={s} variant="secondary" className="text-xs">
-                    {s}
+          {editingBusiness ? (
+            <>
+              <EditRow label="Business name" value={editName} onChange={setEditName} />
+              <SettingRow label="Slug" value={orgDetails?.slug} />
+              <SettingRow label="Category" value={orgDetails?.businessCategory} />
+              <EditRow label="Type" value={editType} onChange={setEditType} />
+              <EditRow label="Website" value={editUrl} onChange={setEditUrl} type="url" />
+              <SettingRow
+                label="Plan"
+                value={
+                  <Badge variant="outline" className="capitalize">
+                    {orgDetails?.billing?.plan || "free"}
                   </Badge>
-                ))}
-              </div>
-            </div>
+                }
+              />
+              <EditableSectors sectors={editSectors} onChange={setEditSectors} />
+            </>
+          ) : (
+            <>
+              <SettingRow label="Business name" value={orgDetails?.name} />
+              <SettingRow label="Slug" value={orgDetails?.slug} />
+              <SettingRow label="Category" value={orgDetails?.businessCategory} />
+              <SettingRow label="Type" value={orgDetails?.businessType} />
+              <SettingRow label="Website" value={orgDetails?.websiteUrl} />
+              <SettingRow
+                label="Plan"
+                value={
+                  <Badge variant="outline" className="capitalize">
+                    {orgDetails?.billing?.plan || "free"}
+                  </Badge>
+                }
+              />
+              {orgDetails?.taxonomy?.sectors && (
+                <div>
+                  <div className="flex items-center gap-1.5 mb-2">
+                    <Tags className="h-3.5 w-3.5 text-muted-foreground" />
+                    <p className="text-sm font-medium text-muted-foreground">
+                      AI-discovered sectors
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {orgDetails.taxonomy.sectors.map((s) => (
+                      <Badge key={s} variant="secondary" className="text-xs">
+                        {s}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>
@@ -345,6 +449,98 @@ function SettingRow({
       <p className="text-sm font-medium">
         {value ?? <span className="text-muted-foreground">--</span>}
       </p>
+    </div>
+  );
+}
+
+function EditRow({
+  label,
+  value,
+  onChange,
+  type = "text",
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <p className="text-sm text-muted-foreground shrink-0">{label}</p>
+      <Input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="max-w-xs text-sm h-8"
+      />
+    </div>
+  );
+}
+
+function EditableSectors({
+  sectors,
+  onChange,
+}: {
+  sectors: string[];
+  onChange: (s: string[]) => void;
+}) {
+  const [newSector, setNewSector] = useState("");
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Tags className="h-3.5 w-3.5 text-muted-foreground" />
+        <p className="text-sm font-medium text-muted-foreground">
+          AI-discovered sectors
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        {sectors.map((s, i) => (
+          <Badge
+            key={`${s}-${i}`}
+            variant="secondary"
+            className="text-xs gap-1 pr-1 cursor-pointer hover:bg-destructive/20"
+          >
+            {s}
+            <button
+              type="button"
+              onClick={() => onChange(sectors.filter((_, j) => j !== i))}
+              className="ml-0.5 rounded-full p-0.5 hover:bg-destructive/30"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          type="text"
+          placeholder="Add a sector..."
+          value={newSector}
+          onChange={(e) => setNewSector(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && newSector.trim()) {
+              e.preventDefault();
+              onChange([...sectors, newSector.trim()]);
+              setNewSector("");
+            }
+          }}
+          className="text-sm h-8 max-w-xs"
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8 gap-1"
+          disabled={!newSector.trim()}
+          onClick={() => {
+            onChange([...sectors, newSector.trim()]);
+            setNewSector("");
+          }}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## **User description**
## Summary
- Edit button on Business Details card toggles inline editing
- Editable: name, business type, website URL, sectors
- Sectors: removable badges with X, add new via input + Enter/button
- Saves to PUT /dashboard/org, refreshes after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make business details in Settings editable inline with add/remove sectors**

### What Changed
- Users can toggle an Edit mode on the Business Details card to change name, type, website and AI-discovered sectors directly on the settings page; Cancel reverts edits and Save persists changes.
- Sectors now support removing individual badges and adding new ones via an input (Enter key or Add button); the list updates immediately in the editor.
- Saving shows a saving state, reports errors to the user, and refreshes the displayed organization details after a successful save.

### Impact
`✅ Shorter business detail edits`
`✅ Fewer full-page refreshes after saving settings`
`✅ Clearer sector add/remove experience`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
