### PR TITLE
fix: backfill result banner shows amber on errors, green on success

### DIFF
--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -114,7 +114,7 @@ export default function IntegrationsPage() {
   const [refreshing, setRefreshing] = useState<string | null>(null);
   const [syncing, setSyncing] = useState<string | null>(null);
   const [backfilling, setBackfilling] = useState(false);
-  const [backfillResult, setBackfillResult] = useState<string | null>(null);
+  const [backfillResult, setBackfillResult] = useState<{ message: string; hasErrors: boolean } | null>(null);
   const [connectModal, setConnectModal] = useState<string | null>(null);
 
   useEffect(() => {
@@ -202,10 +202,11 @@ export default function IntegrationsPage() {
         errors: number;
         message: string;
       }>("/v1/content/backfill-sync", {});
-      setBackfillResult(
-        `Done! Imported ${result.added} new posts, updated ${result.updated} out of ${result.total} total.` +
-        (result.errors > 0 ? ` (${result.errors} errors)` : "")
-      );
+      setBackfillResult({
+        message: `Done! Imported ${result.added} new posts, updated ${result.updated} out of ${result.total} total.` +
+          (result.errors > 0 ? ` (${result.errors} errors)` : ""),
+        hasErrors: result.errors > 0,
+      });
       await loadIntegrations();
     } catch (err) {
       if (err instanceof ApiError) setError(err.message);
@@ -479,7 +480,7 @@ function IntegrationCard({
   onRefresh: () => void;
   onSync: () => void;
   onBackfillSync?: () => Promise<void>;
-  backfillResult?: string | null;
+  backfillResult?: { message: string; hasErrors: boolean } | null;
   disconnecting: boolean;
   refreshing: boolean;
   syncing: boolean;
@@ -572,9 +573,17 @@ function IntegrationCard({
 
                 {/* Backfill result banner */}
                 {backfillResult && (
-                  <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-3 py-2 text-xs text-green-700 dark:text-green-400 flex items-center gap-2">
-                    <CheckCircle className="h-3.5 w-3.5 shrink-0" />
-                    {backfillResult}
+                  <div className={`rounded-lg border px-3 py-2 text-xs flex items-center gap-2 ${
+                    backfillResult.hasErrors
+                      ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+                      : "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-400"
+                  }`}>
+                    {backfillResult.hasErrors ? (
+                      <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                    ) : (
+                      <CheckCircle className="h-3.5 w-3.5 shrink-0" />
+                    )}
+                    {backfillResult.message}
                   </div>
                 )}
 


### PR DESCRIPTION
## **User description**
## Summary
Previously the backfill result banner was always green even when 100% of posts had errors. Now shows amber with AlertCircle icon when `errors > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Show an amber alert when backfill encounters any errors instead of always showing green

### What Changed
- The backfill result banner now shows an amber alert icon and amber styling when there are one or more errors; it remains green with a check icon only when there are no errors
- The banner text includes the same summary ("Imported X new posts, updated Y out of Z total") and appends "(N errors)" when applicable
- Backfill runs continue to reload integration data after completion and display the result banner appropriately

### Impact
`✅ Clearer backfill error visibility`
`✅ Fewer misleading success banners`
`✅ Easier troubleshooting after backfill`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
