### PR TITLE
feat(cms): Ingest health panel on /cms/ai-health

### DIFF
--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
   Database,
   DollarSign,
+  Inbox,
   XCircle,
 } from "lucide-react";
 import { KpiCard } from "@/components/cms/ai/kpi-card";
@@ -218,6 +219,9 @@ export default function AiHealthPage() {
         </CardContent>
       </Card>
 
+      {/* Ingest health — per-connection ingest pipeline state. */}
+      <IngestHealthPanel />
+
       {/* Crons */}
       <Card>
         <CardHeader>
@@ -251,6 +255,191 @@ export default function AiHealthPage() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+// ── Ingest health panel ──────────────────────────────────────────
+//
+// Reads /v1/cms/ingest-health which aggregates ts_integration_events over
+// the last 24h, joined with int_connections. Surfaces stale ingestions
+// (the failure mode that hid the 2026-03-26 Beehiiv break for 30 days).
+
+interface IngestHealthResponse {
+  summary: {
+    activeConnections: number;
+    totalConnections: number;
+    healthyConnections: number;
+    flaggedConnections: number;
+    eventsLast24h: number;
+    errorsLast24h: number;
+    partialFailuresLast24h: number;
+  };
+  connections: Array<{
+    connectionId: string;
+    provider: string;
+    orgId?: string;
+    businessId?: string;
+    status?: string;
+    lastSyncAt?: string;
+    lastError?: string;
+    lastSuccessAt?: string;
+    lastEventAt?: string;
+    last24h: {
+      success: number;
+      partialFailure: number;
+      error: number;
+      noop: number;
+      skipped: number;
+      total: number;
+    };
+    flags: string[];
+  }>;
+  serverTime: string;
+}
+
+function IngestHealthPanel() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["cms-ingest-health"],
+    queryFn: () => api.get<IngestHealthResponse>(`/v1/cms/ingest-health`),
+    refetchInterval: 30_000,
+  });
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Ingest health</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">
+            Failed to load ingest health: {(error as Error).message}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Ingest health</CardTitle>
+        <CardDescription>
+          Per-connection ingest pipeline state from <code className="font-mono">ts_integration_events</code> (last 24h).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading || !data ? (
+          <Skeleton className="h-24 w-full" />
+        ) : (
+          <>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+              <KpiCard
+                label="Active connections"
+                icon={Inbox}
+                value={`${data.summary.activeConnections} / ${data.summary.totalConnections}`}
+                hint="active / total"
+              />
+              <KpiCard
+                label="Healthy"
+                icon={CheckCircle2}
+                value={data.summary.healthyConnections}
+                hint={`${data.summary.flaggedConnections} flagged`}
+                tone={data.summary.flaggedConnections === 0 ? "success" : "warning"}
+              />
+              <KpiCard
+                label="24h events"
+                icon={Activity}
+                value={data.summary.eventsLast24h.toLocaleString()}
+                hint={`${data.summary.errorsLast24h} errors / ${data.summary.partialFailuresLast24h} partial`}
+                tone={
+                  data.summary.errorsLast24h + data.summary.partialFailuresLast24h > 0
+                    ? "warning"
+                    : "default"
+                }
+              />
+              <KpiCard
+                label="Stale (no events)"
+                icon={AlertTriangle}
+                value={
+                  data.connections.filter((c) => c.flags.includes("NO_EVENTS_24H")).length
+                }
+                hint="active connection, no events 24h"
+                tone={
+                  data.connections.some((c) => c.flags.includes("NO_EVENTS_24H"))
+                    ? "danger"
+                    : "default"
+                }
+              />
+            </div>
+
+            {data.connections.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No connections yet.</p>
+            ) : (
+              <div className="overflow-hidden rounded border">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-xs uppercase tracking-wide">
+                    <tr>
+                      <th className="px-3 py-2 text-left">Provider</th>
+                      <th className="px-3 py-2 text-left">Status</th>
+                      <th className="px-3 py-2 text-left">Last success</th>
+                      <th className="px-3 py-2 text-right">24h ✓ / ~ / ✗</th>
+                      <th className="px-3 py-2 text-left">Flags</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.connections.map((conn) => (
+                      <tr key={conn.connectionId} className="border-t">
+                        <td className="px-3 py-2 font-mono text-xs">{conn.provider}</td>
+                        <td className="px-3 py-2">
+                          <Badge
+                            variant={
+                              conn.status === "active"
+                                ? "secondary"
+                                : conn.status === "error"
+                                ? "destructive"
+                                : "outline"
+                            }
+                          >
+                            {conn.status ?? "—"}
+                          </Badge>
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground tabular-nums">
+                          {conn.lastSuccessAt ? formatDateTime(conn.lastSuccessAt) : "—"}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          <span className="text-emerald-600">{conn.last24h.success}</span>
+                          {" / "}
+                          <span className="text-amber-600">{conn.last24h.partialFailure}</span>
+                          {" / "}
+                          <span className="text-destructive">{conn.last24h.error}</span>
+                        </td>
+                        <td className="px-3 py-2">
+                          {conn.flags.length === 0 ? (
+                            <span className="text-xs text-muted-foreground">—</span>
+                          ) : (
+                            <div className="flex flex-wrap gap-1">
+                              {conn.flags.map((f) => (
+                                <Badge
+                                  key={f}
+                                  variant="outline"
+                                  className="text-[10px]"
+                                >
+                                  {f}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -310,7 +310,7 @@ function IngestHealthPanel() {
   const staleNoEventsCount = useMemo(
     () =>
       data?.connections.filter((c) => c.flags.includes("NO_EVENTS_24H")).length ?? 0,
-    [data],
+    [data?.connections],
   );
 
   if (error) {
@@ -420,16 +420,28 @@ function IngestHealthPanel() {
                           {conn.flags.length === 0 ? (
                             <span className="text-xs text-muted-foreground">—</span>
                           ) : (
-                            <div className="flex flex-wrap gap-1">
-                              {conn.flags.map((f) => (
-                                <Badge
-                                  key={f}
-                                  variant="outline"
-                                  className="text-[10px]"
+                            <div className="flex flex-col gap-1">
+                              <div className="flex flex-wrap gap-1">
+                                {conn.flags.map((f) => (
+                                  <Badge
+                                    key={f}
+                                    variant="outline"
+                                    className="text-[10px]"
+                                  >
+                                    {f}
+                                  </Badge>
+                                ))}
+                              </div>
+                              {conn.lastError && (
+                                <span
+                                  className="text-[10px] text-muted-foreground"
+                                  title={conn.lastError}
                                 >
-                                  {f}
-                                </Badge>
-                              ))}
+                                  {conn.lastError.length > 80
+                                    ? conn.lastError.slice(0, 80) + "…"
+                                    : conn.lastError}
+                                </span>
+                              )}
                             </div>
                           )}
                         </td>

--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -302,7 +303,15 @@ function IngestHealthPanel() {
     queryKey: ["cms-ingest-health"],
     queryFn: () => api.get<IngestHealthResponse>(`/v1/cms/ingest-health`),
     refetchInterval: 30_000,
+    staleTime: 25_000,
+    refetchOnWindowFocus: false,
   });
+
+  const staleNoEventsCount = useMemo(
+    () =>
+      data?.connections.filter((c) => c.flags.includes("NO_EVENTS_24H")).length ?? 0,
+    [data],
+  );
 
   if (error) {
     return (
@@ -360,15 +369,9 @@ function IngestHealthPanel() {
               <KpiCard
                 label="Stale (no events)"
                 icon={AlertTriangle}
-                value={
-                  data.connections.filter((c) => c.flags.includes("NO_EVENTS_24H")).length
-                }
+                value={staleNoEventsCount}
                 hint="active connection, no events 24h"
-                tone={
-                  data.connections.some((c) => c.flags.includes("NO_EVENTS_24H"))
-                    ? "danger"
-                    : "default"
-                }
+                tone={staleNoEventsCount > 0 ? "danger" : "default"}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Adds a per-connection "Ingest health" panel to `/cms/ai-health`. Reads the new `/v1/cms/ingest-health` endpoint (peakhour-api PR), surfaces the silent-feed failure mode that hid the 2026-03-26 Beehiiv break for 30 days.

## Changes

- **`src/app/cms/ai-health/page.tsx`** — new `<IngestHealthPanel>` rendered between the existing Retention and Cron panels:
  - 4 KPI cards: Active connections (active/total), Healthy (count + flagged hint), 24h events (with errors/partial subhint), Stale (no events).
  - Per-connection table: provider, status badge, last success time, 24h breakdown (✓ success / ~ partial / ✗ error), flags as small badges.
- Auto-refresh every 30s with 25s `staleTime` and `refetchOnWindowFocus:false` so an idle tab doesn't hammer the aggregation.

## Test plan

- [ ] Navigate to `/cms/ai-health` — panel renders below Retention.
- [ ] Confirm the dev Beehiiv connection appears with `NO_EVENTS_24H` and `STALE_NO_SUCCESS` flags.
- [ ] Trigger a Beehiiv sync — confirm next refresh shows non-zero success in the row.
- [ ] Tab away for 60s — return — confirm only one new fetch fires (not multiple).
- [ ] `npx tsc --noEmit` clean.

🤖 Generated with Claude Code
