### PR TITLE
fix(cms): remove broken /cms/settings nav link

### DIFF
--- a/src/app/cms/layout.tsx
+++ b/src/app/cms/layout.tsx
@@ -36,7 +36,6 @@ import {
   TicketCheck,
   Users,
   Brain,
-  Settings2,
   LogOut,
   ChevronsUpDown,
   ArrowLeftRight,
@@ -93,12 +92,6 @@ const CMS_NAV_GROUPS: NavGroup[] = [
     items: [
       { href: "/cms/api-logs", label: "API Logs", icon: Network },
       { href: "/cms/auth-logs", label: "Auth Logs", icon: ShieldCheck },
-    ],
-  },
-  {
-    label: "",
-    items: [
-      { href: "/cms/settings", label: "CMS Settings", icon: Settings2 },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

The "CMS Settings" entry has been linking to `/cms/settings` since PR #123 but the page was never created — clicking it returns 404. Removed the nav item; can be added back when a real settings page is built.

Also drops the now-unused `Settings2` lucide import.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Reload `/cms/*` — confirm the broken link is gone from the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)