### PR TITLE
fix: deduplicate sector/audience — taxonomy as single source of truth

### DIFF
--- a/src/app/dashboard/content/page.tsx
+++ b/src/app/dashboard/content/page.tsx
@@ -974,6 +974,18 @@ function SentimentBadge({ value }: { value?: string }) {
   );
 }
 
+/** Normalize a string for comparison: lowercase, strip special chars */
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+}
+
+/** Check if two strings match by normalized form or substring containment */
+function fuzzyMatch(a: string, b: string): boolean {
+  const na = normalize(a);
+  const nb = normalize(b);
+  return na === nb || na.includes(nb) || nb.includes(na);
+}
+
 function SectorHeatmap({
   data,
   allSectors,
@@ -981,25 +993,59 @@ function SectorHeatmap({
   data: { _id: string; count: number; avgWeight: number }[];
   allSectors: string[];
 }) {
+  // Taxonomy is the single source of truth. Match tag data to taxonomy entries
+  // using fuzzy matching (e.g., tag "aviation" matches taxonomy "Airlines & Aviation").
+  // Unmatched tag data gets its own entry at the end.
+  const usedTagIds = new Set<string>();
+
+  function findTagData(taxonomyValue: string) {
+    let total = { count: 0, avgWeight: 0, matched: 0 };
+    for (const d of data) {
+      if (fuzzyMatch(taxonomyValue, d._id)) {
+        total.count += d.count;
+        total.avgWeight += d.avgWeight * d.count;
+        total.matched++;
+        usedTagIds.add(d._id);
+      }
+    }
+    if (total.matched === 0) return null;
+    return { count: total.count, avgWeight: total.avgWeight / total.count };
+  }
+
+  const sectors = allSectors.length > 0 ? allSectors : data.map((d) => d._id);
+
+  // Deduplicate taxonomy entries
+  const seen = new Set<string>();
+  const uniqueSectors = sectors.filter((s) => {
+    const norm = normalize(s);
+    if (seen.has(norm)) return false;
+    seen.add(norm);
+    return true;
+  });
+
+  // Add any unmatched tag data as extra entries
+  const unmatched = data.filter((d) => !usedTagIds.has(d._id));
+
   const maxCount = Math.max(...data.map((d) => d.count), 1);
-  const dataMap = new Map(data.map((d) => [d._id, d]));
 
-  // Merge: show taxonomy sectors + any sectors from tag data not in taxonomy
-  const tagSectors = data.map((d) => d._id);
-  const taxonomySet = new Set(allSectors);
-  const merged = [
-    ...allSectors,
-    ...tagSectors.filter((s) => !taxonomySet.has(s)),
-  ];
-
-  if (merged.length === 0) {
+  if (uniqueSectors.length === 0 && unmatched.length === 0) {
     return <p className="text-sm text-muted-foreground">No sectors configured or tagged yet.</p>;
+  }
+
+  // Pre-compute tag data for each taxonomy sector
+  const sectorData = uniqueSectors.map((sector) => ({
+    name: sector,
+    data: findTagData(sector),
+  }));
+
+  // Append unmatched tag data
+  for (const d of unmatched) {
+    sectorData.push({ name: d._id, data: { count: d.count, avgWeight: d.avgWeight } });
   }
 
   return (
     <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-2">
-      {merged.map((sector) => {
-        const d = dataMap.get(sector);
+      {sectorData.map(({ name: sector, data: d }) => {
         const count = d?.count ?? 0;
         const intensity = count > 0 ? Math.max(0.1, count / maxCount) : 0;
         const bg =
@@ -1044,25 +1090,50 @@ function AudienceBars({
   data: { _id: string; count: number; avgRelevance: number }[];
   allAudiences: string[];
 }) {
+  const usedTagIds = new Set<string>();
+
+  function findTagData(taxonomyValue: string) {
+    let total = { count: 0, avgRelevance: 0, matched: 0 };
+    for (const d of data) {
+      if (fuzzyMatch(taxonomyValue, d._id)) {
+        total.count += d.count;
+        total.avgRelevance += d.avgRelevance * d.count;
+        total.matched++;
+        usedTagIds.add(d._id);
+      }
+    }
+    if (total.matched === 0) return null;
+    return { count: total.count, avgRelevance: total.avgRelevance / total.count };
+  }
+
+  const segments = allAudiences.length > 0 ? allAudiences : data.map((d) => d._id);
+
+  const seen = new Set<string>();
+  const uniqueSegments = segments.filter((s) => {
+    const norm = normalize(s);
+    if (seen.has(norm)) return false;
+    seen.add(norm);
+    return true;
+  });
+
+  const unmatched = data.filter((d) => !usedTagIds.has(d._id));
   const maxCount = Math.max(...data.map((d) => d.count), 1);
-  const dataMap = new Map(data.map((d) => [d._id, d]));
 
-  // Merge: show taxonomy audiences + any from tag data not in taxonomy
-  const tagAudiences = data.map((d) => d._id);
-  const taxonomySet = new Set(allAudiences);
-  const merged = [
-    ...allAudiences,
-    ...tagAudiences.filter((a) => !taxonomySet.has(a)),
-  ];
+  const segmentData = uniqueSegments.map((seg) => ({
+    name: seg,
+    data: findTagData(seg),
+  }));
+  for (const d of unmatched) {
+    segmentData.push({ name: d._id, data: { count: d.count, avgRelevance: d.avgRelevance } });
+  }
 
-  if (merged.length === 0) {
+  if (segmentData.length === 0) {
     return <p className="text-sm text-muted-foreground">No audience segments configured or tagged yet.</p>;
   }
 
   return (
     <div className="space-y-3">
-      {merged.map((segment) => {
-        const d = dataMap.get(segment);
+      {segmentData.map(({ name: segment, data: d }) => {
         const count = d?.count ?? 0;
         const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;
         const color =


### PR DESCRIPTION
## **User description**
Fuzzy matching consolidates old enum tag values under current taxonomy names. No duplicates.


___

## **CodeAnt-AI Description**
Consolidate tag-based sectors and audiences into taxonomy names in heatmaps and bars

### What Changed
- Sector heatmap and audience bars now treat the taxonomy list as the single source of truth and merge tagged values that match taxonomy entries (e.g., "aviation" → "Airlines & Aviation") using fuzzy matching.
- Counts and weighted averages from multiple matching tag values are combined under the taxonomy entry; taxonomy entries are deduplicated by normalized name.
- Any tag values that do not match the taxonomy are still shown afterward so no tagged data is lost.
- Empty-state messages remain when there are no taxonomy entries or tags.

### Impact
`✅ Fewer duplicate sectors in heatmap`
`✅ Clearer audience segment breakdowns`
`✅ No loss of unmatched tag data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
