### PR TITLE
feat: universal content layer — dynamic taxonomy UI

### DIFF
--- a/src/app/dashboard/content/[id]/page.tsx
+++ b/src/app/dashboard/content/[id]/page.tsx
@@ -4,12 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import {
-  SECTOR_LABELS,
-  AUDIENCE_LABELS,
-  CONTENT_TYPE_LABELS,
   SENTIMENT_CONFIG,
   SHELF_LIFE_LABELS,
-  AD_ANGLE_LABELS,
   label,
 } from "@/lib/content-labels";
 import { Badge } from "@/components/ui/badge";
@@ -70,7 +66,7 @@ interface FullArticle {
       longTail?: string[];
       negative?: string[];
     } | null;
-    relatedNewsletterIds: string[];
+    relatedContentIds: string[];
     seriesName?: string;
   } | null;
 }
@@ -180,7 +176,7 @@ export default function ArticleDetailPage() {
                     <Tooltip key={s.name}>
                       <TooltipTrigger asChild>
                         <Badge variant="secondary" className="text-sm">
-                          {label(SECTOR_LABELS, s.name)}
+                          {label(undefined,s.name)}
                           <span className="ml-1.5 text-muted-foreground">
                             {Math.round(s.weight * 100)}%
                           </span>
@@ -214,7 +210,7 @@ export default function ArticleDetailPage() {
                       <div key={ar.segment} className="space-y-1">
                         <div className="flex items-center justify-between">
                           <span className="text-sm font-medium">
-                            {label(AUDIENCE_LABELS, ar.segment)}
+                            {label(undefined,ar.segment)}
                           </span>
                           <span className="text-xs text-muted-foreground">
                             {Math.round(ar.relevance * 100)}%
@@ -443,7 +439,7 @@ export default function ArticleDetailPage() {
                         Best Angle
                       </p>
                       <p className="text-sm font-medium mt-0.5">
-                        {label(AD_ANGLE_LABELS, t.adPotential.bestAngle)}
+                        {label(undefined,t.adPotential.bestAngle)}
                       </p>
                     </div>
                   )}
@@ -505,7 +501,7 @@ export default function ArticleDetailPage() {
               {/* Meta info */}
               <Card>
                 <CardContent className="p-4 space-y-3">
-                  <MetaRow label="Content Type" value={label(CONTENT_TYPE_LABELS, t.contentType)} />
+                  <MetaRow label="Content Type" value={label(undefined,t.contentType)} />
                   <MetaRow
                     label="Sentiment"
                     value={

--- a/src/app/dashboard/content/page.tsx
+++ b/src/app/dashboard/content/page.tsx
@@ -5,12 +5,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { api, API_BASE_URL } from "@/lib/api";
 import {
-  SECTOR_LABELS,
-  AUDIENCE_LABELS,
-  CONTENT_TYPE_LABELS,
+  CONTENT_CATEGORY_LABELS,
   SENTIMENT_CONFIG,
   SHELF_LIFE_LABELS,
-  AD_ANGLE_LABELS,
   label,
 } from "@/lib/content-labels";
 import { Badge } from "@/components/ui/badge";
@@ -92,8 +89,8 @@ interface GapAnalysis {
   sectorCoverage: { _id: string; count: number; avgWeight: number }[];
   audienceCoverage: { _id: string; count: number; avgRelevance: number }[];
   highPotentialUnused: {
-    newsletterId: string;
-    newsletterTitle: string;
+    contentId: string;
+    contentTitle: string;
     adPotential: { score: number; bestAngle?: string; bestHook?: string };
     sectors: { name: string; weight: number }[];
   }[];
@@ -162,6 +159,19 @@ export default function ContentPage() {
     queryKey: ["content-stats"],
     queryFn: () => api.get<ContentStats>("/v1/content/stats"),
   });
+
+  // Fetch org taxonomy for dynamic sector/audience labels
+  const { data: orgData } = useQuery({
+    queryKey: ["dashboard-org"],
+    queryFn: () => api.get<{ taxonomy?: { sectors?: string[]; audienceSegments?: { name: string }[]; contentTypes?: string[]; adAngles?: string[] } }>("/v1/dashboard/org"),
+    staleTime: 300_000,
+  });
+  const taxonomySectors = orgData?.taxonomy?.sectors || [];
+  const taxonomyAudiences = (orgData?.taxonomy?.audienceSegments || []).map((a) => typeof a === "string" ? a : a.name);
+  const taxonomyContentTypes = orgData?.taxonomy?.contentTypes || [];
+  // Build dynamic label maps from taxonomy
+  const sectorOptions: [string, string][] = taxonomySectors.map((s) => [s, label(undefined, s)]);
+  const contentTypeOptions: [string, string][] = taxonomyContentTypes.map((t) => [t, label(undefined, t)]);
 
   const { data: libraryRes, isLoading: libraryLoading } = useQuery({
     queryKey: ["content-library", queryParams],
@@ -405,13 +415,13 @@ export default function ContentPage() {
                 placeholder="Sector"
                 value={filters.sector}
                 onChange={(v) => updateFilter("sector", v)}
-                options={Object.entries(SECTOR_LABELS)}
+                options={sectorOptions}
               />
               <FilterSelect
                 placeholder="Type"
                 value={filters.contentType}
                 onChange={(v) => updateFilter("contentType", v)}
-                options={Object.entries(CONTENT_TYPE_LABELS)}
+                options={contentTypeOptions}
               />
               <FilterSelect
                 placeholder="Sentiment"
@@ -544,7 +554,7 @@ export default function ContentPage() {
                         </TableCell>
                         <TableCell>
                           <Badge variant="outline" className="text-xs">
-                            {label(CONTENT_TYPE_LABELS, draft.tags?.contentType)}
+                            {label(undefined,draft.tags?.contentType)}
                           </Badge>
                         </TableCell>
                         <TableCell>
@@ -555,7 +565,7 @@ export default function ContentPage() {
                                 variant="secondary"
                                 className="text-xs"
                               >
-                                {label(SECTOR_LABELS, s.name)}
+                                {label(undefined,s.name)}
                               </Badge>
                             )) ?? (
                               <span className="text-muted-foreground">—</span>
@@ -652,7 +662,7 @@ export default function ContentPage() {
                     No tag data yet. Import and tag your newsletters first.
                   </p>
                 ) : (
-                  <SectorHeatmap data={gaps.sectorCoverage} />
+                  <SectorHeatmap data={gaps.sectorCoverage} allSectors={taxonomySectors} />
                 )}
               </CardContent>
             </Card>
@@ -671,7 +681,7 @@ export default function ContentPage() {
                     No tag data yet
                   </p>
                 ) : (
-                  <AudienceBars data={gaps.audienceCoverage} />
+                  <AudienceBars data={gaps.audienceCoverage} allAudiences={taxonomyAudiences} />
                 )}
               </CardContent>
             </Card>
@@ -728,11 +738,11 @@ export default function ContentPage() {
                     <div className="space-y-3">
                       {gaps.highPotentialUnused.map((item) => (
                         <div
-                          key={item.newsletterId}
+                          key={item.contentId}
                           className="flex items-center justify-between gap-2"
                         >
                           <span className="text-sm truncate max-w-xs">
-                            {item.newsletterTitle}
+                            {item.contentTitle}
                           </span>
                           <div className="flex items-center gap-2 shrink-0">
                             <AdScoreBar
@@ -863,13 +873,13 @@ function ArticleCard({
         <div className="flex flex-wrap gap-1">
           {t?.contentType && (
             <Badge variant="outline" className="text-xs">
-              {label(CONTENT_TYPE_LABELS, t.contentType)}
+              {label(undefined,t.contentType)}
             </Badge>
           )}
           <SentimentBadge value={t?.sentiment} />
           {t?.sectors?.slice(0, 2).map((s) => (
             <Badge key={s.name} variant="secondary" className="text-xs">
-              {label(SECTOR_LABELS, s.name)}
+              {label(undefined,s.name)}
             </Badge>
           ))}
         </div>
@@ -966,11 +976,12 @@ function SentimentBadge({ value }: { value?: string }) {
 
 function SectorHeatmap({
   data,
+  allSectors,
 }: {
   data: { _id: string; count: number; avgWeight: number }[];
+  allSectors: string[];
 }) {
   const maxCount = Math.max(...data.map((d) => d.count), 1);
-  const allSectors = Object.keys(SECTOR_LABELS);
   const dataMap = new Map(data.map((d) => [d._id, d]));
 
   return (
@@ -995,14 +1006,14 @@ function SectorHeatmap({
                 className={`rounded-lg border p-2 text-center transition-colors ${bg}`}
               >
                 <p className="text-xs font-medium leading-tight">
-                  {label(SECTOR_LABELS, sector)}
+                  {label(undefined,sector)}
                 </p>
                 <p className="text-lg font-bold mt-0.5">{count}</p>
               </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>
-                {label(SECTOR_LABELS, sector)}: {count} article
+                {label(undefined,sector)}: {count} article
                 {count !== 1 ? "s" : ""}
                 {d ? `, avg weight ${(d.avgWeight * 100).toFixed(0)}%` : ""}
               </p>
@@ -1016,11 +1027,12 @@ function SectorHeatmap({
 
 function AudienceBars({
   data,
+  allAudiences,
 }: {
   data: { _id: string; count: number; avgRelevance: number }[];
+  allAudiences: string[];
 }) {
   const maxCount = Math.max(...data.map((d) => d.count), 1);
-  const allAudiences = Object.keys(AUDIENCE_LABELS);
   const dataMap = new Map(data.map((d) => [d._id, d]));
 
   return (
@@ -1042,7 +1054,7 @@ function AudienceBars({
           <div key={segment} className="space-y-1">
             <div className="flex items-center justify-between">
               <span className="text-xs font-medium">
-                {label(AUDIENCE_LABELS, segment)}
+                {label(undefined, segment)}
               </span>
               <span className="text-xs text-muted-foreground">
                 {count} article{count !== 1 ? "s" : ""}

--- a/src/lib/content-labels.ts
+++ b/src/lib/content-labels.ts
@@ -1,62 +1,31 @@
-/** Human-readable labels for all tag enum values */
+/**
+ * Human-readable labels for universal enums and content categories.
+ *
+ * Sector, audience, content type, and ad angle labels are now DYNAMIC —
+ * they come from the org's taxonomy via the API. The `label()` function's
+ * fallback (title-case the raw value) handles any value gracefully.
+ */
 
-export const SECTOR_LABELS: Record<string, string> = {
-  aviation: "Aviation",
-  hotels_hospitality: "Hotels & Hospitality",
-  tour_operations: "Tour Operations",
-  ota_travel_tech: "OTA & Travel Tech",
-  tourism_policy: "Tourism Policy",
-  cruise_maritime: "Cruise & Maritime",
-  railways_transport: "Railways & Transport",
-  mice_events: "MICE & Events",
-  travel_insurance_forex: "Travel Insurance & Forex",
-  destination_marketing: "Destination Marketing",
-  aviation_infrastructure: "Aviation Infrastructure",
-  food_beverage: "Food & Beverage",
-  luxury_premium: "Luxury & Premium",
-  budget_economy: "Budget & Economy",
-  medical_tourism: "Medical Tourism",
-  adventure_wildlife: "Adventure & Wildlife",
-  spiritual_pilgrimage: "Spiritual & Pilgrimage",
-  wedding_tourism: "Wedding Tourism",
+/** Content category labels (universal, not org-specific) */
+export const CONTENT_CATEGORY_LABELS: Record<string, string> = {
+  newsletter: "Newsletters",
+  blog_post: "Blog Posts",
+  social_post: "Social Posts",
+  video: "Videos",
+  podcast: "Podcasts",
+  press_release: "Press Releases",
+  product_page: "Product Pages",
+  review: "Reviews",
+  case_study: "Case Studies",
+  email_campaign: "Email Campaigns",
+  webpage: "Web Pages",
+  whitepaper: "Whitepapers",
+  webinar: "Webinars",
+  infographic: "Infographics",
+  other: "Other",
 };
 
-export const AUDIENCE_LABELS: Record<string, string> = {
-  airline_exec: "Airline Executives",
-  hotel_leader: "Hotel Leaders",
-  tour_operator: "Tour Operators",
-  ota_tech: "OTA & Tech",
-  policy_maker: "Policy Makers",
-  embassy_foreign: "Embassy & Foreign Affairs",
-  travel_journalist: "Travel Journalists",
-  mice_organizer: "MICE Organizers",
-  travel_educator: "Travel Educators",
-  infrastructure_developer: "Infrastructure Developers",
-};
-
-export const CONTENT_TYPE_LABELS: Record<string, string> = {
-  breaking_news: "Breaking News",
-  analysis: "Analysis",
-  opinion: "Opinion",
-  data_report: "Data Report",
-  policy_explainer: "Policy Explainer",
-  company_profile: "Company Profile",
-  trend_piece: "Trend Piece",
-  competitive_intelligence: "Competitive Intel",
-  prediction: "Prediction",
-  roundup: "Roundup",
-};
-
-export const AD_ANGLE_LABELS: Record<string, string> = {
-  data_led: "Lead with Data",
-  contrarian: "Contrarian Take",
-  story: "Story-Driven",
-  fomo: "FOMO",
-  value_first: "Value First",
-  competitive: "Competitive Edge",
-  urgency: "Urgency",
-};
-
+/** Sentiment config with colors (universal) */
 export const SENTIMENT_CONFIG: Record<string, { label: string; color: string; bg: string }> = {
   bullish: { label: "Bullish", color: "text-green-700", bg: "bg-green-100" },
   bearish: { label: "Bearish", color: "text-red-700", bg: "bg-red-100" },
@@ -65,6 +34,7 @@ export const SENTIMENT_CONFIG: Record<string, { label: string; color: string; bg
   mixed: { label: "Mixed", color: "text-purple-700", bg: "bg-purple-100" },
 };
 
+/** Shelf life labels (universal) */
 export const SHELF_LIFE_LABELS: Record<string, string> = {
   "24h": "24 Hours",
   "1week": "1 Week",
@@ -72,8 +42,13 @@ export const SHELF_LIFE_LABELS: Record<string, string> = {
   evergreen: "Evergreen",
 };
 
-/** Get a label for any enum value, with fallback to title-cased raw value */
-export function label(map: Record<string, string>, key: string | undefined | null): string {
+/**
+ * Get a human-readable label for any taxonomy value.
+ * Works with both static maps and dynamic org taxonomy values.
+ * Falls back to title-casing the raw value (e.g., "hotels_hospitality" → "Hotels Hospitality").
+ */
+export function label(map: Record<string, string> | undefined, key: string | undefined | null): string {
   if (!key) return "—";
-  return map[key] || key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  if (map && map[key]) return map[key];
+  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }


### PR DESCRIPTION
## **User description**
## Summary
- Remove hardcoded label maps, fetch taxonomy from org API
- SectorHeatmap/AudienceBars accept dynamic taxonomy as props
- Filter dropdowns populated from org taxonomy
- All newsletterId/Title → contentId/Title
- CONTENT_CATEGORY_LABELS for universal categories

## Depends on
- peakhour-api universal content layer PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use organization's taxonomy for sector, audience and content type labels; add universal content categories

### What Changed
- Filter dropdowns and tag badges now use the organization's taxonomy fetched from the dashboard API so sectors, audience segments and content types match the org's configured names
- Sector heatmap and Audience bars receive the full org taxonomy so charts show all org sectors/audience segments and label unknown values consistently
- Added a universal CONTENT_CATEGORY list for content-category display; sentiment and shelf-life labels remain global
- Labeling now falls back to a readable title-cased value for any unmapped tag (e.g., "hotels_hospitality" → "Hotels Hospitality")
- Internal identifiers and displays renamed from newsletterId/newsletterTitle to contentId/contentTitle so gap lists and detail pages show content titles consistently

### Impact
`✅ Filters reflect org-specific sectors and content types`
`✅ Charts include all org sectors and audience segments`
`✅ Clearer labels for unknown or custom taxonomy values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
