### PR TITLE
feat(cms): platforms[] + subCategory in skills UI

### DIFF
--- a/src/app/cms/skills/[id]/page.tsx
+++ b/src/app/cms/skills/[id]/page.tsx
@@ -114,7 +114,12 @@ export default function SkillEditorPage() {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="secondary">{humanize(skill.agent)}</Badge>
-          <Badge variant="outline">{skill.platform}</Badge>
+          {(skill.platforms || []).map((p) => (
+            <Badge key={p} variant="outline" className="capitalize">{p}</Badge>
+          ))}
+          {skill.subCategory && (
+            <Badge variant="secondary" className="text-xs">{humanize(skill.subCategory)}</Badge>
+          )}
           <Badge variant="outline">{skill.executionType}</Badge>
           <div className="flex items-center gap-1 text-sm text-muted-foreground">
             <Shield className="h-3 w-3" />

--- a/src/app/cms/skills/business/[businessId]/page.tsx
+++ b/src/app/cms/skills/business/[businessId]/page.tsx
@@ -240,7 +240,7 @@ export default function BusinessSkillsPage() {
                           {s.displayName}
                         </div>
                         <div className="text-xs text-muted-foreground">
-                          {s.platform} | {s.effectiveness.totalUses} uses
+                          {(s.platforms || []).join(", ") || s.platform || "all"} | {s.effectiveness.totalUses} uses
                         </div>
                       </div>
                       <div className="w-24">

--- a/src/app/cms/skills/page.tsx
+++ b/src/app/cms/skills/page.tsx
@@ -51,6 +51,7 @@ const EXECUTION_BADGES: Record<string, string> = {
 export default function SkillsPage() {
   const [agentFilter, setAgentFilter] = useState<string>("all");
   const [platformFilter, setPlatformFilter] = useState<string>("all");
+  const [subCategoryFilter, setSubCategoryFilter] = useState<string>("all");
   const [search, setSearch] = useState("");
 
   const { data, isLoading, isError, error } = useQuery({
@@ -62,13 +63,19 @@ export default function SkillsPage() {
 
   const filtered = skills.filter((s) => {
     if (agentFilter !== "all" && s.agent !== agentFilter) return false;
-    if (platformFilter !== "all" && s.platform !== platformFilter) return false;
+    if (platformFilter !== "all") {
+      const targets = s.platforms || [];
+      // 'all' templates should match any specific platform filter.
+      if (!targets.includes(platformFilter) && !targets.includes("all")) return false;
+    }
+    if (subCategoryFilter !== "all" && (s.subCategory || "") !== subCategoryFilter) return false;
     if (search) {
       const q = search.toLowerCase();
       return (
         s.skillId.toLowerCase().includes(q) ||
         s.displayName.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q)
+        s.description.toLowerCase().includes(q) ||
+        (s.subCategory || "").toLowerCase().includes(q)
       );
     }
     return true;
@@ -83,7 +90,12 @@ export default function SkillsPage() {
   );
 
   const uniqueAgents = [...new Set(skills.map((s) => s.agent))].sort();
-  const uniquePlatforms = [...new Set(skills.map((s) => s.platform))].sort();
+  const uniquePlatforms = [
+    ...new Set(skills.flatMap((s) => s.platforms || [])),
+  ].sort();
+  const uniqueSubCategories = [
+    ...new Set(skills.map((s) => s.subCategory).filter((sc): sc is string => !!sc)),
+  ].sort();
 
   if (isError) {
     return (
@@ -163,6 +175,21 @@ export default function SkillsPage() {
             ))}
           </SelectContent>
         </Select>
+        {uniqueSubCategories.length > 0 && (
+          <Select value={subCategoryFilter} onValueChange={setSubCategoryFilter}>
+            <SelectTrigger className="w-40" aria-label="Filter by sub-category">
+              <SelectValue placeholder="Sub-category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All sub-categories</SelectItem>
+              {uniqueSubCategories.map((sc) => (
+                <SelectItem key={sc} value={sc}>
+                  {humanize(sc)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
 
       {/* Table */}
@@ -179,7 +206,8 @@ export default function SkillsPage() {
               <TableRow>
                 <TableHead>Skill</TableHead>
                 <TableHead>Agent</TableHead>
-                <TableHead>Platform</TableHead>
+                <TableHead>Platforms</TableHead>
+                <TableHead>Sub-category</TableHead>
                 <TableHead>Role</TableHead>
                 <TableHead>Type</TableHead>
                 <TableHead className="text-center">Trust</TableHead>
@@ -209,7 +237,18 @@ export default function SkillsPage() {
                       {humanize(skill.agent)}
                     </Badge>
                   </TableCell>
-                  <TableCell className="capitalize">{skill.platform}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {(skill.platforms || []).map((p) => (
+                        <Badge key={p} variant="outline" className="text-[10px] capitalize">
+                          {p}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {skill.subCategory ? humanize(skill.subCategory) : "—"}
+                  </TableCell>
                   <TableCell className="capitalize text-sm">
                     {humanize(skill.role)}
                   </TableCell>
@@ -238,7 +277,7 @@ export default function SkillsPage() {
               ))}
               {filtered.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
+                  <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
                     No skills match your filters
                   </TableCell>
                 </TableRow>

--- a/src/types/skills.ts
+++ b/src/types/skills.ts
@@ -4,8 +4,11 @@ export interface SkillTemplate {
   displayName: string;
   description: string;
   category: string;
+  /** Free-form sub-grouping within `category` (e.g. 'seo', 'long_form', 'ad_copy'). */
+  subCategory?: string;
   agent: string;
-  platform: string;
+  /** Platforms this skill targets. ['all'] = platform-agnostic. */
+  platforms: string[];
   role: string;
   trustLevel: number;
   executionType: "ai" | "code" | "hybrid";
@@ -52,7 +55,16 @@ export interface BizSkill {
 
 export interface BusinessSkillsResponse {
   business: { name: string; type: string };
-  skills: Array<BizSkill & { agent: string; platform: string; displayName: string }>;
+  skills: Array<
+    BizSkill & {
+      agent: string;
+      platforms: string[];
+      /** First entry of `platforms[]` for backward compat with single-Badge UIs. */
+      platform: string;
+      subCategory?: string;
+      displayName: string;
+    }
+  >;
   autonomyScore: number;
 }
 


### PR DESCRIPTION
## Summary

Final piece of the skill-clustering trilogy:
- peakhour-mongodb#41 — schema (platforms[] replaces platform; + subCategory)
- peakhour-api#116 — code reads platforms[]; CMS routes filter on platforms / subCategory
- **this PR** — CMS UI surfaces both new fields

### Changes

- `types/skills.ts` — `SkillTemplate.platform: string` → `platforms: string[]`; + optional `subCategory`. `BusinessSkillsResponse.skills` exposes `platforms[]` alongside the API's legacy single `platform` (derived from `platforms[0]` by the API for compat).
- `app/cms/skills/page.tsx`:
  - Platform filter now matches `platforms[]`; `'all'` template targets are wildcards.
  - New optional **Sub-category filter** — only renders when at least one template has subCategory set.
  - Search also matches subCategory.
  - Table shows `platforms[]` as stacked Badges and a new Sub-category column.
- `app/cms/skills/[id]/page.tsx` — header shows one Badge per platform + a small subCategory Badge when set.
- `app/cms/skills/business/[businessId]/page.tsx` — per-skill row joins platforms for display.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] `/cms/skills` list — confirm Platforms column renders multi-Badge per row, Sub-category column shows `—` for now (no rows have it set yet)
- [ ] Filter by platform `linkedin` — should show all-platform skills + linkedin-targeted skills
- [ ] Edit a skill, set subCategory='seo', save → reload list, Sub-category filter dropdown appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)