### PR TITLE
feat(dashboard): tasks page + nav badge, switch Analyse to job queue

### DIFF
--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -182,25 +182,24 @@ export default function ContentPage() {
    * highlighted and can monitor progress. The runner handles the
    * actual fan-out (one tag_drafts child per 10 drafts).
    *
-   * Spam-click protection: we send a per-business idempotencyKey
-   * bucketed to the current minute. The api enforces uniqueness via
-   * a partial unique index on (orgId, idempotencyKey, status:
-   * pending|running), so a second click within the same minute hits
-   * E11000 and the api returns the existing parent jobId.
+   * Idempotency: a single stable per-business key. The api's partial
+   * unique index on (orgId, idempotencyKey, status:pending|running)
+   * means a second submit while the first is still pending|running
+   * returns the existing jobId — no double-spend, regardless of
+   * whether the user picks Analyse-untagged or Re-analyse-all. Once
+   * the prior job terminates the key becomes reusable for the next
+   * run.
    */
   function startAnalysis(force: boolean) {
     if (!business?._id) {
       toast.error("Pick a business first.");
       return;
     }
-    const minuteBucket = Math.floor(Date.now() / 60_000);
-    const idempotencyKey = `content_analyse:${force ? "force" : "untagged"}:${business._id}:${minuteBucket}`;
-
     enqueueJob.mutate(
       {
         kind: "content_analyse",
         params: force ? { force: true } : undefined,
-        idempotencyKey,
+        idempotencyKey: `content_analyse:${business._id}`,
       },
       {
         onSuccess: (data) => {

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { api, API_BASE_URL } from "@/lib/api";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
 import { useSyncProvider } from "@/hooks/use-sync-provider";
+import { useEnqueueJob } from "@/hooks/use-jobs";
 import { useAuth } from "@/providers/auth-provider";
 import {
   SENTIMENT_CONFIG,
@@ -88,25 +90,15 @@ const CONTENT_FETCH_LIMIT = 500;
 
 // ── Main Page ────────────────────────────────────────────────────
 
-interface AnalyseProgress {
-  tagged: number;
-  total: number;
-  remaining: number;
-  batchNum: number;
-  currentTitle: string;
-  currentStatus: "tagged" | "partial" | "error";
-}
-
 export default function ContentPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { user } = useAuth();
+  const { user, business } = useAuth();
   const prefs = user?.preferences ?? null;
   const contentColumns = useMemo(() => getContentColumns(prefs), [prefs]);
   const [view, setView] = useState<"card" | "table">("table");
-  const [analysing, setAnalysing] = useState(false);
-  const [analyseProgress, setAnalyseProgress] = useState<AnalyseProgress | null>(null);
-  const [analyseResult, setAnalyseResult] = useState<string | null>(null);
+
+  const enqueueJob = useEnqueueJob();
 
   const { sync: syncBeehiiv, syncing } = useSyncProvider("beehiiv", {
     onSuccess: () => {
@@ -182,115 +174,50 @@ export default function ContentPage() {
   const library = libraryRes || [];
   const hasActiveFilters = table.getState().columnFilters.length > 0 || !!globalFilter;
   const hasUntagged = stats && stats.tagged < stats.total;
-  const cancelRef = useRef(false);
+  const analysing = enqueueJob.isPending;
 
-  const startAnalysis = useCallback((force: boolean) => {
-    setAnalysing(true);
-    setAnalyseProgress(null);
-    setAnalyseResult(null);
-    cancelRef.current = false;
+  /**
+   * Enqueue a content_analyse job and redirect to /dashboard/tasks
+   * with the new jobId in the URL so the user sees their submission
+   * highlighted and can monitor progress. The runner handles the
+   * actual fan-out (one tag_drafts child per 10 drafts).
+   *
+   * Spam-click protection: we send a per-business idempotencyKey
+   * bucketed to the current minute. The api enforces uniqueness via
+   * a partial unique index on (orgId, idempotencyKey, status:
+   * pending|running), so a second click within the same minute hits
+   * E11000 and the api returns the existing parent jobId.
+   */
+  function startAnalysis(force: boolean) {
+    if (!business?._id) {
+      toast.error("Pick a business first.");
+      return;
+    }
+    const minuteBucket = Math.floor(Date.now() / 60_000);
+    const idempotencyKey = `content_analyse:${force ? "force" : "untagged"}:${business._id}:${minuteBucket}`;
 
-    const url = `${API_BASE_URL}/v1/content/analyse${force ? "?force=true" : ""}`;
-
-    // Use fetch with ReadableStream for SSE (EventSource doesn't send cookies)
-    fetch(url, { credentials: "include" })
-      .then(async (res) => {
-        if (!res.ok) {
-          const json = await res.json().catch(() => null);
-          setAnalyseResult(json?.error?.message || "Failed to start analysis.");
-          setAnalysing(false);
-          return;
-        }
-
-        const reader = res.body?.getReader();
-        if (!reader) {
-          setAnalyseResult("Streaming not supported.");
-          setAnalysing(false);
-          return;
-        }
-
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let eventType = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (cancelRef.current) {
-            reader.cancel();
-            break;
-          }
-
-          buffer += decoder.decode(value, { stream: true });
-
-          // SSE format: "event: X\ndata: Y\nid: Z\n\n"
-          // Split on double newline to get complete events
-          const events = buffer.split("\n\n");
-          buffer = events.pop() || ""; // Last element is incomplete
-
-          for (const event of events) {
-            const lines = event.split("\n");
-            let data = "";
-            for (const line of lines) {
-              if (line.startsWith("event:")) eventType = line.slice(6).trim();
-              else if (line.startsWith("data:")) data = line.slice(5).trim();
-            }
-
-            if (!data) continue;
-            try {
-              const parsed = JSON.parse(data);
-
-              if (eventType === "progress") {
-                setAnalyseProgress({
-                  tagged: parsed.tagged,
-                  total: parsed.total,
-                  remaining: parsed.remaining,
-                  batchNum: 0,
-                  currentTitle: parsed.title,
-                  currentStatus: parsed.status,
-                });
-              } else if (eventType === "complete") {
-                // The server caps each request at 240s (Vercel's 300s hard
-                // limit minus headroom) and emits truncated:true with the
-                // remaining count when it bails early. Show the partial
-                // status + a "click Analyse to continue" prompt so the user
-                // doesn't think it silently succeeded.
-                if (parsed.truncated && parsed.remaining > 0) {
-                  setAnalyseResult(
-                    `Tagged ${parsed.tagged} of ${parsed.total} so far` +
-                    (parsed.skipped > 0 ? `, ${parsed.skipped} partial` : "") +
-                    (parsed.errors > 0 ? `, ${parsed.errors} errors` : "") +
-                    `. ${parsed.remaining} remaining — click Analyse to continue.`
-                  );
-                } else {
-                  setAnalyseResult(
-                    `All done! ${parsed.tagged} newsletters tagged with AI insights.` +
-                    (parsed.skipped > 0 ? ` ${parsed.skipped} partially tagged.` : "") +
-                    (parsed.errors > 0 ? ` ${parsed.errors} failed.` : "")
-                  );
-                }
-              }
-            } catch { /* skip malformed events */ }
-          }
-        }
-
-        if (cancelRef.current) {
-          setAnalyseResult("Analysis cancelled. Click Analyse to continue with remaining.");
-        }
-
-        queryClient.invalidateQueries({ queryKey: ["content-stats"] });
-        // The actual library query key is "content-library-all" (line ~141).
-        // Invalidating "content-library" here was a no-op — the table never
-        // refreshed after analysis. Caught while wiring up sync invalidation.
-        queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
-        queryClient.invalidateQueries({ queryKey: ["content-gaps"] });
-        setAnalysing(false);
-      })
-      .catch(() => {
-        setAnalyseResult("Analysis failed. Please try again.");
-        setAnalysing(false);
-      });
-  }, [queryClient]);
+    enqueueJob.mutate(
+      {
+        kind: "content_analyse",
+        params: force ? { force: true } : undefined,
+        idempotencyKey,
+      },
+      {
+        onSuccess: (data) => {
+          // Refresh content stats once the job lands so the UI doesn't
+          // get stuck on stale "untagged" counts after the user returns.
+          queryClient.invalidateQueries({ queryKey: ["content-stats"] });
+          queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
+          queryClient.invalidateQueries({ queryKey: ["content-gaps"] });
+          toast.success("Analysis queued — track progress in Tasks.");
+          router.push(`/dashboard/tasks?jobId=${data.jobId}`);
+        },
+        onError: (err: Error) => {
+          toast.error(err.message || "Failed to queue analysis. Please try again.");
+        },
+      },
+    );
+  }
 
   function clearFilters() {
     table.resetColumnFilters();
@@ -311,75 +238,34 @@ export default function ContentPage() {
             </p>
           </div>
           <div className="flex gap-2">
-            {!analysing && (
-              <Button
-                variant="outline"
-                onClick={() => syncBeehiiv()}
-                disabled={syncing}
-                aria-busy={syncing}
-                className="min-w-[140px]"
-              >
-                {syncing ? "Syncing Beehiiv…" : "Sync Beehiiv"}
+            <Button
+              variant="outline"
+              onClick={() => syncBeehiiv()}
+              disabled={syncing}
+              aria-busy={syncing}
+              className="min-w-[140px]"
+            >
+              {syncing ? "Syncing Beehiiv…" : "Sync Beehiiv"}
+            </Button>
+            {hasUntagged && (
+              <Button onClick={() => startAnalysis(false)} disabled={analysing}>
+                {analysing ? "Queuing…" : `Analyse ${stats.total - stats.tagged} untagged`}
               </Button>
             )}
-            {hasUntagged && !analysing && (
-              <Button onClick={() => startAnalysis(false)}>
-                Analyse {stats.total - stats.tagged} untagged
-              </Button>
-            )}
-            {!analysing && stats && stats.tagged > 0 && (
+            {stats && stats.tagged > 0 && (
               <ConfirmDialog
                 trigger={
-                  <Button variant="outline">Re-analyse all</Button>
+                  <Button variant="outline" disabled={analysing}>Re-analyse all</Button>
                 }
                 title="Re-analyse all content"
-                description="This will delete all existing AI tags and re-analyse every newsletter from scratch. This may take a while."
+                description="This will queue a background job that wipes existing tags and re-analyses every newsletter. You can track it on the Tasks page."
                 confirmLabel="Re-analyse"
                 variant="destructive"
                 onConfirm={() => startAnalysis(true)}
               />
             )}
-            {analysing && (
-              <Button variant="outline" onClick={() => { cancelRef.current = true; }}>
-                Cancel
-              </Button>
-            )}
           </div>
         </div>
-
-        {/* Analysis progress */}
-        {(analysing || analyseResult) && (
-          <Card className={analyseResult ? "border-green-200 bg-green-50/50" : "border-blue-200 bg-blue-50/50"}>
-            <CardContent className="py-3 px-4">
-              {analysing && analyseProgress ? (
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="truncate max-w-md">
-                      {analyseProgress.currentStatus === "tagged" ? "✓" : analyseProgress.currentStatus === "partial" ? "◐" : "✗"}{" "}
-                      <span className="font-medium">{analyseProgress.currentTitle}</span>
-                    </span>
-                    <span className="text-muted-foreground font-medium shrink-0 ml-2">
-                      {analyseProgress.tagged} / {analyseProgress.total}
-                    </span>
-                  </div>
-                  <Progress
-                    value={analyseProgress.total > 0 ? (analyseProgress.tagged / analyseProgress.total) * 100 : 0}
-                    className="h-2"
-                  />
-                </div>
-              ) : analysing ? (
-                <AnalysingPlaceholder />
-              ) : analyseResult ? (
-                <div className="flex items-center justify-between">
-                  <p className="text-sm font-medium">{analyseResult}</p>
-                  <Button variant="ghost" size="sm" onClick={() => setAnalyseResult(null)}>
-                    Dismiss
-                  </Button>
-                </div>
-              ) : null}
-            </CardContent>
-          </Card>
-        )}
 
         {/* KPI Strip */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -847,43 +733,6 @@ function AdScoreBar({ score }: { score?: number }) {
         <p>Ad Potential Score: {score}/10</p>
       </TooltipContent>
     </Tooltip>
-  );
-}
-
-// ~17s per AI call (Haiku 4.5) for first chunk of 5.
-// 12 messages × 2.5s = 30s coverage (17s + 75% buffer) before first result streams.
-const LOADING_MESSAGES = [
-  "Warming up AI engines...",
-  "Reading your content library...",
-  "Sending content to AI for analysis...",
-  "Identifying industry sectors...",
-  "Mapping companies and people mentioned...",
-  "Extracting key metrics and data points...",
-  "Scoring ad potential for each article...",
-  "Mapping audience relevance per segment...",
-  "Analysing sentiment and urgency...",
-  "Cross-referencing with your taxonomy...",
-  "Finalising 12-dimension analysis...",
-  "Almost there — first results coming...",
-];
-
-function AnalysingPlaceholder() {
-  const [msgIndex, setMsgIndex] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setMsgIndex((i) => (i + 1) % LOADING_MESSAGES.length);
-    }, 2500);
-    return () => clearInterval(interval);
-  }, []);
-
-  return (
-    <div className="space-y-2">
-      <p className="text-sm animate-pulse">{LOADING_MESSAGES[msgIndex]}</p>
-      <div className="h-2 rounded-full bg-muted overflow-hidden">
-        <div className="h-full w-1/3 rounded-full bg-primary/40 animate-[shimmer_2s_ease-in-out_infinite]" />
-      </div>
-    </div>
   );
 }
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -47,6 +47,7 @@ import {
   ChevronsUpDown,
   ArrowLeftRight,
   ChevronRight,
+  ListChecks,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -55,11 +56,13 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { useMyTickets } from "@/hooks/use-feedback";
+import { useRunningJobCount } from "@/hooks/use-jobs";
 
 interface NavItem {
   href: string;
   label: string;
   icon: LucideIcon;
+  badge?: () => React.ReactNode;
   subItems?: { href: string; label: string; badge?: () => React.ReactNode }[];
 }
 
@@ -93,6 +96,7 @@ const NAV_GROUPS: NavGroup[] = [
           { href: "/dashboard/optimizer", label: "Optimizer" },
         ],
       },
+      { href: "/dashboard/tasks", label: "Tasks", icon: ListChecks, badge: () => <RunningJobsBadge /> },
       { href: "/dashboard/integrations", label: "Integrations", icon: Plug },
       {
         href: "/dashboard/settings",
@@ -120,6 +124,17 @@ function OpenTicketBadge() {
   return (
     <span className="ml-auto flex size-5 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
       {openCount > 9 ? "9+" : openCount}
+    </span>
+  );
+}
+
+/** Badge showing count of running/pending background jobs for this business */
+function RunningJobsBadge() {
+  const count = useRunningJobCount();
+  if (!count) return null;
+  return (
+    <span className="ml-auto flex size-5 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
+      {count > 9 ? "9+" : count}
     </span>
   );
 }
@@ -275,6 +290,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
                           <Link href={item.href}>
                             <Icon />
                             <span>{item.label}</span>
+                            {item.badge?.()}
                           </Link>
                         </SidebarMenuButton>
                       </SidebarMenuItem>

--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -160,7 +160,6 @@ function JobCard({ job, expanded: initialExpanded = false }: { job: Job; expande
                 title="Cancel this task?"
                 description="In-flight work will finish, then everything else stops. You can restart later."
                 confirmLabel="Cancel task"
-                variant="destructive"
                 onConfirm={onCancel}
               />
             )}

--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StatusBadge } from "@/components/molecules/status-badge";
+import { ElapsedTimer } from "@/components/molecules/elapsed-timer";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
+import { ListChecks, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { formatDate } from "@/lib/locale";
+import {
+  useJobs,
+  useJobDetail,
+  useCancelJob,
+  type Job,
+  type JobDetail,
+} from "@/hooks/use-jobs";
+
+export default function TasksPage() {
+  const searchParams = useSearchParams();
+  const focusJobId = searchParams.get("jobId");
+
+  const { data: active, isLoading: activeLoading } = useJobs("active");
+  const { data: recent, isLoading: recentLoading } = useJobs("recent");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Tasks</h2>
+        <p className="text-muted-foreground">
+          Background work running on your library — analysis, syncs, and more.
+        </p>
+      </div>
+
+      {/* In-progress section */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-semibold">In progress</h3>
+          {activeLoading && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+        </div>
+        {activeLoading && !active ? (
+          <JobListSkeleton />
+        ) : !active?.rows.length ? (
+          <EmptyState
+            icon={ListChecks}
+            title="Nothing running right now"
+            description="Kick off an analysis or sync from the Content page and we'll track progress here."
+          />
+        ) : (
+          <div className="space-y-3">
+            {active.rows.map((job) => (
+              <JobCard key={job._id} job={job} expanded={focusJobId === job._id} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent section */}
+      <section className="space-y-3">
+        <h3 className="text-base font-semibold">Recently completed</h3>
+        {recentLoading && !recent ? (
+          <JobListSkeleton />
+        ) : !recent?.rows.length ? (
+          <p className="text-sm text-muted-foreground">No completed tasks in the last 24 hours.</p>
+        ) : (
+          <div className="space-y-3">
+            {recent.rows.map((job) => (
+              <JobCard key={job._id} job={job} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+// ── Subcomponents ────────────────────────────────────────────────
+
+function JobCard({ job, expanded: initialExpanded = false }: { job: Job; expanded?: boolean }) {
+  const [expanded, setExpanded] = useState(initialExpanded);
+  const isActive = job.status === "running" || job.status === "pending";
+  const cancelMutation = useCancelJob();
+
+  const totalUnits = job.progress?.totalUnits ?? 0;
+  const processedUnits = job.progress?.processedUnits ?? 0;
+  const pct = totalUnits > 0 ? Math.round((processedUnits / totalUnits) * 100) : 0;
+
+  const onCancel = () => {
+    cancelMutation.mutate(job._id, {
+      onSuccess: () => toast.success("Cancellation requested"),
+      onError: (err: Error) => toast.error(err.message || "Failed to cancel task"),
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-base">
+              {job.displayName || formatKind(job.kind)}
+            </CardTitle>
+            {job.displayHint && (
+              <CardDescription className="mt-1 line-clamp-2">{job.displayHint}</CardDescription>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <StatusBadge
+              status={statusForBadge(job)}
+              dot={isActive}
+            />
+            {isActive && <ElapsedTimer running />}
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3 pt-0">
+        {totalUnits > 0 && (
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs text-muted-foreground tabular-nums">
+              <span className="truncate pr-2">
+                {job.progress?.currentLabel || (isActive ? "Working…" : `${pct}% complete`)}
+              </span>
+              <span>{processedUnits} / {totalUnits}</span>
+            </div>
+            <Progress value={pct} className="h-1.5" />
+          </div>
+        )}
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>Started {formatDate(job.createdAt, null)}</span>
+          <div className="flex items-center gap-2">
+            {job.childrenTotal != null && (
+              <button
+                type="button"
+                className="hover:text-foreground hover:underline"
+                onClick={() => setExpanded((v) => !v)}
+              >
+                {expanded ? "Hide" : "Show"} {job.childrenTotal} batch{job.childrenTotal === 1 ? "" : "es"}
+              </button>
+            )}
+            {isActive && !job.cancelRequested && (
+              <ConfirmDialog
+                trigger={
+                  <Button variant="ghost" size="sm" className="h-7 text-xs">
+                    Cancel
+                  </Button>
+                }
+                title="Cancel this task?"
+                description="In-flight work will finish, then everything else stops. You can restart later."
+                confirmLabel="Cancel task"
+                variant="destructive"
+                onConfirm={onCancel}
+              />
+            )}
+            {job.cancelRequested && isActive && (
+              <span className="text-amber-600">Cancelling…</span>
+            )}
+          </div>
+        </div>
+
+        {job.status === "failed" && (
+          <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+            We hit a snag. The team has been notified — try again or contact support.
+          </p>
+        )}
+
+        {expanded && <JobChildrenList jobId={job._id} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function JobChildrenList({ jobId }: { jobId: string }) {
+  const { data, isLoading } = useJobDetail(jobId);
+  if (isLoading) {
+    return (
+      <div className="space-y-2 border-t pt-3">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+      </div>
+    );
+  }
+  if (!data?.children?.length) return null;
+  return (
+    <div className="space-y-2 border-t pt-3">
+      {data.children.map((child) => {
+        const total = child.progress?.totalUnits ?? 0;
+        const done = child.progress?.processedUnits ?? 0;
+        const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+        return (
+          <div key={child._id} className="flex items-center gap-3 text-xs">
+            <StatusBadge
+              status={child.status}
+              dot={child.status === "running" || child.status === "pending"}
+            />
+            <span className="min-w-0 flex-1 truncate">
+              {child.displayName || `Batch ${child._id.slice(-6)}`}
+            </span>
+            <span className="text-muted-foreground tabular-nums">{done} / {total}</span>
+            <div className="w-20">
+              <Progress value={pct} className="h-1" />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function JobListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 2 }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="pb-3">
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="mt-2 h-3 w-2/3" />
+          </CardHeader>
+          <CardContent className="space-y-2 pt-0">
+            <Skeleton className="h-1.5 w-full" />
+            <Skeleton className="h-3 w-1/4" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Map raw kind to a human label for jobs without a `displayName`.
+ * displayName is set at submit time and should always be present going
+ * forward; this is a fallback for ad-hoc enqueues.
+ */
+function formatKind(kind: string): string {
+  switch (kind) {
+    case "content_analyse":
+      return "Re-analysing content library";
+    case "tag_drafts":
+      return "Tagging batch";
+    case "voice_card_refresh":
+      return "Refreshing brand voice";
+    case "beehiiv_sync_full":
+      return "Syncing Beehiiv";
+    default:
+      return kind.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+}
+
+/**
+ * Pick the badge label. We surface "running" as "In Progress" via the
+ * StatusBadge map, but for "pending" we want "Queued" (clearer for users).
+ */
+/**
+ * Map job.status to the label rendered in the badge. Synthetic labels
+ * (queued, cancelling, in_progress) read better than the raw enum.
+ * StatusBadge's STATUS_MAP knows about all of these.
+ */
+function statusForBadge(job: Job | JobDetail): string {
+  if (job.cancelRequested && (job.status === "running" || job.status === "pending")) {
+    return "cancelling";
+  }
+  if (job.status === "pending") return "queued";
+  if (job.status === "running") return "in_progress";
+  return job.status;
+}

--- a/src/components/molecules/status-badge.tsx
+++ b/src/components/molecules/status-badge.tsx
@@ -56,6 +56,12 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   disconnected: "error",
   expired: "error",
   error: "error",
+  // Background-job statuses (Tasks dashboard)
+  queued: "muted",
+  cancelling: "warning",
+  cancelled: "muted",
+  failed: "error",
+  done: "success",
 };
 
 interface StatusBadgeProps {

--- a/src/hooks/use-jobs.ts
+++ b/src/hooks/use-jobs.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface Job {
+  _id: string;
+  kind: string;
+  status: "pending" | "running" | "done" | "failed" | "cancelled";
+  displayName?: string;
+  displayHint?: string;
+  progress?: {
+    totalUnits: number;
+    processedUnits: number;
+    currentLabel?: string;
+    etaMs?: number;
+  };
+  childrenTotal?: number;
+  childrenDone?: number;
+  cancelRequested: boolean;
+  createdAt: string;
+  finishedAt?: string;
+}
+
+export interface JobChild {
+  _id: string;
+  status: Job["status"];
+  displayName?: string;
+  progress?: Job["progress"];
+}
+
+export interface JobDetail extends Job {
+  children: JobChild[];
+}
+
+export type JobListStatus = "active" | "recent" | "all";
+
+// ── Query keys ───────────────────────────────────────────────
+
+export const jobsKeys = {
+  all: ["jobs"] as const,
+  list: (status: JobListStatus) => ["jobs", "list", status] as const,
+  detail: (id: string) => ["jobs", "detail", id] as const,
+};
+
+// ── Hooks ────────────────────────────────────────────────────
+
+/**
+ * Polls the user's job list.
+ *
+ * `active` (pending+running): 10s when there's anything to watch, 60s
+ * when the list is empty — the latter is the "is anything queued?" poll
+ * driving the nav badge on every dashboard route, and we don't want
+ * that hammering the api at 6 RPM forever for an idle user.
+ *
+ * `recent` (last 24h finished): 60s; rows aren't moving but new completions
+ * still surface here without a refresh.
+ */
+export function useJobs(status: JobListStatus = "active") {
+  const isActive = status === "active";
+  return useQuery({
+    queryKey: jobsKeys.list(status),
+    queryFn: () => api.get<{ rows: Job[] }>("/v1/jobs", { status }),
+    refetchInterval: (q) => {
+      if (!isActive) return 60_000;
+      const data = q.state.data as { rows: Job[] } | undefined;
+      return data?.rows?.length ? 10_000 : 60_000;
+    },
+    // Don't burn polls when the user has tabbed away.
+    refetchIntervalInBackground: false,
+    staleTime: isActive ? 5_000 : 30_000,
+  });
+}
+
+/**
+ * Drilldown for a single job — includes children in summarised form.
+ * Polling stops once the job reaches a terminal state OR if the request
+ * errors (e.g. 404 after the row was TTL'd) so we don't spin forever.
+ */
+export function useJobDetail(id: string | null | undefined) {
+  return useQuery({
+    queryKey: id ? jobsKeys.detail(id) : ["jobs", "detail", "__noop__"],
+    queryFn: () => api.get<JobDetail>(`/v1/jobs/${id}`),
+    enabled: !!id,
+    refetchInterval: (q) => {
+      // If the request errored (404, 403, etc.) stop polling.
+      if (q.state.error) return false;
+      const data = q.state.data as JobDetail | undefined;
+      // Pre-first-fetch: poll once at 5s.
+      if (!data) return q.state.dataUpdatedAt === 0 ? 5_000 : false;
+      // Active jobs poll; terminal jobs don't.
+      return data.status === "pending" || data.status === "running" ? 5_000 : false;
+    },
+  });
+}
+
+interface EnqueueParams {
+  kind: "content_analyse";
+  params?: Record<string, unknown>;
+  displayName?: string;
+  displayHint?: string;
+  idempotencyKey?: string;
+}
+
+interface EnqueueResponse {
+  jobId: string;
+  kind: string;
+  status: Job["status"];
+  priority: number;
+  displayName?: string;
+  displayHint?: string;
+}
+
+/** POST /v1/jobs — enqueue a job. */
+export function useEnqueueJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: EnqueueParams) => api.post<EnqueueResponse>("/v1/jobs", body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: jobsKeys.all });
+    },
+  });
+}
+
+/**
+ * POST /v1/jobs/:id/cancel — cooperative cancel.
+ *
+ * The runner picks up `cancelRequested` at the next chunk boundary
+ * (running children) or at claim time (pending children). Backend
+ * confirmation arrives on the next poll up to 10s later, so we
+ * optimistically flip `cancelRequested:true` on the cached row to
+ * remove the Cancel button immediately.
+ */
+export function useCancelJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<{ jobId: string; status: string }>(`/v1/jobs/${id}/cancel`),
+    onMutate: (id: string) => {
+      const flip = (rows?: Job[]) =>
+        rows?.map((j) => (j._id === id ? { ...j, cancelRequested: true } : j));
+      queryClient.setQueryData<{ rows: Job[] }>(
+        jobsKeys.list("active"),
+        (old) => (old ? { ...old, rows: flip(old.rows) || old.rows } : old),
+      );
+      queryClient.setQueryData<JobDetail>(jobsKeys.detail(id), (old) =>
+        old ? { ...old, cancelRequested: true } : old,
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: jobsKeys.all });
+    },
+    onError: () => {
+      // Roll back by refetching truth from the server.
+      queryClient.invalidateQueries({ queryKey: jobsKeys.all });
+    },
+  });
+}
+
+// ── Derived helpers ──────────────────────────────────────────
+
+/** Count of currently-running jobs — used by the nav badge. */
+export function useRunningJobCount(): number {
+  const { data } = useJobs("active");
+  if (!data?.rows) return 0;
+  return data.rows.filter((j) => j.status === "running" || j.status === "pending").length;
+}

--- a/src/hooks/use-jobs.ts
+++ b/src/hooks/use-jobs.ts
@@ -132,28 +132,51 @@ export function useEnqueueJob() {
  * confirmation arrives on the next poll up to 10s later, so we
  * optimistically flip `cancelRequested:true` on the cached row to
  * remove the Cancel button immediately.
+ *
+ * On error we restore the snapshot — relying on `invalidateQueries`
+ * alone leaves the optimistic-flipped row visible until the next poll
+ * lands.
  */
 export function useCancelJob() {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<
+    { jobId: string; status: string },
+    Error,
+    string,
+    { prevList?: { rows: Job[] }; prevDetail?: JobDetail }
+  >({
     mutationFn: (id: string) =>
       api.post<{ jobId: string; status: string }>(`/v1/jobs/${id}/cancel`),
-    onMutate: (id: string) => {
+    onMutate: async (id: string) => {
+      // Cancel any in-flight refetch so it can't overwrite our optimistic write.
+      await queryClient.cancelQueries({ queryKey: jobsKeys.all });
+      const prevList = queryClient.getQueryData<{ rows: Job[] }>(jobsKeys.list("active"));
+      const prevDetail = queryClient.getQueryData<JobDetail>(jobsKeys.detail(id));
       const flip = (rows?: Job[]) =>
         rows?.map((j) => (j._id === id ? { ...j, cancelRequested: true } : j));
-      queryClient.setQueryData<{ rows: Job[] }>(
-        jobsKeys.list("active"),
-        (old) => (old ? { ...old, rows: flip(old.rows) || old.rows } : old),
-      );
-      queryClient.setQueryData<JobDetail>(jobsKeys.detail(id), (old) =>
-        old ? { ...old, cancelRequested: true } : old,
-      );
+      if (prevList) {
+        queryClient.setQueryData<{ rows: Job[] }>(
+          jobsKeys.list("active"),
+          { ...prevList, rows: flip(prevList.rows) || prevList.rows },
+        );
+      }
+      if (prevDetail) {
+        queryClient.setQueryData<JobDetail>(jobsKeys.detail(id), {
+          ...prevDetail,
+          cancelRequested: true,
+        });
+      }
+      return { prevList, prevDetail };
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: jobsKeys.all });
+    onError: (_err, id, ctx) => {
+      if (ctx?.prevList) {
+        queryClient.setQueryData(jobsKeys.list("active"), ctx.prevList);
+      }
+      if (ctx?.prevDetail) {
+        queryClient.setQueryData(jobsKeys.detail(id), ctx.prevDetail);
+      }
     },
-    onError: () => {
-      // Roll back by refetching truth from the server.
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: jobsKeys.all });
     },
   });

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   type AuthUser,
   type AuthOrg,
@@ -41,6 +42,7 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [state, setState] = useState<AuthState>({
     user: null,
     org: null,
@@ -88,6 +90,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } catch {
       // Best-effort — clear local state regardless
     }
+    queryClient.clear();
     setState({
       user: null,
       org: null,
@@ -98,22 +101,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       isAuthenticated: false,
     });
     router.push("/auth");
-  }, [router]);
+  }, [router, queryClient]);
 
+  // Cache scope: most queries (jobs, content stats, integrations, …) are
+  // implicitly scoped to the active org/business via the auth cookie. When
+  // the user switches scope, the cached results from the previous scope
+  // would otherwise leak into the new view for up to staleTime — including
+  // private jobs from another business. Clear everything to be safe.
   const switchOrg = useCallback(
     async (orgId: string) => {
       await apiSwitchOrg(orgId);
+      queryClient.clear();
       await refreshUser();
     },
-    [refreshUser]
+    [refreshUser, queryClient]
   );
 
   const switchBusiness = useCallback(
     async (businessId: string) => {
       await apiSwitchBusiness(businessId);
+      queryClient.clear();
       await refreshUser();
     },
-    [refreshUser]
+    [refreshUser, queryClient]
   );
 
   return (

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -107,9 +107,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // implicitly scoped to the active org/business via the auth cookie. When
   // the user switches scope, the cached results from the previous scope
   // would otherwise leak into the new view for up to staleTime — including
-  // private jobs from another business. Clear everything to be safe.
+  // private jobs from another business. cancelQueries() first so any
+  // in-flight fetch from the OLD scope can't land post-clear and
+  // re-populate the cache; then clear() drops everything; then refresh
+  // pulls the new auth state which the next render's queries pick up.
   const switchOrg = useCallback(
     async (orgId: string) => {
+      await queryClient.cancelQueries();
       await apiSwitchOrg(orgId);
       queryClient.clear();
       await refreshUser();
@@ -119,6 +123,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const switchBusiness = useCallback(
     async (businessId: string) => {
+      await queryClient.cancelQueries();
       await apiSwitchBusiness(businessId);
       queryClient.clear();
       await refreshUser();


### PR DESCRIPTION
## Summary

Adds the user-facing surface for the `bg_jobs` runner shipped in peakhour-api PR #148. The Beehiiv **Analyse** button no longer races Vercel's 300s timeout via SSE — it enqueues a `content_analyse` job and redirects to `/dashboard/tasks` where progress is polled.

- **`src/hooks/use-jobs.ts`** — `useJobs`, `useJobDetail`, `useEnqueueJob`, `useCancelJob`, `useRunningJobCount`. Adaptive polling: 10s when there's something running, 60s when idle.
- **`src/app/dashboard/tasks/page.tsx`** — In Progress + Recently Completed sections, marketing-friendly labels, `StatusBadge` + `ElapsedTimer` + progress bar, child-batch drilldown, cancel.
- **`src/app/dashboard/layout.tsx`** — Tasks nav entry (before Integrations) + `RunningJobsBadge` showing pending/running count.
- **`src/app/dashboard/content/beehiiv/page.tsx`** — Analyse button now `enqueueJob.mutate(...)` → `router.push("/dashboard/tasks?jobId=…")` + sonner toast. Drops the SSE reader, AnalysingPlaceholder, in-page progress card.
- **`src/components/molecules/status-badge.tsx`** — `queued`, `cancelling`, `cancelled`, `failed`, `done` variants for the Tasks dashboard.
- **`src/providers/auth-provider.tsx`** — `queryClient.clear()` on `switchOrg`/`switchBusiness`/`logout` so cached jobs/content/integrations from the previous scope cannot leak across business switches.

## Review #1 fixes already applied
- **CRITICAL** — cross-business cache leak after `BusinessSwitcher` (clear on scope change).
- **HIGH** — spam-click race on Analyse (per-business + per-minute `idempotencyKey`; api dedupes via the new unique partial index).
- **HIGH** — `useJobDetail` runaway poll when `data` undefined or 404 (terminate on error + first-fetch guard).
- **HIGH** — cancel feels stale until next poll (`onMutate` optimistic update).
- **MEDIUM** — nav badge polling cost (10s when there's work, 60s when idle).
- **MEDIUM** — synthetic statuses skipping dot color (added to STATUS_MAP).

## Test plan

- [ ] Visit `/dashboard/tasks` with no jobs — see "Nothing running right now" empty state.
- [ ] Click Analyse on Beehiiv library → toast → land on `/dashboard/tasks?jobId=…` with parent task visible.
- [ ] Watch progress climb every 10s, child batches expandable inline.
- [ ] Cancel a running job — Cancel button hides immediately (optimistic), toast confirms.
- [ ] Switch business via `BusinessSwitcher` — Tasks list refetches and shows the new business's jobs only.
- [ ] Spam-click Analyse — only one parent job created (idempotencyKey dedupes).
- [ ] Tasks page across deploys — refresh during run, state survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)