### PR TITLE
feat(cms): /cms/logs viewer + detail-sheet upgrades on ai/api/auth logs

### DIFF
--- a/src/app/cms/ai-logs/page.tsx
+++ b/src/app/cms/ai-logs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
@@ -242,6 +243,14 @@ export default function AiLogsPage() {
                 {selected.errorMessage && (
                   <Field label="Error">
                     <pre className="text-xs whitespace-pre-wrap rounded bg-red-50 text-red-900 p-3">{selected.errorMessage}</pre>
+                    {selected.requestId && (
+                      <Link
+                        href={`/cms/logs?requestId=${encodeURIComponent(selected.requestId)}`}
+                        className="text-xs text-blue-600 hover:underline mt-2 inline-block"
+                      >
+                        View full stack + cause in /cms/logs →
+                      </Link>
+                    )}
                   </Field>
                 )}
                 {selected.contentRedacted && (

--- a/src/app/cms/api-logs/page.tsx
+++ b/src/app/cms/api-logs/page.tsx
@@ -70,12 +70,13 @@ export default function ApiLogsPage() {
   const [method, setMethod] = useState("all");
   const [path, setPath] = useState("");
   const [errorsOnly, setErrorsOnly] = useState(false);
+  const [statusCode, setStatusCode] = useState("");
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<LogRow | null>(null);
   const limit = 50;
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["cms-api-logs", days, method, path, errorsOnly, page],
+    queryKey: ["cms-api-logs", days, method, path, errorsOnly, statusCode, page],
     queryFn: () => {
       const params: Record<string, string> = {
         days,
@@ -85,6 +86,8 @@ export default function ApiLogsPage() {
       if (method !== "all") params.method = method;
       if (path) params.path = path;
       if (errorsOnly) params.errorsOnly = "true";
+      const trimmedStatus = statusCode.trim();
+      if (/^\d{3}$/.test(trimmedStatus)) params.statusCode = trimmedStatus;
       return api.get<LogsResponse>("/v1/cms/api-logs", params);
     },
   });
@@ -109,7 +112,7 @@ export default function ApiLogsPage() {
       )}
 
       <Card>
-        <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-5 gap-3">
+        <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-6 gap-3">
           <TimeRangeSelector
             value={days}
             onChange={(v) => { setDays(v); setPage(0); }}
@@ -135,6 +138,13 @@ export default function ApiLogsPage() {
             placeholder="Path contains…"
             value={path}
             onChange={(e) => { setPath(e.target.value); setPage(0); }}
+          />
+          <Input
+            placeholder="Status (e.g. 500)"
+            inputMode="numeric"
+            maxLength={3}
+            value={statusCode}
+            onChange={(e) => { setStatusCode(e.target.value); setPage(0); }}
           />
           <Button
             variant={errorsOnly ? "default" : "outline"}
@@ -224,6 +234,18 @@ export default function ApiLogsPage() {
                     <pre className="text-xs whitespace-pre-wrap rounded bg-red-50 text-red-900 p-3">{selected.error}</pre>
                   </div>
                 )}
+                {selected.request && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Request body</p>
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-96 overflow-auto">{prettyOrRaw(selected.request)}</pre>
+                  </div>
+                )}
+                {selected.response && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Response body</p>
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-96 overflow-auto">{prettyOrRaw(selected.response)}</pre>
+                  </div>
+                )}
               </div>
             </>
           )}
@@ -237,7 +259,15 @@ function KV({ k, v, mono = false }: { k: string; v: string; mono?: boolean }) {
   return (
     <div className="flex justify-between gap-4">
       <span className="text-muted-foreground">{k}</span>
-      <span className={mono ? "font-mono text-xs" : ""}>{v}</span>
+      <span className={mono ? "font-mono text-xs break-all" : ""}>{v}</span>
     </div>
   );
+}
+
+function prettyOrRaw(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
 }

--- a/src/app/cms/auth-logs/page.tsx
+++ b/src/app/cms/auth-logs/page.tsx
@@ -9,6 +9,13 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -58,6 +65,7 @@ export default function AuthLogsPage() {
   const [success, setSuccess] = useState("all");
   const [userId, setUserId] = useState("");
   const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<LogRow | null>(null);
   const limit = 50;
 
   const { data, isLoading, error } = useQuery({
@@ -168,7 +176,11 @@ export default function AuthLogsPage() {
                 </TableRow>
               ) : (
                 rows.map((row, i) => (
-                  <TableRow key={`${row.timestamp}-${i}`}>
+                  <TableRow
+                    key={`${row.timestamp}-${i}`}
+                    onClick={() => setSelected(row)}
+                    className="cursor-pointer hover:bg-muted/50"
+                  >
                     <TableCell className="text-xs whitespace-nowrap">{formatDateTime(row.timestamp)}</TableCell>
                     <TableCell className="font-mono text-xs">{row.event}</TableCell>
                     <TableCell>
@@ -199,6 +211,57 @@ export default function AuthLogsPage() {
           <Button variant="outline" disabled={page >= lastPage} onClick={() => setPage((p) => p + 1)}>Next</Button>
         </div>
       </div>
+
+      <Sheet open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
+        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+          {selected && (
+            <>
+              <SheetHeader>
+                <SheetTitle className="font-mono">{selected.event}</SheetTitle>
+                <SheetDescription>{formatDateTime(selected.timestamp)}</SheetDescription>
+              </SheetHeader>
+              <div className="mt-6 space-y-3 text-sm">
+                <div className="flex items-center gap-2">
+                  {selected.success ? (
+                    <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">success</Badge>
+                  ) : (
+                    <Badge className="bg-red-100 text-red-800 hover:bg-red-100">failure</Badge>
+                  )}
+                  {selected.channel && <Badge variant="outline">{selected.channel}</Badge>}
+                  {selected.platform && <Badge variant="outline">{selected.platform}</Badge>}
+                </div>
+                <KV k="User ID" v={selected.userId || "—"} mono />
+                <KV k="Request ID" v={selected.requestId || "—"} mono />
+                {selected.reason && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Reason</p>
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-red-50 text-red-900 p-3">{selected.reason}</pre>
+                  </div>
+                )}
+                <div>
+                  <p className="text-xs text-muted-foreground mb-2">Origin</p>
+                  <div className="rounded border bg-muted/30 p-3 space-y-1.5 text-xs">
+                    <KV k="IP" v={selected.metadata?.ip || "—"} />
+                    <KV k="City" v={selected.metadata?.city || "—"} />
+                    <KV k="State" v={selected.metadata?.state || "—"} />
+                    <KV k="Country" v={selected.metadata?.country || "—"} />
+                    <KV k="User agent" v={selected.metadata?.userAgent || "—"} />
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function KV({ k, v, mono = false }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <span className="text-muted-foreground">{k}</span>
+      <span className={mono ? "font-mono text-xs break-all" : "text-xs break-all"}>{v}</span>
     </div>
   );
 }

--- a/src/app/cms/layout.tsx
+++ b/src/app/cms/layout.tsx
@@ -90,6 +90,7 @@ const CMS_NAV_GROUPS: NavGroup[] = [
   {
     label: "Observability",
     items: [
+      { href: "/cms/logs", label: "Application Logs", icon: ScrollText },
       { href: "/cms/api-logs", label: "API Logs", icon: Network },
       { href: "/cms/auth-logs", label: "Auth Logs", icon: ShieldCheck },
     ],

--- a/src/app/cms/logs/page.tsx
+++ b/src/app/cms/logs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
@@ -78,11 +79,22 @@ function tryPrettyJson(s?: string): string | undefined {
 }
 
 export default function LogsPage() {
-  const [days, setDays] = useState("7");
-  const [severity, setSeverity] = useState("all");
-  const [component, setComponent] = useState("all");
-  const [q, setQ] = useState("");
-  const [requestId, setRequestId] = useState("");
+  return (
+    <Suspense fallback={null}>
+      <LogsPageInner />
+    </Suspense>
+  );
+}
+
+function LogsPageInner() {
+  // Seed filters from the URL so deep-links from /cms/ai-logs (which carry
+  // a requestId) filter correctly on first render.
+  const searchParams = useSearchParams();
+  const [days, setDays] = useState(() => searchParams.get("days") || "7");
+  const [severity, setSeverity] = useState(() => searchParams.get("severity") || "all");
+  const [component, setComponent] = useState(() => searchParams.get("component") || "all");
+  const [q, setQ] = useState(() => searchParams.get("q") || "");
+  const [requestId, setRequestId] = useState(() => searchParams.get("requestId") || "");
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<LogRow | null>(null);
   const limit = 50;
@@ -148,7 +160,8 @@ export default function LogsPage() {
               <SelectItem value="all">All severities</SelectItem>
               <SelectItem value="error">Error</SelectItem>
               <SelectItem value="warn">Warn</SelectItem>
-              <SelectItem value="info">Info</SelectItem>
+              {/* "info" is supported by the API and schema, but no logInfo() callsite
+                  emits at that level today — re-add when we start using it. */}
             </SelectContent>
           </Select>
           <Select value={component} onValueChange={(v) => { setComponent(v); setPage(0); }}>

--- a/src/app/cms/logs/page.tsx
+++ b/src/app/cms/logs/page.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TimeRangeSelector } from "@/components/cms/ai/time-range-selector";
+import { formatDateTime } from "@/components/cms/ai/format";
+
+interface LogRow {
+  timestamp: string;
+  component?: string;
+  severity?: "error" | "warn" | "info";
+  product?: string;
+  message?: string;
+  errorName?: string;
+  stack?: string;
+  causeMessage?: string;
+  context?: string;
+  requestId?: string;
+  orgId?: string;
+  userId?: string;
+  businessId?: string;
+  detailRedacted?: boolean;
+}
+
+interface LogsResponse {
+  total: number;
+  offset: number;
+  limit: number;
+  rows: LogRow[];
+}
+
+interface ComponentsResponse {
+  components: string[];
+}
+
+function severityBadge(s?: string) {
+  if (s === "error") return <Badge className="bg-red-100 text-red-800 hover:bg-red-100">error</Badge>;
+  if (s === "warn") return <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">warn</Badge>;
+  if (s === "info") return <Badge className="bg-sky-100 text-sky-800 hover:bg-sky-100">info</Badge>;
+  return <Badge variant="outline">{s || "—"}</Badge>;
+}
+
+function tryPrettyJson(s?: string): string | undefined {
+  if (!s) return undefined;
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
+}
+
+export default function LogsPage() {
+  const [days, setDays] = useState("7");
+  const [severity, setSeverity] = useState("all");
+  const [component, setComponent] = useState("all");
+  const [q, setQ] = useState("");
+  const [requestId, setRequestId] = useState("");
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<LogRow | null>(null);
+  const limit = 50;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["cms-logs", days, severity, component, q, requestId, page],
+    queryFn: () => {
+      const params: Record<string, string> = {
+        days,
+        limit: String(limit),
+        offset: String(page * limit),
+      };
+      if (severity !== "all") params.severity = severity;
+      if (component !== "all") params.component = component;
+      if (q) params.q = q;
+      if (requestId) params.requestId = requestId;
+      return api.get<LogsResponse>("/v1/cms/logs", params);
+    },
+  });
+
+  const { data: componentsData } = useQuery({
+    queryKey: ["cms-logs-components", days],
+    queryFn: () => api.get<ComponentsResponse>("/v1/cms/logs/components", { days }),
+  });
+
+  const rows = data?.rows || [];
+  const total = data?.total || 0;
+  const lastPage = Math.max(0, Math.ceil(total / limit) - 1);
+  const components = componentsData?.components || [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Application Logs</h2>
+        <p className="text-muted-foreground mt-1">
+          Structured errors from agent catches, cron handlers, and background jobs (30-day retention). Click any row for full stack and context.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Failed to load logs: {(error as Error).message}
+        </div>
+      )}
+
+      <Card>
+        <CardContent className="pt-6 grid grid-cols-1 md:grid-cols-6 gap-3">
+          <TimeRangeSelector
+            value={days}
+            onChange={(v) => { setDays(v); setPage(0); }}
+            options={[
+              { value: "1", label: "Last 24 hours" },
+              { value: "3", label: "Last 3 days" },
+              { value: "7", label: "Last 7 days" },
+              { value: "30", label: "Last 30 days" },
+            ]}
+          />
+          <Select value={severity} onValueChange={(v) => { setSeverity(v); setPage(0); }}>
+            <SelectTrigger>
+              <SelectValue placeholder="Severity" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All severities</SelectItem>
+              <SelectItem value="error">Error</SelectItem>
+              <SelectItem value="warn">Warn</SelectItem>
+              <SelectItem value="info">Info</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={component} onValueChange={(v) => { setComponent(v); setPage(0); }}>
+            <SelectTrigger>
+              <SelectValue placeholder="Component" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All components</SelectItem>
+              {components.map((c) => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="Search message…"
+            value={q}
+            onChange={(e) => { setQ(e.target.value); setPage(0); }}
+          />
+          <Input
+            placeholder="Request ID"
+            value={requestId}
+            onChange={(e) => { setRequestId(e.target.value); setPage(0); }}
+          />
+          <div className="flex items-center justify-end gap-2 text-sm text-muted-foreground">
+            {isLoading ? "Loading…" : `${total.toLocaleString()} matches`}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[180px]">Timestamp</TableHead>
+                <TableHead>Severity</TableHead>
+                <TableHead>Component</TableHead>
+                <TableHead>Message</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                [0, 1, 2, 3, 4].map((i) => (
+                  <TableRow key={i}>
+                    <TableCell colSpan={4}><Skeleton className="h-5 w-full" /></TableCell>
+                  </TableRow>
+                ))
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
+                    No logs match these filters.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row, i) => (
+                  <TableRow
+                    key={`${row.timestamp}-${i}`}
+                    onClick={() => setSelected(row)}
+                    className="cursor-pointer hover:bg-muted/50"
+                  >
+                    <TableCell className="text-xs whitespace-nowrap">{formatDateTime(row.timestamp)}</TableCell>
+                    <TableCell>{severityBadge(row.severity)}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.component || "—"}</TableCell>
+                    <TableCell className="text-xs max-w-md truncate" title={row.message}>{row.message || "—"}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Page {page + 1} of {lastPage + 1}</p>
+        <div className="flex gap-2">
+          <Button variant="outline" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>Previous</Button>
+          <Button variant="outline" disabled={page >= lastPage} onClick={() => setPage((p) => p + 1)}>Next</Button>
+        </div>
+      </div>
+
+      <Sheet open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
+        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+          {selected && (
+            <>
+              <SheetHeader>
+                <SheetTitle className="font-mono text-base">{selected.component || "log"}</SheetTitle>
+                <SheetDescription>{formatDateTime(selected.timestamp)}</SheetDescription>
+              </SheetHeader>
+              <div className="mt-6 space-y-4 text-sm">
+                <div className="flex items-center gap-2">
+                  {severityBadge(selected.severity)}
+                  {selected.errorName && (
+                    <Badge variant="outline" className="font-mono text-xs">{selected.errorName}</Badge>
+                  )}
+                </div>
+                <KV k="Request ID" v={selected.requestId || "—"} mono />
+                <KV k="Org" v={selected.orgId || "—"} mono />
+                <KV k="Business" v={selected.businessId || "—"} mono />
+                <KV k="User" v={selected.userId || "—"} mono />
+                {selected.message && (
+                  <Field label="Message">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-red-50 text-red-900 p-3">{selected.message}</pre>
+                  </Field>
+                )}
+                {selected.causeMessage && (
+                  <Field label="Cause">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-amber-50 text-amber-900 p-3">{selected.causeMessage}</pre>
+                  </Field>
+                )}
+                {selected.stack && (
+                  <Field label="Stack trace">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-96 overflow-auto">{selected.stack}</pre>
+                  </Field>
+                )}
+                {selected.context && (
+                  <Field label="Context">
+                    <pre className="text-xs whitespace-pre-wrap rounded bg-muted p-3 max-h-96 overflow-auto">{tryPrettyJson(selected.context)}</pre>
+                  </Field>
+                )}
+                {selected.detailRedacted && (
+                  <p className="text-xs text-muted-foreground italic">
+                    Stack and context are redacted at viewer-level. Ask a support+ user to reveal.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function KV({ k, v, mono = false }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <span className="text-muted-foreground">{k}</span>
+      <span className={mono ? "font-mono text-xs break-all" : ""}>{v}</span>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Pairs with peakhour-api PR #140 (already merged). Surfaces the new \`ts_logs\` collection in the CMS and closes the click-to-inspect gap with the foodxp-cms reference implementation across the existing log viewers.

- **\`/cms/logs\`** (new): list view of structured app errors written by agent catches and cron handlers via \`logError()\`. Filters: severity, component (dropdown populated from \`/v1/cms/logs/components\`), time range, free-text on message, requestId. URL-state seeded so deep-links from /cms/ai-logs filter to a single request. Click-to-open detail sheet with errorName badge, message + cause + stack panes, JSON-pretty context, and entity correlation. Stack and context are gated server-side behind support+; the sheet shows a "redacted" hint for viewer-role users.
- **\`/cms/api-logs\`**: render \`request\` and \`response\` bodies in the detail sheet (already returned by the API but never rendered). Added an exact status-code filter input alongside the existing "Errors only" toggle.
- **\`/cms/auth-logs\`**: rows are now clickable. New detail sheet surfaces the failure reason, the auth metadata (ip, city, state, country, userAgent) in a grouped origin panel, and the requestId for cross-log correlation.
- **\`/cms/ai-logs\`**: cross-reference link in the error block deep-links to /cms/logs filtered by requestId.
- Layout: \`/cms/logs\` nav entry under Observability.

## Test plan

- [ ] Visit \`/cms/logs\` — confirm list renders, filters work, components dropdown populates, detail sheet shows the right fields.
- [ ] Visit \`/cms/logs?requestId=abc\` directly — confirm the requestId filter is pre-populated.
- [ ] In \`/cms/api-logs\`, click any 4xx/5xx row — confirm request and response bodies render pretty-printed.
- [ ] In \`/cms/api-logs\`, type \`500\` in the new status field — confirm only 500 rows return.
- [ ] In \`/cms/auth-logs\`, click any failed login — confirm reason + ip/city/state/country/userAgent show in the sheet.
- [ ] Trigger a \`/v1/content/weekly-plan\` failure (via the gateway misconfig if available) — confirm the resulting row in \`/cms/ai-logs\` has a working "View full stack in /cms/logs" deep-link once requestId plumbing lands in the next API PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)