### PR TITLE
feat: suggestion cards with accept/reject feedback

### DIFF
--- a/src/app/dashboard/strategist/page.tsx
+++ b/src/app/dashboard/strategist/page.tsx
@@ -20,8 +20,20 @@ import { label } from "@/lib/content-labels";
 
 // ── Types ────────────────────────────────────────────────────
 
+interface Suggestion {
+  _id: string | null;
+  topic: string;
+  sector?: string;
+  targetAudience?: string;
+  contentType?: string;
+  angle?: string;
+  whyNow?: string;
+  estimatedAdPotential?: number;
+}
+
 interface SuggestResponse {
-  suggestions: string;
+  suggestions: Suggestion[] | null;
+  rawText: string;
   toolsUsed: string[];
   usage: { inputTokens: number; outputTokens: number; totalTokens: number };
 }
@@ -231,11 +243,21 @@ export default function StrategistPage() {
               {(suggestions.usage?.totalTokens ?? 0).toLocaleString()} tokens
             </span>
           </div>
-          <Card>
-            <CardContent className="p-6 prose prose-sm max-w-none">
-              <MarkdownContent content={suggestions.suggestions} />
-            </CardContent>
-          </Card>
+
+          {/* Structured suggestion cards */}
+          {suggestions.suggestions && suggestions.suggestions.length > 0 ? (
+            <div className="space-y-3">
+              {suggestions.suggestions.map((s, i) => (
+                <SuggestionCard key={s._id || i} suggestion={s} index={i} />
+              ))}
+            </div>
+          ) : (
+            <Card>
+              <CardContent className="p-6 prose prose-sm max-w-none">
+                <MarkdownContent content={suggestions.rawText} />
+              </CardContent>
+            </Card>
+          )}
         </div>
       )}
 
@@ -365,6 +387,105 @@ function ToolBadges({ tools }: { tools: string[] }) {
 }
 
 /** Styled markdown renderer */
+function SuggestionCard({ suggestion: s, index }: { suggestion: Suggestion; index: number }) {
+  const [feedbackSent, setFeedbackSent] = useState<string | null>(null);
+  const [feedbackError, setFeedbackError] = useState(false);
+  const [rejecting, setRejecting] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  async function sendFeedback(action: "accepted" | "rejected" | "saved_for_later", reason?: string) {
+    if (!s._id || sending) return;
+    setSending(true);
+    setFeedbackError(false);
+    try {
+      await api.post(`/v1/content/ideas/${s._id}/feedback`, { action, reason });
+      setFeedbackSent(action);
+      setRejecting(false);
+    } catch {
+      setFeedbackError(true);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  const scoreColor = (s.estimatedAdPotential ?? 0) >= 8 ? "text-green-600" :
+    (s.estimatedAdPotential ?? 0) >= 6 ? "text-amber-600" : "text-muted-foreground";
+
+  return (
+    <Card className={feedbackSent === "accepted" ? "border-green-200 bg-green-50/30" : feedbackSent === "rejected" ? "border-red-200 bg-red-50/30 opacity-60" : ""}>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-mono text-muted-foreground">{index + 1}.</span>
+              <h3 className="font-semibold text-sm">{s.topic}</h3>
+            </div>
+            {s.whyNow && (
+              <p className="text-xs text-muted-foreground mt-1">{s.whyNow}</p>
+            )}
+          </div>
+          {s.estimatedAdPotential && (
+            <span className={`text-lg font-bold ${scoreColor}`}>
+              {s.estimatedAdPotential}<span className="text-xs font-normal">/10</span>
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {s.sector && <Badge variant="secondary" className="text-xs">{s.sector}</Badge>}
+          {s.targetAudience && <Badge variant="outline" className="text-xs">{s.targetAudience}</Badge>}
+          {s.contentType && <Badge variant="outline" className="text-xs">{s.contentType}</Badge>}
+          {s.angle && <Badge className="text-xs bg-primary/10 text-primary border-0">{s.angle}</Badge>}
+        </div>
+
+        {/* Feedback buttons */}
+        {!feedbackSent && s._id && (
+          <div className="flex items-center gap-2 pt-1">
+            <Button size="sm" variant="default" disabled={sending} onClick={() => sendFeedback("accepted")}>
+              Accept
+            </Button>
+            <Button size="sm" variant="outline" disabled={sending} onClick={() => setRejecting(!rejecting)}>
+              Reject
+            </Button>
+            <Button size="sm" variant="ghost" disabled={sending} onClick={() => sendFeedback("saved_for_later")}>
+              Save for later
+            </Button>
+          </div>
+        )}
+
+        {/* Reject reasons */}
+        {rejecting && !feedbackSent && (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            <span className="text-xs text-muted-foreground mr-1">Why?</span>
+            {["not_timely", "wrong_audience", "already_covered", "not_relevant", "too_generic"].map((reason) => (
+              <Button key={reason} size="sm" variant="outline" className="text-xs h-7" disabled={sending}
+                onClick={() => sendFeedback("rejected", reason)}>
+                {label(undefined, reason)}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {/* Feedback error */}
+        {feedbackError && (
+          <p className="text-xs text-red-600 font-medium">
+            Failed to save feedback. Please try again.
+          </p>
+        )}
+
+        {/* Feedback confirmation */}
+        {feedbackSent && (
+          <p className="text-xs text-muted-foreground">
+            {feedbackSent === "accepted" ? "Accepted — will be scheduled for creation" :
+             feedbackSent === "rejected" ? "Rejected — AI will learn from this" :
+             "Saved for later"}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 function MarkdownContent({ content }: { content: string }) {
   return (
     <ReactMarkdown


### PR DESCRIPTION
## **User description**
## Summary
- Structured suggestion cards with topic, sector, audience, angle, ad score
- Accept/Reject/Save buttons with reject reason picker
- Visual state: green on accept, dimmed on reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Show structured suggestion cards with accept/reject/save feedback

### What Changed
- Suggestions are shown as structured cards (topic, sector, audience, type, angle, why now, ad score) instead of raw markdown when parsing succeeds
- Each card has Accept, Reject, and Save for later actions; Accept marks the idea as planned, Reject opens a reason picker (not timely, wrong audience, already covered, not relevant, too generic), and Save keeps it for later
- Visual confirmation: accepted cards get a green highlight, rejected cards are dimmed and both show a small confirmation message; if structured parsing fails the UI falls back to showing the original markdown
- Tools used and token counts remain visible above the suggestions

### Impact
`✅ Clearer idea cards for faster review`
`✅ Easier triage with actionable accept/reject/save controls`
`✅ Feedback fed back to AI to reduce future irrelevant suggestions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
