### PR TITLE
feat: clickable pipeline stepper replaces tab bar

### DIFF
--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -9,11 +9,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ChannelIcon } from "@/components/ui/channel-icon";
 import { PipelineStatusBadge } from "../components/status-badge";
-import { PipelineStepper } from "../components/pipeline-stepper";
+import { PipelineStepper, STAGE_PANEL_MAP } from "../components/pipeline-stepper";
 import {
   ArrowLeft,
   Loader2,
@@ -25,8 +24,6 @@ import {
   XCircle,
   Calendar,
   ExternalLink,
-  Eye,
-  ClipboardList,
   Check,
   Star,
   StickyNote,
@@ -129,20 +126,7 @@ interface IdeaDetail {
   updatedAt?: string;
 }
 
-const TABS = ["overview", "brief", "write", "review", "publish"] as const;
-type Tab = (typeof TABS)[number];
-
-const STATUS_TAB_MAP: Record<string, Tab> = {
-  brainstorm: "overview",
-  planned: "overview",
-  brief_ready: "brief",
-  writing: "write",
-  review: "review",
-  approved: "publish",
-  scheduled: "publish",
-  published: "publish",
-  in_progress: "write",
-};
+type Panel = "overview" | "brief" | "write" | "review" | "publish";
 
 const ACTION_LABELS: Record<string, string> = {
   "submit-review": "Submitted for review",
@@ -157,7 +141,7 @@ export default function IdeaDetailPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const ideaId = params.id as string;
-  const [activeTab, setActiveTab] = useState<Tab>("overview");
+  const [activePanel, setActivePanel] = useState<Panel>("overview");
   const [loading, setLoading] = useState<string | null>(null);
 
   const { data: idea, isLoading } = useQuery({
@@ -167,7 +151,7 @@ export default function IdeaDetailPage() {
 
   useEffect(() => {
     if (idea?.status) {
-      setActiveTab(STATUS_TAB_MAP[idea.status] || "overview");
+      setActivePanel((STAGE_PANEL_MAP[idea.status] || "overview") as Panel);
     }
   }, [idea?.status]);
 
@@ -229,54 +213,21 @@ export default function IdeaDetailPage() {
           </div>
         </div>
 
-        {/* Pipeline Stepper */}
-        <PipelineStepper currentStatus={idea.status} />
+        {/* Pipeline Stepper — clickable, replaces tabs */}
+        <PipelineStepper
+          currentStatus={idea.status}
+          activePanel={activePanel}
+          onStepClick={(panel) => setActivePanel(panel as Panel)}
+        />
 
-        {/* Tabs */}
-        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as Tab)}>
-          <TabsList variant="line">
-            <TabsTrigger value="overview">
-              <Eye className="h-3.5 w-3.5" />
-              Overview
-            </TabsTrigger>
-            <TabsTrigger value="brief">
-              <ClipboardList className="h-3.5 w-3.5" />
-              Brief
-              {idea.brief && <Check className="h-3 w-3 text-emerald-500" />}
-            </TabsTrigger>
-            <TabsTrigger value="write">
-              <Pen className="h-3.5 w-3.5" />
-              Write
-              {idea.content?.html && <Check className="h-3 w-3 text-emerald-500" />}
-            </TabsTrigger>
-            <TabsTrigger value="review">
-              <Send className="h-3.5 w-3.5" />
-              Review
-              {idea.review?.verdict === "approved" && <Check className="h-3 w-3 text-emerald-500" />}
-            </TabsTrigger>
-            <TabsTrigger value="publish">
-              <ExternalLink className="h-3.5 w-3.5" />
-              Publish
-              {idea.publishing?.beehiivPostId && <Check className="h-3 w-3 text-emerald-500" />}
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="overview">
-            <OverviewTab idea={idea} />
-          </TabsContent>
-          <TabsContent value="brief">
-            <BriefTab idea={idea} ideaId={ideaId} onRefresh={refresh} />
-          </TabsContent>
-          <TabsContent value="write">
-            <WriteTab idea={idea} ideaId={ideaId} onRefresh={refresh} />
-          </TabsContent>
-          <TabsContent value="review">
-            <ReviewTab idea={idea} loading={loading} onSubmitReview={() => action("submit-review")} onApprove={() => action("approve")} onReject={(notes: string) => action("reject-review", { notes })} />
-          </TabsContent>
-          <TabsContent value="publish">
-            <PublishTab idea={idea} loading={loading} onSchedule={(date: string) => action("schedule", { scheduledAt: date })} onPublish={() => action("publish")} />
-          </TabsContent>
-        </Tabs>
+        {/* Content panel for active step */}
+        <div>
+          {activePanel === "overview" && <OverviewTab idea={idea} />}
+          {activePanel === "brief" && <BriefTab idea={idea} ideaId={ideaId} onRefresh={refresh} />}
+          {activePanel === "write" && <WriteTab idea={idea} ideaId={ideaId} onRefresh={refresh} />}
+          {activePanel === "review" && <ReviewTab idea={idea} loading={loading} onSubmitReview={() => action("submit-review")} onApprove={() => action("approve")} onReject={(notes: string) => action("reject-review", { notes })} />}
+          {activePanel === "publish" && <PublishTab idea={idea} loading={loading} onSchedule={(date: string) => action("schedule", { scheduledAt: date })} onPublish={() => action("publish")} />}
+        </div>
       </div>
     </TooltipProvider>
   );

--- a/src/app/dashboard/strategist/components/pipeline-stepper.tsx
+++ b/src/app/dashboard/strategist/components/pipeline-stepper.tsx
@@ -19,7 +19,27 @@ const STAGE_COLORS: Record<string, string> = {
   published: "rgb(34 197 94)",          // green-500
 };
 
-export function PipelineStepper({ currentStatus }: { currentStatus: string }) {
+/** Maps each pipeline stage to its content panel */
+export const STAGE_PANEL_MAP: Record<string, string> = {
+  brainstorm: "overview",
+  planned: "overview",
+  brief_ready: "brief",
+  writing: "write",
+  review: "review",
+  approved: "publish",
+  scheduled: "publish",
+  published: "publish",
+};
+
+export function PipelineStepper({
+  currentStatus,
+  activePanel,
+  onStepClick,
+}: {
+  currentStatus: string;
+  activePanel?: string;
+  onStepClick?: (panel: string) => void;
+}) {
   const currentIndex = PIPELINE_COLUMNS.findIndex(
     (col) => col.key === currentStatus
   );
@@ -30,12 +50,20 @@ export function PipelineStepper({ currentStatus }: { currentStatus: string }) {
       {PIPELINE_COLUMNS.map((stage, i) => {
         const isCompleted = i < resolvedIndex;
         const isCurrent = i === resolvedIndex;
+        const isClickable = i <= resolvedIndex && onStepClick;
+        const panel = STAGE_PANEL_MAP[stage.key] || "overview";
+        const isActivePanel = activePanel === panel;
         const color = STAGE_COLORS[stage.key] || "rgb(115 115 115)";
 
         return (
           <div key={stage.key} className="flex items-center flex-1 last:flex-none">
             {/* Step circle + label */}
-            <div className="flex flex-col items-center gap-1.5">
+            <button
+              type="button"
+              disabled={!isClickable}
+              onClick={() => isClickable && onStepClick(panel)}
+              className={`flex flex-col items-center gap-1.5 ${isClickable ? "cursor-pointer" : "cursor-default"}`}
+            >
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div
@@ -71,17 +99,20 @@ export function PipelineStepper({ currentStatus }: { currentStatus: string }) {
                 </TooltipContent>
               </Tooltip>
               <span
-                className={`text-[10px] leading-tight hidden sm:block ${
-                  isCurrent
-                    ? "font-semibold text-foreground"
-                    : isCompleted
-                      ? "text-muted-foreground"
-                      : "text-muted-foreground/50"
+                className={`text-[10px] leading-tight hidden sm:block transition-colors ${
+                  isActivePanel && (isCompleted || isCurrent)
+                    ? "font-bold"
+                    : isCurrent
+                      ? "font-semibold text-foreground"
+                      : isCompleted
+                        ? "text-muted-foreground"
+                        : "text-muted-foreground/50"
                 }`}
+                style={isActivePanel && (isCompleted || isCurrent) ? { color } : undefined}
               >
                 {stage.label}
               </span>
-            </div>
+            </button>
 
             {/* Connector line */}
             {i < PIPELINE_COLUMNS.length - 1 && (


### PR DESCRIPTION
## **User description**
## Summary
- Remove the redundant tab bar (Overview, Brief, Write, Review, Publish)
- The pipeline stepper itself is now the navigation — click any completed/current step to view its content panel
- Active panel label is highlighted with the step's color
- Future steps are disabled and greyed out
- Net reduction of ~18 lines — simpler, less confusing UI

## Test plan
- [ ] Click "Brainstorm" or "Planned" step → shows Overview panel
- [ ] Click "Brief Ready" step → shows Brief panel
- [ ] Verify future steps are not clickable
- [ ] Active step label highlights with color
- [ ] Auto-selects correct panel based on idea status on page load
- [ ] Generate brief → stepper updates and panel switches automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use the pipeline stepper as the main navigation for idea details**

### What Changed
- The tab bar was removed and the pipeline stepper now switches between Overview, Brief, Write, Review, and Publish
- Completed and current steps can be clicked to open their matching content panel
- Future steps stay disabled, and the active step is highlighted with its stage color
- The page still opens on the panel that matches the idea’s current status

### Impact
`✅ Fewer clicks to move between idea stages`
`✅ Clearer stage navigation`
`✅ Less UI clutter on the idea detail page`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
