### PR TITLE
feat(x): live X content and X Ads dashboards

### DIFF
--- a/src/app/dashboard/content/channels.config.ts
+++ b/src/app/dashboard/content/channels.config.ts
@@ -113,10 +113,11 @@ export const CHANNELS: readonly ChannelConfig[] = [
   {
     slug: "x",
     name: "X (Twitter)",
-    description: "Schedule threads and posts; track impressions.",
+    description: "Publish tweets, track impressions, manage your mentions inbox.",
     category: "Social",
     providerKey: "x",
-    status: "available",
+    status: "live",
+    dashboardPath: "/dashboard/content/x",
     logoUrl: `${SHADCN_LOGOS}/x-icon.svg`,
     logoInvertOnDark: true,
   },
@@ -205,10 +206,13 @@ export const CHANNELS: readonly ChannelConfig[] = [
   {
     slug: "x-ads",
     name: "X Ads",
-    description: "Promote threads and posts on X.",
+    description: "Launch and manage promoted-tweet campaigns on X.",
     category: "Ads",
     providerKey: "x_ads",
-    status: "coming_soon",
+    status: "live",
+    dashboardPath: "/dashboard/content/x-ads",
+    logoUrl: `${SHADCN_LOGOS}/x-icon.svg`,
+    logoInvertOnDark: true,
   },
 
   // ── Messaging ───────────────────────────────────────────────

--- a/src/app/dashboard/content/x-ads/page.tsx
+++ b/src/app/dashboard/content/x-ads/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -154,11 +155,27 @@ function ConnectedView() {
     enabled: !!accountId && (campaigns.data?.length ?? 0) > 0,
   });
 
+  // Capture accountId in mutation variables (not the outer closure) so a
+  // mid-flight account switch can't redirect onSuccess invalidation to the
+  // newly-selected account's cache while the response was for the previous one.
   const setStatus = useMutation({
-    mutationFn: ({ campaignId, status }: { campaignId: string; status: "ACTIVE" | "PAUSED" }) =>
-      xAdsApi.setCampaignStatus(accountId!, campaignId, status),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["x-ads-campaigns", accountId] });
+    mutationFn: ({
+      accountId: forAccount,
+      campaignId,
+      status,
+    }: {
+      accountId: string;
+      campaignId: string;
+      status: "ACTIVE" | "PAUSED";
+    }) => xAdsApi.setCampaignStatus(forAccount, campaignId, status),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["x-ads-campaigns", variables.accountId],
+      });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof ApiError ? err.message : "Couldn't update campaign status.";
+      toast.error(message);
     },
   });
 
@@ -282,7 +299,7 @@ function ConnectedView() {
                     spend={analytics.data?.find((a) => a.id === c.id)?.spend}
                     currency={account?.currency}
                     onToggle={(next) =>
-                      setStatus.mutate({ campaignId: c.id, status: next })
+                      setStatus.mutate({ accountId: accountId!, campaignId: c.id, status: next })
                     }
                     pending={
                       setStatus.isPending && setStatus.variables?.campaignId === c.id

--- a/src/app/dashboard/content/x-ads/page.tsx
+++ b/src/app/dashboard/content/x-ads/page.tsx
@@ -104,15 +104,18 @@ function ConnectedView() {
   });
 
   // Auto-select first account if none chosen and there's at least one.
+  // Depend on the id (a primitive) rather than accounts.data (a fresh array
+  // reference on every refetch) so the effect doesn't refire on every refetch.
+  const firstAccountId = accounts.data?.[0]?.id;
   useEffect(() => {
-    if (!queryAccountId && (accounts.data?.length ?? 0) > 0) {
+    if (!queryAccountId && firstAccountId) {
       const url = new URL(window.location.href);
-      url.searchParams.set(ACCOUNT_PARAM, accounts.data![0].id);
+      url.searchParams.set(ACCOUNT_PARAM, firstAccountId);
       router.replace(url.pathname + url.search);
     }
-  }, [queryAccountId, accounts.data, router]);
+  }, [queryAccountId, firstAccountId, router]);
 
-  const accountId = queryAccountId ?? accounts.data?.[0]?.id ?? null;
+  const accountId = queryAccountId ?? firstAccountId ?? null;
 
   function changeAccount(next: string) {
     const url = new URL(window.location.href);

--- a/src/app/dashboard/content/x-ads/page.tsx
+++ b/src/app/dashboard/content/x-ads/page.tsx
@@ -1,0 +1,551 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter, useSearchParams } from "next/navigation";
+import { api } from "@/lib/api";
+import { ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { Megaphone, Plus } from "lucide-react";
+import {
+  xAdsApi,
+  dollarsToMicros,
+  microsToDollars,
+  type XCampaign,
+} from "@/lib/api/x-ads";
+
+interface ApiIntegration {
+  provider: string;
+  connected?: boolean;
+  status?: string;
+}
+
+const ACCOUNT_PARAM = "account";
+const ANALYTICS_RANGE_DAYS = 30;
+
+export default function XAdsDashboardPage() {
+  const integrations = useQuery({
+    queryKey: ["content-hub-integrations"],
+    queryFn: () =>
+      api.get<{ integrations: ApiIntegration[] }>("/v1/integrations"),
+    staleTime: 30_000,
+  });
+
+  const xAdsConnection = useMemo(
+    () => integrations.data?.integrations.find((i) => i.provider === "x_ads"),
+    [integrations.data]
+  );
+  const isConnected = xAdsConnection?.connected === true;
+
+  if (integrations.isLoading) {
+    return <PageShell loading />;
+  }
+
+  if (!isConnected) {
+    return (
+      <PageShell>
+        <EmptyState
+          icon={Megaphone}
+          title="Connect X Ads to launch campaigns"
+          description="Once connected, you can create and manage promoted-tweet campaigns from here."
+          action={{ label: "Connect X Ads", href: "/dashboard/integrations" }}
+        />
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <ConnectedView />
+    </PageShell>
+  );
+}
+
+function ConnectedView() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const queryClient = useQueryClient();
+  const queryAccountId = params.get(ACCOUNT_PARAM) ?? null;
+
+  const accounts = useQuery({
+    queryKey: ["x-ads-accounts"],
+    queryFn: () => xAdsApi.listAccounts(),
+  });
+
+  // Auto-select first account if none chosen and there's at least one.
+  useEffect(() => {
+    if (!queryAccountId && (accounts.data?.length ?? 0) > 0) {
+      const url = new URL(window.location.href);
+      url.searchParams.set(ACCOUNT_PARAM, accounts.data![0].id);
+      router.replace(url.pathname + url.search);
+    }
+  }, [queryAccountId, accounts.data, router]);
+
+  const accountId = queryAccountId ?? accounts.data?.[0]?.id ?? null;
+
+  function changeAccount(next: string) {
+    const url = new URL(window.location.href);
+    url.searchParams.set(ACCOUNT_PARAM, next);
+    router.replace(url.pathname + url.search);
+  }
+
+  const campaigns = useQuery({
+    queryKey: ["x-ads-campaigns", accountId],
+    queryFn: () => xAdsApi.listCampaigns(accountId!),
+    enabled: !!accountId,
+  });
+
+  const analytics = useQuery({
+    queryKey: [
+      "x-ads-analytics",
+      accountId,
+      campaigns.data?.map((c) => c.id).join(","),
+    ],
+    queryFn: () => {
+      const ids = (campaigns.data ?? []).map((c) => c.id);
+      if (ids.length === 0) {
+        return Promise.resolve([]);
+      }
+      const end = new Date();
+      const start = new Date(
+        end.getTime() - ANALYTICS_RANGE_DAYS * 24 * 60 * 60 * 1000
+      );
+      return xAdsApi.analytics({
+        accountId: accountId!,
+        campaignIds: ids,
+        startDate: start.toISOString(),
+        endDate: end.toISOString(),
+      });
+    },
+    enabled: !!accountId && (campaigns.data?.length ?? 0) > 0,
+  });
+
+  const setStatus = useMutation({
+    mutationFn: ({ campaignId, status }: { campaignId: string; status: "ACTIVE" | "PAUSED" }) =>
+      xAdsApi.setCampaignStatus(accountId!, campaignId, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["x-ads-campaigns", accountId] });
+    },
+  });
+
+  const totals = useMemo(() => {
+    const list = analytics.data ?? [];
+    if (list.length === 0) return null;
+    return list.reduce(
+      (acc, a) => {
+        acc.spend += a.spend;
+        acc.impressions += a.impressions;
+        acc.engagements += a.engagements;
+        return acc;
+      },
+      { spend: 0, impressions: 0, engagements: 0 }
+    );
+  }, [analytics.data]);
+
+  const cpe = totals && totals.engagements > 0 ? totals.spend / totals.engagements : null;
+  const account = accounts.data?.find((a) => a.id === accountId);
+
+  if (accounts.isLoading) {
+    return <SkeletonStack />;
+  }
+
+  if ((accounts.data ?? []).length === 0) {
+    return (
+      <EmptyState
+        icon={Megaphone}
+        title="No ad accounts found"
+        description="Your X account doesn't have any ad accounts associated. Set one up at ads.x.com first."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Account selector + KPIs */}
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-1.5">
+          <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+            Ad account
+          </Label>
+          <Select value={accountId ?? undefined} onValueChange={changeAccount}>
+            <SelectTrigger className="w-72">
+              <SelectValue placeholder="Choose an ad account" />
+            </SelectTrigger>
+            <SelectContent>
+              {(accounts.data ?? []).map((a) => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.name} ({a.currency})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {accountId && (
+          <CreateCampaignDialog
+            accountId={accountId}
+            onCreated={() =>
+              queryClient.invalidateQueries({ queryKey: ["x-ads-campaigns", accountId] })
+            }
+          />
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard
+          title={`Spend (${ANALYTICS_RANGE_DAYS}d)`}
+          value={totals ? formatCurrency(totals.spend, account?.currency) : undefined}
+          loading={analytics.isLoading}
+        />
+        <KpiCard
+          title="Impressions"
+          value={totals ? compact(totals.impressions) : undefined}
+          loading={analytics.isLoading}
+        />
+        <KpiCard
+          title="Engagements"
+          value={totals ? compact(totals.engagements) : undefined}
+          loading={analytics.isLoading}
+        />
+        <KpiCard
+          title="CPE"
+          value={cpe != null ? formatCurrency(cpe, account?.currency) : "—"}
+          subtitle="Cost per engagement"
+          loading={analytics.isLoading}
+        />
+      </div>
+
+      {/* Campaigns table */}
+      <Card>
+        <CardContent className="p-0">
+          {campaigns.isLoading ? (
+            <div className="p-5">
+              <Skeleton className="h-48 w-full" />
+            </div>
+          ) : (campaigns.data ?? []).length === 0 ? (
+            <div className="p-8">
+              <EmptyState
+                icon={Megaphone}
+                title="No campaigns yet"
+                description="Create your first campaign to start promoting tweets."
+              />
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Daily budget</TableHead>
+                  <TableHead className="text-right">Spend (30d)</TableHead>
+                  <TableHead className="w-24 text-right">Active</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(campaigns.data ?? []).map((c) => (
+                  <CampaignRow
+                    key={c.id}
+                    campaign={c}
+                    spend={analytics.data?.find((a) => a.id === c.id)?.spend}
+                    currency={account?.currency}
+                    onToggle={(next) =>
+                      setStatus.mutate({ campaignId: c.id, status: next })
+                    }
+                    pending={
+                      setStatus.isPending && setStatus.variables?.campaignId === c.id
+                    }
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-muted-foreground">
+        Drilldowns into line items, promoted tweets, and per-campaign analytics
+        are coming. Pause/resume and campaign creation are live.
+      </p>
+    </div>
+  );
+}
+
+function CampaignRow({
+  campaign,
+  spend,
+  currency,
+  onToggle,
+  pending,
+}: {
+  campaign: XCampaign;
+  spend: number | undefined;
+  currency: string | undefined;
+  onToggle: (next: "ACTIVE" | "PAUSED") => void;
+  pending: boolean;
+}) {
+  const isActive = campaign.status === "ACTIVE";
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{campaign.name}</TableCell>
+      <TableCell>
+        <Badge variant={isActive ? "default" : "secondary"}>
+          {campaign.status}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatCurrency(microsToDollars(campaign.dailyBudgetAmountLocalMicro), currency)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {spend != null ? formatCurrency(spend, currency) : "—"}
+      </TableCell>
+      <TableCell className="text-right">
+        <Switch
+          checked={isActive}
+          onCheckedChange={(next) => onToggle(next ? "ACTIVE" : "PAUSED")}
+          disabled={pending}
+          aria-label={`${isActive ? "Pause" : "Activate"} campaign ${campaign.name}`}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function CreateCampaignDialog({
+  accountId,
+  onCreated,
+}: {
+  accountId: string;
+  onCreated: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [fundingId, setFundingId] = useState<string>("");
+  const [dailyBudget, setDailyBudget] = useState("10");
+  const [error, setError] = useState<string | null>(null);
+
+  const fundingInstruments = useQuery({
+    queryKey: ["x-ads-funding", accountId],
+    queryFn: () => xAdsApi.listFundingInstruments(accountId),
+    enabled: open,
+  });
+
+  const create = useMutation({
+    mutationFn: () =>
+      xAdsApi.createCampaign({
+        accountId,
+        name: name.trim(),
+        fundingInstrumentId: fundingId,
+        dailyBudgetAmountLocalMicro: dollarsToMicros(parseFloat(dailyBudget)),
+        status: "PAUSED",
+        startTime: new Date().toISOString(),
+      }),
+    onSuccess: () => {
+      setOpen(false);
+      setName("");
+      setFundingId("");
+      setDailyBudget("10");
+      setError(null);
+      onCreated();
+    },
+    onError: (err: unknown) => {
+      setError(err instanceof ApiError ? err.message : "Failed to create campaign.");
+    },
+  });
+
+  const dailyDollars = parseFloat(dailyBudget);
+  const valid =
+    name.trim().length > 0 &&
+    fundingId.length > 0 &&
+    Number.isFinite(dailyDollars) &&
+    dailyDollars > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="size-4 mr-1.5" />
+          Create campaign
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create campaign</DialogTitle>
+          <DialogDescription>
+            Starts paused so you can attach line items and promoted tweets before going live.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="x-camp-name">Name</Label>
+            <Input
+              id="x-camp-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. April brand awareness"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="x-camp-funding">Funding instrument</Label>
+            <Select value={fundingId} onValueChange={setFundingId}>
+              <SelectTrigger id="x-camp-funding">
+                <SelectValue placeholder={
+                  fundingInstruments.isLoading ? "Loading…" : "Choose a funding source"
+                } />
+              </SelectTrigger>
+              <SelectContent>
+                {(fundingInstruments.data ?? []).map((f) => (
+                  <SelectItem key={f.id} value={f.id}>
+                    {f.description} ({f.currency})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="x-camp-budget">Daily budget</Label>
+            <Input
+              id="x-camp-budget"
+              type="number"
+              min="1"
+              step="1"
+              value={dailyBudget}
+              onChange={(e) => setDailyBudget(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              In the funding instrument&apos;s currency. Stored as micros server-side.
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive" role="status">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => create.mutate()}
+            disabled={!valid || create.isPending}
+            aria-busy={create.isPending}
+          >
+            {create.isPending ? "Creating…" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">X Ads</h2>
+        <p className="text-muted-foreground">
+          Launch and manage promoted-tweet campaigns on X.
+        </p>
+      </div>
+      {loading ? <SkeletonStack /> : children}
+    </div>
+  );
+}
+
+function SkeletonStack() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-10 w-72" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24" />
+        ))}
+      </div>
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}
+
+function KpiCard({
+  title,
+  value,
+  subtitle,
+  loading,
+}: {
+  title: string;
+  value?: string | number;
+  subtitle?: string;
+  loading?: boolean;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-8 w-16" />
+          </div>
+        ) : (
+          <>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              {title}
+            </p>
+            <p className="text-2xl font-bold mt-1 tabular-nums">{value ?? "—"}</p>
+            {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function compact(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function formatCurrency(amount: number, currency: string | undefined): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency || "USD",
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${currency ?? "$"} ${amount.toFixed(2)}`;
+  }
+}

--- a/src/app/dashboard/content/x/_components/tweet-card.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-card.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
+import {
+  Heart,
+  MessageCircle,
+  Repeat2,
+  Quote,
+  BarChart3,
+  MoreHorizontal,
+} from "lucide-react";
+import { formatDate } from "@/lib/locale";
+import { xApi, type XTweet } from "@/lib/api/x";
+
+export function TweetCard({ tweet }: { tweet: XTweet }) {
+  const queryClient = useQueryClient();
+  const del = useMutation({
+    mutationFn: () => xApi.deleteTweet(tweet.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
+    },
+  });
+
+  const m = tweet.publicMetrics;
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed flex-1">{tweet.text}</p>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0" aria-label="Tweet actions">
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <ConfirmDialog
+                trigger={
+                  <DropdownMenuItem
+                    onSelect={(e) => e.preventDefault()}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    Delete tweet
+                  </DropdownMenuItem>
+                }
+                title="Delete this tweet?"
+                description="This permanently removes the tweet from x.com. This action cannot be undone."
+                confirmLabel="Delete"
+                variant="destructive"
+                onConfirm={() => del.mutate()}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>{formatDate(tweet.createdAt, null)}</span>
+          {m && (
+            <div className="flex items-center gap-3">
+              <Metric icon={Heart} label="Likes" value={m.likeCount} />
+              <Metric icon={MessageCircle} label="Replies" value={m.replyCount} />
+              <Metric icon={Repeat2} label="Retweets" value={m.retweetCount} />
+              <Metric icon={Quote} label="Quotes" value={m.quoteCount} />
+              <Metric icon={BarChart3} label="Impressions" value={m.impressionCount} />
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: number;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1" title={`${label}: ${value}`}>
+      <Icon className="size-3.5" />
+      <span className="tabular-nums">{compact(value)}</span>
+    </span>
+  );
+}
+
+function compact(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/src/app/dashboard/content/x/_components/tweet-card.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,13 +21,19 @@ import {
 } from "lucide-react";
 import { formatDate } from "@/lib/locale";
 import { xApi, type XTweet } from "@/lib/api/x";
+import { ApiError } from "@/lib/api";
 
 export function TweetCard({ tweet }: { tweet: XTweet }) {
   const queryClient = useQueryClient();
   const del = useMutation({
     mutationFn: () => xApi.deleteTweet(tweet.id),
     onSuccess: () => {
+      toast.success("Tweet deleted.");
       queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof ApiError ? err.message : "Couldn't delete tweet.";
+      toast.error(message);
     },
   });
 

--- a/src/app/dashboard/content/x/_components/tweet-composer.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-composer.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Reply, Quote, X, Send } from "lucide-react";
+import { xApi, extractTweetId, type PublishTweetInput } from "@/lib/api/x";
+import { ApiError } from "@/lib/api";
+
+const MAX_LEN = 280;
+
+type ReplyMode = { kind: "none" } | { kind: "reply"; id: string; raw: string } | { kind: "quote"; id: string; raw: string };
+
+export function TweetComposer() {
+  const queryClient = useQueryClient();
+  const [text, setText] = useState("");
+  const [showRefs, setShowRefs] = useState(false);
+  const [refMode, setRefMode] = useState<ReplyMode>({ kind: "none" });
+  const [refInput, setRefInput] = useState("");
+  const [refError, setRefError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
+
+  const publish = useMutation({
+    mutationFn: (input: PublishTweetInput) => xApi.publish(input),
+    onSuccess: () => {
+      setText("");
+      setRefMode({ kind: "none" });
+      setRefInput("");
+      setShowRefs(false);
+      setFeedback({ kind: "success", message: "Tweet published." });
+      queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof ApiError ? err.message : "Failed to publish tweet.";
+      setFeedback({ kind: "error", message });
+    },
+  });
+
+  const remaining = MAX_LEN - text.length;
+  const tooLong = remaining < 0;
+  const empty = text.trim().length === 0;
+  const disabled = empty || tooLong || publish.isPending;
+
+  function attachReference(kind: "reply" | "quote") {
+    const id = extractTweetId(refInput);
+    if (!id) {
+      setRefError("Couldn't read a tweet id from that input. Paste a status URL or numeric id.");
+      return;
+    }
+    setRefError(null);
+    setRefMode({ kind, id, raw: refInput.trim() });
+  }
+
+  function clearReference() {
+    setRefMode({ kind: "none" });
+    setRefInput("");
+    setRefError(null);
+  }
+
+  function onSubmit() {
+    if (disabled) return;
+    setFeedback(null);
+    const body: PublishTweetInput = { text: text.trim() };
+    if (refMode.kind === "reply") body.replyToTweetId = refMode.id;
+    if (refMode.kind === "quote") body.quoteTweetId = refMode.id;
+    publish.mutate(body);
+  }
+
+  return (
+    <div className="space-y-3">
+      {refMode.kind !== "none" && (
+        <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+          {refMode.kind === "reply" ? <Reply className="size-4" /> : <Quote className="size-4" />}
+          <span className="text-muted-foreground">
+            {refMode.kind === "reply" ? "Replying to" : "Quoting"}
+          </span>
+          <span className="font-mono text-xs truncate">{refMode.raw}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="ml-auto h-6 px-2"
+            onClick={clearReference}
+            aria-label="Remove reference"
+          >
+            <X className="size-3" />
+          </Button>
+        </div>
+      )}
+
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="What's happening?"
+        rows={4}
+        className="resize-none"
+        aria-label="Tweet text"
+      />
+
+      {showRefs && refMode.kind === "none" && (
+        <div className="space-y-2 rounded-md border p-3">
+          <Label htmlFor="x-ref-input" className="text-xs uppercase tracking-wide text-muted-foreground">
+            Reply to / quote a tweet
+          </Label>
+          <Input
+            id="x-ref-input"
+            value={refInput}
+            onChange={(e) => setRefInput(e.target.value)}
+            placeholder="https://x.com/user/status/123..."
+          />
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={() => attachReference("reply")} disabled={!refInput}>
+              <Reply className="size-3.5 mr-1" /> Reply
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => attachReference("quote")} disabled={!refInput}>
+              <Quote className="size-3.5 mr-1" /> Quote
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => { setShowRefs(false); setRefInput(""); setRefError(null); }}>
+              Cancel
+            </Button>
+          </div>
+          {refError && <p className="text-xs text-destructive">{refError}</p>}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <div className="flex gap-2">
+          {refMode.kind === "none" && !showRefs && (
+            <Button type="button" variant="ghost" size="sm" onClick={() => setShowRefs(true)}>
+              <Reply className="size-3.5 mr-1" /> Reply / quote
+            </Button>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className={
+              tooLong
+                ? "text-sm font-medium text-destructive"
+                : remaining <= 20
+                  ? "text-sm font-medium text-amber-600"
+                  : "text-sm text-muted-foreground"
+            }
+            aria-live="polite"
+          >
+            {remaining}
+          </span>
+          <Button onClick={onSubmit} disabled={disabled} aria-busy={publish.isPending}>
+            <Send className="size-4 mr-1.5" />
+            {publish.isPending ? "Publishing…" : "Publish"}
+          </Button>
+        </div>
+      </div>
+
+      {feedback && (
+        <p
+          role="status"
+          className={
+            feedback.kind === "error"
+              ? "rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+              : "rounded-md border border-green-200 bg-green-50/60 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
+          }
+        >
+          {feedback.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/content/x/page.tsx
+++ b/src/app/dashboard/content/x/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { MessageCircle, Send, Inbox, MessageSquare, RefreshCw } from "lucide-react";
+import { xApi, type XTweet } from "@/lib/api/x";
+import { TweetComposer } from "./_components/tweet-composer";
+import { TweetCard } from "./_components/tweet-card";
+
+interface ApiIntegration {
+  provider: string;
+  connected?: boolean;
+  status?: string;
+}
+
+const RECENT_TWEET_COUNT = 20;
+
+export default function XContentDashboardPage() {
+  const queryClient = useQueryClient();
+
+  const integrations = useQuery({
+    queryKey: ["content-hub-integrations"],
+    queryFn: () =>
+      api.get<{ integrations: ApiIntegration[] }>("/v1/integrations"),
+    staleTime: 30_000,
+  });
+
+  const xConnection = useMemo(
+    () => integrations.data?.integrations.find((i) => i.provider === "x"),
+    [integrations.data]
+  );
+  const isConnected = xConnection?.connected === true;
+
+  const tweets = useQuery({
+    queryKey: ["x-tweets", RECENT_TWEET_COUNT],
+    queryFn: () => xApi.listTweets(RECENT_TWEET_COUNT),
+    enabled: isConnected,
+  });
+
+  const stats = useMemo(() => {
+    const list = tweets.data ?? [];
+    if (list.length === 0) return null;
+    const totals = list.reduce(
+      (acc, t) => {
+        const m = t.publicMetrics;
+        if (!m) return acc;
+        acc.impressions += m.impressionCount;
+        acc.engagements +=
+          m.likeCount + m.replyCount + m.retweetCount + m.quoteCount;
+        acc.measured++;
+        return acc;
+      },
+      { impressions: 0, engagements: 0, measured: 0 }
+    );
+    return {
+      total: list.length,
+      avgImpressions: totals.measured ? Math.round(totals.impressions / totals.measured) : 0,
+      avgEngagements: totals.measured ? Math.round(totals.engagements / totals.measured) : 0,
+    };
+  }, [tweets.data]);
+
+  async function refreshMetrics() {
+    const ids = (tweets.data ?? []).map((t) => t.id);
+    if (ids.length === 0) return;
+    await xApi.refreshMetrics(ids);
+    queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
+  }
+
+  if (integrations.isLoading) {
+    return <PageShell loading />;
+  }
+
+  if (!isConnected) {
+    return (
+      <PageShell>
+        <EmptyState
+          icon={MessageCircle}
+          title="Connect X (MessageCircle) to get started"
+          description="Once connected, you can publish tweets, track engagement, and manage your mentions inbox from here."
+          action={{ label: "Connect X", href: "/dashboard/integrations" }}
+        />
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      {/* KPI strip */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <KpiCard title="Tweets shown" value={stats?.total} loading={tweets.isLoading} />
+        <KpiCard
+          title="Avg impressions"
+          value={stats ? compact(stats.avgImpressions) : undefined}
+          loading={tweets.isLoading}
+        />
+        <KpiCard
+          title="Avg engagements"
+          value={stats ? compact(stats.avgEngagements) : undefined}
+          subtitle="likes + replies + retweets + quotes"
+          loading={tweets.isLoading}
+        />
+      </div>
+
+      <Tabs defaultValue="compose">
+        <TabsList>
+          <TabsTrigger value="compose" className="gap-1.5">
+            <Send className="size-4" /> Compose
+          </TabsTrigger>
+          <TabsTrigger value="recent" className="gap-1.5">
+            <MessageSquare className="size-4" /> Recent
+          </TabsTrigger>
+          <TabsTrigger value="mentions" className="gap-1.5">
+            <Inbox className="size-4" /> Mentions
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="compose" className="mt-4">
+          <Card>
+            <CardContent className="p-5">
+              <TweetComposer />
+            </CardContent>
+          </Card>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Text-only for now — media upload, threads, and scheduling are coming.
+          </p>
+        </TabsContent>
+
+        <TabsContent value="recent" className="mt-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              Last {RECENT_TWEET_COUNT} tweets from your account.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={refreshMetrics}
+              disabled={tweets.isLoading || (tweets.data ?? []).length === 0}
+            >
+              <RefreshCw className="size-3.5 mr-1.5" />
+              Refresh metrics
+            </Button>
+          </div>
+
+          {tweets.isLoading ? (
+            <RecentSkeleton />
+          ) : tweets.isError ? (
+            <p className="text-sm text-destructive">
+              Couldn&apos;t load tweets. Try refreshing.
+            </p>
+          ) : (tweets.data ?? []).length === 0 ? (
+            <EmptyState
+              icon={MessageSquare}
+              title="No tweets yet"
+              description="Publish your first tweet from the Compose tab and it'll appear here."
+            />
+          ) : (
+            <div className="space-y-3">
+              {(tweets.data ?? []).map((t: XTweet) => (
+                <TweetCard key={t.id} tweet={t} />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="mentions" className="mt-4">
+          <Card>
+            <CardContent className="p-8 text-center space-y-2">
+              <Inbox className="size-8 text-muted-foreground mx-auto" />
+              <h3 className="font-semibold">Mentions inbox is warming up</h3>
+              <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                The mentions sync runs every 10 minutes. Replies, quotes and
+                @-mentions will appear here once they&apos;re ingested.
+              </p>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </PageShell>
+  );
+}
+
+function PageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">X (MessageCircle)</h2>
+        <p className="text-muted-foreground">
+          Publish tweets, track engagement, and manage your mentions inbox.
+        </p>
+      </div>
+      {loading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+function KpiCard({
+  title,
+  value,
+  subtitle,
+  loading,
+}: {
+  title: string;
+  value?: string | number;
+  subtitle?: string;
+  loading?: boolean;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-8 w-16" />
+          </div>
+        ) : (
+          <>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              {title}
+            </p>
+            <p className="text-2xl font-bold mt-1 tabular-nums">{value ?? "—"}</p>
+            {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Card key={i}>
+          <CardContent className="p-4 space-y-3">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-3 w-1/3" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function compact(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/src/app/dashboard/content/x/page.tsx
+++ b/src/app/dashboard/content/x/page.tsx
@@ -81,7 +81,7 @@ export default function XContentDashboardPage() {
       <PageShell>
         <EmptyState
           icon={MessageCircle}
-          title="Connect X (MessageCircle) to get started"
+          title="Connect X (Twitter) to get started"
           description="Once connected, you can publish tweets, track engagement, and manage your mentions inbox from here."
           action={{ label: "Connect X", href: "/dashboard/integrations" }}
         />
@@ -189,7 +189,7 @@ function PageShell({ children, loading }: { children?: React.ReactNode; loading?
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">X (MessageCircle)</h2>
+        <h2 className="text-2xl font-bold tracking-tight">X (Twitter)</h2>
         <p className="text-muted-foreground">
           Publish tweets, track engagement, and manage your mentions inbox.
         </p>

--- a/src/lib/api/x-ads.ts
+++ b/src/lib/api/x-ads.ts
@@ -1,0 +1,96 @@
+import { api } from "@/lib/api";
+
+export interface XAdAccount {
+  id: string;
+  name: string;
+  currency: string;
+  timezone: string;
+  approvalStatus: string;
+}
+
+export interface XFundingInstrument {
+  id: string;
+  type: string;
+  currency: string;
+  description: string;
+  status: string;
+}
+
+export interface XCampaign {
+  id: string;
+  name: string;
+  status: string;
+  dailyBudgetAmountLocalMicro: number;
+  totalBudgetAmountLocalMicro?: number;
+  startTime?: string;
+  endTime?: string;
+  fundingInstrumentId: string;
+}
+
+export interface XCampaignAnalytics {
+  id: string;
+  impressions: number;
+  engagements: number;
+  clicks: number;
+  spend: number;
+  retweets: number;
+  likes: number;
+  replies: number;
+}
+
+export interface CreateCampaignInput {
+  accountId: string;
+  name: string;
+  fundingInstrumentId: string;
+  dailyBudgetAmountLocalMicro: number;
+  totalBudgetAmountLocalMicro?: number;
+  status?: "ACTIVE" | "PAUSED";
+  startTime?: string;
+  endTime?: string;
+}
+
+export const xAdsApi = {
+  listAccounts: () => api.get<XAdAccount[]>("/v1/x/ads/ad-accounts"),
+
+  listFundingInstruments: (accountId: string) =>
+    api.get<XFundingInstrument[]>("/v1/x/ads/funding-instruments", { accountId }),
+
+  listCampaigns: (accountId: string) =>
+    api.get<XCampaign[]>("/v1/x/ads/campaigns", { accountId }),
+
+  createCampaign: (input: CreateCampaignInput) =>
+    api.post<XCampaign>("/v1/x/ads/campaigns", input),
+
+  setCampaignStatus: (
+    accountId: string,
+    campaignId: string,
+    status: "ACTIVE" | "PAUSED"
+  ) =>
+    api.patch<unknown>(`/v1/x/ads/campaigns/${campaignId}/status`, {
+      accountId,
+      status,
+    }),
+
+  analytics: (params: {
+    accountId: string;
+    campaignIds: string[];
+    startDate: string;
+    endDate: string;
+  }) =>
+    api.get<XCampaignAnalytics[]>("/v1/x/ads/analytics", {
+      accountId: params.accountId,
+      campaignIds: params.campaignIds.join(","),
+      startDate: params.startDate,
+      endDate: params.endDate,
+    }),
+};
+
+const MICROS = 1_000_000;
+
+export function dollarsToMicros(dollars: number): number {
+  return Math.round(dollars * MICROS);
+}
+
+export function microsToDollars(micros: number): number {
+  return micros / MICROS;
+}

--- a/src/lib/api/x-ads.ts
+++ b/src/lib/api/x-ads.ts
@@ -61,15 +61,16 @@ export const xAdsApi = {
   createCampaign: (input: CreateCampaignInput) =>
     api.post<XCampaign>("/v1/x/ads/campaigns", input),
 
+  // Note: the backend resolves the ad account from the stored connection
+  // (single ad account per int_connection), so accountId isn't part of the
+  // request body. We still take it as a parameter so callers stay symmetric
+  // with the rest of this surface.
   setCampaignStatus: (
-    accountId: string,
+    _accountId: string,
     campaignId: string,
     status: "ACTIVE" | "PAUSED"
   ) =>
-    api.patch<unknown>(`/v1/x/ads/campaigns/${campaignId}/status`, {
-      accountId,
-      status,
-    }),
+    api.patch<unknown>(`/v1/x/ads/campaigns/${campaignId}/status`, { status }),
 
   analytics: (params: {
     accountId: string;

--- a/src/lib/api/x.ts
+++ b/src/lib/api/x.ts
@@ -1,0 +1,47 @@
+import { api } from "@/lib/api";
+
+export interface XTweet {
+  id: string;
+  text: string;
+  createdAt?: string;
+  publicMetrics?: {
+    retweetCount: number;
+    replyCount: number;
+    likeCount: number;
+    quoteCount: number;
+    impressionCount: number;
+  };
+}
+
+export interface PublishTweetInput {
+  text: string;
+  replyToTweetId?: string;
+  quoteTweetId?: string;
+  mediaIds?: string[];
+}
+
+export const xApi = {
+  publish: (body: PublishTweetInput) =>
+    api.post<{ id: string; text: string }>("/v1/x/content/publish", body),
+
+  listTweets: (count = 20) =>
+    api.get<XTweet[]>("/v1/x/content/tweets", { count: String(count) }),
+
+  refreshMetrics: (ids: string[]) =>
+    api.get<XTweet[]>("/v1/x/content/tweets/metrics", { ids: ids.join(",") }),
+
+  deleteTweet: (id: string) =>
+    api.delete<unknown>(`/v1/x/content/tweets/${id}`),
+};
+
+/**
+ * Extract the tweet id from a status URL. Used by the composer's reply-to /
+ * quote-tweet input — accepting a URL is friendlier than asking for the raw id.
+ * Returns undefined if the input doesn't look like a tweet URL.
+ */
+export function extractTweetId(input: string): string | undefined {
+  const trimmed = input.trim();
+  if (/^\d+$/.test(trimmed)) return trimmed;
+  const match = trimmed.match(/(?:x\.com|twitter\.com)\/[^/]+\/status\/(\d+)/i);
+  return match?.[1];
+}


### PR DESCRIPTION
## Summary

Flips the X (Twitter) and X Ads channel cards from "available" / "coming_soon" to **live** and ships v1 dashboards behind both. The hub's Manage button now routes through.

## What's live

### X Content — \`/dashboard/content/x\`

- Connection guard via \`/v1/integrations\`; routes to \`/dashboard/integrations\` if not connected.
- KPI strip: tweets shown, avg impressions, avg engagements (last 20).
- **Compose tab** — 280-char counter (red at >280, amber at <20 left), reply-to / quote via tweet URL or numeric id, Publish via \`POST /v1/x/content/publish\`.
- **Recent tab** — list of \`<TweetCard>\` with delete (\`<ConfirmDialog>\`) and a manual *Refresh metrics* button.
- **Mentions tab** — placeholder while \`soc_social_mentions\` ingest warms up (peakhour-api PR #136 already shipped the cron).

### X Ads — \`/dashboard/content/x-ads\`

- Account selector persisted in URL \`?account=…\`. Auto-selects first account on first load.
- KPI strip: spend, impressions, engagements, CPE for the last 30d.
- Campaigns table with pause/resume \`<Switch>\` (\`PATCH …/status\`).
- Create-campaign \`<Dialog>\` — name + funding instrument + daily budget. Campaigns start \`PAUSED\` so users can attach line items before going live.

## Deferred to v2 (called out in PRs)

- Media upload (\`mediaIds\`) — backend accepts the field but no upload route exists yet.
- Threads, scheduling, drafts.
- Mentions inbox UI (waits on first real mention to come through the cron).
- X Ads drilldowns: line items, promoted tweets, targeting, per-campaign analytics chart.
- Analytics date range picker (hardcoded 30d).

## Other changes

- New typed wrappers: \`src/lib/api/x.ts\` and \`src/lib/api/x-ads.ts\` (plus an \`extractTweetId\` URL→id parser, and \`dollarsToMicros\` / \`microsToDollars\` helpers).
- \`channels.config.ts\` X entries flipped to \`status: "live"\` with \`dashboardPath\` set so the dev-time invariant at the bottom of the file passes.

## Review #1 fixes (separate commit)

| # | Sev | Finding | Fix |
|---|---|---|---|
| 1 | BLOCKER | EmptyState title and page \`<h2>\` read "X (MessageCircle)" — \`replace_all\` of \`Twitter\` → \`MessageCircle\` (lucide no longer exports \`Twitter\`) accidentally rewrote user-facing strings. | Restored "X (Twitter)" in both places. |
| 2 | NIT | \`useEffect\` auto-select depended on the \`accounts.data\` array reference, which gets a fresh identity on every refetch — effect re-ran on every refetch. | Depend on the primitive \`firstAccountId\` instead. |

## Depends on

- ✅ peakhour-mongodb #51 — \`soc_social_mentions\` schema (merged)
- ✅ peakhour-api #136 — three X sync crons + \`getMentions\` helper (merged)

## Test plan

- [ ] \`npx tsc --noEmit\` clean (verified before push)
- [ ] \`pnpm lint\` clean for the new files (verified before push)
- [ ] Reviewer: visit \`/dashboard/content\` — both X cards show "Manage" (not "Connect") when integration is connected
- [ ] \`/dashboard/content/x\`: compose a test tweet → appears in Recent tab, then on x.com
- [ ] Delete via card menu → ConfirmDialog → tweet gone from list and x.com
- [ ] Disconnect X → page shows \`<EmptyState>\` with "Connect X" CTA (no auto-redirect)
- [ ] \`/dashboard/content/x-ads\`: select an ad account, KPIs/table populate, create a small paused campaign → confirm at ads.x.com
- [ ] Pause/resume a campaign via the Switch → reflects on ads.x.com
- [ ] >280 char compose: counter goes red, Publish disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)