### PR TITLE
fix: sector heatmap + audience bars showing blank

### DIFF
--- a/src/app/dashboard/content/page.tsx
+++ b/src/app/dashboard/content/page.tsx
@@ -984,9 +984,21 @@ function SectorHeatmap({
   const maxCount = Math.max(...data.map((d) => d.count), 1);
   const dataMap = new Map(data.map((d) => [d._id, d]));
 
+  // Merge: show taxonomy sectors + any sectors from tag data not in taxonomy
+  const tagSectors = data.map((d) => d._id);
+  const taxonomySet = new Set(allSectors);
+  const merged = [
+    ...allSectors,
+    ...tagSectors.filter((s) => !taxonomySet.has(s)),
+  ];
+
+  if (merged.length === 0) {
+    return <p className="text-sm text-muted-foreground">No sectors configured or tagged yet.</p>;
+  }
+
   return (
     <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-2">
-      {allSectors.map((sector) => {
+      {merged.map((sector) => {
         const d = dataMap.get(sector);
         const count = d?.count ?? 0;
         const intensity = count > 0 ? Math.max(0.1, count / maxCount) : 0;
@@ -1035,9 +1047,21 @@ function AudienceBars({
   const maxCount = Math.max(...data.map((d) => d.count), 1);
   const dataMap = new Map(data.map((d) => [d._id, d]));
 
+  // Merge: show taxonomy audiences + any from tag data not in taxonomy
+  const tagAudiences = data.map((d) => d._id);
+  const taxonomySet = new Set(allAudiences);
+  const merged = [
+    ...allAudiences,
+    ...tagAudiences.filter((a) => !taxonomySet.has(a)),
+  ];
+
+  if (merged.length === 0) {
+    return <p className="text-sm text-muted-foreground">No audience segments configured or tagged yet.</p>;
+  }
+
   return (
     <div className="space-y-3">
-      {allAudiences.map((segment) => {
+      {merged.map((segment) => {
         const d = dataMap.get(segment);
         const count = d?.count ?? 0;
         const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;


### PR DESCRIPTION
## **User description**
Merges taxonomy + tag data sources so both human-readable taxonomy names AND old enum values from tags are displayed.


___

## **CodeAnt-AI Description**
**Display taxonomy names plus legacy tag values in sector heatmap and audience bars**

### What Changed
- Sector heatmap now lists taxonomy sectors first and then any additional sector values found only in tag data, so both human-readable taxonomy names and old tag enums appear.
- Audience bars now list taxonomy audience segments first and then any additional audience values from tag data.
- When no sectors or audience segments exist (neither taxonomy nor tag data), the UI shows a clear "No ... configured or tagged yet." message instead of empty grids.

### Impact
`✅ Clearer sector labels in heatmap`
`✅ More audience segments visible on dashboard`
`✅ Informative empty state when no sectors or audiences are present`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
