### PR TITLE
fix: user-friendly backfill messages

### DIFF
--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -202,11 +202,23 @@ export default function IntegrationsPage() {
         errors: number;
         message: string;
       }>("/v1/content/backfill-sync", {});
-      setBackfillResult({
-        message: `Done! Imported ${result.added} new posts, updated ${result.updated} out of ${result.total} total.` +
-          (result.errors > 0 ? ` (${result.errors} errors)` : ""),
-        hasErrors: result.errors > 0,
-      });
+      // Build a user-friendly message
+      let msg = "";
+      if (result.errors === 0) {
+        if (result.added > 0 && result.updated === 0) {
+          msg = `All done! ${result.added} newsletters imported successfully.`;
+        } else if (result.added === 0 && result.updated > 0) {
+          msg = `All done! ${result.updated} newsletters refreshed with latest content.`;
+        } else if (result.added > 0 && result.updated > 0) {
+          msg = `All done! ${result.added} new newsletters imported, ${result.updated} existing ones refreshed.`;
+        } else {
+          msg = "All done! Your newsletters are already up to date.";
+        }
+      } else {
+        const succeeded = result.added + result.updated;
+        msg = `Imported ${succeeded} of ${result.total} newsletters. ${result.errors} couldn\u2019t be imported \u2014 try again in a few minutes.`;
+      }
+      setBackfillResult({ message: msg, hasErrors: result.errors > 0 });
       await loadIntegrations();
     } catch (err) {
       if (err instanceof ApiError) setError(err.message);


### PR DESCRIPTION
## **User description**
Replace dev-speak with clear messages for SME users.


___

## **CodeAnt-AI Description**
Show friendly, plain-language messages after newsletter backfill

### What Changed
- Replaced developer-style backfill text with clear, user-facing messages after a newsletter backfill
- Success messages now vary by outcome: "All done! X newsletters imported successfully.", "All done! X new imported, Y refreshed.", "All done! X refreshed with latest content.", or "All done! Your newsletters are already up to date."
- Partial-failure message now says how many succeeded and how many failed and suggests retrying soon: "Imported <succeeded> of <total> newsletters. <errors> couldn't be imported — try again in a few minutes."

### Impact
`✅ Clearer backfill status`
`✅ Clearer retry guidance for failed imports`
`✅ Fewer support inquiries about import results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
