### PR TITLE
fix: connection status fields + OAuth success param

### DIFF
--- a/src/app/dashboard/overview/page.tsx
+++ b/src/app/dashboard/overview/page.tsx
@@ -37,7 +37,8 @@ interface DashboardStats {
     total: number;
   };
   connections: {
-    linkedin: boolean;
+    linkedinContent: boolean;
+    linkedinAds: boolean;
     beehiiv: boolean;
   };
   onboarding: {
@@ -82,14 +83,14 @@ export default function OverviewPage() {
         // Determine next incomplete onboarding step
         const nextStep = !stats.hasTaxonomy
           ? "/onboarding/add-business"
-          : !stats.connections.linkedin && !stats.connections.beehiiv
+          : !(stats.connections.linkedinContent || stats.connections.linkedinAds) && !stats.connections.beehiiv
             ? "/onboarding/connect-platforms"
             : !stats.hasBudget
               ? "/onboarding/budget"
               : "/onboarding/launch";
         const stepLabel = !stats.hasTaxonomy
           ? "Add your business"
-          : !stats.connections.linkedin && !stats.connections.beehiiv
+          : !(stats.connections.linkedinContent || stats.connections.linkedinAds) && !stats.connections.beehiiv
             ? "Connect a platform"
             : !stats.hasBudget
               ? "Set your budget"
@@ -181,8 +182,8 @@ export default function OverviewPage() {
           </CardHeader>
           <CardContent className="space-y-3">
             <ConnectionRow
-              name="LinkedIn Ads"
-              connected={stats?.connections.linkedin}
+              name="LinkedIn"
+              connected={stats?.connections.linkedinContent || stats?.connections.linkedinAds}
               loading={isLoading}
             />
             <ConnectionRow
@@ -192,7 +193,7 @@ export default function OverviewPage() {
               label={stats?.connections.beehiiv ? "Synced" : undefined}
             />
             {!isLoading &&
-              !stats?.connections.linkedin &&
+              !(stats?.connections.linkedinContent || stats?.connections.linkedinAds) &&
               !stats?.connections.beehiiv && (
                 <Button asChild size="sm" variant="outline" className="mt-2 w-full">
                   <Link href="/dashboard/settings">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -134,7 +134,7 @@ function SettingsContent() {
   }
 
   useEffect(() => {
-    if (searchParams?.get("linkedin") === "connected") {
+    if (searchParams?.get("linkedin") === "connected" || searchParams?.get("integration") === "connected") {
       setLinkedInJustConnected(true);
     }
   }, [searchParams]);


### PR DESCRIPTION
## **User description**
API returns linkedinContent/linkedinAds. Settings handles integration=connected.


___

## **CodeAnt-AI Description**
Consolidate LinkedIn connection handling and accept alternate OAuth success param

### What Changed
- Settings page now recognizes LinkedIn OAuth success when the URL has either "linkedin=connected" or "integration=connected", so recent OAuth flows reliably trigger the "just connected" state.
- Dashboard overview treats LinkedIn as connected if either a LinkedIn content source or LinkedIn ads account is linked; the Connected Platforms row now shows "LinkedIn" active when either is present.
- Onboarding quick-setup and the "Connect accounts" CTA use the combined LinkedIn check, preventing unnecessary prompts when any LinkedIn integration is already linked.

### Impact
`✅ Clearer LinkedIn connection indicator`
`✅ Fewer missed onboarding prompts after LinkedIn OAuth`
`✅ Fix detection of successful LinkedIn OAuth flows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
