### PR TITLE
feat: CMS Skills Management UI

### DIFF
--- a/src/app/cms/layout.tsx
+++ b/src/app/cms/layout.tsx
@@ -41,6 +41,7 @@ import {
   LogOut,
   ChevronsUpDown,
   ArrowLeftRight,
+  Zap,
   type LucideIcon,
 } from "lucide-react";
 
@@ -66,6 +67,7 @@ const CMS_NAV_GROUPS: NavGroup[] = [
     label: "Operations",
     items: [
       { href: "/cms/feedback", label: "Feedback Tickets", icon: TicketCheck },
+      { href: "/cms/skills", label: "Skills", icon: Zap },
       { href: "/cms/ai-usage", label: "AI Usage", icon: Brain },
       { href: "/cms/team", label: "CMS Team", icon: Users },
     ],

--- a/src/app/cms/skills/[id]/page.tsx
+++ b/src/app/cms/skills/[id]/page.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Progress } from "@/components/ui/progress";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft, Save, Shield, Loader2 } from "lucide-react";
+import Link from "next/link";
+
+interface SkillTemplate {
+  _id: string;
+  skillId: string;
+  displayName: string;
+  description: string;
+  category: string;
+  agent: string;
+  platform: string;
+  role: string;
+  trustLevel: number;
+  executionType: "ai" | "code" | "hybrid";
+  systemPrompt?: string;
+  userPromptTemplate?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  constraints?: {
+    maxOutputChars?: number;
+    requiredElements?: string[];
+    forbiddenPatterns?: string[];
+  };
+  defaultEffectiveness: number;
+  tags: string[];
+  triggerPhrases?: string[];
+  codeHandler?: string;
+  version: number;
+  status: "active" | "draft" | "deprecated";
+}
+
+interface BizSkill {
+  _id: string;
+  businessId: string;
+  skillId: string;
+  businessContext?: { businessName?: string };
+  effectiveness: {
+    score: number;
+    totalUses: number;
+    accepted: number;
+    rejected: number;
+    edited: number;
+  };
+  status: string;
+}
+
+export default function SkillEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const id = params.id as string;
+
+  const { data: skill, isLoading } = useQuery({
+    queryKey: ["cms", "skill-template", id],
+    queryFn: () => api.get<SkillTemplate>(`/v1/cms/skill-templates/${id}`),
+    enabled: !!id,
+  });
+
+  const { data: instances } = useQuery({
+    queryKey: ["cms", "skill-instances", id],
+    queryFn: () => api.get<BizSkill[]>(`/v1/cms/skill-templates/${id}/instances`),
+    enabled: !!id,
+  });
+
+  const [systemPrompt, setSystemPrompt] = useState<string | null>(null);
+  const [userPromptTemplate, setUserPromptTemplate] = useState<string | null>(null);
+  const [maxOutputChars, setMaxOutputChars] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+
+  // Initialize form values when data loads
+  const effectiveSystemPrompt = systemPrompt ?? skill?.systemPrompt ?? "";
+  const effectiveUserPrompt = userPromptTemplate ?? skill?.userPromptTemplate ?? "";
+  const effectiveMaxChars = maxOutputChars || String(skill?.constraints?.maxOutputChars || "");
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      return api.put(`/v1/cms/skill-templates/${id}`, {
+        systemPrompt: effectiveSystemPrompt || undefined,
+        userPromptTemplate: effectiveUserPrompt || undefined,
+        constraints: {
+          ...skill?.constraints,
+          maxOutputChars: effectiveMaxChars ? Number(effectiveMaxChars) : undefined,
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cms", "skill-template", id] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (!skill) {
+    return <div className="text-muted-foreground">Skill not found</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Link href="/cms/skills">
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold">{skill.displayName}</h1>
+          <p className="text-sm text-muted-foreground font-mono">{skill.skillId}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">{skill.agent.replace("_", " ")}</Badge>
+          <Badge variant="outline">{skill.platform}</Badge>
+          <Badge variant="outline">{skill.executionType}</Badge>
+          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <Shield className="h-3 w-3" />
+            Trust {skill.trustLevel}
+          </div>
+          <Badge variant={skill.status === "active" ? "default" : "secondary"}>
+            {skill.status}
+          </Badge>
+        </div>
+      </div>
+
+      <p className="text-muted-foreground">{skill.description}</p>
+
+      {/* Tags */}
+      {skill.tags?.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {skill.tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Tabs */}
+      <Tabs defaultValue="prompt">
+        <TabsList>
+          <TabsTrigger value="prompt">Prompt</TabsTrigger>
+          <TabsTrigger value="config">Config</TabsTrigger>
+          <TabsTrigger value="schema">Schema</TabsTrigger>
+          <TabsTrigger value="instances">
+            Business Instances ({instances?.length || 0})
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Prompt Tab */}
+        <TabsContent value="prompt" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">System Prompt</CardTitle>
+              <CardDescription>
+                Instructions for the AI model. Variables: {"{{businessName}}"}, {"{{brandVoice}}"}, etc.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Textarea
+                value={effectiveSystemPrompt}
+                onChange={(e) => setSystemPrompt(e.target.value)}
+                className="min-h-[200px] font-mono text-sm"
+                placeholder="No system prompt defined (code-only skill)"
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">User Prompt Template</CardTitle>
+              <CardDescription>
+                Template with {"{{variable}}"} placeholders. Rendered per invocation.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Textarea
+                value={effectiveUserPrompt}
+                onChange={(e) => setUserPromptTemplate(e.target.value)}
+                className="min-h-[200px] font-mono text-sm"
+                placeholder="No user prompt template defined"
+              />
+            </CardContent>
+          </Card>
+
+          <Button
+            onClick={() => saveMutation.mutate()}
+            disabled={saveMutation.isPending}
+          >
+            {saveMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <Save className="h-4 w-4 mr-2" />
+            )}
+            Save Changes
+          </Button>
+        </TabsContent>
+
+        {/* Config Tab */}
+        <TabsContent value="config" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Constraints</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="text-sm font-medium">Max Output Characters</label>
+                <Input
+                  type="number"
+                  value={effectiveMaxChars}
+                  onChange={(e) => setMaxOutputChars(e.target.value)}
+                  placeholder="No limit"
+                  className="max-w-xs mt-1"
+                />
+              </div>
+              {skill.constraints?.requiredElements?.length ? (
+                <div>
+                  <label className="text-sm font-medium">Required Elements</label>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {skill.constraints.requiredElements.map((el) => (
+                      <Badge key={el} variant="outline">{el}</Badge>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {skill.constraints?.forbiddenPatterns?.length ? (
+                <div>
+                  <label className="text-sm font-medium">Forbidden Patterns</label>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {skill.constraints.forbiddenPatterns.map((p) => (
+                      <Badge key={p} variant="destructive">{p}</Badge>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Metadata</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <span className="text-muted-foreground">Category:</span>{" "}
+                <span className="capitalize">{skill.category.replace("_", " ")}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Role:</span>{" "}
+                <span className="capitalize">{skill.role.replace("_", " ")}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Version:</span> {skill.version}
+              </div>
+              <div>
+                <span className="text-muted-foreground">Default Effectiveness:</span>{" "}
+                {Math.round(skill.defaultEffectiveness * 100)}%
+              </div>
+              {skill.codeHandler && (
+                <div className="col-span-2">
+                  <span className="text-muted-foreground">Code Handler:</span>{" "}
+                  <code className="text-xs bg-muted px-1 py-0.5 rounded">{skill.codeHandler}</code>
+                </div>
+              )}
+              {skill.triggerPhrases?.length ? (
+                <div className="col-span-2">
+                  <span className="text-muted-foreground">Trigger Phrases:</span>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {skill.triggerPhrases.map((p) => (
+                      <Badge key={p} variant="outline" className="text-xs">{p}</Badge>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Schema Tab */}
+        <TabsContent value="schema" className="space-y-4">
+          {skill.inputSchema && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Input Schema</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <pre className="text-xs bg-muted p-4 rounded-md overflow-auto max-h-[400px]">
+                  {JSON.stringify(skill.inputSchema, null, 2)}
+                </pre>
+              </CardContent>
+            </Card>
+          )}
+          {skill.outputSchema && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Output Schema</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <pre className="text-xs bg-muted p-4 rounded-md overflow-auto max-h-[400px]">
+                  {JSON.stringify(skill.outputSchema, null, 2)}
+                </pre>
+              </CardContent>
+            </Card>
+          )}
+          {!skill.inputSchema && !skill.outputSchema && (
+            <p className="text-muted-foreground">No schemas defined (code-only skill)</p>
+          )}
+        </TabsContent>
+
+        {/* Business Instances Tab */}
+        <TabsContent value="instances" className="space-y-4">
+          {instances?.length ? (
+            instances.map((inst) => (
+              <Card key={inst._id}>
+                <CardContent className="flex items-center gap-4 py-4">
+                  <div className="flex-1">
+                    <div className="font-medium">
+                      {inst.businessContext?.businessName || inst.businessId}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {inst.effectiveness.totalUses} uses |{" "}
+                      {inst.effectiveness.accepted} accepted |{" "}
+                      {inst.effectiveness.edited} edited |{" "}
+                      {inst.effectiveness.rejected} rejected
+                    </div>
+                  </div>
+                  <div className="w-32">
+                    <div className="flex items-center justify-between text-sm mb-1">
+                      <span>Effectiveness</span>
+                      <span className="font-medium">
+                        {Math.round(inst.effectiveness.score * 100)}%
+                      </span>
+                    </div>
+                    <Progress
+                      value={inst.effectiveness.score * 100}
+                      className={
+                        inst.effectiveness.score > 0.8
+                          ? "[&>div]:bg-green-500"
+                          : inst.effectiveness.score > 0.6
+                            ? "[&>div]:bg-yellow-500"
+                            : "[&>div]:bg-red-500"
+                      }
+                    />
+                  </div>
+                  <Badge variant={inst.status === "active" ? "default" : "secondary"}>
+                    {inst.status}
+                  </Badge>
+                </CardContent>
+              </Card>
+            ))
+          ) : (
+            <p className="text-muted-foreground">
+              No businesses are using this skill yet
+            </p>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/cms/skills/business/[businessId]/page.tsx
+++ b/src/app/cms/skills/business/[businessId]/page.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { CheckCircle, TrendingUp, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+interface BizSkill {
+  _id: string;
+  skillId: string;
+  templateId: string;
+  businessContext?: { businessName?: string };
+  effectiveness: {
+    score: number;
+    totalUses: number;
+    accepted: number;
+    rejected: number;
+    edited: number;
+  };
+  learnings: {
+    whatWorks: string[];
+    whatDoesntWork: string[];
+  };
+  status: "active" | "paused" | "deprecated";
+}
+
+interface BusinessSkillsResponse {
+  business: { name: string; type: string };
+  skills: Array<BizSkill & { agent: string; platform: string; displayName: string }>;
+  autonomyScore: number;
+}
+
+function getEffectivenessColor(score: number): string {
+  if (score >= 0.8) return "[&>div]:bg-green-500";
+  if (score >= 0.6) return "[&>div]:bg-yellow-500";
+  return "[&>div]:bg-red-500";
+}
+
+export default function BusinessSkillsPage() {
+  const params = useParams();
+  const businessId = params.businessId as string;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms", "business-skills", businessId],
+    queryFn: () =>
+      api.get<BusinessSkillsResponse>(`/v1/cms/skill-templates/business/${businessId}`),
+    enabled: !!businessId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div className="text-muted-foreground">Business not found</div>;
+  }
+
+  const { skills, autonomyScore, business } = data;
+
+  // Group by agent
+  const byAgent = skills.reduce(
+    (acc, s) => {
+      if (!acc[s.agent]) acc[s.agent] = [];
+      acc[s.agent].push(s);
+      return acc;
+    },
+    {} as Record<string, typeof skills>
+  );
+
+  // Top and bottom performers
+  const sorted = [...skills].sort((a, b) => b.effectiveness.score - a.effectiveness.score);
+  const topSkills = sorted.slice(0, 3).filter((s) => s.effectiveness.score > 0);
+  const learningSkills = sorted
+    .slice(-3)
+    .reverse()
+    .filter((s) => s.effectiveness.totalUses > 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Link href="/cms/skills">
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold">{business.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            {skills.length} active skills | {business.type}
+          </p>
+        </div>
+      </div>
+
+      {/* Autonomy Score */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Autonomy Score</CardTitle>
+          <CardDescription>
+            How much of the content pipeline runs without human intervention
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-4">
+            <div className="flex-1">
+              <Progress
+                value={autonomyScore}
+                className="h-4 [&>div]:bg-blue-500"
+              />
+            </div>
+            <span className="text-3xl font-bold">{autonomyScore}%</span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-2">
+            Target: 90% | {autonomyScore >= 90 ? "Target reached" : `${90 - autonomyScore}% to go`}
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Top performers + Still learning */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <CheckCircle className="h-4 w-4 text-green-500" />
+              Working well
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {topSkills.length > 0 ? (
+              topSkills.map((s) => (
+                <div key={s._id} className="flex items-center gap-3">
+                  <div className="flex-1">
+                    <div className="text-sm font-medium">{s.displayName}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {s.effectiveness.totalUses} uses
+                    </div>
+                  </div>
+                  <Badge variant="outline" className="bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300">
+                    {Math.round(s.effectiveness.score * 100)}%
+                  </Badge>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">No data yet</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <TrendingUp className="h-4 w-4 text-yellow-500" />
+              Still learning
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {learningSkills.length > 0 ? (
+              learningSkills.map((s) => (
+                <div key={s._id} className="flex items-center gap-3">
+                  <div className="flex-1">
+                    <div className="text-sm font-medium">{s.displayName}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {s.effectiveness.totalUses} uses
+                    </div>
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className={
+                      s.effectiveness.score >= 0.6
+                        ? "bg-yellow-50 text-yellow-700 dark:bg-yellow-950 dark:text-yellow-300"
+                        : "bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300"
+                    }
+                  >
+                    {Math.round(s.effectiveness.score * 100)}%
+                  </Badge>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">No data yet</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Learnings */}
+      {skills.some((s) => s.learnings?.whatWorks?.length || s.learnings?.whatDoesntWork?.length) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Recent Learnings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {skills
+              .flatMap((s) => (s.learnings?.whatWorks || []).map((w) => ({ text: w, type: "works" as const })))
+              .slice(0, 5)
+              .map((l, i) => (
+                <div key={i} className="flex items-start gap-2">
+                  <span className="text-green-500 mt-0.5">+</span>
+                  <span>{l.text}</span>
+                </div>
+              ))}
+            {skills
+              .flatMap((s) => (s.learnings?.whatDoesntWork || []).map((w) => ({ text: w, type: "avoid" as const })))
+              .slice(0, 3)
+              .map((l, i) => (
+                <div key={i} className="flex items-start gap-2">
+                  <span className="text-red-500 mt-0.5">-</span>
+                  <span>{l.text}</span>
+                </div>
+              ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Skills by Agent */}
+      <Accordion type="multiple" defaultValue={Object.keys(byAgent)}>
+        {Object.entries(byAgent)
+          .sort((a, b) => b[1].length - a[1].length)
+          .map(([agent, agentSkills]) => (
+            <AccordionItem key={agent} value={agent}>
+              <AccordionTrigger className="capitalize">
+                {agent.replace("_", " ")} ({agentSkills.length} skills)
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-2">
+                  {agentSkills.map((s) => (
+                    <div key={s._id} className="flex items-center gap-3 py-1.5">
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium truncate">
+                          {s.displayName}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {s.platform} | {s.effectiveness.totalUses} uses
+                        </div>
+                      </div>
+                      <div className="w-24">
+                        <Progress
+                          value={s.effectiveness.score * 100}
+                          className={`h-2 ${getEffectivenessColor(s.effectiveness.score)}`}
+                        />
+                      </div>
+                      <span className="text-sm font-medium w-10 text-right">
+                        {Math.round(s.effectiveness.score * 100)}%
+                      </span>
+                      <Badge
+                        variant={s.status === "active" ? "default" : "secondary"}
+                        className="text-xs"
+                      >
+                        {s.status}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+      </Accordion>
+    </div>
+  );
+}

--- a/src/app/cms/skills/page.tsx
+++ b/src/app/cms/skills/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Zap,
+  Search,
+  Shield,
+  type LucideIcon,
+} from "lucide-react";
+
+interface SkillTemplate {
+  _id: string;
+  skillId: string;
+  displayName: string;
+  description: string;
+  category: string;
+  agent: string;
+  platform: string;
+  role: string;
+  trustLevel: number;
+  executionType: "ai" | "code" | "hybrid";
+  defaultEffectiveness: number;
+  tags: string[];
+  version: number;
+  status: "active" | "draft" | "deprecated";
+}
+
+const AGENT_COLORS: Record<string, string> = {
+  strategist: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
+  repurposer: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+  publisher: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300",
+  ad_engine: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+  optimizer: "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300",
+  control: "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300",
+  feedback: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300",
+};
+
+const EXECUTION_BADGES: Record<string, string> = {
+  ai: "bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-300",
+  code: "bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300",
+  hybrid: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300",
+};
+
+export default function SkillsPage() {
+  const [agentFilter, setAgentFilter] = useState<string>("all");
+  const [platformFilter, setPlatformFilter] = useState<string>("all");
+  const [search, setSearch] = useState("");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms", "skill-templates"],
+    queryFn: () => api.get<SkillTemplate[]>("/v1/cms/skill-templates"),
+  });
+
+  const skills = data || [];
+
+  const filtered = skills.filter((s) => {
+    if (agentFilter !== "all" && s.agent !== agentFilter) return false;
+    if (platformFilter !== "all" && s.platform !== platformFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return (
+        s.skillId.toLowerCase().includes(q) ||
+        s.displayName.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q)
+      );
+    }
+    return true;
+  });
+
+  // Stats
+  const agentCounts = skills.reduce(
+    (acc, s) => {
+      acc[s.agent] = (acc[s.agent] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  const uniqueAgents = [...new Set(skills.map((s) => s.agent))].sort();
+  const uniquePlatforms = [...new Set(skills.map((s) => s.platform))].sort();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Skill Templates</h1>
+        <p className="text-muted-foreground">
+          {skills.length} skills across {uniqueAgents.length} agents
+        </p>
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid gap-4 md:grid-cols-4">
+        {uniqueAgents.slice(0, 4).map((agent) => (
+          <Card key={agent}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium capitalize">
+                {agent.replace("_", " ")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{agentCounts[agent]}</div>
+              <p className="text-xs text-muted-foreground">skills</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search skills..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Select value={agentFilter} onValueChange={setAgentFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Agent" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All agents</SelectItem>
+            {uniqueAgents.map((a) => (
+              <SelectItem key={a} value={a}>
+                {a.replace("_", " ")}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={platformFilter} onValueChange={setPlatformFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Platform" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All platforms</SelectItem>
+            {uniquePlatforms.map((p) => (
+              <SelectItem key={p} value={p}>
+                {p}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Skill</TableHead>
+                <TableHead>Agent</TableHead>
+                <TableHead>Platform</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead className="text-center">Trust</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((skill) => (
+                <TableRow key={skill._id}>
+                  <TableCell>
+                    <Link
+                      href={`/cms/skills/${skill._id}`}
+                      className="hover:underline"
+                    >
+                      <div className="font-medium">{skill.displayName}</div>
+                      <div className="text-xs text-muted-foreground font-mono">
+                        {skill.skillId}
+                      </div>
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="secondary"
+                      className={AGENT_COLORS[skill.agent] || ""}
+                    >
+                      {skill.agent.replace("_", " ")}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="capitalize">{skill.platform}</TableCell>
+                  <TableCell className="capitalize text-sm">
+                    {skill.role.replace("_", " ")}
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="outline"
+                      className={EXECUTION_BADGES[skill.executionType] || ""}
+                    >
+                      {skill.executionType}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex items-center justify-center gap-1">
+                      <Shield className="h-3 w-3" />
+                      <span className="text-sm">{skill.trustLevel}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={skill.status === "active" ? "default" : "secondary"}
+                    >
+                      {skill.status}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
+                    No skills match your filters
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Skills template list with filtering (agent, platform, search)
- Skill template editor with prompt editing, config, schema, business instances
- Business skills view with autonomy score, learnings, effectiveness bars
- Skills nav item added to CMS sidebar

## Test plan
- [x] Next.js build passes
- [ ] Skills list renders with filters
- [ ] Skill editor loads and saves changes
- [ ] Business view shows autonomy score and skill breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)