### PR TITLE
feat: persistent strategist — load saved ideas + channel icons

### DIFF
--- a/src/app/dashboard/strategist/page.tsx
+++ b/src/app/dashboard/strategist/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ReactMarkdown from "react-markdown";
 import { api } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
@@ -29,6 +30,7 @@ interface Suggestion {
   angle?: string;
   whyNow?: string;
   estimatedAdPotential?: number;
+  channels?: string[];
 }
 
 interface SuggestResponse {
@@ -69,11 +71,33 @@ const LOADING_MESSAGES = [
 
 // ── Main Page ────────────────────────────────────────────────
 
+interface SavedIdea {
+  _id: string;
+  title: string;
+  description?: string;
+  status: string;
+  sector?: string;
+  targetAudience?: string;
+  contentType?: string;
+  angle?: string;
+  aiScore?: number;
+  channels?: string[];
+  targetDate?: string;
+  createdAt: string;
+}
+
 export default function StrategistPage() {
+  const queryClient = useQueryClient();
   const [mode, setMode] = useState<"suggest" | "brief" | "plan">("suggest");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [topic, setTopic] = useState("");
+
+  // Load saved AI suggestions
+  const { data: savedIdeas } = useQuery({
+    queryKey: ["content-ideas"],
+    queryFn: () => api.get<SavedIdea[]>("/v1/content/ideas"),
+  });
 
   // Suggest state
   const [suggestions, setSuggestions] = useState<SuggestResponse | null>(null);
@@ -121,7 +145,10 @@ export default function StrategistPage() {
           "/v1/content/suggest",
           topic ? { topic } : {}
         );
-        if (!controller.signal.aborted) setSuggestions(result);
+        if (!controller.signal.aborted) {
+          setSuggestions(result);
+          queryClient.invalidateQueries({ queryKey: ["content-ideas"] });
+        }
       } else if (mode === "brief") {
         const result = await api.post<BriefResponse>(
           "/v1/content/brief",
@@ -132,7 +159,10 @@ export default function StrategistPage() {
         const result = await api.get<{ plan: string; toolsUsed: string[] }>(
           "/v1/content/weekly-plan"
         );
-        if (!controller.signal.aborted) setPlan(result);
+        if (!controller.signal.aborted) {
+          setPlan(result);
+          queryClient.invalidateQueries({ queryKey: ["content-ideas"] });
+        }
       }
     } catch (err: any) {
       if (!controller.signal.aborted) {
@@ -363,6 +393,34 @@ export default function StrategistPage() {
           </Card>
         </div>
       )}
+
+      {/* Saved ideas — persists across page refreshes */}
+      {savedIdeas && savedIdeas.length > 0 && !loading && (
+        <div className="space-y-4">
+          <Separator />
+          <h3 className="text-lg font-semibold">Your Content Ideas</h3>
+          <div className="space-y-3">
+            {savedIdeas.map((idea, i) => (
+              <SuggestionCard
+                key={idea._id}
+                suggestion={{
+                  _id: idea._id,
+                  topic: idea.title,
+                  sector: idea.sector,
+                  targetAudience: idea.targetAudience,
+                  contentType: idea.contentType,
+                  angle: idea.angle,
+                  whyNow: idea.description,
+                  estimatedAdPotential: idea.aiScore,
+                  channels: idea.channels,
+                }}
+                index={i}
+                initialStatus={idea.status !== "brainstorm" ? idea.status : undefined}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -387,8 +445,15 @@ function ToolBadges({ tools }: { tools: string[] }) {
 }
 
 /** Styled markdown renderer */
-function SuggestionCard({ suggestion: s, index }: { suggestion: Suggestion; index: number }) {
-  const [feedbackSent, setFeedbackSent] = useState<string | null>(null);
+const CHANNEL_ICONS: Record<string, string> = {
+  newsletter: "📧", linkedin: "💼", x: "𝕏", instagram: "📷",
+  blog: "📝", youtube: "▶️", facebook: "📘", tiktok: "🎵",
+};
+
+function SuggestionCard({ suggestion: s, index, initialStatus }: { suggestion: Suggestion; index: number; initialStatus?: string }) {
+  const [feedbackSent, setFeedbackSent] = useState<string | null>(
+    initialStatus === "planned" ? "accepted" : initialStatus === "archived" ? "rejected" : null
+  );
   const [feedbackError, setFeedbackError] = useState(false);
   const [rejecting, setRejecting] = useState(false);
   const [sending, setSending] = useState(false);
@@ -436,6 +501,11 @@ function SuggestionCard({ suggestion: s, index }: { suggestion: Suggestion; inde
           {s.targetAudience && <Badge variant="outline" className="text-xs">{s.targetAudience}</Badge>}
           {s.contentType && <Badge variant="outline" className="text-xs">{s.contentType}</Badge>}
           {s.angle && <Badge className="text-xs bg-primary/10 text-primary border-0">{s.angle}</Badge>}
+          {s.channels?.map((ch) => (
+            <span key={ch} className="text-xs" title={ch}>
+              {CHANNEL_ICONS[ch.toLowerCase()] || "📢"} {ch}
+            </span>
+          ))}
         </div>
 
         {/* Feedback buttons */}


### PR DESCRIPTION
## **User description**
## Summary
- Loads saved ideas from API on page mount (persists across refresh)
- Channel icons on suggestion cards (📧 💼 𝕏 📷 etc.)
- Pre-set accept/reject state for already-actioned ideas
- Invalidates query after new AI suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show saved content ideas and channel icons on Strategist page**

### What Changed
- The Strategist page now loads and displays saved content ideas from the server in a "Your Content Ideas" section so ideas persist across page refreshes
- Suggestion cards show channel labels with icons (e.g., 📧 newsletter, 💼 linkedin, 𝕏) for clearer distribution context
- Cards reflect prior user actions: ideas already accepted/planned or archived/rejected show their accept/reject state when rendered
- When new suggestions or a weekly plan are generated, the saved ideas list is refreshed so newly created ideas appear immediately

### Impact
`✅ No lost saved ideas on refresh`
`✅ Clearer channel visibility on idea cards`
`✅ Saved ideas update immediately after new suggestions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
