### PR TITLE
fix: add-business page — 2 CRITICAL + 2 HIGH from code review

### DIFF
--- a/src/app/onboarding/add-business/page.tsx
+++ b/src/app/onboarding/add-business/page.tsx
@@ -66,9 +66,11 @@ export default function AddBusinessPage() {
     confidence: number;
   } | null>(null);
 
-  // Check onboarding status on mount — auto-run discovery if URL exists but taxonomy is missing
+  // Check onboarding status on mount — only for first-time onboarding
+  // Skip when adding a second business (isAddingToExistingOrg) — the status
+  // would check the OLD business and redirect away before the form loads.
   useEffect(() => {
-    if (!org) {
+    if (!org || isAddingToExistingOrg) {
       setCheckingStatus(false);
       return;
     }
@@ -136,10 +138,10 @@ export default function AddBusinessPage() {
 
     try {
       if (isAddingToExistingOrg) {
-        // Adding a new business to existing org
+        // Adding a new business to existing org — use domain as initial name
+        const displayName = hostname.replace(/\.(com|io|co|org|net|ai)$/i, "").replace(/[.-]/g, " ").replace(/\b\w/g, c => c.toUpperCase());
         await api.post("/v1/auth/businesses/create", {
-          name: hostname,
-          businessCategory: "other",
+          name: displayName || hostname,
         });
         await refreshUser();
       } else {
@@ -188,7 +190,14 @@ export default function AddBusinessPage() {
       }
 
       await refreshUser();
-      router.push("/onboarding/connect-platforms");
+
+      // If URL was provided, run discovery before proceeding
+      if (websiteUrl.trim()) {
+        await runDiscovery(websiteUrl);
+        return;
+      }
+
+      router.push("/dashboard/overview");
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);


### PR DESCRIPTION
## **User description**
## Fixes
1. **CRITICAL**: Status check redirected away when adding second business (old business had taxonomy → redirect)
2. **HIGH**: Hostname cleaned up as display name (travelxp.com → "Travelxp")
3. **HIGH**: Manual submit with URL runs discovery before redirect
4. **HIGH**: Manual submit without URL goes to dashboard (not connect-platforms which needs taxonomy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix add-business onboarding flow to handle second businesses, clean hostnames, and conditionally run discovery

### What Changed
- Prevents an automatic redirect that hid the add-business form when adding a second business to an existing organization
- Uses a cleaned hostname (e.g., travelxp.com → "Travelxp") as the initial display name when adding a business to an existing org
- When submitting the form:
  - If a website URL is provided, discovery runs before navigating away
  - If no website URL is provided, the user is taken directly to the dashboard instead of the connect-platforms step

### Impact
`✅ Fewer blocked add-business attempts for organizations adding another business`
`✅ Clearer initial business names shown for newly added businesses`
`✅ Discovery runs when users provide a website, avoiding premature navigation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
