### PR TITLE
fix(beehiiv): gate Analyse on active job; deep-link to in-progress

### DIFF
--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { useSyncProvider } from "@/hooks/use-sync-provider";
-import { useEnqueueJob } from "@/hooks/use-jobs";
+import { useEnqueueJob, useJobs } from "@/hooks/use-jobs";
 import { useAuth } from "@/providers/auth-provider";
 import {
   SENTIMENT_CONFIG,
@@ -99,6 +99,9 @@ export default function ContentPage() {
   const [view, setView] = useState<"card" | "table">("table");
 
   const enqueueJob = useEnqueueJob();
+  // useJobs("active") is already mounted at the dashboard layout level
+  // for the nav badge; React Query dedupes, so this is a free read.
+  const { data: activeJobs } = useJobs("active");
 
   const { sync: syncBeehiiv, syncing } = useSyncProvider("beehiiv", {
     onEnqueue: () => {
@@ -181,6 +184,22 @@ export default function ContentPage() {
   // resolved — prevents the "Pick a business first" toast from firing
   // on a hydration race when stats arrive before AuthProvider does.
   const businessReady = !!business?._id;
+  // Backend already dedupes via partial unique index — second click
+  // returns the same jobId, no double-spend. But the user gets no
+  // feedback after enqueueJob.isPending flips back, so they keep
+  // clicking. Gate on whether a content_analyse job is already active
+  // (cookie-scoped, so this is implicitly per-business). The Job's
+  // jobId is also used to deep-link to /dashboard/tasks for progress.
+  const pendingAnalyseJob = useMemo(
+    () =>
+      activeJobs?.rows?.find(
+        (j) =>
+          j.kind === "content_analyse" &&
+          (j.status === "pending" || j.status === "running"),
+      ),
+    [activeJobs?.rows],
+  );
+  const hasPendingAnalyse = !!pendingAnalyseJob;
 
   /**
    * Enqueue a content_analyse job and redirect to /dashboard/tasks
@@ -254,16 +273,32 @@ export default function ContentPage() {
             </Button>
             {hasUntagged && (
               <Button
-                onClick={() => startAnalysis(false)}
+                onClick={() => {
+                  if (pendingAnalyseJob) {
+                    router.push(
+                      `/dashboard/tasks?jobId=${pendingAnalyseJob._id}`,
+                    );
+                    return;
+                  }
+                  startAnalysis(false);
+                }}
                 disabled={analysing || !businessReady}
+                variant={hasPendingAnalyse ? "outline" : "default"}
               >
-                {analysing ? "Queuing…" : `Analyse ${stats.total - stats.tagged} untagged`}
+                {hasPendingAnalyse
+                  ? "Analysis in progress — view"
+                  : analysing
+                    ? "Queuing…"
+                    : `Analyse ${stats.total - stats.tagged} untagged`}
               </Button>
             )}
             {stats && stats.tagged > 0 && (
               <ConfirmDialog
                 trigger={
-                  <Button variant="outline" disabled={analysing || !businessReady}>
+                  <Button
+                    variant="outline"
+                    disabled={analysing || !businessReady || hasPendingAnalyse}
+                  >
                     Re-analyse all
                   </Button>
                 }

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -275,7 +275,13 @@ export default function ContentPage() {
             {hasUntagged && (
               <Button
                 onClick={() => {
-                  if (pendingAnalyseJob) {
+                  // `analysing` (mutation in-flight) takes precedence
+                  // over `pendingAnalyseJob`: the active-jobs poll runs
+                  // every 10s, so for up to 10s after a job finishes
+                  // the rows still contain it. Short-circuiting on the
+                  // stale row would deep-link to a finished job
+                  // instead of starting the new one the user intends.
+                  if (!analysing && pendingAnalyseJob) {
                     router.push(
                       `/dashboard/tasks?jobId=${pendingAnalyseJob._id}`,
                     );
@@ -284,12 +290,14 @@ export default function ContentPage() {
                   startAnalysis(false);
                 }}
                 disabled={analysing || !businessReady}
-                variant={hasPendingAnalyse ? "secondary" : "default"}
+                variant={
+                  hasPendingAnalyse && !analysing ? "secondary" : "default"
+                }
               >
-                {hasPendingAnalyse
-                  ? "Analysis in progress — view"
-                  : analysing
-                    ? "Queuing…"
+                {analysing
+                  ? "Queuing…"
+                  : hasPendingAnalyse
+                    ? "Analysis in progress — view"
                     : `Analyse ${stats.total - stats.tagged} untagged`}
               </Button>
             )}

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -187,9 +187,10 @@ export default function ContentPage() {
   // Backend already dedupes via partial unique index — second click
   // returns the same jobId, no double-spend. But the user gets no
   // feedback after enqueueJob.isPending flips back, so they keep
-  // clicking. Gate on whether a content_analyse job is already active
-  // (cookie-scoped, so this is implicitly per-business). The Job's
-  // jobId is also used to deep-link to /dashboard/tasks for progress.
+  // clicking. Gate on whether a content_analyse job is already active.
+  // Server filters /v1/jobs by orgId+businessId from JWT, so this is
+  // safely scoped per-business. The Job's id is also used to deep-link
+  // to /dashboard/tasks for progress.
   const pendingAnalyseJob = useMemo(
     () =>
       activeJobs?.rows?.find(
@@ -283,7 +284,7 @@ export default function ContentPage() {
                   startAnalysis(false);
                 }}
                 disabled={analysing || !businessReady}
-                variant={hasPendingAnalyse ? "outline" : "default"}
+                variant={hasPendingAnalyse ? "secondary" : "default"}
               >
                 {hasPendingAnalyse
                   ? "Analysis in progress — view"
@@ -306,7 +307,20 @@ export default function ContentPage() {
                 description="This will queue a background job that wipes existing tags and re-analyses every newsletter. You can track it on the Tasks page."
                 confirmLabel="Re-analyse"
                 variant="destructive"
-                onConfirm={() => startAnalysis(true)}
+                onConfirm={() => {
+                  // Race guard: the trigger was disabled when this
+                  // dialog opened, but the active-jobs poll can land
+                  // a fresh content_analyse between trigger-click and
+                  // confirm-click. If so, deep-link to it instead of
+                  // re-enqueuing (backend would dedupe anyway).
+                  if (pendingAnalyseJob) {
+                    router.push(
+                      `/dashboard/tasks?jobId=${pendingAnalyseJob._id}`,
+                    );
+                    return;
+                  }
+                  startAnalysis(true);
+                }}
               />
             )}
           </div>

--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
@@ -60,7 +60,12 @@ export default function TasksPage() {
         ) : (
           <div className="space-y-3">
             {active.rows.map((job) => (
-              <JobCard key={job._id} job={job} expanded={focusJobId === job._id} />
+              <JobCard
+                key={job._id}
+                job={job}
+                expanded={focusJobId === job._id}
+                focused={focusJobId === job._id}
+              />
             ))}
           </div>
         )}
@@ -76,7 +81,12 @@ export default function TasksPage() {
         ) : (
           <div className="space-y-3">
             {recent.rows.map((job) => (
-              <JobCard key={job._id} job={job} />
+              <JobCard
+                key={job._id}
+                job={job}
+                expanded={focusJobId === job._id}
+                focused={focusJobId === job._id}
+              />
             ))}
           </div>
         )}
@@ -87,10 +97,31 @@ export default function TasksPage() {
 
 // ── Subcomponents ────────────────────────────────────────────────
 
-function JobCard({ job, expanded: initialExpanded = false }: { job: Job; expanded?: boolean }) {
+function JobCard({
+  job,
+  expanded: initialExpanded = false,
+  focused = false,
+}: {
+  job: Job;
+  expanded?: boolean;
+  focused?: boolean;
+}) {
   const [expanded, setExpanded] = useState(initialExpanded);
   const isActive = job.status === "running" || job.status === "pending";
   const cancelMutation = useCancelJob();
+  // When a deep-link lands here with ?jobId=<id>, scroll the matched
+  // card into view and apply a brief ring so the user can spot which
+  // job they were sent to. Only fires once on mount; subsequent
+  // re-renders (poll updates etc.) don't re-trigger.
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [highlighted, setHighlighted] = useState(focused);
+  useEffect(() => {
+    if (!focused) return;
+    cardRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    const timer = setTimeout(() => setHighlighted(false), 2500);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
+  }, []);
 
   const totalUnits = job.progress?.totalUnits ?? 0;
   const processedUnits = job.progress?.processedUnits ?? 0;
@@ -104,7 +135,14 @@ function JobCard({ job, expanded: initialExpanded = false }: { job: Job; expande
   };
 
   return (
-    <Card>
+    <Card
+      ref={cardRef}
+      className={
+        highlighted
+          ? "ring-2 ring-primary transition-shadow duration-300"
+          : "transition-shadow duration-300"
+      }
+    >
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

Backend already dedupes via the partial unique index on \`(orgId, idempotencyKey, status:pending|running)\` — duplicate Analyse clicks return the same jobId, no double-spend. But UX dead-ends: \`enqueueJob.isPending\` flips back to false within ~100ms, the button re-enables, the user keeps clicking because there's no visible feedback. (Reported symptom: an enqueued content_analyse, then the user mashing the button looking for it to do something.)

## Changes

\`src/app/dashboard/content/beehiiv/page.tsx\`:

- Wire the existing \`useJobs(\"active\")\` query (already mounted at the dashboard layout for the nav badge — React Query dedupes, so this is a free read) into the page.
- Find any in-flight \`content_analyse\` job. Server filters \`/v1/jobs\` by \`(orgId, businessId)\` from the JWT, so this is per-business safe.
- When one exists, repurpose the Analyse button into a \"view in progress\" CTA that deep-links to \`/dashboard/tasks?jobId=...\`. Re-analyse-all stays disabled.
- Race guard inside the Re-analyse-all ConfirmDialog: if a fresh job lands between trigger-click and confirm-click, the confirm path also deep-links instead of re-enqueuing.

## Out of scope (follow-ups)

- Same UX gap exists on Sync Beehiiv — \`useSyncProvider\`'s \`syncing\` state is the in-flight HTTP mutation, not the queued integration_sync job. Per-provider matching of integration_sync rows takes more thought.
- Same gap on x-ads / x sync sub-pages.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [ ] Click Analyse → button immediately changes to \"Analysis in progress — view\" → click again → navigates to Tasks page with the job highlighted
- [ ] Job completes → button reverts to \"Analyse N untagged\"
- [ ] Re-analyse-all confirm dialog open + active job lands → confirm-click navigates instead of enqueuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)