### PR TITLE
feat(cms): retention card on /cms/ai-health

### DIFF
--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -54,7 +54,10 @@ interface HealthResponse {
 function formatRetention(seconds?: number): string {
   if (seconds == null) return "—";
   const days = seconds / 86400;
-  if (days >= 365) return `${(days / 365).toFixed(1)}y`;
+  if (days >= 365) {
+    const years = days / 365;
+    return Number.isInteger(years) ? `${years}y` : `${years.toFixed(1)}y`;
+  }
   return `${days.toFixed(0)}d`;
 }
 

--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -32,6 +32,12 @@ interface HealthResponse {
     skillTemplates: number;
     bizSkills: number;
   };
+  retention?: {
+    name: string;
+    expireAfterSeconds?: number;
+    granularity?: string;
+    count: number;
+  }[];
   last24h: {
     requests: number;
     errors: number;
@@ -43,6 +49,13 @@ interface HealthResponse {
   };
   crons: { job: string; lastRunAt?: string; status?: string }[];
   serverTime: string;
+}
+
+function formatRetention(seconds?: number): string {
+  if (seconds == null) return "—";
+  const days = seconds / 86400;
+  if (days >= 365) return `${(days / 365).toFixed(1)}y`;
+  return `${days.toFixed(0)}d`;
 }
 
 const CHECKLIST_LABELS: Record<keyof HealthResponse["checklist"], string> = {
@@ -162,6 +175,42 @@ export default function AiHealthPage() {
               <Stat label="Skill templates" value={data.counts.skillTemplates} />
               <Stat label="Business skills" value={data.counts.bizSkills} />
             </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Retention */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Retention</CardTitle>
+          <CardDescription>
+            Currently-applied TTL per time-series log collection. Use{" "}
+            <code className="font-mono">npm run ttl:dev</code> /{" "}
+            <code className="font-mono">ttl:prod</code> in peakhour-mongodb to swap.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading || !data ? (
+            <Skeleton className="h-24 w-full" />
+          ) : !data.retention?.length ? (
+            <p className="text-sm text-muted-foreground">No retention metadata reported.</p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {data.retention.map((r) => (
+                <div key={r.name} className="rounded border p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="font-mono text-xs">{r.name}</span>
+                    <span className="font-semibold tabular-nums">
+                      {formatRetention(r.expireAfterSeconds)}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+                    <span>granularity: {r.granularity || "—"}</span>
+                    <span>{r.count >= 0 ? `${r.count.toLocaleString()} rows` : "count unavailable"}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

Renders the new `retention` array from `/v1/cms/ai-health` (peakhour-api PR #114) as a foodxp-style "Retention" card on the AI Health page. One tile per `ts_*` log collection showing TTL, granularity, and estimated row count — lets ops confirm at a glance whether dev short-TTL is applied or whether prod retention is in effect.

### Review history

**Review #1** (subagent) — found:
- Cosmetic: `formatRetention(157680000)` returned `"5.0y"`. Whole-year values now show as `"5y"`. Fix in `b90e60f`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Visit `/cms/ai-health` after API PR #114 lands — confirm the card renders the four TS collections with their current TTL
- [ ] Run `npm run ttl:dev` / `ttl:prod` in peakhour-mongodb and reload — confirm card updates within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)