### PR TITLE
feat(cms): AI ops + observability dashboards

### DIFF
--- a/src/app/cms/ai-config/page.tsx
+++ b/src/app/cms/ai-config/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+import { hasCmsRole, type CmsRole } from "@/components/cms/ai/role-gate";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -67,6 +69,10 @@ const EMPTY_FORM: Partial<ConfigRow> = { active: true, modelType: "chat" };
 
 export default function AiConfigPage() {
   const qc = useQueryClient();
+  const { user } = useAuth();
+  const role = user?.cmsRole as CmsRole;
+  const canWrite = hasCmsRole(role, "ops");
+  const canDelete = hasCmsRole(role, "superadmin");
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<ConfigRow | null>(null);
   const [form, setForm] = useState<Partial<ConfigRow>>(EMPTY_FORM);
@@ -112,9 +118,11 @@ export default function AiConfigPage() {
             Per-useCase model selection + prompt templates. Edits flow through an audit log.
           </p>
         </div>
-        <Button onClick={() => open(null)}>
-          <Plus className="mr-2 size-4" /> New useCase
-        </Button>
+        {canWrite && (
+          <Button onClick={() => open(null)}>
+            <Plus className="mr-2 size-4" /> New useCase
+          </Button>
+        )}
       </div>
 
       <Card>
@@ -163,20 +171,24 @@ export default function AiConfigPage() {
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-1">
-                        <Button variant="ghost" size="icon" onClick={() => open(row)}>
-                          <Pencil className="size-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => {
-                            if (confirm(`Delete useCase '${row.useCase}'?`)) {
-                              remove.mutate(row.useCase);
-                            }
-                          }}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
+                        {canWrite && (
+                          <Button variant="ghost" size="icon" onClick={() => open(row)}>
+                            <Pencil className="size-4" />
+                          </Button>
+                        )}
+                        {canDelete && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              if (confirm(`Delete useCase '${row.useCase}'?`)) {
+                                remove.mutate(row.useCase);
+                              }
+                            }}
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        )}
                       </div>
                     </TableCell>
                   </TableRow>
@@ -294,13 +306,20 @@ export default function AiConfigPage() {
             )}
           </Tabs>
 
+          {(upsert.isError || remove.isError) && (
+            <p className="mt-4 text-sm text-red-600">
+              {((upsert.error || remove.error) as Error)?.message ||
+                "Operation failed. You may not have the required CMS role."}
+            </p>
+          )}
+
           <SheetFooter className="mt-6">
             <Button variant="outline" onClick={() => setSheetOpen(false)}>
               Cancel
             </Button>
             <Button
               onClick={() => upsert.mutate(form)}
-              disabled={upsert.isPending || !form.useCase || !form.modelId}
+              disabled={upsert.isPending || !form.useCase || !form.modelId || !canWrite}
             >
               {upsert.isPending ? "Saving…" : editing ? "Save changes" : "Create"}
             </Button>

--- a/src/app/cms/ai-config/page.tsx
+++ b/src/app/cms/ai-config/page.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Plus, Pencil, Trash2 } from "lucide-react";
+import { formatDateTime } from "@/components/cms/ai/format";
+
+interface ConfigRow {
+  _id: string;
+  useCase: string;
+  displayName?: string;
+  description?: string;
+  modelId: string;
+  fallbackModelId?: string;
+  provider?: string;
+  modelType?: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  systemPrompt?: string;
+  userPromptTemplate?: string;
+  active: boolean;
+  updatedAt?: string;
+}
+
+interface AuditRow {
+  _id: string;
+  fieldName: string;
+  oldValue?: unknown;
+  newValue?: unknown;
+  changedAt: string;
+  changedByName?: string;
+}
+
+const EMPTY_FORM: Partial<ConfigRow> = { active: true, modelType: "chat" };
+
+export default function AiConfigPage() {
+  const qc = useQueryClient();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editing, setEditing] = useState<ConfigRow | null>(null);
+  const [form, setForm] = useState<Partial<ConfigRow>>(EMPTY_FORM);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms-ai-config"],
+    queryFn: () => api.get<{ rows: ConfigRow[]; total: number }>("/v1/cms/ai-config"),
+  });
+
+  const upsert = useMutation({
+    mutationFn: async (input: Partial<ConfigRow>) => {
+      if (editing) {
+        return api.put(`/v1/cms/ai-config/${editing.useCase}`, input);
+      }
+      return api.post(`/v1/cms/ai-config`, input);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cms-ai-config"] });
+      setSheetOpen(false);
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (useCase: string) => api.delete(`/v1/cms/ai-config/${useCase}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-config"] }),
+  });
+
+  function open(row: ConfigRow | null) {
+    setEditing(row);
+    setForm(row || EMPTY_FORM);
+    setSheetOpen(true);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">AI Configuration</h2>
+          <p className="text-muted-foreground mt-1">
+            Per-useCase model selection + prompt templates. Edits flow through an audit log.
+          </p>
+        </div>
+        <Button onClick={() => open(null)}>
+          <Plus className="mr-2 size-4" /> New useCase
+        </Button>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Use case</TableHead>
+                <TableHead>Display name</TableHead>
+                <TableHead>Model</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Active</TableHead>
+                <TableHead className="text-right">Updated</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                [0, 1, 2].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell colSpan={7}><Skeleton className="h-5 w-full" /></TableCell>
+                  </TableRow>
+                ))
+              ) : !data?.rows?.length ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
+                    No useCase configs yet.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                data.rows.map((row) => (
+                  <TableRow key={row._id}>
+                    <TableCell className="font-mono text-xs">{row.useCase}</TableCell>
+                    <TableCell>{row.displayName || "—"}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.modelId}</TableCell>
+                    <TableCell><Badge variant="outline">{row.modelType || "chat"}</Badge></TableCell>
+                    <TableCell>
+                      {row.active ? (
+                        <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">Active</Badge>
+                      ) : (
+                        <Badge variant="secondary">Disabled</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right text-xs text-muted-foreground">
+                      {formatDateTime(row.updatedAt)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button variant="ghost" size="icon" onClick={() => open(row)}>
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => {
+                            if (confirm(`Delete useCase '${row.useCase}'?`)) {
+                              remove.mutate(row.useCase);
+                            }
+                          }}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>{editing ? `Edit ${editing.useCase}` : "New useCase"}</SheetTitle>
+            <SheetDescription>
+              {editing
+                ? "Changes are audited per-field."
+                : "useCase identifiers are stable keys consumed by helpers/ai.ts resolveModel()."}
+            </SheetDescription>
+          </SheetHeader>
+          <Tabs defaultValue="form" className="mt-6">
+            <TabsList>
+              <TabsTrigger value="form">Configuration</TabsTrigger>
+              {editing && <TabsTrigger value="audit">Audit log</TabsTrigger>}
+            </TabsList>
+
+            <TabsContent value="form" className="space-y-4 mt-4">
+              <FormRow label="useCase">
+                <Input
+                  value={form.useCase || ""}
+                  disabled={!!editing}
+                  onChange={(e) => setForm({ ...form, useCase: e.target.value })}
+                  placeholder="content_brief"
+                />
+              </FormRow>
+              <FormRow label="Display name">
+                <Input
+                  value={form.displayName || ""}
+                  onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+                />
+              </FormRow>
+              <FormRow label="Description">
+                <Textarea
+                  value={form.description || ""}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                />
+              </FormRow>
+              <div className="grid grid-cols-2 gap-3">
+                <FormRow label="Model ID">
+                  <Input
+                    value={form.modelId || ""}
+                    onChange={(e) => setForm({ ...form, modelId: e.target.value })}
+                    placeholder="anthropic/claude-sonnet-4.5"
+                  />
+                </FormRow>
+                <FormRow label="Fallback model ID">
+                  <Input
+                    value={form.fallbackModelId || ""}
+                    onChange={(e) => setForm({ ...form, fallbackModelId: e.target.value })}
+                  />
+                </FormRow>
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <FormRow label="Max tokens">
+                  <Input
+                    type="number"
+                    value={form.maxOutputTokens || ""}
+                    onChange={(e) => setForm({ ...form, maxOutputTokens: Number(e.target.value) || undefined })}
+                  />
+                </FormRow>
+                <FormRow label="Temperature">
+                  <Input
+                    type="number"
+                    step="0.1"
+                    value={form.temperature ?? ""}
+                    onChange={(e) => setForm({ ...form, temperature: Number(e.target.value) })}
+                  />
+                </FormRow>
+                <FormRow label="topP">
+                  <Input
+                    type="number"
+                    step="0.05"
+                    value={form.topP ?? ""}
+                    onChange={(e) => setForm({ ...form, topP: Number(e.target.value) })}
+                  />
+                </FormRow>
+              </div>
+              <FormRow label="System prompt (optional)">
+                <Textarea
+                  rows={5}
+                  value={form.systemPrompt || ""}
+                  onChange={(e) => setForm({ ...form, systemPrompt: e.target.value })}
+                />
+              </FormRow>
+              <FormRow label="User prompt template (optional)">
+                <Textarea
+                  rows={5}
+                  value={form.userPromptTemplate || ""}
+                  onChange={(e) => setForm({ ...form, userPromptTemplate: e.target.value })}
+                />
+              </FormRow>
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={form.active ?? true}
+                  onCheckedChange={(v) => setForm({ ...form, active: v })}
+                />
+                <Label>Active</Label>
+              </div>
+            </TabsContent>
+
+            {editing && (
+              <TabsContent value="audit">
+                <AuditTab useCase={editing.useCase} />
+              </TabsContent>
+            )}
+          </Tabs>
+
+          <SheetFooter className="mt-6">
+            <Button variant="outline" onClick={() => setSheetOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => upsert.mutate(form)}
+              disabled={upsert.isPending || !form.useCase || !form.modelId}
+            >
+              {upsert.isPending ? "Saving…" : editing ? "Save changes" : "Create"}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function FormRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs">{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function AuditTab({ useCase }: { useCase: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms-ai-config-audit", useCase],
+    queryFn: () => api.get<{ rows: AuditRow[] }>(`/v1/cms/ai-config/${useCase}/audit`),
+  });
+  if (isLoading) return <Skeleton className="h-24" />;
+  const rows = data?.rows || [];
+  if (!rows.length) return <p className="text-sm text-muted-foreground py-4">No edits yet.</p>;
+  return (
+    <div className="space-y-2 mt-4">
+      {rows.map((r) => (
+        <div key={r._id} className="rounded border p-3 text-xs">
+          <div className="flex justify-between mb-1">
+            <span className="font-mono">{r.fieldName}</span>
+            <span className="text-muted-foreground">
+              {formatDateTime(r.changedAt)}
+              {r.changedByName ? ` · ${r.changedByName}` : ""}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <p className="text-muted-foreground">Before</p>
+              <pre className="whitespace-pre-wrap break-all rounded bg-muted p-1.5">{JSON.stringify(r.oldValue, null, 2) || "—"}</pre>
+            </div>
+            <div>
+              <p className="text-muted-foreground">After</p>
+              <pre className="whitespace-pre-wrap break-all rounded bg-muted p-1.5">{JSON.stringify(r.newValue, null, 2) || "—"}</pre>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/cms/ai-config/page.tsx
+++ b/src/app/cms/ai-config/page.tsx
@@ -85,6 +85,9 @@ export default function AiConfigPage() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["cms-ai-config"] });
+      if (editing) {
+        qc.invalidateQueries({ queryKey: ["cms-ai-config-audit", editing.useCase] });
+      }
       setSheetOpen(false);
     },
   });
@@ -240,8 +243,8 @@ export default function AiConfigPage() {
                 <FormRow label="Max tokens">
                   <Input
                     type="number"
-                    value={form.maxOutputTokens || ""}
-                    onChange={(e) => setForm({ ...form, maxOutputTokens: Number(e.target.value) || undefined })}
+                    value={form.maxOutputTokens ?? ""}
+                    onChange={(e) => setForm({ ...form, maxOutputTokens: parseNumberInput(e.target.value, true) })}
                   />
                 </FormRow>
                 <FormRow label="Temperature">
@@ -249,7 +252,7 @@ export default function AiConfigPage() {
                     type="number"
                     step="0.1"
                     value={form.temperature ?? ""}
-                    onChange={(e) => setForm({ ...form, temperature: Number(e.target.value) })}
+                    onChange={(e) => setForm({ ...form, temperature: parseNumberInput(e.target.value) })}
                   />
                 </FormRow>
                 <FormRow label="topP">
@@ -257,7 +260,7 @@ export default function AiConfigPage() {
                     type="number"
                     step="0.05"
                     value={form.topP ?? ""}
-                    onChange={(e) => setForm({ ...form, topP: Number(e.target.value) })}
+                    onChange={(e) => setForm({ ...form, topP: parseNumberInput(e.target.value) })}
                   />
                 </FormRow>
               </div>
@@ -306,6 +309,19 @@ export default function AiConfigPage() {
       </Sheet>
     </div>
   );
+}
+
+/**
+ * Parse a numeric input value, returning undefined for empty / partial /
+ * non-numeric input so we never serialize NaN to the wire (the Zod schema
+ * rejects NaN). When `integer` is true, fractional input is also rejected.
+ */
+function parseNumberInput(raw: string, integer = false): number | undefined {
+  if (raw === "" || raw === "-" || raw === "." || raw === "-.") return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return undefined;
+  if (integer && !Number.isInteger(n)) return undefined;
+  return n;
 }
 
 function FormRow({ label, children }: { label: string; children: React.ReactNode }) {

--- a/src/app/cms/ai-evaluator/page.tsx
+++ b/src/app/cms/ai-evaluator/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Play } from "lucide-react";
+import { formatDateTime } from "@/components/cms/ai/format";
+
+interface Recommendation {
+  useCase: string;
+  currentModelId: string;
+  candidateModelId: string;
+  costDeltaPct?: number;
+  latencyDeltaPct?: number;
+  rationale?: string;
+  applied?: boolean;
+}
+
+interface RunRow {
+  _id: string;
+  runAt: string;
+  mode: "manual" | "scheduled";
+  status: string;
+  appliedCount: number;
+  recommendations?: Recommendation[];
+}
+
+export default function AiEvaluatorPage() {
+  const qc = useQueryClient();
+
+  const history = useQuery({
+    queryKey: ["cms-ai-evaluator-history"],
+    queryFn: () => api.get<{ rows: RunRow[] }>("/v1/cms/ai-evaluator/history"),
+  });
+
+  const run = useMutation({
+    mutationFn: () =>
+      api.post<{ runId: string; recommendations: Recommendation[] }>(
+        "/v1/cms/ai-evaluator/run",
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-evaluator-history"] }),
+  });
+
+  const apply = useMutation({
+    mutationFn: (input: { runId: string; useCase: string; candidateModelId: string }) =>
+      api.post(`/v1/cms/ai-evaluator/apply`, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-evaluator-history"] }),
+  });
+
+  const latest = history.data?.rows?.[0];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">AI Evaluator</h2>
+          <p className="text-muted-foreground mt-1">
+            Compares each active useCase against the model registry. Recommends cheaper or faster
+            alternatives that match capabilities.
+          </p>
+        </div>
+        <Button onClick={() => run.mutate()} disabled={run.isPending}>
+          <Play className="mr-2 size-4" />
+          {run.isPending ? "Running…" : "Run evaluation"}
+        </Button>
+      </div>
+
+      {/* Latest recommendations */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Latest recommendations</CardTitle>
+          <CardDescription>
+            From the most recent run. Apply individually with a superadmin role.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {history.isLoading ? (
+            <div className="p-6"><Skeleton className="h-24" /></div>
+          ) : !latest?.recommendations?.length ? (
+            <p className="p-6 text-sm text-muted-foreground">
+              {latest ? "No recommendations from the last run." : "No runs yet — click 'Run evaluation'."}
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Use case</TableHead>
+                  <TableHead>Current</TableHead>
+                  <TableHead>Candidate</TableHead>
+                  <TableHead>Cost Δ</TableHead>
+                  <TableHead>Latency Δ</TableHead>
+                  <TableHead>Rationale</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {latest.recommendations.map((r, i) => (
+                  <TableRow key={`${r.useCase}-${i}`}>
+                    <TableCell className="font-mono text-xs">{r.useCase}</TableCell>
+                    <TableCell className="font-mono text-xs">{r.currentModelId}</TableCell>
+                    <TableCell className="font-mono text-xs">{r.candidateModelId}</TableCell>
+                    <TableCell className={r.costDeltaPct != null && r.costDeltaPct < 0 ? "text-emerald-700" : "text-amber-700"}>
+                      {r.costDeltaPct != null ? `${r.costDeltaPct.toFixed(1)}%` : "—"}
+                    </TableCell>
+                    <TableCell className={r.latencyDeltaPct != null && r.latencyDeltaPct < 0 ? "text-emerald-700" : "text-amber-700"}>
+                      {r.latencyDeltaPct != null ? `${r.latencyDeltaPct.toFixed(1)}%` : "—"}
+                    </TableCell>
+                    <TableCell className="text-xs">{r.rationale}</TableCell>
+                    <TableCell className="text-right">
+                      {r.applied ? (
+                        <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">Applied</Badge>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={apply.isPending}
+                          onClick={() =>
+                            apply.mutate({
+                              runId: latest._id,
+                              useCase: r.useCase,
+                              candidateModelId: r.candidateModelId,
+                            })
+                          }
+                        >
+                          Apply
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* History */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Run history</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {history.isLoading ? (
+            <div className="p-6"><Skeleton className="h-12" /></div>
+          ) : !history.data?.rows?.length ? (
+            <p className="p-6 text-sm text-muted-foreground">No runs yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Run at</TableHead>
+                  <TableHead>Mode</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Recommendations</TableHead>
+                  <TableHead className="text-right">Applied</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.data.rows.map((r) => (
+                  <TableRow key={r._id}>
+                    <TableCell className="text-xs">{formatDateTime(r.runAt)}</TableCell>
+                    <TableCell><Badge variant="outline">{r.mode}</Badge></TableCell>
+                    <TableCell>{r.status}</TableCell>
+                    <TableCell className="text-right">{r.recommendations?.length ?? 0}</TableCell>
+                    <TableCell className="text-right">{r.appliedCount}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/cms/ai-evaluator/page.tsx
+++ b/src/app/cms/ai-evaluator/page.tsx
@@ -2,6 +2,8 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+import { hasCmsRole, type CmsRole } from "@/components/cms/ai/role-gate";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -38,6 +40,10 @@ interface RunRow {
 
 export default function AiEvaluatorPage() {
   const qc = useQueryClient();
+  const { user } = useAuth();
+  const role = user?.cmsRole as CmsRole;
+  const canRun = hasCmsRole(role, "ops");
+  const canApply = hasCmsRole(role, "superadmin");
 
   const history = useQuery({
     queryKey: ["cms-ai-evaluator-history"],
@@ -75,11 +81,20 @@ export default function AiEvaluatorPage() {
             alternatives that match capabilities.
           </p>
         </div>
-        <Button onClick={() => run.mutate()} disabled={run.isPending}>
-          <Play className="mr-2 size-4" />
-          {run.isPending ? "Running…" : "Run evaluation"}
-        </Button>
+        {canRun && (
+          <Button onClick={() => run.mutate()} disabled={run.isPending}>
+            <Play className="mr-2 size-4" />
+            {run.isPending ? "Running…" : "Run evaluation"}
+          </Button>
+        )}
       </div>
+
+      {(run.isError || apply.isError) && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {((run.error || apply.error) as Error)?.message ||
+            "Operation failed. You may not have the required CMS role."}
+        </div>
+      )}
 
       {/* Latest recommendations */}
       <Card>
@@ -125,7 +140,7 @@ export default function AiEvaluatorPage() {
                     <TableCell className="text-right">
                       {r.applied ? (
                         <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">Applied</Badge>
-                      ) : (
+                      ) : canApply ? (
                         <Button
                           variant="outline"
                           size="sm"
@@ -140,6 +155,8 @@ export default function AiEvaluatorPage() {
                         >
                           Apply
                         </Button>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">superadmin only</span>
                       )}
                     </TableCell>
                   </TableRow>

--- a/src/app/cms/ai-evaluator/page.tsx
+++ b/src/app/cms/ai-evaluator/page.tsx
@@ -55,7 +55,12 @@ export default function AiEvaluatorPage() {
   const apply = useMutation({
     mutationFn: (input: { runId: string; useCase: string; candidateModelId: string }) =>
       api.post(`/v1/cms/ai-evaluator/apply`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-evaluator-history"] }),
+    onSuccess: () => {
+      // /apply mutates cfg_ai_models — invalidate the config view too so
+      // the new modelId shows up immediately on the AI Config page.
+      qc.invalidateQueries({ queryKey: ["cms-ai-evaluator-history"] });
+      qc.invalidateQueries({ queryKey: ["cms-ai-config"] });
+    },
   });
 
   const latest = history.data?.rows?.[0];

--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -5,16 +5,13 @@ import { api } from "@/lib/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Progress } from "@/components/ui/progress";
 import {
   Activity,
   AlertTriangle,
   CheckCircle2,
-  Clock,
   Database,
   DollarSign,
   XCircle,
-  Zap,
 } from "lucide-react";
 import { KpiCard } from "@/components/cms/ai/kpi-card";
 import { formatMs, formatUsd, formatDateTime } from "@/components/cms/ai/format";

--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Database,
+  DollarSign,
+  XCircle,
+  Zap,
+} from "lucide-react";
+import { KpiCard } from "@/components/cms/ai/kpi-card";
+import { formatMs, formatUsd, formatDateTime } from "@/components/cms/ai/format";
+
+interface HealthResponse {
+  mongoPingMs: number | null;
+  checklist: {
+    step1_seed_models: boolean;
+    step2_model_registry_sync: boolean;
+    step3_first_ai_call: boolean;
+    step4_skill_corpus: boolean;
+  };
+  counts: {
+    aiModelsTotal: number;
+    aiModelsActive: number;
+    registryTotal: number;
+    registryWithPricing: number;
+    skillTemplates: number;
+    bizSkills: number;
+  };
+  last24h: {
+    requests: number;
+    errors: number;
+    fallbacks: number;
+    errorRate: number;
+    totalCostUsd: number;
+    avgLatencyMs: number;
+    maxLatencyMs: number;
+  };
+  crons: { job: string; lastRunAt?: string; status?: string }[];
+  serverTime: string;
+}
+
+const CHECKLIST_LABELS: Record<keyof HealthResponse["checklist"], string> = {
+  step1_seed_models: "AI useCase configs seeded",
+  step2_model_registry_sync: "Model registry synced from Vercel Gateway",
+  step3_first_ai_call: "AI call observed in last 24h",
+  step4_skill_corpus: "Skill corpus populated",
+};
+
+export default function AiHealthPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["cms-ai-health"],
+    queryFn: () => api.get<HealthResponse>(`/v1/cms/ai-health`),
+    refetchInterval: 30_000,
+  });
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
+        Failed to load health: {(error as Error).message}
+      </div>
+    );
+  }
+
+  const errorTone =
+    data && data.last24h.errorRate > 0.05
+      ? "danger"
+      : data && data.last24h.errorRate > 0.01
+      ? "warning"
+      : "success";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">AI Health</h2>
+        <p className="text-muted-foreground mt-1">
+          Live activation status, last-24h KPIs, and infrastructure pulse.
+          {data && <span className="ml-2 text-xs">Updated {formatDateTime(data.serverTime)}</span>}
+        </p>
+      </div>
+
+      {/* Activation checklist */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Activation</CardTitle>
+          <CardDescription>Steps required for the AI ops surface to be fully wired up.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading || !data ? (
+            <div className="space-y-2">
+              {[0, 1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-6 w-full" />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {(Object.keys(CHECKLIST_LABELS) as (keyof HealthResponse["checklist"])[]).map((key) => {
+                const ok = data.checklist[key];
+                return (
+                  <div key={key} className="flex items-center gap-2 text-sm">
+                    {ok ? (
+                      <CheckCircle2 className="size-4 text-emerald-600" />
+                    ) : (
+                      <XCircle className="size-4 text-muted-foreground" />
+                    )}
+                    <span className={ok ? "" : "text-muted-foreground"}>{CHECKLIST_LABELS[key]}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Core KPIs */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard
+          label="Mongo ping"
+          icon={Database}
+          value={isLoading || !data ? "—" : data.mongoPingMs == null ? "down" : `${data.mongoPingMs}ms`}
+          hint="Round-trip to primary"
+          tone={data?.mongoPingMs == null ? "danger" : data.mongoPingMs > 200 ? "warning" : "success"}
+        />
+        <KpiCard
+          label="24h requests"
+          icon={Activity}
+          value={isLoading || !data ? "—" : data.last24h.requests.toLocaleString()}
+          hint={data ? `${data.last24h.fallbacks} fallback${data.last24h.fallbacks === 1 ? "" : "s"}` : undefined}
+        />
+        <KpiCard
+          label="Error rate"
+          icon={AlertTriangle}
+          value={isLoading || !data ? "—" : `${(data.last24h.errorRate * 100).toFixed(2)}%`}
+          hint={data ? `${data.last24h.errors} errors / ${data.last24h.requests} calls` : undefined}
+          tone={errorTone as "default" | "success" | "warning" | "danger"}
+        />
+        <KpiCard
+          label="24h cost"
+          icon={DollarSign}
+          value={isLoading || !data ? "—" : formatUsd(data.last24h.totalCostUsd)}
+          hint={data ? `avg ${formatMs(data.last24h.avgLatencyMs)}` : undefined}
+        />
+      </div>
+
+      {/* Counts */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Configuration</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          {isLoading || !data ? (
+            [0, 1, 2, 3].map((i) => <Skeleton key={i} className="h-16" />)
+          ) : (
+            <>
+              <Stat label="useCase configs" value={`${data.counts.aiModelsActive} / ${data.counts.aiModelsTotal}`} hint="active / total" />
+              <Stat label="Registry models" value={data.counts.registryTotal} hint={`${data.counts.registryWithPricing} priced`} />
+              <Stat label="Skill templates" value={data.counts.skillTemplates} />
+              <Stat label="Business skills" value={data.counts.bizSkills} />
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Crons */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Cron jobs</CardTitle>
+          <CardDescription>Schedule + last run status (populated as jobs report).</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading || !data ? (
+            <Skeleton className="h-12 w-full" />
+          ) : data.crons.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No cron status reported yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.crons.map((cron) => (
+                <div key={cron.job} className="flex items-center justify-between text-sm">
+                  <span>{cron.job}</span>
+                  <div className="flex items-center gap-2">
+                    {cron.status && (
+                      <Badge variant={cron.status === "completed" ? "secondary" : "destructive"}>
+                        {cron.status}
+                      </Badge>
+                    )}
+                    <span className="text-xs text-muted-foreground">
+                      {formatDateTime(cron.lastRunAt)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Stat({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-semibold mt-1">{value}</p>
+      {hint && <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>}
+    </div>
+  );
+}

--- a/src/app/cms/ai-logs/page.tsx
+++ b/src/app/cms/ai-logs/page.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TimeRangeSelector } from "@/components/cms/ai/time-range-selector";
+import { StatusChip } from "@/components/cms/ai/status-chip";
+import { formatMs, formatTokens, formatUsd, formatDateTime } from "@/components/cms/ai/format";
+
+interface LogRow {
+  timestamp: string;
+  useCase?: string;
+  modelId?: string;
+  callType?: string;
+  status?: string;
+  success?: boolean;
+  errorMessage?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+  durationMs?: number;
+  ttftMs?: number;
+  steps?: number;
+  toolsUsed?: string[];
+  requestId?: string;
+  entityType?: string;
+  entityId?: string;
+  promptContent?: string;
+  responseContent?: string;
+  contentRedacted?: boolean;
+}
+
+interface LogsResponse {
+  total: number;
+  offset: number;
+  limit: number;
+  rows: LogRow[];
+}
+
+export default function AiLogsPage() {
+  const [days, setDays] = useState("7");
+  const [status, setStatus] = useState<string>("all");
+  const [useCase, setUseCase] = useState("");
+  const [modelId, setModelId] = useState("");
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<LogRow | null>(null);
+  const limit = 50;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms-ai-logs", days, status, useCase, modelId, page],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        days,
+        limit: String(limit),
+        offset: String(page * limit),
+      };
+      if (status !== "all") params.status = status;
+      if (useCase) params.useCase = useCase;
+      if (modelId) params.modelId = modelId;
+      return api.get<LogsResponse>("/v1/cms/ai-logs", params);
+    },
+  });
+
+  const rows = data?.rows || [];
+  const total = data?.total || 0;
+  const lastPage = Math.max(0, Math.ceil(total / limit) - 1);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">AI Logs</h2>
+        <p className="text-muted-foreground mt-1">
+          Drill into individual ts_ai_usage rows. Click any row to inspect the prompt/response.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <Card>
+        <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-5 gap-3">
+          <TimeRangeSelector value={days} onChange={(v) => { setDays(v); setPage(0); }} />
+          <Select value={status} onValueChange={(v) => { setStatus(v); setPage(0); }}>
+            <SelectTrigger>
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              <SelectItem value="success">Success</SelectItem>
+              <SelectItem value="error">Error</SelectItem>
+              <SelectItem value="rate_limited">Rate-limited</SelectItem>
+              <SelectItem value="fallback_used">Fallback used</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="useCase (e.g. content_brief)"
+            value={useCase}
+            onChange={(e) => { setUseCase(e.target.value); setPage(0); }}
+          />
+          <Input
+            placeholder="modelId (e.g. anthropic/claude-...)"
+            value={modelId}
+            onChange={(e) => { setModelId(e.target.value); setPage(0); }}
+          />
+          <div className="flex items-center justify-end gap-2 text-sm text-muted-foreground">
+            {isLoading ? "Loading…" : `${total.toLocaleString()} matches`}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[180px]">Timestamp</TableHead>
+                <TableHead>Use case</TableHead>
+                <TableHead>Model</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Tokens</TableHead>
+                <TableHead className="text-right">Cost</TableHead>
+                <TableHead className="text-right">Latency</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                [0, 1, 2, 3, 4].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell colSpan={7}><Skeleton className="h-5 w-full" /></TableCell>
+                  </TableRow>
+                ))
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
+                    No logs match these filters.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row, i) => (
+                  <TableRow
+                    key={`${row.timestamp}-${i}`}
+                    onClick={() => setSelected(row)}
+                    className="cursor-pointer hover:bg-muted/50"
+                  >
+                    <TableCell className="text-xs whitespace-nowrap">
+                      {formatDateTime(row.timestamp)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{row.useCase || "—"}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.modelId || "—"}</TableCell>
+                    <TableCell><StatusChip status={row.status} /></TableCell>
+                    <TableCell className="text-right text-xs">
+                      {formatTokens(row.totalTokens)}
+                    </TableCell>
+                    <TableCell className="text-right text-xs">
+                      {formatUsd(row.estimatedCostUsd)}
+                    </TableCell>
+                    <TableCell className="text-right text-xs">
+                      {formatMs(row.durationMs)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Page {page + 1} of {lastPage + 1}
+        </p>
+        <div className="flex gap-2">
+          <Button variant="outline" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>
+            Previous
+          </Button>
+          <Button variant="outline" disabled={page >= lastPage} onClick={() => setPage((p) => p + 1)}>
+            Next
+          </Button>
+        </div>
+      </div>
+
+      {/* Drill-down sheet */}
+      <Sheet open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
+        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+          {selected && (
+            <>
+              <SheetHeader>
+                <SheetTitle>{selected.useCase || "AI call"}</SheetTitle>
+                <SheetDescription>{formatDateTime(selected.timestamp)}</SheetDescription>
+              </SheetHeader>
+              <div className="mt-6 space-y-4 text-sm">
+                <Field label="Status"><StatusChip status={selected.status} /></Field>
+                <Field label="Model" value={selected.modelId} mono />
+                <Field label="Call type" value={selected.callType} />
+                <Field label="Request ID" value={selected.requestId} mono />
+                <div className="grid grid-cols-3 gap-3">
+                  <Mini label="Input" value={formatTokens(selected.inputTokens)} />
+                  <Mini label="Output" value={formatTokens(selected.outputTokens)} />
+                  <Mini label="Total" value={formatTokens(selected.totalTokens)} />
+                </div>
+                <div className="grid grid-cols-3 gap-3">
+                  <Mini label="Latency" value={formatMs(selected.durationMs)} />
+                  <Mini label="TTFT" value={formatMs(selected.ttftMs)} />
+                  <Mini label="Cost" value={formatUsd(selected.estimatedCostUsd)} />
+                </div>
+                {selected.toolsUsed && selected.toolsUsed.length > 0 && (
+                  <Field label="Tools used" value={selected.toolsUsed.join(", ")} />
+                )}
+                {selected.errorMessage && (
+                  <Field label="Error">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-red-50 text-red-900 p-3">{selected.errorMessage}</pre>
+                  </Field>
+                )}
+                {selected.contentRedacted && (
+                  <p className="text-xs text-muted-foreground italic">
+                    Prompt and response are redacted at viewer-level. Ask a support+ user to reveal.
+                  </p>
+                )}
+                {selected.promptContent && (
+                  <Field label="Prompt">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-[300px] overflow-auto">{selected.promptContent}</pre>
+                  </Field>
+                )}
+                {selected.responseContent && (
+                  <Field label="Response">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-[300px] overflow-auto">{selected.responseContent}</pre>
+                  </Field>
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function Field({ label, value, children, mono = false }: { label: string; value?: string; children?: React.ReactNode; mono?: boolean }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      {children ?? <p className={mono ? "font-mono text-xs mt-1" : "mt-1"}>{value || "—"}</p>}
+    </div>
+  );
+}
+
+function Mini({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border bg-muted/50 p-2">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/src/app/cms/ai-logs/page.tsx
+++ b/src/app/cms/ai-logs/page.tsx
@@ -73,7 +73,7 @@ export default function AiLogsPage() {
   const [selected, setSelected] = useState<LogRow | null>(null);
   const limit = 50;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["cms-ai-logs", days, status, useCase, modelId, page],
     queryFn: () => {
       const params: Record<string, string> = {
@@ -100,6 +100,12 @@ export default function AiLogsPage() {
           Drill into individual ts_ai_usage rows. Click any row to inspect the prompt/response.
         </p>
       </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Failed to load logs: {(error as Error).message}
+        </div>
+      )}
 
       {/* Filters */}
       <Card>
@@ -245,12 +251,12 @@ export default function AiLogsPage() {
                 )}
                 {selected.promptContent && (
                   <Field label="Prompt">
-                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-[300px] overflow-auto">{selected.promptContent}</pre>
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-75 overflow-auto">{selected.promptContent}</pre>
                   </Field>
                 )}
                 {selected.responseContent && (
                   <Field label="Response">
-                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-[300px] overflow-auto">{selected.responseContent}</pre>
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-75 overflow-auto">{selected.responseContent}</pre>
                   </Field>
                 )}
               </div>

--- a/src/app/cms/ai-models/page.tsx
+++ b/src/app/cms/ai-models/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { RefreshCw } from "lucide-react";
+import { formatUsd, formatMs, formatDateTime } from "@/components/cms/ai/format";
+
+interface ModelRow {
+  _id: string;
+  modelId: string;
+  provider: string;
+  modelType: string;
+  pricing?: { inputPerMillion?: number; outputPerMillion?: number; currency?: string };
+  performance?: { contextWindow?: number; maxOutputTokens?: number; p50TtftMs?: number };
+  capabilities?: Record<string, boolean>;
+  lastSyncedAt?: string;
+}
+
+export default function AiModelsPage() {
+  const qc = useQueryClient();
+  const [search, setSearch] = useState("");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms-ai-models"],
+    queryFn: () => api.get<{ rows: ModelRow[]; total: number }>("/v1/cms/ai-models"),
+  });
+
+  const sync = useMutation({
+    mutationFn: () =>
+      api.post<{ synced: number; totalReceived: number }>("/v1/cms/ai-models/sync"),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-models"] }),
+  });
+
+  const rows = data?.rows ?? [];
+  const filtered = search
+    ? rows.filter((r) =>
+        `${r.modelId} ${r.provider}`.toLowerCase().includes(search.toLowerCase()),
+      )
+    : rows;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">AI Model Registry</h2>
+          <p className="text-muted-foreground mt-1">
+            Synced from Vercel AI Gateway. Powers the evaluator's recommendations.
+          </p>
+        </div>
+        <Button onClick={() => sync.mutate()} disabled={sync.isPending}>
+          <RefreshCw className={`mr-2 size-4 ${sync.isPending ? "animate-spin" : ""}`} />
+          {sync.isPending ? "Syncing…" : "Sync now"}
+        </Button>
+      </div>
+
+      {sync.isSuccess && sync.data && (
+        <Card className="border-emerald-200 bg-emerald-50">
+          <CardContent className="py-3 text-sm text-emerald-900">
+            Synced {sync.data.synced} of {sync.data.totalReceived} models from Vercel.
+          </CardContent>
+        </Card>
+      )}
+      {sync.isError && (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="py-3 text-sm text-red-900">
+            Sync failed: {(sync.error as Error).message}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Search</CardTitle>
+          <CardDescription>Filter by provider or modelId substring.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Input
+            placeholder="Search…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Model</TableHead>
+                <TableHead>Provider</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead className="text-right">Input $/M</TableHead>
+                <TableHead className="text-right">Output $/M</TableHead>
+                <TableHead className="text-right">P50 TTFT</TableHead>
+                <TableHead>Capabilities</TableHead>
+                <TableHead className="text-right">Last sync</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                [0, 1, 2, 3, 4].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell colSpan={8}><Skeleton className="h-5 w-full" /></TableCell>
+                  </TableRow>
+                ))
+              ) : filtered.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
+                    {data?.total === 0 ? "Registry empty — click 'Sync now'." : "No matches."}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filtered.map((row) => (
+                  <TableRow key={row._id}>
+                    <TableCell className="font-mono text-xs">{row.modelId}</TableCell>
+                    <TableCell>{row.provider}</TableCell>
+                    <TableCell><Badge variant="outline">{row.modelType}</Badge></TableCell>
+                    <TableCell className="text-right">
+                      {formatUsd(row.pricing?.inputPerMillion)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatUsd(row.pricing?.outputPerMillion)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatMs(row.performance?.p50TtftMs)}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {row.capabilities &&
+                          Object.entries(row.capabilities)
+                            .filter(([, v]) => v)
+                            .map(([k]) => (
+                              <Badge key={k} variant="secondary" className="text-[10px]">
+                                {k}
+                              </Badge>
+                            ))}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right text-xs text-muted-foreground">
+                      {formatDateTime(row.lastSyncedAt)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/cms/ai-models/page.tsx
+++ b/src/app/cms/ai-models/page.tsx
@@ -42,7 +42,11 @@ export default function AiModelsPage() {
   const sync = useMutation({
     mutationFn: () =>
       api.post<{ synced: number; totalReceived: number }>("/v1/cms/ai-models/sync"),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-models"] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cms-ai-models"] });
+      // ai-health checklist depends on registry rows existing.
+      qc.invalidateQueries({ queryKey: ["cms-ai-health"] });
+    },
   });
 
   const rows = data?.rows ?? [];

--- a/src/app/cms/ai-models/page.tsx
+++ b/src/app/cms/ai-models/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+import { hasCmsRole, type CmsRole } from "@/components/cms/ai/role-gate";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -32,6 +34,8 @@ interface ModelRow {
 
 export default function AiModelsPage() {
   const qc = useQueryClient();
+  const { user } = useAuth();
+  const canSync = hasCmsRole(user?.cmsRole as CmsRole, "ops");
   const [search, setSearch] = useState("");
 
   const { data, isLoading } = useQuery({
@@ -65,10 +69,12 @@ export default function AiModelsPage() {
             Synced from Vercel AI Gateway. Powers the evaluator's recommendations.
           </p>
         </div>
-        <Button onClick={() => sync.mutate()} disabled={sync.isPending}>
-          <RefreshCw className={`mr-2 size-4 ${sync.isPending ? "animate-spin" : ""}`} />
-          {sync.isPending ? "Syncing…" : "Sync now"}
-        </Button>
+        {canSync && (
+          <Button onClick={() => sync.mutate()} disabled={sync.isPending}>
+            <RefreshCw className={`mr-2 size-4 ${sync.isPending ? "animate-spin" : ""}`} />
+            {sync.isPending ? "Syncing…" : "Sync now"}
+          </Button>
+        )}
       </div>
 
       {sync.isSuccess && sync.data && (

--- a/src/app/cms/api-logs/page.tsx
+++ b/src/app/cms/api-logs/page.tsx
@@ -74,7 +74,7 @@ export default function ApiLogsPage() {
   const [selected, setSelected] = useState<LogRow | null>(null);
   const limit = 50;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["cms-api-logs", days, method, path, errorsOnly, page],
     queryFn: () => {
       const params: Record<string, string> = {
@@ -101,6 +101,12 @@ export default function ApiLogsPage() {
           peakhour-api request stream (30-day retention). Click a row for full details.
         </p>
       </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Failed to load logs: {(error as Error).message}
+        </div>
+      )}
 
       <Card>
         <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-5 gap-3">

--- a/src/app/cms/api-logs/page.tsx
+++ b/src/app/cms/api-logs/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TimeRangeSelector } from "@/components/cms/ai/time-range-selector";
+import { formatMs, formatDateTime } from "@/components/cms/ai/format";
+
+interface LogRow {
+  timestamp: string;
+  method?: string;
+  routePath?: string;
+  path?: string;
+  statusCode?: number;
+  latencyMs?: number;
+  requestId?: string;
+  userId?: string;
+  orgId?: string;
+  ip?: string;
+  userAgent?: string;
+  error?: string;
+  request?: string;
+  response?: string;
+}
+
+interface LogsResponse {
+  total: number;
+  offset: number;
+  limit: number;
+  rows: LogRow[];
+}
+
+function statusBadge(code?: number) {
+  if (!code) return null;
+  if (code >= 500) return <Badge className="bg-red-100 text-red-800 hover:bg-red-100">{code}</Badge>;
+  if (code >= 400) return <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">{code}</Badge>;
+  if (code >= 300) return <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">{code}</Badge>;
+  return <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">{code}</Badge>;
+}
+
+export default function ApiLogsPage() {
+  const [days, setDays] = useState("1");
+  const [method, setMethod] = useState("all");
+  const [path, setPath] = useState("");
+  const [errorsOnly, setErrorsOnly] = useState(false);
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<LogRow | null>(null);
+  const limit = 50;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms-api-logs", days, method, path, errorsOnly, page],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        days,
+        limit: String(limit),
+        offset: String(page * limit),
+      };
+      if (method !== "all") params.method = method;
+      if (path) params.path = path;
+      if (errorsOnly) params.errorsOnly = "true";
+      return api.get<LogsResponse>("/v1/cms/api-logs", params);
+    },
+  });
+
+  const rows = data?.rows || [];
+  const total = data?.total || 0;
+  const lastPage = Math.max(0, Math.ceil(total / limit) - 1);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">API Logs</h2>
+        <p className="text-muted-foreground mt-1">
+          peakhour-api request stream (30-day retention). Click a row for full details.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-5 gap-3">
+          <TimeRangeSelector
+            value={days}
+            onChange={(v) => { setDays(v); setPage(0); }}
+            options={[
+              { value: "1", label: "Last 24 hours" },
+              { value: "3", label: "Last 3 days" },
+              { value: "7", label: "Last 7 days" },
+              { value: "30", label: "Last 30 days" },
+            ]}
+          />
+          <Select value={method} onValueChange={(v) => { setMethod(v); setPage(0); }}>
+            <SelectTrigger>
+              <SelectValue placeholder="Method" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All methods</SelectItem>
+              {["GET", "POST", "PUT", "PATCH", "DELETE"].map((m) => (
+                <SelectItem key={m} value={m}>{m}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="Path contains…"
+            value={path}
+            onChange={(e) => { setPath(e.target.value); setPage(0); }}
+          />
+          <Button
+            variant={errorsOnly ? "default" : "outline"}
+            onClick={() => { setErrorsOnly((v) => !v); setPage(0); }}
+          >
+            {errorsOnly ? "Errors only ✓" : "Errors only"}
+          </Button>
+          <div className="flex items-center justify-end gap-2 text-sm text-muted-foreground">
+            {isLoading ? "Loading…" : `${total.toLocaleString()} matches`}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[180px]">Timestamp</TableHead>
+                <TableHead>Method</TableHead>
+                <TableHead>Path</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Latency</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                [0, 1, 2, 3, 4].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell colSpan={5}><Skeleton className="h-5 w-full" /></TableCell>
+                  </TableRow>
+                ))
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                    No logs match these filters.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row, i) => (
+                  <TableRow
+                    key={`${row.timestamp}-${i}`}
+                    onClick={() => setSelected(row)}
+                    className="cursor-pointer hover:bg-muted/50"
+                  >
+                    <TableCell className="text-xs whitespace-nowrap">{formatDateTime(row.timestamp)}</TableCell>
+                    <TableCell><Badge variant="outline">{row.method}</Badge></TableCell>
+                    <TableCell className="font-mono text-xs">{row.path}</TableCell>
+                    <TableCell>{statusBadge(row.statusCode)}</TableCell>
+                    <TableCell className="text-right text-xs">{formatMs(row.latencyMs)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Page {page + 1} of {lastPage + 1}</p>
+        <div className="flex gap-2">
+          <Button variant="outline" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>Previous</Button>
+          <Button variant="outline" disabled={page >= lastPage} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      </div>
+
+      <Sheet open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
+        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+          {selected && (
+            <>
+              <SheetHeader>
+                <SheetTitle>{selected.method} {selected.path}</SheetTitle>
+                <SheetDescription>{formatDateTime(selected.timestamp)}</SheetDescription>
+              </SheetHeader>
+              <div className="mt-6 space-y-3 text-sm">
+                <KV k="Status" v={selected.statusCode != null ? String(selected.statusCode) : "—"} />
+                <KV k="Latency" v={formatMs(selected.latencyMs)} />
+                <KV k="Route pattern" v={selected.routePath || "—"} />
+                <KV k="Request ID" v={selected.requestId || "—"} mono />
+                <KV k="User" v={selected.userId || "—"} mono />
+                <KV k="Org" v={selected.orgId || "—"} mono />
+                <KV k="IP" v={selected.ip || "—"} />
+                <KV k="User agent" v={selected.userAgent || "—"} />
+                {selected.error && (
+                  <div>
+                    <p className="text-xs text-muted-foreground">Error</p>
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-red-50 text-red-900 p-3">{selected.error}</pre>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function KV({ k, v, mono = false }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <span className="text-muted-foreground">{k}</span>
+      <span className={mono ? "font-mono text-xs" : ""}>{v}</span>
+    </div>
+  );
+}

--- a/src/app/cms/auth-logs/page.tsx
+++ b/src/app/cms/auth-logs/page.tsx
@@ -60,7 +60,7 @@ export default function AuthLogsPage() {
   const [page, setPage] = useState(0);
   const limit = 50;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["cms-auth-logs", days, event, success, userId, page],
     queryFn: () => {
       const params: Record<string, string> = {
@@ -87,6 +87,12 @@ export default function AuthLogsPage() {
           Combined view of routine (90d) and security (730d) auth events.
         </p>
       </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Failed to load logs: {(error as Error).message}
+        </div>
+      )}
 
       <Card>
         <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-5 gap-3">

--- a/src/app/cms/auth-logs/page.tsx
+++ b/src/app/cms/auth-logs/page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TimeRangeSelector } from "@/components/cms/ai/time-range-selector";
+import { formatDateTime } from "@/components/cms/ai/format";
+
+interface LogRow {
+  timestamp: string;
+  event?: string;
+  channel?: string;
+  platform?: string;
+  userId?: string;
+  success?: boolean;
+  reason?: string;
+  requestId?: string;
+  metadata?: { ip?: string; userAgent?: string; country?: string; state?: string; city?: string };
+}
+
+interface LogsResponse {
+  total: number;
+  offset: number;
+  limit: number;
+  rows: LogRow[];
+}
+
+const EVENT_OPTIONS = [
+  "OTP_SENT", "OTP_VERIFIED", "OTP_FAILED", "OTP_EXPIRED", "OTP_MAX_ATTEMPTS",
+  "MAGIC_LINK_REQUEST", "MAGIC_LINK_GENERATED", "MAGIC_LINK_SENT",
+  "MAGIC_LINK_VERIFIED", "MAGIC_LINK_FAILED",
+  "LOGIN_SUCCESS", "LOGIN_FAILED", "LOGOUT", "SESSION_EXPIRED", "SUSPICIOUS_ACTIVITY",
+];
+
+export default function AuthLogsPage() {
+  const [days, setDays] = useState("7");
+  const [event, setEvent] = useState("all");
+  const [success, setSuccess] = useState("all");
+  const [userId, setUserId] = useState("");
+  const [page, setPage] = useState(0);
+  const limit = 50;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["cms-auth-logs", days, event, success, userId, page],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        days,
+        limit: String(limit),
+        offset: String(page * limit),
+      };
+      if (event !== "all") params.event = event;
+      if (success !== "all") params.success = success;
+      if (userId) params.userId = userId;
+      return api.get<LogsResponse>("/v1/cms/auth-logs", params);
+    },
+  });
+
+  const rows = data?.rows || [];
+  const total = data?.total || 0;
+  const lastPage = Math.max(0, Math.ceil(total / limit) - 1);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Auth Logs</h2>
+        <p className="text-muted-foreground mt-1">
+          Combined view of routine (90d) and security (730d) auth events.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-5 gap-3">
+          <TimeRangeSelector
+            value={days}
+            onChange={(v) => { setDays(v); setPage(0); }}
+            options={[
+              { value: "1", label: "Last 24 hours" },
+              { value: "7", label: "Last 7 days" },
+              { value: "30", label: "Last 30 days" },
+              { value: "90", label: "Last 90 days" },
+              { value: "730", label: "Last 2 years (security)" },
+            ]}
+          />
+          <Select value={event} onValueChange={(v) => { setEvent(v); setPage(0); }}>
+            <SelectTrigger>
+              <SelectValue placeholder="Event" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All events</SelectItem>
+              {EVENT_OPTIONS.map((e) => (
+                <SelectItem key={e} value={e}>{e}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={success} onValueChange={(v) => { setSuccess(v); setPage(0); }}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All outcomes</SelectItem>
+              <SelectItem value="true">Success only</SelectItem>
+              <SelectItem value="false">Failures only</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="User ID (ObjectId)"
+            value={userId}
+            onChange={(e) => { setUserId(e.target.value); setPage(0); }}
+          />
+          <div className="flex items-center justify-end gap-2 text-sm text-muted-foreground">
+            {isLoading ? "Loading…" : `${total.toLocaleString()} matches`}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[180px]">Timestamp</TableHead>
+                <TableHead>Event</TableHead>
+                <TableHead>Outcome</TableHead>
+                <TableHead>Channel</TableHead>
+                <TableHead>User</TableHead>
+                <TableHead>Geo</TableHead>
+                <TableHead>Reason</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                [0, 1, 2, 3, 4].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell colSpan={7}><Skeleton className="h-5 w-full" /></TableCell>
+                  </TableRow>
+                ))
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
+                    No logs match these filters.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row, i) => (
+                  <TableRow key={`${row.timestamp}-${i}`}>
+                    <TableCell className="text-xs whitespace-nowrap">{formatDateTime(row.timestamp)}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.event}</TableCell>
+                    <TableCell>
+                      {row.success ? (
+                        <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">success</Badge>
+                      ) : (
+                        <Badge className="bg-red-100 text-red-800 hover:bg-red-100">failure</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-xs">{row.channel || "—"}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.userId || "—"}</TableCell>
+                    <TableCell className="text-xs">
+                      {[row.metadata?.city, row.metadata?.state, row.metadata?.country].filter(Boolean).join(", ") || "—"}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">{row.reason || "—"}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Page {page + 1} of {lastPage + 1}</p>
+        <div className="flex gap-2">
+          <Button variant="outline" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>Previous</Button>
+          <Button variant="outline" disabled={page >= lastPage} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cms/layout.tsx
+++ b/src/app/cms/layout.tsx
@@ -41,6 +41,13 @@ import {
   ChevronsUpDown,
   ArrowLeftRight,
   Zap,
+  Activity,
+  ScrollText,
+  Cpu,
+  SlidersHorizontal,
+  Wand2,
+  Network,
+  ShieldCheck,
   type LucideIcon,
 } from "lucide-react";
 
@@ -67,8 +74,25 @@ const CMS_NAV_GROUPS: NavGroup[] = [
     items: [
       { href: "/cms/feedback", label: "Feedback Tickets", icon: TicketCheck },
       { href: "/cms/skills", label: "Skills", icon: Zap },
-      { href: "/cms/ai-usage", label: "AI Usage", icon: Brain },
       { href: "/cms/team", label: "CMS Team", icon: Users },
+    ],
+  },
+  {
+    label: "AI Operations",
+    items: [
+      { href: "/cms/ai-health", label: "Health", icon: Activity },
+      { href: "/cms/ai-usage", label: "Usage", icon: Brain },
+      { href: "/cms/ai-logs", label: "Logs", icon: ScrollText },
+      { href: "/cms/ai-models", label: "Model Registry", icon: Cpu },
+      { href: "/cms/ai-config", label: "Configuration", icon: SlidersHorizontal },
+      { href: "/cms/ai-evaluator", label: "Evaluator", icon: Wand2 },
+    ],
+  },
+  {
+    label: "Observability",
+    items: [
+      { href: "/cms/api-logs", label: "API Logs", icon: Network },
+      { href: "/cms/auth-logs", label: "Auth Logs", icon: ShieldCheck },
     ],
   },
   {

--- a/src/components/cms/ai/format.ts
+++ b/src/components/cms/ai/format.ts
@@ -1,0 +1,30 @@
+/** Shared formatters for the CMS AI Operations pages. */
+
+export function formatTokens(n: number | undefined | null): string {
+  if (!n) return "0";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function formatMs(ms: number | undefined | null): string {
+  if (ms == null) return "—";
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+export function formatUsd(n: number | undefined | null): string {
+  if (n == null) return "—";
+  if (n < 0.01 && n > 0) return `<$0.01`;
+  return `$${n.toFixed(2)}`;
+}
+
+export function formatPct(n: number | undefined | null, digits = 1): string {
+  if (n == null) return "—";
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+export function formatDateTime(d: string | Date | undefined | null): string {
+  if (!d) return "—";
+  return new Date(d).toLocaleString();
+}

--- a/src/components/cms/ai/kpi-card.tsx
+++ b/src/components/cms/ai/kpi-card.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type LucideIcon } from "lucide-react";
+
+interface KpiCardProps {
+  label: string;
+  value: string | number;
+  hint?: string;
+  icon?: LucideIcon;
+  tone?: "default" | "success" | "warning" | "danger";
+}
+
+const TONE: Record<NonNullable<KpiCardProps["tone"]>, string> = {
+  default: "text-foreground",
+  success: "text-emerald-600",
+  warning: "text-amber-600",
+  danger: "text-red-600",
+};
+
+export function KpiCard({ label, value, hint, icon: Icon, tone = "default" }: KpiCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-xs font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+        {Icon && <Icon className="size-4 text-muted-foreground" />}
+      </CardHeader>
+      <CardContent>
+        <div className={`text-2xl font-bold ${TONE[tone]}`}>{value}</div>
+        {hint && <p className="text-xs text-muted-foreground mt-1">{hint}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/cms/ai/role-gate.ts
+++ b/src/components/cms/ai/role-gate.ts
@@ -1,0 +1,18 @@
+/**
+ * Mirror of the CMS role hierarchy in peakhour-api/middleware/requireCmsRole.ts.
+ * Use to gate buttons + actions client-side so viewers don't click into 403s.
+ * Server-side enforcement is the source of truth — this is UX only.
+ */
+
+const TIER: Record<string, number> = {
+  superadmin: 40,
+  ops: 30,
+  support: 20,
+  viewer: 10,
+};
+
+export type CmsRole = "viewer" | "support" | "ops" | "superadmin" | undefined;
+
+export function hasCmsRole(role: CmsRole, required: keyof typeof TIER): boolean {
+  return (TIER[role || ""] ?? 0) >= (TIER[required] ?? 100);
+}

--- a/src/components/cms/ai/status-chip.tsx
+++ b/src/components/cms/ai/status-chip.tsx
@@ -1,0 +1,24 @@
+import { Badge } from "@/components/ui/badge";
+
+const VARIANT: Record<string, string> = {
+  success: "bg-emerald-100 text-emerald-800 hover:bg-emerald-100",
+  error: "bg-red-100 text-red-800 hover:bg-red-100",
+  rate_limited: "bg-amber-100 text-amber-800 hover:bg-amber-100",
+  fallback_used: "bg-violet-100 text-violet-800 hover:bg-violet-100",
+};
+
+const LABEL: Record<string, string> = {
+  success: "OK",
+  error: "Error",
+  rate_limited: "Rate-limited",
+  fallback_used: "Fallback",
+};
+
+export function StatusChip({ status }: { status?: string }) {
+  const key = status || "success";
+  return (
+    <Badge variant="secondary" className={VARIANT[key] || ""}>
+      {LABEL[key] || key}
+    </Badge>
+  );
+}

--- a/src/components/cms/ai/time-range-selector.tsx
+++ b/src/components/cms/ai/time-range-selector.tsx
@@ -26,7 +26,7 @@ export function TimeRangeSelector({
 }: TimeRangeSelectorProps) {
   return (
     <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className="w-[180px]">
+      <SelectTrigger className="w-45">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/cms/ai/time-range-selector.tsx
+++ b/src/components/cms/ai/time-range-selector.tsx
@@ -1,0 +1,41 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface TimeRangeSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  options?: { value: string; label: string }[];
+}
+
+const DEFAULT_OPTIONS = [
+  { value: "1", label: "Last 24 hours" },
+  { value: "7", label: "Last 7 days" },
+  { value: "30", label: "Last 30 days" },
+  { value: "90", label: "Last 90 days" },
+];
+
+export function TimeRangeSelector({
+  value,
+  onChange,
+  options = DEFAULT_OPTIONS,
+}: TimeRangeSelectorProps) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}


### PR DESCRIPTION
## Summary

**Phase 3 of 3.** Depends on peakhour-mongodb#39 (merged) and peakhour-api#113 (merged).

### What this adds

**Eight new CMS pages** under `/cms/*`:

| Page | Purpose |
|---|---|
| `ai-health` | Activation checklist + last-24h KPIs + mongo ping + cron status. Polls every 30s. |
| `ai-usage` *(existing)* | Reused — already comprehensive (KPIs + by-useCase + by-model + by-org + daily) |
| `ai-logs` | Paginated `ts_ai_usage` viewer with status / useCase / model filters + drill-down sheet |
| `ai-models` | Vercel AI Gateway registry view + "Sync now" button |
| `ai-config` | CRUD on `cfg_ai_models` with per-field audit log tab |
| `ai-evaluator` | "Run evaluation" + recommendations table with apply button + run history |
| `api-logs` | Request log viewer with method/path/status filters + drill-down sheet |
| `auth-logs` | Combined security + routine auth events with event/success/userId filters |

**Reusable atoms** under `src/components/cms/ai/`:
- `kpi-card`, `status-chip`, `time-range-selector`, formatters (tokens / ms / USD / pct / date-time)

**Sidebar** updated:
- New "AI Operations" group (6 entries)
- New "Observability" group (api-logs, auth-logs)

**MCP**: Shadcnblocks PRO entry added to local `.mcp.json` (gitignored — uses existing `SHADCNBLOCKS_API_KEY` from `.env`).

### Privacy + role gating

- All pages require `viewer` CMS role at minimum.
- `ai-logs` page renders `promptContent` / `responseContent` only when the backend includes it (server-side gate at `support+` role); shows a "redacted" notice otherwise.
- Mutations (ai-config CRUD, ai-evaluator apply, ai-models sync) require `ops` or `superadmin` per backend.

### Review history

**Review #1** (manual + subagent) found:
- **C2** NaN risk on numeric form inputs — centralized `parseNumberInput()` helper rejects empty / partial / non-numeric input.
- **M5** ai-evaluator /apply now invalidates `cms-ai-config` so the page reflects the mutation immediately.
- **L7** ai-config PUT now invalidates `cms-ai-config-audit/<useCase>`.
- **M6** ai-models /sync now invalidates `cms-ai-health` (registry-sync checklist step).
- **M1** ai-logs / api-logs / auth-logs render an error banner on `useQuery.error`.
- Tailwind v4: replaced `w-[180px]` and `max-h-[300px]` with canonical `w-45` and `max-h-75`.

All fixes in commit `01f113b`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] `npm run dev`; navigate to `/cms/ai-health` as a CMS user — confirm checklist + KPIs render and re-poll every 30s
- [ ] `/cms/ai-logs` filter combos (status, useCase, modelId) and pagination
- [ ] `/cms/ai-logs` drill-down sheet — confirm `contentRedacted: true` shows the muted notice for `viewer` role; full content for `support+`
- [ ] `/cms/ai-models` "Sync now" → confirm registry populates + checklist updates
- [ ] `/cms/ai-config` create + edit + delete a useCase; confirm audit tab shows diff rows
- [ ] `/cms/ai-evaluator` "Run evaluation" → recommendations show; "Apply" updates `ai-config` view
- [ ] `/cms/api-logs` and `/cms/auth-logs` filter combos and pagination
- [ ] Sidebar — new groups render and active highlight works

🤖 Generated with [Claude Code](https://claude.com/claude-code)