### PR TITLE
fix(content/beehiiv): self-heal stale business cookie + stop 403 polling spam

### DIFF
--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -177,6 +177,10 @@ export default function ContentPage() {
   const hasActiveFilters = table.getState().columnFilters.length > 0 || !!globalFilter;
   const hasUntagged = stats && stats.tagged < stats.total;
   const analysing = enqueueJob.isPending;
+  // Disable business-scoped actions until the active business has
+  // resolved — prevents the "Pick a business first" toast from firing
+  // on a hydration race when stats arrive before AuthProvider does.
+  const businessReady = !!business?._id;
 
   /**
    * Enqueue a content_analyse job and redirect to /dashboard/tasks
@@ -242,21 +246,26 @@ export default function ContentPage() {
             <Button
               variant="outline"
               onClick={() => syncBeehiiv()}
-              disabled={syncing}
+              disabled={syncing || !businessReady}
               aria-busy={syncing}
-              className="min-w-[140px]"
+              className="min-w-35"
             >
               {syncing ? "Syncing Beehiiv…" : "Sync Beehiiv"}
             </Button>
             {hasUntagged && (
-              <Button onClick={() => startAnalysis(false)} disabled={analysing}>
+              <Button
+                onClick={() => startAnalysis(false)}
+                disabled={analysing || !businessReady}
+              >
                 {analysing ? "Queuing…" : `Analyse ${stats.total - stats.tagged} untagged`}
               </Button>
             )}
             {stats && stats.tagged > 0 && (
               <ConfirmDialog
                 trigger={
-                  <Button variant="outline" disabled={analysing}>Re-analyse all</Button>
+                  <Button variant="outline" disabled={analysing || !businessReady}>
+                    Re-analyse all
+                  </Button>
                 }
                 title="Re-analyse all content"
                 description="This will queue a background job that wipes existing tags and re-analyses every newsletter. You can track it on the Tasks page."

--- a/src/hooks/use-jobs.ts
+++ b/src/hooks/use-jobs.ts
@@ -64,6 +64,12 @@ export function useJobs(status: JobListStatus = "active") {
     queryKey: jobsKeys.list(status),
     queryFn: () => api.get<{ rows: Job[] }>("/v1/jobs", { status }),
     refetchInterval: (q) => {
+      // Stop polling when the request errors (403 from a stale auth
+      // cookie, 5xx, etc.). Otherwise this hammers devtools with one
+      // failure per cycle on every dashboard route until the user
+      // navigates. A fresh mount or a successful refetch resumes the
+      // schedule. Mirrors useJobDetail's pattern.
+      if (q.state.error) return false;
       if (!isActive) return 60_000;
       const data = q.state.data as { rows: Job[] } | undefined;
       return data?.rows?.length ? 10_000 : 60_000;

--- a/src/hooks/use-jobs.ts
+++ b/src/hooks/use-jobs.ts
@@ -67,12 +67,11 @@ export function useJobs(status: JobListStatus = "active") {
       // Stop polling when the request errors (403 from a stale auth
       // cookie, 5xx, etc.). Otherwise this hammers devtools with one
       // failure per cycle on every dashboard route until the user
-      // navigates. A fresh mount or a successful refetch resumes the
-      // schedule. Mirrors useJobDetail's pattern.
+      // navigates. A fresh mount, window focus, or successful refetch
+      // resumes the schedule. Mirrors useJobDetail's pattern.
       if (q.state.error) return false;
       if (!isActive) return 60_000;
-      const data = q.state.data as { rows: Job[] } | undefined;
-      return data?.rows?.length ? 10_000 : 60_000;
+      return q.state.data?.rows?.length ? 10_000 : 60_000;
     },
     // Don't burn polls when the user has tabbed away.
     refetchIntervalInBackground: false,

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -95,6 +95,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Mirrors switchBusiness's cache management: cancel in-flight queries
   // that fired against the previous (no-business) scope, clear cached
   // empty results so the next render refetches with the new scope.
+  //
+  // Race-with-manual-pick is not a concern here: single-business orgs
+  // (the only case this effect fires for) render the BusinessSwitcher
+  // as a read-only name display — there's no dropdown to click — so
+  // the user cannot race the auto-resolve.
+  //
+  // Latch policy: latched true on attempt; we do NOT reset on catch.
+  // A deterministic 4xx (e.g. business soft-deleted between getMe and
+  // switch) would otherwise re-fire on every render and storm the
+  // server. switchOrg resets the latch so a freshly-switched org
+  // gets a clean attempt; a logout/login cycle remounts the provider,
+  // resetting the ref naturally.
   const autoResolveAttempted = useRef(false);
   useEffect(() => {
     if (autoResolveAttempted.current) return;
@@ -109,9 +121,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         queryClient.clear();
         await refreshUser();
       } catch {
-        // Reset so a manual pick (or a future re-mount) still has
-        // a clean attempt.
-        autoResolveAttempted.current = false;
+        // Latched — see comment block above. Re-mount to retry.
       }
     })();
   }, [
@@ -155,6 +165,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await queryClient.cancelQueries();
       await apiSwitchOrg(orgId);
       queryClient.clear();
+      // Reset the auto-resolve latch — the new org may be a single-
+      // business org that needs its own pinning round-trip.
+      autoResolveAttempted.current = false;
       await refreshUser();
     },
     [refreshUser, queryClient]

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -114,16 +114,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (state.business) return;
     if (state.businesses.length !== 1) return;
     autoResolveAttempted.current = true;
+    let cancelled = false;
     (async () => {
       try {
         await queryClient.cancelQueries();
+        if (cancelled) return;
         await apiSwitchBusiness(state.businesses[0]._id);
+        if (cancelled) return;
         queryClient.clear();
         await refreshUser();
       } catch {
         // Latched — see comment block above. Re-mount to retry.
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [
     state.isLoading,
     state.isAuthenticated,
@@ -140,6 +146,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // Best-effort — clear local state regardless
     }
     queryClient.clear();
+    // Reset the auto-resolve latch so the next login (which may share
+    // this provider instance if the layout doesn't unmount) gets a
+    // clean attempt. router.push("/auth") doesn't guarantee remount.
+    autoResolveAttempted.current = false;
     setState({
       user: null,
       org: null,
@@ -178,6 +188,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await queryClient.cancelQueries();
       await apiSwitchBusiness(businessId);
       queryClient.clear();
+      // Symmetric with switchOrg: if the backend later invalidates
+      // this pin and refreshUser returns business=null while the lone
+      // business remains, auto-resolve should be free to recover.
+      autoResolveAttempted.current = false;
       await refreshUser();
     },
     [refreshUser, queryClient]

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
@@ -83,6 +84,44 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- bootstrap auth from server cookie on mount; setState inside refreshUser is required to populate context
     refreshUser();
   }, [refreshUser]);
+
+  // Auto-resolve a single-business org. If the JWT cookie has no
+  // businessId (or a stale one) but the user has exactly one business
+  // in the active org, pin it server-side so business-scoped actions
+  // (Analyse, Sync, etc.) don't dead-end on "Pick a business first."
+  // Multi-business orgs are left to the user — the BusinessSwitcher
+  // dropdown handles that case.
+  //
+  // Mirrors switchBusiness's cache management: cancel in-flight queries
+  // that fired against the previous (no-business) scope, clear cached
+  // empty results so the next render refetches with the new scope.
+  const autoResolveAttempted = useRef(false);
+  useEffect(() => {
+    if (autoResolveAttempted.current) return;
+    if (state.isLoading || !state.isAuthenticated) return;
+    if (state.business) return;
+    if (state.businesses.length !== 1) return;
+    autoResolveAttempted.current = true;
+    (async () => {
+      try {
+        await queryClient.cancelQueries();
+        await apiSwitchBusiness(state.businesses[0]._id);
+        queryClient.clear();
+        await refreshUser();
+      } catch {
+        // Reset so a manual pick (or a future re-mount) still has
+        // a clean attempt.
+        autoResolveAttempted.current = false;
+      }
+    })();
+  }, [
+    state.isLoading,
+    state.isAuthenticated,
+    state.business,
+    state.businesses,
+    refreshUser,
+    queryClient,
+  ]);
 
   const logout = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary

Two reported bugs, same root cause class (stale/missing `businessId` in JWT cookie):

1. **\"Pick a business first\" toast on `/dashboard/content/beehiiv`** when clicking Analyse/Sync — `business?._id` was falsy at click time even when the user had exactly one business.
2. **`/v1/jobs?status=active` 403-spamming** the console nonstop on every dashboard route.

### Fixes

- **AuthProvider auto-resolve** — when `getMe()` returns `business: null` but `businesses.length === 1`, automatically call `switchBusiness(businesses[0]._id)` then `refreshUser()`. Mirrors `switchBusiness`'s `cancelQueries → switch → clear → refresh` cache pattern. Latched via `useRef` so it runs at most once per provider mount; `switchOrg` resets the latch for the new org. Latch sticks on failure to avoid a deterministic-4xx retry storm.
- **Defensive button gate on beehiiv page** — Sync, Analyse, Re-analyse buttons disabled until `business?._id` is truthy (`businessReady`). Prevents the misleading toast from firing on a hydration race where stats arrive before AuthProvider does.
- **`useJobs` stops polling on error** — mirrors `useJobDetail`'s existing pattern (line 88). A 403 from a stale cookie no longer hammers devtools every 10–60s on every dashboard route. React Query auto-resumes on success / window focus / mount.

Tailwind v4 cleanup on the touched line: `min-w-[140px]` → `min-w-35`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Single-business user with stale cookie: load `/dashboard/content/beehiiv` → AuthProvider auto-resolves silently → buttons enable → Analyse enqueues a `content_analyse` job
- [ ] Multi-business user (`businesses.length > 1`): auto-resolve does NOT fire — user picks via BusinessSwitcher as before
- [ ] User with 0 businesses: auto-resolve doesn't fire, buttons stay disabled, toast guard remains as belt-and-braces
- [ ] Tasks page open while cookie is stale: useJobs returns 403, polling stops, console quiet

🤖 Generated with [Claude Code](https://claude.com/claude-code)