### PR TITLE
feat(content): Sync Beehiiv button on the library page + reusable useSyncProvider hook

### DIFF
--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -294,6 +294,7 @@ export default function ContentPage() {
                 onClick={() => syncBeehiiv()}
                 disabled={syncing}
                 aria-busy={syncing}
+                className="min-w-[140px]"
               >
                 {syncing ? "Syncing Beehiiv…" : "Sync Beehiiv"}
               </Button>

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { api, API_BASE_URL } from "@/lib/api";
+import { useSyncProvider } from "@/hooks/use-sync-provider";
 import { useAuth } from "@/providers/auth-provider";
 import {
   SENTIMENT_CONFIG,
@@ -106,6 +107,16 @@ export default function ContentPage() {
   const [analysing, setAnalysing] = useState(false);
   const [analyseProgress, setAnalyseProgress] = useState<AnalyseProgress | null>(null);
   const [analyseResult, setAnalyseResult] = useState<string | null>(null);
+
+  const { sync: syncBeehiiv, syncing } = useSyncProvider("beehiiv", {
+    onSuccess: () => {
+      // Refresh derived views so freshly-imported drafts surface here
+      // without a manual reload.
+      queryClient.invalidateQueries({ queryKey: ["content-stats"] });
+      queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
+      queryClient.invalidateQueries({ queryKey: ["content-gaps"] });
+    },
+  });
 
   const { data: stats, isLoading: statsLoading } = useQuery({
     queryKey: ["content-stats"],
@@ -274,6 +285,15 @@ export default function ContentPage() {
             </p>
           </div>
           <div className="flex gap-2">
+            {!analysing && (
+              <Button
+                variant="outline"
+                onClick={() => syncBeehiiv()}
+                disabled={syncing}
+              >
+                {syncing ? "Syncing Beehiiv…" : "Sync Beehiiv"}
+              </Button>
+            )}
             {hasUntagged && !analysing && (
               <Button onClick={() => startAnalysis(false)}>
                 Analyse {stats.total - stats.tagged} untagged

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -256,7 +256,10 @@ export default function ContentPage() {
         }
 
         queryClient.invalidateQueries({ queryKey: ["content-stats"] });
-        queryClient.invalidateQueries({ queryKey: ["content-library"] });
+        // The actual library query key is "content-library-all" (line ~141).
+        // Invalidating "content-library" here was a no-op — the table never
+        // refreshed after analysis. Caught while wiring up sync invalidation.
+        queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
         queryClient.invalidateQueries({ queryKey: ["content-gaps"] });
         setAnalysing(false);
       })
@@ -290,6 +293,7 @@ export default function ContentPage() {
                 variant="outline"
                 onClick={() => syncBeehiiv()}
                 disabled={syncing}
+                aria-busy={syncing}
               >
                 {syncing ? "Syncing Beehiiv…" : "Sync Beehiiv"}
               </Button>

--- a/src/hooks/use-sync-provider.ts
+++ b/src/hooks/use-sync-provider.ts
@@ -40,11 +40,19 @@ export interface UseSyncProviderOptions {
 }
 
 interface UseSyncProviderReturn {
-  /** Trigger a manual sync. No-op if already in flight. */
+  /**
+   * Trigger a manual sync. No-op if already in flight (returns null).
+   *
+   * Behavior on failure depends on the `notify` option:
+   * - `notify: true` (default): errors are toasted, promise resolves to null
+   * - `notify: false`: promise REJECTS with the underlying error so the
+   *   caller can render their own UI. Always wrap in try/catch when
+   *   using this option.
+   */
   sync: () => Promise<SyncResult | null>;
   /** True between request start and request settle. */
   syncing: boolean;
-  /** Last completed result (cleared on next sync start). */
+  /** Last successful result. Persists across re-syncs until the next success. */
   lastResult: SyncResult | null;
 }
 
@@ -77,7 +85,9 @@ export function useSyncProvider(
     if (inFlightRef.current) return null;
     inFlightRef.current = true;
     setSyncing(true);
-    setLastResult(null);
+    // Don't clear `lastResult` here — keep the previous successful result
+    // visible to consumers (e.g. an inline banner) while the new sync is
+    // in flight. Overwrite only when we have a fresh successful result.
     let result: SyncResult | null = null;
     try {
       const res = await api.post<SyncResponse>(
@@ -166,6 +176,7 @@ function defaultSuccessMessage(result: SyncResult): {
 
 /** Title-case a provider key for user-facing messages. */
 function humanProvider(provider: string): string {
+  if (!provider) return "Provider";
   return provider
     .split("_")
     .map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1) : ""))

--- a/src/hooks/use-sync-provider.ts
+++ b/src/hooks/use-sync-provider.ts
@@ -1,0 +1,151 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+
+export interface SyncResult {
+  added: number;
+  updated: number;
+  errors: number;
+  postsFetched?: number;
+}
+
+interface SyncResponse {
+  provider: string;
+  sync: SyncResult;
+}
+
+export interface UseSyncProviderOptions {
+  /**
+   * Called after a successful sync. Use it to invalidate or refetch
+   * caller-specific queries (the hook doesn't know what's relevant to
+   * each surface).
+   */
+  onSuccess?: (result: SyncResult) => void;
+  /**
+   * Set to false to suppress toast notifications and let the caller
+   * render results in its own UI (e.g. the integrations page uses an
+   * inline banner instead of a toast).
+   */
+  notify?: boolean;
+  /**
+   * Override the default success message. Receives the sync result.
+   */
+  formatSuccess?: (result: SyncResult) => { title: string; description?: string };
+}
+
+interface UseSyncProviderReturn {
+  /** Trigger a manual sync. No-op if already in flight. */
+  sync: () => Promise<SyncResult | null>;
+  /** True between request start and request settle. */
+  syncing: boolean;
+  /** Last completed result (cleared on next sync start). */
+  lastResult: SyncResult | null;
+}
+
+/**
+ * Wraps `POST /v1/integrations/:provider/sync` with loading state, toast
+ * UX, and error-code handling (ALREADY_RUNNING / NOT_CONNECTED).
+ *
+ * Used anywhere the user can trigger a manual sync — currently the
+ * /dashboard/content/beehiiv library, planned for the channels hub and
+ * strategist surfaces. Callers pass `onSuccess` to refetch their own
+ * queries; the hook doesn't assume what's relevant.
+ */
+export function useSyncProvider(
+  provider: string,
+  options: UseSyncProviderOptions = {},
+): UseSyncProviderReturn {
+  const { onSuccess, notify = true, formatSuccess } = options;
+  const [syncing, setSyncing] = useState(false);
+  const [lastResult, setLastResult] = useState<SyncResult | null>(null);
+
+  const sync = useCallback(async (): Promise<SyncResult | null> => {
+    if (syncing) return null;
+    setSyncing(true);
+    setLastResult(null);
+    try {
+      const res = await api.post<SyncResponse>(
+        `/v1/integrations/${provider}/sync`,
+        {},
+      );
+      const result = res.sync;
+      setLastResult(result);
+
+      if (notify) {
+        const formatted = formatSuccess
+          ? formatSuccess(result)
+          : defaultSuccessMessage(result);
+        if (result.errors > 0) {
+          toast.warning(formatted.title, { description: formatted.description });
+        } else {
+          toast.success(formatted.title, { description: formatted.description });
+        }
+      }
+
+      onSuccess?.(result);
+      return result;
+    } catch (err) {
+      if (notify) {
+        if (err instanceof ApiError && err.code === "ALREADY_RUNNING") {
+          toast.error("A sync is already in progress", {
+            description: "Wait for it to complete before triggering another.",
+          });
+        } else if (err instanceof ApiError && err.code === "NOT_CONNECTED") {
+          toast.error(`${humanProvider(provider)} is not connected`, {
+            description: "Reconnect from the Integrations page.",
+          });
+        } else {
+          const msg = err instanceof Error ? err.message : "Sync failed";
+          toast.error("Sync failed", { description: msg });
+        }
+      } else if (!(err instanceof ApiError)) {
+        // When notifications are suppressed, callers want to handle errors
+        // themselves — but unexpected non-ApiError throws should still
+        // surface so they don't get swallowed silently.
+        throw err;
+      }
+      return null;
+    } finally {
+      setSyncing(false);
+    }
+  }, [provider, syncing, onSuccess, notify, formatSuccess]);
+
+  return { sync, syncing, lastResult };
+}
+
+function defaultSuccessMessage(result: SyncResult): {
+  title: string;
+  description?: string;
+} {
+  const { added, updated, errors, postsFetched } = result;
+  if (errors > 0) {
+    return {
+      title: `Synced with ${errors} error${errors === 1 ? "" : "s"}`,
+      description: `${added} added, ${updated} updated. Check the integration page for details.`,
+    };
+  }
+  if (added === 0 && updated === 0) {
+    return {
+      title: "Already up to date",
+      description:
+        postsFetched && postsFetched > 0
+          ? `Provider returned ${postsFetched} item${postsFetched === 1 ? "" : "s"}, all already imported.`
+          : "No new items since the last sync.",
+    };
+  }
+  const total = added + updated;
+  return {
+    title: `${total} item${total === 1 ? "" : "s"} synced`,
+    description: `${added} new, ${updated} updated.`,
+  };
+}
+
+/** Title-case a provider key for user-facing messages. */
+function humanProvider(provider: string): string {
+  return provider
+    .split("_")
+    .map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1) : ""))
+    .join(" ");
+}

--- a/src/hooks/use-sync-provider.ts
+++ b/src/hooks/use-sync-provider.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 
@@ -30,7 +30,11 @@ export interface UseSyncProviderOptions {
    */
   notify?: boolean;
   /**
-   * Override the default success message. Receives the sync result.
+   * Override the default success message. Receives the sync result —
+   * implementations MUST inspect `result.errors` because the same
+   * formatter renders both success (`errors === 0`) and partial-failure
+   * (`errors > 0`) toasts; a formatter that ignores `errors` will
+   * mislead users on partial failures.
    */
   formatSuccess?: (result: SyncResult) => { title: string; description?: string };
 }
@@ -57,22 +61,33 @@ export function useSyncProvider(
   provider: string,
   options: UseSyncProviderOptions = {},
 ): UseSyncProviderReturn {
-  const { onSuccess, notify = true, formatSuccess } = options;
   const [syncing, setSyncing] = useState(false);
   const [lastResult, setLastResult] = useState<SyncResult | null>(null);
+  // Ref-based in-flight guard: closes a double-tap race that React's
+  // state batching can let through, AND lets us drop `syncing` from the
+  // useCallback deps so the `sync` identity stays stable across the
+  // intermediate state flips.
+  const inFlightRef = useRef(false);
+  // Latest callbacks captured via ref so the hook's `sync` identity
+  // doesn't change every time the caller passes inline closures.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   const sync = useCallback(async (): Promise<SyncResult | null> => {
-    if (syncing) return null;
+    if (inFlightRef.current) return null;
+    inFlightRef.current = true;
     setSyncing(true);
     setLastResult(null);
+    let result: SyncResult | null = null;
     try {
       const res = await api.post<SyncResponse>(
         `/v1/integrations/${provider}/sync`,
         {},
       );
-      const result = res.sync;
+      result = res.sync;
       setLastResult(result);
 
+      const { notify = true, formatSuccess } = optionsRef.current;
       if (notify) {
         const formatted = formatSuccess
           ? formatSuccess(result)
@@ -83,10 +98,8 @@ export function useSyncProvider(
           toast.success(formatted.title, { description: formatted.description });
         }
       }
-
-      onSuccess?.(result);
-      return result;
     } catch (err) {
+      const { notify = true } = optionsRef.current;
       if (notify) {
         if (err instanceof ApiError && err.code === "ALREADY_RUNNING") {
           toast.error("A sync is already in progress", {
@@ -100,17 +113,26 @@ export function useSyncProvider(
           const msg = err instanceof Error ? err.message : "Sync failed";
           toast.error("Sync failed", { description: msg });
         }
-      } else if (!(err instanceof ApiError)) {
-        // When notifications are suppressed, callers want to handle errors
-        // themselves — but unexpected non-ApiError throws should still
-        // surface so they don't get swallowed silently.
+      } else {
+        // notify:false callers want to render their own UI. Re-throw so
+        // the caller's await sees the failure (silently returning null
+        // would be indistinguishable from a successful no-op sync).
         throw err;
       }
-      return null;
     } finally {
+      inFlightRef.current = false;
       setSyncing(false);
     }
-  }, [provider, syncing, onSuccess, notify, formatSuccess]);
+
+    // onSuccess runs OUTSIDE the try so a callback throw doesn't get
+    // caught by the error branch and falsely report failure to the
+    // awaiter. The sync itself succeeded; downstream side-effects
+    // failing is the caller's problem to handle.
+    if (result !== null) {
+      optionsRef.current.onSuccess?.(result);
+    }
+    return result;
+  }, [provider]);
 
   return { sync, syncing, lastResult };
 }


### PR DESCRIPTION
## Summary

Adds a "Sync Beehiiv" button next to "Re-analyse all" on `/dashboard/content/beehiiv` so users don't have to navigate to `/dashboard/integrations` to pull new newsletters while working in the content library.

The sync logic is extracted to a reusable per-provider hook so the channels hub, strategist, and other surfaces can adopt it without re-implementing.

## Changes

**New: `src/hooks/use-sync-provider.ts`**

Per-provider sync hook. Caller passes the provider name, gets back `{ sync, syncing, lastResult }`. Default behavior shows a toast on success / partial failure / 409 ALREADY_RUNNING / 404 NOT_CONNECTED. Caller passes `onSuccess` to invalidate their own queries.

```ts
const { sync: syncBeehiiv, syncing } = useSyncProvider("beehiiv", {
  onSuccess: () => queryClient.invalidateQueries(...),
});
```

Opt-out flag `notify: false` for callers using inline banners (e.g. existing `/dashboard/integrations` page can adopt this in a follow-up).

**Modified: `src/app/dashboard/content/beehiiv/page.tsx`**

- Adds the Sync Beehiiv button to the existing action group (Sync → Analyse → Re-analyse)
- Drops the inline sync handler in favor of the hook
- Fixes a pre-existing query-key typo: `startAnalysis` was invalidating `["content-library"]` but the actual key is `["content-library-all"]` — the table never refreshed after analysis. Caught while wiring up the new sync invalidation which uses the correct key.

## Test plan

- [ ] Click "Sync Beehiiv" — toast shows result based on returned counts (added/updated/errors).
- [ ] Click twice rapidly — second call no-ops (ref-based guard); even if both reach the API, the second returns 409 ALREADY_RUNNING which surfaces as "A sync is already in progress" toast.
- [ ] Disconnect Beehiiv, click Sync — toast: "Beehiiv is not connected" with "Reconnect from the Integrations page".
- [ ] After successful sync, the library table refreshes without manual reload.
- [ ] After analysis, the library table refreshes (pre-existing bug fixed).
- [ ] Screen reader announces loading state via `aria-busy`.

🤖 Generated with Claude Code
