### PR TITLE
fix: CMS skills UI review fixes

### DIFF
--- a/src/app/cms/skills/[id]/page.tsx
+++ b/src/app/cms/skills/[id]/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { toast } from "sonner";
 import {
   Card,
   CardContent,
@@ -22,67 +23,18 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowLeft, Save, Shield, Loader2 } from "lucide-react";
+import { ArrowLeft, Save, Shield, Loader2, AlertCircle } from "lucide-react";
 import Link from "next/link";
-
-interface SkillTemplate {
-  _id: string;
-  skillId: string;
-  displayName: string;
-  description: string;
-  category: string;
-  agent: string;
-  platform: string;
-  role: string;
-  trustLevel: number;
-  executionType: "ai" | "code" | "hybrid";
-  systemPrompt?: string;
-  userPromptTemplate?: string;
-  inputSchema?: Record<string, unknown>;
-  outputSchema?: Record<string, unknown>;
-  constraints?: {
-    maxOutputChars?: number;
-    requiredElements?: string[];
-    forbiddenPatterns?: string[];
-  };
-  defaultEffectiveness: number;
-  tags: string[];
-  triggerPhrases?: string[];
-  codeHandler?: string;
-  version: number;
-  status: "active" | "draft" | "deprecated";
-}
-
-interface BizSkill {
-  _id: string;
-  businessId: string;
-  skillId: string;
-  businessContext?: { businessName?: string };
-  effectiveness: {
-    score: number;
-    totalUses: number;
-    accepted: number;
-    rejected: number;
-    edited: number;
-  };
-  status: string;
-}
+import type { SkillTemplate, BizSkill } from "@/types/skills";
+import { humanize } from "@/types/skills";
 
 export default function SkillEditorPage() {
   const params = useParams();
-  const router = useRouter();
   const queryClient = useQueryClient();
   const id = params.id as string;
 
-  const { data: skill, isLoading } = useQuery({
+  const { data: skill, isLoading, isError, error } = useQuery({
     queryKey: ["cms", "skill-template", id],
     queryFn: () => api.get<SkillTemplate>(`/v1/cms/skill-templates/${id}`),
     enabled: !!id,
@@ -97,9 +49,7 @@ export default function SkillEditorPage() {
   const [systemPrompt, setSystemPrompt] = useState<string | null>(null);
   const [userPromptTemplate, setUserPromptTemplate] = useState<string | null>(null);
   const [maxOutputChars, setMaxOutputChars] = useState<string>("");
-  const [saving, setSaving] = useState(false);
 
-  // Initialize form values when data loads
   const effectiveSystemPrompt = systemPrompt ?? skill?.systemPrompt ?? "";
   const effectiveUserPrompt = userPromptTemplate ?? skill?.userPromptTemplate ?? "";
   const effectiveMaxChars = maxOutputChars || String(skill?.constraints?.maxOutputChars || "");
@@ -117,6 +67,12 @@ export default function SkillEditorPage() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cms", "skill-template", id] });
+      toast.success("Skill template saved");
+    },
+    onError: (err) => {
+      toast.error("Failed to save", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
     },
   });
 
@@ -129,25 +85,35 @@ export default function SkillEditorPage() {
     );
   }
 
-  if (!skill) {
-    return <div className="text-muted-foreground">Skill not found</div>;
+  if (isError || !skill) {
+    return (
+      <div className="flex items-center gap-3 p-6 rounded-lg border border-destructive/50 bg-destructive/5">
+        <AlertCircle className="h-5 w-5 text-destructive" />
+        <div>
+          <p className="font-medium">Failed to load skill template</p>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Skill not found"}
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-4">
-        <Link href="/cms/skills">
+      <div className="flex items-start gap-4">
+        <Link href="/cms/skills" aria-label="Back to skills list">
           <Button variant="ghost" size="icon">
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           <h1 className="text-2xl font-bold">{skill.displayName}</h1>
           <p className="text-sm text-muted-foreground font-mono">{skill.skillId}</p>
         </div>
-        <div className="flex items-center gap-2">
-          <Badge variant="secondary">{skill.agent.replace("_", " ")}</Badge>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary">{humanize(skill.agent)}</Badge>
           <Badge variant="outline">{skill.platform}</Badge>
           <Badge variant="outline">{skill.executionType}</Badge>
           <div className="flex items-center gap-1 text-sm text-muted-foreground">
@@ -199,6 +165,7 @@ export default function SkillEditorPage() {
                 onChange={(e) => setSystemPrompt(e.target.value)}
                 className="min-h-[200px] font-mono text-sm"
                 placeholder="No system prompt defined (code-only skill)"
+                aria-label="System prompt"
               />
             </CardContent>
           </Card>
@@ -216,6 +183,7 @@ export default function SkillEditorPage() {
                 onChange={(e) => setUserPromptTemplate(e.target.value)}
                 className="min-h-[200px] font-mono text-sm"
                 placeholder="No user prompt template defined"
+                aria-label="User prompt template"
               />
             </CardContent>
           </Card>
@@ -241,8 +209,9 @@ export default function SkillEditorPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
-                <label className="text-sm font-medium">Max Output Characters</label>
+                <label className="text-sm font-medium" htmlFor="maxOutputChars">Max Output Characters</label>
                 <Input
+                  id="maxOutputChars"
                   type="number"
                   value={effectiveMaxChars}
                   onChange={(e) => setMaxOutputChars(e.target.value)}
@@ -252,7 +221,7 @@ export default function SkillEditorPage() {
               </div>
               {skill.constraints?.requiredElements?.length ? (
                 <div>
-                  <label className="text-sm font-medium">Required Elements</label>
+                  <span className="text-sm font-medium">Required Elements</span>
                   <div className="flex flex-wrap gap-1 mt-1">
                     {skill.constraints.requiredElements.map((el) => (
                       <Badge key={el} variant="outline">{el}</Badge>
@@ -262,7 +231,7 @@ export default function SkillEditorPage() {
               ) : null}
               {skill.constraints?.forbiddenPatterns?.length ? (
                 <div>
-                  <label className="text-sm font-medium">Forbidden Patterns</label>
+                  <span className="text-sm font-medium">Forbidden Patterns</span>
                   <div className="flex flex-wrap gap-1 mt-1">
                     {skill.constraints.forbiddenPatterns.map((p) => (
                       <Badge key={p} variant="destructive">{p}</Badge>
@@ -280,11 +249,11 @@ export default function SkillEditorPage() {
             <CardContent className="grid grid-cols-2 gap-4 text-sm">
               <div>
                 <span className="text-muted-foreground">Category:</span>{" "}
-                <span className="capitalize">{skill.category.replace("_", " ")}</span>
+                <span className="capitalize">{humanize(skill.category)}</span>
               </div>
               <div>
                 <span className="text-muted-foreground">Role:</span>{" "}
-                <span className="capitalize">{skill.role.replace("_", " ")}</span>
+                <span className="capitalize">{humanize(skill.role)}</span>
               </div>
               <div>
                 <span className="text-muted-foreground">Version:</span> {skill.version}
@@ -321,7 +290,7 @@ export default function SkillEditorPage() {
                 <CardTitle className="text-base">Input Schema</CardTitle>
               </CardHeader>
               <CardContent>
-                <pre className="text-xs bg-muted p-4 rounded-md overflow-auto max-h-[400px]">
+                <pre className="text-xs bg-muted p-4 rounded-md overflow-auto max-h-96">
                   {JSON.stringify(skill.inputSchema, null, 2)}
                 </pre>
               </CardContent>
@@ -333,7 +302,7 @@ export default function SkillEditorPage() {
                 <CardTitle className="text-base">Output Schema</CardTitle>
               </CardHeader>
               <CardContent>
-                <pre className="text-xs bg-muted p-4 rounded-md overflow-auto max-h-[400px]">
+                <pre className="text-xs bg-muted p-4 rounded-md overflow-auto max-h-96">
                   {JSON.stringify(skill.outputSchema, null, 2)}
                 </pre>
               </CardContent>

--- a/src/app/cms/skills/business/[businessId]/page.tsx
+++ b/src/app/cms/skills/business/[businessId]/page.tsx
@@ -19,34 +19,11 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { CheckCircle, TrendingUp, ArrowLeft } from "lucide-react";
+import { CheckCircle, TrendingUp, ArrowLeft, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-
-interface BizSkill {
-  _id: string;
-  skillId: string;
-  templateId: string;
-  businessContext?: { businessName?: string };
-  effectiveness: {
-    score: number;
-    totalUses: number;
-    accepted: number;
-    rejected: number;
-    edited: number;
-  };
-  learnings: {
-    whatWorks: string[];
-    whatDoesntWork: string[];
-  };
-  status: "active" | "paused" | "deprecated";
-}
-
-interface BusinessSkillsResponse {
-  business: { name: string; type: string };
-  skills: Array<BizSkill & { agent: string; platform: string; displayName: string }>;
-  autonomyScore: number;
-}
+import type { BusinessSkillsResponse } from "@/types/skills";
+import { humanize } from "@/types/skills";
 
 function getEffectivenessColor(score: number): string {
   if (score >= 0.8) return "[&>div]:bg-green-500";
@@ -58,7 +35,7 @@ export default function BusinessSkillsPage() {
   const params = useParams();
   const businessId = params.businessId as string;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ["cms", "business-skills", businessId],
     queryFn: () =>
       api.get<BusinessSkillsResponse>(`/v1/cms/skill-templates/business/${businessId}`),
@@ -75,8 +52,18 @@ export default function BusinessSkillsPage() {
     );
   }
 
-  if (!data) {
-    return <div className="text-muted-foreground">Business not found</div>;
+  if (isError || !data) {
+    return (
+      <div className="flex items-center gap-3 p-6 rounded-lg border border-destructive/50 bg-destructive/5">
+        <AlertCircle className="h-5 w-5 text-destructive" />
+        <div>
+          <p className="font-medium">Failed to load business skills</p>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Business not found"}
+          </p>
+        </div>
+      </div>
+    );
   }
 
   const { skills, autonomyScore, business } = data;
@@ -103,7 +90,7 @@ export default function BusinessSkillsPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-4">
-        <Link href="/cms/skills">
+        <Link href="/cms/skills" aria-label="Back to skills list">
           <Button variant="ghost" size="icon">
             <ArrowLeft className="h-4 w-4" />
           </Button>
@@ -242,7 +229,7 @@ export default function BusinessSkillsPage() {
           .map(([agent, agentSkills]) => (
             <AccordionItem key={agent} value={agent}>
               <AccordionTrigger className="capitalize">
-                {agent.replace("_", " ")} ({agentSkills.length} skills)
+                {agent.replace(/_/g, " ")} ({agentSkills.length} skills)
               </AccordionTrigger>
               <AccordionContent>
                 <div className="space-y-2">

--- a/src/app/cms/skills/business/[businessId]/page.tsx
+++ b/src/app/cms/skills/business/[businessId]/page.tsx
@@ -229,7 +229,7 @@ export default function BusinessSkillsPage() {
           .map(([agent, agentSkills]) => (
             <AccordionItem key={agent} value={agent}>
               <AccordionTrigger className="capitalize">
-                {agent.replace(/_/g, " ")} ({agentSkills.length} skills)
+                {humanize(agent)} ({agentSkills.length} skills)
               </AccordionTrigger>
               <AccordionContent>
                 <div className="space-y-2">

--- a/src/app/cms/skills/page.tsx
+++ b/src/app/cms/skills/page.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Progress } from "@/components/ui/progress";
 import {
   Select,
   SelectContent,
@@ -29,29 +28,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Zap,
-  Search,
-  Shield,
-  type LucideIcon,
-} from "lucide-react";
-
-interface SkillTemplate {
-  _id: string;
-  skillId: string;
-  displayName: string;
-  description: string;
-  category: string;
-  agent: string;
-  platform: string;
-  role: string;
-  trustLevel: number;
-  executionType: "ai" | "code" | "hybrid";
-  defaultEffectiveness: number;
-  tags: string[];
-  version: number;
-  status: "active" | "draft" | "deprecated";
-}
+import { Search, Shield, AlertCircle } from "lucide-react";
+import type { SkillTemplate } from "@/types/skills";
+import { humanize } from "@/types/skills";
 
 const AGENT_COLORS: Record<string, string> = {
   strategist: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
@@ -74,7 +53,7 @@ export default function SkillsPage() {
   const [platformFilter, setPlatformFilter] = useState<string>("all");
   const [search, setSearch] = useState("");
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ["cms", "skill-templates"],
     queryFn: () => api.get<SkillTemplate[]>("/v1/cms/skill-templates"),
   });
@@ -95,7 +74,6 @@ export default function SkillsPage() {
     return true;
   });
 
-  // Stats
   const agentCounts = skills.reduce(
     (acc, s) => {
       acc[s.agent] = (acc[s.agent] || 0) + 1;
@@ -106,6 +84,20 @@ export default function SkillsPage() {
 
   const uniqueAgents = [...new Set(skills.map((s) => s.agent))].sort();
   const uniquePlatforms = [...new Set(skills.map((s) => s.platform))].sort();
+
+  if (isError) {
+    return (
+      <div className="flex items-center gap-3 p-6 rounded-lg border border-destructive/50 bg-destructive/5">
+        <AlertCircle className="h-5 w-5 text-destructive" />
+        <div>
+          <p className="font-medium">Failed to load skill templates</p>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Unknown error"}
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -122,7 +114,7 @@ export default function SkillsPage() {
           <Card key={agent}>
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium capitalize">
-                {agent.replace("_", " ")}
+                {humanize(agent)}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -134,31 +126,32 @@ export default function SkillsPage() {
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-3">
-        <div className="relative flex-1 max-w-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-50 max-w-sm">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search skills..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"
+            aria-label="Search skill templates"
           />
         </div>
         <Select value={agentFilter} onValueChange={setAgentFilter}>
-          <SelectTrigger className="w-[160px]">
+          <SelectTrigger className="w-40" aria-label="Filter by agent">
             <SelectValue placeholder="Agent" />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">All agents</SelectItem>
             {uniqueAgents.map((a) => (
               <SelectItem key={a} value={a}>
-                {a.replace("_", " ")}
+                {humanize(a)}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
         <Select value={platformFilter} onValueChange={setPlatformFilter}>
-          <SelectTrigger className="w-[160px]">
+          <SelectTrigger className="w-40" aria-label="Filter by platform">
             <SelectValue placeholder="Platform" />
           </SelectTrigger>
           <SelectContent>
@@ -200,6 +193,7 @@ export default function SkillsPage() {
                     <Link
                       href={`/cms/skills/${skill._id}`}
                       className="hover:underline"
+                      aria-label={`Edit skill: ${skill.displayName}`}
                     >
                       <div className="font-medium">{skill.displayName}</div>
                       <div className="text-xs text-muted-foreground font-mono">
@@ -212,12 +206,12 @@ export default function SkillsPage() {
                       variant="secondary"
                       className={AGENT_COLORS[skill.agent] || ""}
                     >
-                      {skill.agent.replace("_", " ")}
+                      {humanize(skill.agent)}
                     </Badge>
                   </TableCell>
                   <TableCell className="capitalize">{skill.platform}</TableCell>
                   <TableCell className="capitalize text-sm">
-                    {skill.role.replace("_", " ")}
+                    {humanize(skill.role)}
                   </TableCell>
                   <TableCell>
                     <Badge

--- a/src/types/skills.ts
+++ b/src/types/skills.ts
@@ -1,0 +1,62 @@
+export interface SkillTemplate {
+  _id: string;
+  skillId: string;
+  displayName: string;
+  description: string;
+  category: string;
+  agent: string;
+  platform: string;
+  role: string;
+  trustLevel: number;
+  executionType: "ai" | "code" | "hybrid";
+  systemPrompt?: string;
+  userPromptTemplate?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  constraints?: {
+    maxOutputChars?: number;
+    requiredElements?: string[];
+    forbiddenPatterns?: string[];
+  };
+  defaultEffectiveness: number;
+  tags: string[];
+  triggerPhrases?: string[];
+  codeHandler?: string;
+  version: number;
+  status: "active" | "draft" | "deprecated";
+}
+
+export interface BizSkill {
+  _id: string;
+  orgId: string;
+  businessId: string;
+  skillId: string;
+  templateId: string;
+  displayName?: string;
+  agent?: string;
+  platform?: string;
+  businessContext?: { businessName?: string };
+  effectiveness: {
+    score: number;
+    totalUses: number;
+    accepted: number;
+    rejected: number;
+    edited: number;
+  };
+  learnings: {
+    whatWorks: string[];
+    whatDoesntWork: string[];
+  };
+  status: "active" | "paused" | "deprecated";
+}
+
+export interface BusinessSkillsResponse {
+  business: { name: string; type: string };
+  skills: Array<BizSkill & { agent: string; platform: string; displayName: string }>;
+  autonomyScore: number;
+}
+
+/** Replace all underscores with spaces */
+export function humanize(s: string): string {
+  return s.replace(/_/g, " ");
+}


### PR DESCRIPTION
## Summary
Retroactive code review fixes for CMS Skills UI (PR #128):
- Error handling on all queries + mutations (with toast feedback)
- Shared types file (src/types/skills.ts)
- Accessibility: aria-labels, htmlFor, responsive flex-wrap
- Tailwind v4 canonical classes
- Removed all unused imports and dead code

## Test plan
- [x] Next.js build passes
- [ ] Error state renders when API fails
- [ ] Toast shows on save success/failure
- [ ] Filters accessible with screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)