### PR TITLE
fix: sector/audience doubles — execution order bug

### DIFF
--- a/src/app/dashboard/content/page.tsx
+++ b/src/app/dashboard/content/page.tsx
@@ -1030,20 +1030,20 @@ function SectorHeatmap({
     return true;
   });
 
-  // Add any unmatched tag data as extra entries
-  const unmatched = data.filter((d) => !usedTagIds.has(d._id));
-
-  const maxCount = Math.max(...data.map((d) => d.count), 1);
-
-  if (uniqueSectors.length === 0 && unmatched.length === 0) {
-    return <p className="text-sm text-muted-foreground">No sectors configured or tagged yet.</p>;
-  }
-
-  // Pre-compute tag data for each taxonomy sector
+  // Pre-compute tag data FIRST — this populates usedTagIds via findTagData calls
   const sectorData = uniqueSectors.map((sector) => ({
     name: sector,
     data: findTagData(sector),
   }));
+
+  // THEN find unmatched — usedTagIds is now populated
+  const unmatched = data.filter((d) => !usedTagIds.has(d._id));
+
+  const maxCount = Math.max(...data.map((d) => d.count), 1);
+
+  if (sectorData.length === 0 && unmatched.length === 0) {
+    return <p className="text-sm text-muted-foreground">No sectors configured or tagged yet.</p>;
+  }
 
   // Append unmatched tag data
   for (const d of unmatched) {
@@ -1123,13 +1123,16 @@ function AudienceBars({
     return true;
   });
 
-  const unmatched = data.filter((d) => !usedTagIds.has(d._id));
-  const maxCount = Math.max(...data.map((d) => d.count), 1);
-
+  // Pre-compute FIRST — populates usedTagIds
   const segmentData = uniqueSegments.map((seg) => ({
     name: seg,
     data: findTagData(seg),
   }));
+
+  // THEN find unmatched
+  const unmatched = data.filter((d) => !usedTagIds.has(d._id));
+  const maxCount = Math.max(...data.map((d) => d.count), 1);
+
   for (const d of unmatched) {
     segmentData.push({ name: d._id, data: { count: d.count, avgRelevance: d.avgRelevance } });
   }


### PR DESCRIPTION
## **User description**
## Root cause
`unmatched = data.filter(d => !usedTagIds.has(d._id))` ran BEFORE
`findTagData()` was called — usedTagIds was always empty — ALL tag
entries appeared as unmatched → duplicated every sector/audience.

## Fix
Compute sectorData/segmentData FIRST (calls findTagData, populates
usedTagIds), THEN filter unmatched. Same fix in both components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix duplicate sector and audience entries caused by incorrect processing order

### What Changed
- Tag data for each configured sector/audience is computed before identifying unmatched tags, so the set of already-used tag IDs is populated correctly
- Unmatched tags are now appended only when truly unused, preventing duplicated sector and audience rows in the UI
- Empty-state messages remain shown when no sectors or audiences are configured or tagged

### Impact
`✅ Fewer duplicate sectors and audiences in visualizations`
`✅ Accurate counts in sector heatmap and audience bars`
`✅ Clearer taxonomy lists for users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
