### PR TITLE
feat: content references + channels on new line

### DIFF
--- a/src/app/dashboard/strategist/page.tsx
+++ b/src/app/dashboard/strategist/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
@@ -465,6 +465,7 @@ function ToolBadges({ tools }: { tools: string[] }) {
 
 /** Styled markdown renderer */
 import { ChannelIcon } from "@/components/ui/channel-icon";
+import { ContentLinkedText } from "@/components/ui/content-ref";
 
 function SuggestionCard({ suggestion: s, index, initialStatus }: { suggestion: Suggestion; index: number; initialStatus?: string }) {
   const [feedbackSent, setFeedbackSent] = useState<string | null>(
@@ -521,10 +522,17 @@ function SuggestionCard({ suggestion: s, index, initialStatus }: { suggestion: S
           )}
           {s.contentType && <Badge variant="outline" className="text-xs max-w-50 truncate">{s.contentType}</Badge>}
           {s.angle && <Badge className="text-xs bg-primary/10 text-primary border-0 max-w-50 truncate">{s.angle}</Badge>}
-          {s.channels?.map((ch) => (
-            <ChannelIcon key={ch} channel={ch} size={14} />
-          ))}
         </div>
+
+        {/* Channels — separate line */}
+        {s.channels && s.channels.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-muted-foreground">Publish on:</span>
+            {s.channels.map((ch) => (
+              <ChannelIcon key={ch} channel={ch} size={14} />
+            ))}
+          </div>
+        )}
 
         {/* Feedback buttons */}
         {!feedbackSent && s._id && (
@@ -594,19 +602,43 @@ function SuggestionCard({ suggestion: s, index, initialStatus }: { suggestion: S
   );
 }
 
+/** Walk React children, find text nodes with #\d+ patterns, wrap with ContentLinkedText */
+function LinkifyContentRefs({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {React.Children.map(children, (child) => {
+        if (typeof child === "string" && /#\d+/.test(child)) {
+          return <ContentLinkedText text={child} />;
+        }
+        return child;
+      })}
+    </>
+  );
+}
+
 function MarkdownContent({ content }: { content: string }) {
+  // Pre-process: apply content reference linking to the raw text
+  // ContentLinkedText will parse #24 patterns into hoverable links
   return (
     <ReactMarkdown
       components={{
         h1: ({ children }) => <h1 className="text-xl font-bold mt-6 mb-3">{children}</h1>,
         h2: ({ children }) => <h2 className="text-lg font-bold mt-5 mb-2">{children}</h2>,
         h3: ({ children }) => <h3 className="text-base font-semibold mt-4 mb-2">{children}</h3>,
-        p: ({ children }) => <p className="text-sm leading-relaxed mb-3">{children}</p>,
+        p: ({ children }) => (
+          <p className="text-sm leading-relaxed mb-3">
+            <LinkifyContentRefs>{children}</LinkifyContentRefs>
+          </p>
+        ),
         strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
         em: ({ children }) => <em className="italic">{children}</em>,
         ul: ({ children }) => <ul className="list-disc pl-5 mb-3 space-y-1">{children}</ul>,
         ol: ({ children }) => <ol className="list-decimal pl-5 mb-3 space-y-1">{children}</ol>,
-        li: ({ children }) => <li className="text-sm leading-relaxed">{children}</li>,
+        li: ({ children }) => (
+          <li className="text-sm leading-relaxed">
+            <LinkifyContentRefs>{children}</LinkifyContentRefs>
+          </li>
+        ),
         hr: () => <hr className="my-4 border-border" />,
         blockquote: ({ children }) => (
           <blockquote className="border-l-2 border-primary/30 pl-4 my-3 italic text-muted-foreground">

--- a/src/components/ui/content-ref.tsx
+++ b/src/components/ui/content-ref.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { api } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+
+interface ContentMatch {
+  _id: string;
+  title: string;
+  webUrl?: string;
+  adScore?: number;
+  sectors?: string[];
+  sentiment?: string;
+}
+
+/**
+ * Renders text with content references (#24, Daily #24, etc.) as
+ * hoverable links. On hover shows preview, on click opens content detail.
+ */
+export function ContentLinkedText({ text }: { text: string }) {
+  // Match patterns: #24, Daily #24, Quests Daily #24, "Your Daily #24"
+  const refPattern = /(?:(?:Quests\s+)?Daily\s+)?#(\d+)/gi;
+  const parts: { type: "text" | "ref"; content: string; num?: string }[] = [];
+
+  let lastIndex = 0;
+  let match;
+  while ((match = refPattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: "text", content: text.slice(lastIndex, match.index) });
+    }
+    parts.push({ type: "ref", content: match[0], num: match[1] });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    parts.push({ type: "text", content: text.slice(lastIndex) });
+  }
+
+  if (parts.every((p) => p.type === "text")) {
+    return <>{text}</>;
+  }
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.type === "text" ? (
+          <span key={i}>{part.content}</span>
+        ) : (
+          <ContentRefLink key={i} display={part.content} searchNum={part.num!} />
+        )
+      )}
+    </>
+  );
+}
+
+function ContentRefLink({ display, searchNum }: { display: string; searchNum: string }) {
+  const [match, setMatch] = useState<ContentMatch | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const search = useCallback(async () => {
+    if (searched) return;
+    setSearched(true);
+    setLoading(true);
+    try {
+      const results = await api.get<ContentMatch[]>("/v1/content/search", { q: `#${searchNum}` });
+      if (results.length > 0) {
+        // Find best match — title contains the number
+        const best = results.find((r) => r.title.includes(`#${searchNum}`)) || results[0];
+        setMatch(best);
+      }
+    } catch {
+      // Non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, [searchNum, searched]);
+
+  function handleMouseEnter() {
+    search();
+    timeoutRef.current = setTimeout(() => setShowPreview(true), 300);
+  }
+
+  function handleMouseLeave() {
+    clearTimeout(timeoutRef.current);
+    setShowPreview(false);
+  }
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  if (!match && searched && !loading) {
+    // No match found — render as plain text
+    return <span>{display}</span>;
+  }
+
+  return (
+    <span
+      className="relative inline-block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <a
+        href={match ? `/dashboard/content/${match._id}` : "#"}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary underline underline-offset-2 decoration-primary/40 hover:decoration-primary cursor-pointer font-medium"
+        onClick={(e) => {
+          if (!match) e.preventDefault();
+        }}
+      >
+        {display}
+      </a>
+
+      {/* Hover preview */}
+      {showPreview && match && (
+        <div className="absolute z-50 bottom-full left-0 mb-2 w-72 rounded-lg border bg-popover p-3 shadow-lg animate-in fade-in-0 zoom-in-95">
+          <p className="text-sm font-medium leading-tight">{match.title}</p>
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {match.adScore && (
+              <Badge variant={match.adScore >= 7 ? "default" : "secondary"} className="text-xs">
+                Score: {match.adScore}
+              </Badge>
+            )}
+            {match.sentiment && (
+              <Badge variant="outline" className="text-xs">{match.sentiment}</Badge>
+            )}
+            {match.sectors?.slice(0, 2).map((s) => (
+              <Badge key={s} variant="secondary" className="text-xs">{s}</Badge>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground mt-1.5">Click to open in new tab</p>
+        </div>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## **User description**
Hoverable #24 links in AI text. Channels as 'Publish on:' line.


___

## **CodeAnt-AI Description**
Make #NN content references hoverable with previews and show channels on a separate "Publish on:" line

### What Changed
- Text like "#24" inside suggestions and markdown now becomes a hoverable link that shows a small preview (title, ad score, sectors, sentiment) and opens the referenced content in a new tab when clicked
- If no matching content is found the reference renders as plain text; preview appears after a short hover delay and is fetched lazily
- Channel badges are moved off the badges row and displayed on their own "Publish on:" line for clearer visibility

### Impact
`✅ Clickable content reference previews`
`✅ Faster access to referenced content in a new tab`
`✅ Clearer display of publish channels`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
