### PR TITLE
feat(security): CASA Tier 2 baseline — security headers, CSP, security.txt

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  poweredByHeader: false,
 };
 
 export default nextConfig;

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@peakhour.ai
+Expires: 2027-04-26T00:00:00Z
+Preferred-Languages: en
+Canonical: https://peakhour.ai/.well-known/security.txt
+Policy: https://peakhour.ai/security

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,5 +1,4 @@
 Contact: mailto:security@peakhour.ai
-Expires: 2027-04-26T00:00:00Z
+Expires: 2027-04-25T23:59:59Z
 Preferred-Languages: en
 Canonical: https://peakhour.ai/.well-known/security.txt
-Policy: https://peakhour.ai/security

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,6 @@
 User-agent: *
 Disallow: /api/
 Disallow: /dashboard/
-Disallow: /admin/
 Disallow: /auth/
 Disallow: /onboarding/
 Sitemap: https://peakhour.ai/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /api/
+Disallow: /dashboard/
+Disallow: /admin/
+Disallow: /auth/
+Disallow: /onboarding/
+Sitemap: https://peakhour.ai/sitemap.xml

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { connection } from "next/server";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { QueryProvider } from "@/providers/query-provider";
 import { AuthProvider } from "@/providers/auth-provider";
@@ -23,11 +24,16 @@ export const metadata: Metadata = {
     "Your AI-powered marketing team. Content intelligence, creative factory, and optimization engine — all in one platform.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Opt every route into dynamic rendering so the CSP middleware can stamp a
+  // per-request nonce onto Next's injected <script> tags. Without this, statically
+  // prerendered pages have no nonce and 'strict-dynamic' blocks all framework chunks.
+  await connection();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,6 +46,9 @@ export function middleware(req: NextRequest) {
 
   const reqHeaders = new Headers(req.headers);
   reqHeaders.set("x-nonce", nonce);
+  // Next.js extracts the nonce from this request header and stamps it onto
+  // framework-injected <script> tags. Required for 'strict-dynamic' to work.
+  reqHeaders.set("content-security-policy", csp);
 
   const res = NextResponse.next({ request: { headers: reqHeaders } });
   res.headers.set("Content-Security-Policy", csp);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,12 +2,33 @@ import { NextResponse, type NextRequest } from "next/server";
 
 const isDev = process.env.NODE_ENV !== "production";
 
+const apiOrigin = (() => {
+  try {
+    return new URL(process.env.NEXT_PUBLIC_API_URL ?? "").origin;
+  } catch {
+    return "";
+  }
+})();
+
 export function middleware(req: NextRequest) {
-  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const nonce = btoa(
+    String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
+  );
 
   const scriptSrc = isDev
     ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
     : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
+
+  const connectSrc = [
+    "connect-src 'self'",
+    apiOrigin,
+    "https://*.vercel-insights.com",
+    "https://vitals.vercel-insights.com",
+    "https://*.vercel-analytics.com",
+    isDev ? "ws: wss: http://localhost:* ws://localhost:*" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   const csp = [
     "default-src 'self'",
@@ -15,7 +36,7 @@ export function middleware(req: NextRequest) {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    `connect-src 'self' https://*.vercel-insights.com${isDev ? " ws: wss:" : ""}`,
+    connectSrc,
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",
@@ -25,7 +46,6 @@ export function middleware(req: NextRequest) {
 
   const reqHeaders = new Headers(req.headers);
   reqHeaders.set("x-nonce", nonce);
-  reqHeaders.set("content-security-policy", csp);
 
   const res = NextResponse.next({ request: { headers: reqHeaders } });
   res.headers.set("Content-Security-Policy", csp);
@@ -34,6 +54,14 @@ export function middleware(req: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
+    {
+      source: "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+        { type: "header", key: "next-action" },
+        { type: "header", key: "rsc" },
+      ],
+    },
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const isDev = process.env.NODE_ENV !== "production";
+
+export function middleware(req: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+
+  const scriptSrc = isDev
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
+
+  const csp = [
+    "default-src 'self'",
+    scriptSrc,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    `connect-src 'self' https://*.vercel-insights.com${isDev ? " ws: wss:" : ""}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+  ].join("; ");
+
+  const reqHeaders = new Headers(req.headers);
+  reqHeaders.set("x-nonce", nonce);
+  reqHeaders.set("content-security-policy", csp);
+
+  const res = NextResponse.next({ request: { headers: reqHeaders } });
+  res.headers.set("Content-Security-Policy", csp);
+  return res;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
+  ],
+};

--- a/vercel.json
+++ b/vercel.json
@@ -7,8 +7,8 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=()" },
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), display-capture=(), picture-in-picture=(), fullscreen=(self), autoplay=(self)" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
         { "key": "Cross-Origin-Resource-Policy", "value": "same-site" },
         { "key": "X-DNS-Prefetch-Control", "value": "off" },
         { "key": "X-XSS-Protection", "value": "0" },
@@ -16,7 +16,7 @@
       ]
     },
     {
-      "source": "/(api|auth|oauth|dashboard)/(.*)",
+      "source": "/(api|auth|oauth)/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "no-store, max-age=0" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=()" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-site" },
+        { "key": "X-DNS-Prefetch-Control", "value": "off" },
+        { "key": "X-XSS-Protection", "value": "0" },
+        { "key": "X-Permitted-Cross-Domain-Policies", "value": "none" }
+      ]
+    },
+    {
+      "source": "/(api|auth|oauth|dashboard)/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, max-age=0" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proactive security hardening so the app passes Mozilla Observatory ≥ A and securityheaders.com ≥ A, in preparation for eventual CASA Tier 2 review when restricted-scope Google OAuth (Gmail/Drive/Calendar) is added. Maps to OWASP ASVS L2 §V14.4.

- **`vercel.json`** — HSTS (2y, preload), X-Content-Type-Options, X-Frame-Options DENY, Referrer-Policy, Permissions-Policy (full set for Observatory bonus), COOP `same-origin-allow-popups`, CORP `same-site`, plus `Cache-Control: no-store` on `/(api|auth|oauth)/*`.
- **`src/middleware.ts`** — per-request nonce-based CSP. Strict (`'strict-dynamic'` + nonce) in prod, permissive in dev so HMR works. Uses Edge-safe `crypto.getRandomValues` + `btoa` (not `Buffer`). Matcher uses `missing` clauses to skip RSC/prefetch/server-action fetches so the nonce only generates per document request. `connect-src` includes `process.env.NEXT_PUBLIC_API_URL` origin so dashboard fetches to `api.peakhour.ai` aren't blocked.
- **`public/.well-known/security.txt`** — RFC 9116 contact, `security@peakhour.ai`, expires 2027-04-25.
- **`public/robots.txt`** — disallow `/api/`, `/dashboard/`, `/auth/`, `/onboarding/`.
- **`next.config.ts`** — `poweredByHeader: false`.

CSP intentionally lives in middleware (not vercel.json) because ASVS L2 forbids `unsafe-inline` and Next.js needs per-request nonces. Vercel.json static CSP would either ship `unsafe-inline` (fails CASA) or block all Next-injected scripts (breaks the app).

Headers automatically apply to every preview branch deploy, not just prod — `vercel.json` has no per-env override syntax. CSP middleware has an `isDev` branch so `next dev` HMR keeps working.

## Test plan

- [ ] Vercel preview deploy succeeds for this PR
- [ ] Open the preview URL, confirm dashboard renders, no CSP errors in the browser console
- [ ] Confirm at least one fetch to `api.peakhour.ai` succeeds from the preview (e.g., load `/dashboard`)
- [ ] `curl -sI <preview-url>/ | grep -iE 'strict-transport|x-frame|x-content-type|referrer|permissions|cross-origin|content-security'` returns all expected headers
- [ ] `curl -s <preview-url>/.well-known/security.txt` and `<preview-url>/robots.txt` reachable
- [ ] Local `npm run dev` — edit a component, confirm HMR still works, no CSP error in console
- [ ] Mozilla Observatory scan of preview URL: target ≥ A
- [ ] securityheaders.com scan of preview URL: target ≥ A

## TODO before CASA submission (out of scope for this PR)

- Create `/security` page and re-add `Policy:` line to security.txt
- Add `Encryption:` field with PGP key
- Wire CSP `report-uri` to a `api.peakhour.ai` endpoint
- Tighten `img-src https:` to explicit cloudfront origin
- Pair with peakhour-api PR adding equivalent headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)