### PR TITLE
feat(integrations): manual sync now enqueues a job + redirects to Tasks

### DIFF
--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -101,9 +101,11 @@ export default function ContentPage() {
   const enqueueJob = useEnqueueJob();
 
   const { sync: syncBeehiiv, syncing } = useSyncProvider("beehiiv", {
-    onSuccess: () => {
-      // Refresh derived views so freshly-imported drafts surface here
-      // without a manual reload.
+    onEnqueue: () => {
+      // Pre-invalidate derived views so when the user returns from the
+      // Tasks page the library is fresh by the time the runner has
+      // finished. The actual data lands later via the runner; this just
+      // marks the cache so the next refetch picks up the new state.
       queryClient.invalidateQueries({ queryKey: ["content-stats"] });
       queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
       queryClient.invalidateQueries({ queryKey: ["content-gaps"] });

--- a/src/hooks/use-sync-provider.ts
+++ b/src/hooks/use-sync-provider.ts
@@ -1,177 +1,111 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 
-export interface SyncResult {
-  added: number;
-  updated: number;
-  errors: number;
-  postsFetched?: number;
-}
-
-interface SyncResponse {
+export interface SyncEnqueueResponse {
   provider: string;
-  sync: SyncResult;
+  jobId: string;
+  status: "pending" | "running" | "done" | "failed" | "cancelled";
 }
 
 export interface UseSyncProviderOptions {
   /**
-   * Called after a successful sync. Use it to invalidate or refetch
-   * caller-specific queries (the hook doesn't know what's relevant to
-   * each surface).
+   * Called after a successful enqueue. Use it to invalidate or refetch
+   * caller-specific queries that depend on the synced data so they're
+   * fresh when the user returns from /dashboard/tasks. The hook does NOT
+   * wait for the job to finish — invalidations here run on enqueue, not
+   * completion.
    */
-  onSuccess?: (result: SyncResult) => void;
+  onEnqueue?: (response: SyncEnqueueResponse) => void;
   /**
-   * Set to false to suppress toast notifications and let the caller
-   * render results in its own UI (e.g. the integrations page uses an
-   * inline banner instead of a toast).
+   * If true (default), redirect the user to /dashboard/tasks?jobId=…
+   * after the enqueue succeeds so they can monitor progress. Set to
+   * false to keep them on the current page (e.g. an admin surface that
+   * just wants to fire-and-forget).
    */
-  notify?: boolean;
-  /**
-   * Override the default success message. Receives the sync result —
-   * implementations MUST inspect `result.errors` because the same
-   * formatter renders both success (`errors === 0`) and partial-failure
-   * (`errors > 0`) toasts; a formatter that ignores `errors` will
-   * mislead users on partial failures.
-   */
-  formatSuccess?: (result: SyncResult) => { title: string; description?: string };
+  redirectToTasks?: boolean;
 }
 
 interface UseSyncProviderReturn {
-  /**
-   * Trigger a manual sync. No-op if already in flight (returns null).
-   *
-   * Behavior on failure depends on the `notify` option:
-   * - `notify: true` (default): errors are toasted, promise resolves to null
-   * - `notify: false`: promise REJECTS with the underlying error so the
-   *   caller can render their own UI. Always wrap in try/catch when
-   *   using this option.
-   */
-  sync: () => Promise<SyncResult | null>;
-  /** True between request start and request settle. */
+  /** Enqueue a sync job. No-op if a previous enqueue is still in flight. */
+  sync: () => Promise<SyncEnqueueResponse | null>;
+  /** True between request start and request settle (the enqueue, not the job). */
   syncing: boolean;
-  /** Last successful result. Persists across re-syncs until the next success. */
-  lastResult: SyncResult | null;
 }
 
 /**
- * Wraps `POST /v1/integrations/:provider/sync` with loading state, toast
- * UX, and error-code handling (ALREADY_RUNNING / NOT_CONNECTED).
+ * Wraps `POST /v1/integrations/:provider/sync`.
  *
- * Used anywhere the user can trigger a manual sync — currently the
- * /dashboard/content/beehiiv library, planned for the channels hub and
- * strategist surfaces. Callers pass `onSuccess` to refetch their own
- * queries; the hook doesn't assume what's relevant.
+ * The api now enqueues an `integration_sync` job and returns
+ * `{ jobId }` instead of running synchronously — single source of
+ * truth so every sync (manual + cron) is observable in
+ * /dashboard/tasks and /cms/jobs. By default the hook redirects the
+ * user to the Tasks page with the new jobId in the URL so they see
+ * their submission highlighted.
+ *
+ * Idempotency: the api stamps a per-connection `idempotencyKey`. A
+ * double-click while the previous sync is still queued|running
+ * returns the same jobId — no double-spend.
  */
 export function useSyncProvider(
   provider: string,
   options: UseSyncProviderOptions = {},
 ): UseSyncProviderReturn {
+  const router = useRouter();
   const [syncing, setSyncing] = useState(false);
-  const [lastResult, setLastResult] = useState<SyncResult | null>(null);
   // Ref-based in-flight guard: closes a double-tap race that React's
   // state batching can let through, AND lets us drop `syncing` from the
   // useCallback deps so the `sync` identity stays stable across the
   // intermediate state flips.
   const inFlightRef = useRef(false);
-  // Latest callbacks captured via ref so the hook's `sync` identity
-  // doesn't change every time the caller passes inline closures.
+  // Latest options captured via ref so the hook's `sync` identity
+  // doesn't change when callers pass inline closures.
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  const sync = useCallback(async (): Promise<SyncResult | null> => {
+  const sync = useCallback(async (): Promise<SyncEnqueueResponse | null> => {
     if (inFlightRef.current) return null;
     inFlightRef.current = true;
     setSyncing(true);
-    // Don't clear `lastResult` here — keep the previous successful result
-    // visible to consumers (e.g. an inline banner) while the new sync is
-    // in flight. Overwrite only when we have a fresh successful result.
-    let result: SyncResult | null = null;
     try {
-      const res = await api.post<SyncResponse>(
+      const res = await api.post<SyncEnqueueResponse>(
         `/v1/integrations/${provider}/sync`,
         {},
       );
-      result = res.sync;
-      setLastResult(result);
 
-      const { notify = true, formatSuccess } = optionsRef.current;
-      if (notify) {
-        const formatted = formatSuccess
-          ? formatSuccess(result)
-          : defaultSuccessMessage(result);
-        if (result.errors > 0) {
-          toast.warning(formatted.title, { description: formatted.description });
-        } else {
-          toast.success(formatted.title, { description: formatted.description });
-        }
+      const { onEnqueue, redirectToTasks = true } = optionsRef.current;
+      onEnqueue?.(res);
+
+      toast.success(`${humanProvider(provider)} sync queued`, {
+        description: "Track progress on the Tasks page.",
+      });
+
+      if (redirectToTasks) {
+        router.push(`/dashboard/tasks?jobId=${res.jobId}`);
       }
+      return res;
     } catch (err) {
-      const { notify = true } = optionsRef.current;
-      if (notify) {
-        if (err instanceof ApiError && err.code === "ALREADY_RUNNING") {
-          toast.error("A sync is already in progress", {
-            description: "Wait for it to complete before triggering another.",
-          });
-        } else if (err instanceof ApiError && err.code === "NOT_CONNECTED") {
-          toast.error(`${humanProvider(provider)} is not connected`, {
-            description: "Reconnect from the Integrations page.",
-          });
-        } else {
-          const msg = err instanceof Error ? err.message : "Sync failed";
-          toast.error("Sync failed", { description: msg });
-        }
+      if (err instanceof ApiError && err.code === "NOT_CONNECTED") {
+        toast.error(`${humanProvider(provider)} is not connected`, {
+          description: "Reconnect from the Integrations page.",
+        });
+      } else if (err instanceof ApiError && err.code === "SYNC_NOT_SUPPORTED") {
+        toast.error(`${humanProvider(provider)} doesn't support sync.`);
       } else {
-        // notify:false callers want to render their own UI. Re-throw so
-        // the caller's await sees the failure (silently returning null
-        // would be indistinguishable from a successful no-op sync).
-        throw err;
+        const msg = err instanceof Error ? err.message : "Sync failed";
+        toast.error("Couldn't queue sync", { description: msg });
       }
+      return null;
     } finally {
       inFlightRef.current = false;
       setSyncing(false);
     }
+  }, [provider, router]);
 
-    // onSuccess runs OUTSIDE the try so a callback throw doesn't get
-    // caught by the error branch and falsely report failure to the
-    // awaiter. The sync itself succeeded; downstream side-effects
-    // failing is the caller's problem to handle.
-    if (result !== null) {
-      optionsRef.current.onSuccess?.(result);
-    }
-    return result;
-  }, [provider]);
-
-  return { sync, syncing, lastResult };
-}
-
-function defaultSuccessMessage(result: SyncResult): {
-  title: string;
-  description?: string;
-} {
-  const { added, updated, errors, postsFetched } = result;
-  if (errors > 0) {
-    return {
-      title: `Synced with ${errors} error${errors === 1 ? "" : "s"}`,
-      description: `${added} added, ${updated} updated. Check the integration page for details.`,
-    };
-  }
-  if (added === 0 && updated === 0) {
-    return {
-      title: "Already up to date",
-      description:
-        postsFetched && postsFetched > 0
-          ? `Provider returned ${postsFetched} item${postsFetched === 1 ? "" : "s"}, all already imported.`
-          : "No new items since the last sync.",
-    };
-  }
-  const total = added + updated;
-  return {
-    title: `${total} item${total === 1 ? "" : "s"} synced`,
-    description: `${added} new, ${updated} updated.`,
-  };
+  return { sync, syncing };
 }
 
 /** Title-case a provider key for user-facing messages. */


### PR DESCRIPTION
## Summary

Companion to peakhour-api PR #149 (merged). The api's `POST /v1/integrations/:provider/sync` now returns `{ jobId }` instead of running synchronously, so the `useSyncProvider` hook is rewritten to match the new contract.

Single source of truth: every sync (manual + cron) is now observable on `/dashboard/tasks` and `/cms/jobs`.

## useSyncProvider rewrite

- **Old**: `Promise<SyncResult | null>` with `added/updated/errors` after work completed; exposed `lastResult` for inline banners.
- **New**: `Promise<SyncEnqueueResponse | null>` with `{ provider, jobId, status }` immediately after enqueue. Default redirects to `/dashboard/tasks?jobId=…` so the user follows progress on the canonical Tasks page (same pattern as the Analyse button from PR-2).
- Drops `formatSuccess`/`notify`/`lastResult` — Tasks page owns progress UI.
- Single canonical toast: `"{Provider} sync queued — Track progress on the Tasks page."`
- `onSuccess` → `onEnqueue`: callback fires when the job is queued (not when work completes). Used by the Beehiiv page to mark `content-stats`/`content-library-all`/`content-gaps` caches stale so they refetch fresh when the user returns from Tasks.

## Beehiiv page

- `onSuccess: () => invalidate(...)` → `onEnqueue: () => invalidate(...)`. Comment updated to explain the semantics shift.

## Idempotency

API sends `integration_sync:${connectionId}` per click. The partial unique index on `(orgId, idempotencyKey, status:pending|running)` means a double-click while the prior is still queued|running returns the same `jobId`.

## Test plan

- [ ] Click Sync Beehiiv → toast → land on `/dashboard/tasks?jobId=…` with the integration_sync job visible.
- [ ] Watch the job tick through `pending → running → done`. After done, navigate back to /content/beehiiv: stats refetch (they were invalidated on enqueue) and reflect the synced content.
- [ ] Spam-click Sync — only one job created (idempotencyKey + inFlightRef both gate).
- [ ] Disconnected provider: api returns 404 NOT_CONNECTED → toast "{Provider} is not connected" with reconnect prompt.
- [ ] Network blip on enqueue → toast "Couldn't queue sync".

🤖 Generated with [Claude Code](https://claude.com/claude-code)