### PR TITLE
fix(tasks): anchor ElapsedTimer to job.createdAt + render server ETA

### DIFF
--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -158,7 +158,13 @@ function JobCard({
               status={statusForBadge(job)}
               dot={isActive}
             />
-            {isActive && <ElapsedTimer running />}
+            {isActive && (
+              <ElapsedTimer
+                running
+                startedAt={job.createdAt}
+                etaMs={job.progress?.etaMs}
+              />
+            )}
           </div>
         </div>
       </CardHeader>

--- a/src/components/molecules/elapsed-timer.tsx
+++ b/src/components/molecules/elapsed-timer.tsx
@@ -1,46 +1,92 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
 /**
  * PeakHour branded elapsed timer — shows time ticking while an async
  * operation is in progress. Reusable across strategist, content gen, etc.
  *
+ * Modes:
+ * - Anchored (preferred): pass `startedAt` so elapsed survives a refresh
+ *   and reflects the real time since the job was enqueued. When the
+ *   handler also fills `etaMs`, a "~Xs left" hint counts down beside it.
+ * - Legacy: omit `startedAt` and the timer ticks from component-mount
+ *   time (kept for ad-hoc loading spinners that don't have a server
+ *   anchor — e.g. one-shot strategist calls without a job row).
+ *
  * Usage:
  *   <ElapsedTimer running={isLoading} />
+ *   <ElapsedTimer running startedAt={job.createdAt} etaMs={job.progress?.etaMs} />
  *   <ElapsedTimer running={isLoading} estimatedSeconds={20} />
  */
 export function ElapsedTimer({
   running,
+  startedAt,
+  etaMs,
   estimatedSeconds,
   className,
 }: {
   running: boolean;
+  /** ISO string or Date — when set, elapsed = now - startedAt (refresh-safe). */
+  startedAt?: Date | string;
+  /** Server-side ETA in ms (e.g. job.progress.etaMs). Requires `startedAt` to render. */
+  etaMs?: number;
+  /** Static fallback ETA in seconds — only used when `etaMs` isn't provided. */
   estimatedSeconds?: number;
   className?: string;
 }) {
-  const [elapsed, setElapsed] = useState(0);
+  const anchorMs = useMemo(() => {
+    if (!startedAt) return null;
+    const t = typeof startedAt === "string" ? Date.parse(startedAt) : startedAt.getTime();
+    return Number.isFinite(t) ? t : null;
+  }, [startedAt]);
+
+  // Single `now` state drives both elapsed and remaining derivations —
+  // avoids the prior "setElapsed inside effect" pattern flagged by the
+  // old TODO and keeps the two values in lockstep.
+  const [now, setNow] = useState(() => Date.now());
+  // Mount epoch — used as the elapsed origin only when there's no
+  // `startedAt` anchor (legacy callers). Lazy useState initialiser
+  // captures Date.now() exactly once and stays stable across renders.
+  const [mountAt] = useState(() => Date.now());
 
   useEffect(() => {
-    if (!running) {
-      // TODO: refactor to avoid synchronous setState in effect (reset elapsed when timer stops).
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setElapsed(0);
-      return;
-    }
-    const t0 = Date.now();
-    const id = setInterval(() => setElapsed(Math.floor((Date.now() - t0) / 1000)), 1000);
+    if (!running) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
   }, [running]);
 
   if (!running) return null;
 
+  const origin = anchorMs ?? mountAt;
+  const elapsed = Math.max(0, Math.floor((now - origin) / 1000));
+
   const mins = Math.floor(elapsed / 60);
   const secs = elapsed % 60;
-  const display = mins > 0 ? `${mins}:${secs.toString().padStart(2, "0")}` : `${secs}s`;
+  const elapsedDisplay = mins > 0 ? `${mins}:${secs.toString().padStart(2, "0")}` : `${secs}s`;
 
-  const progress = estimatedSeconds ? Math.min(elapsed / estimatedSeconds, 1) : undefined;
+  // Server ETA: only meaningful with an anchor — without one we can't
+  // infer "how long until done" from a duration alone.
+  const remainingSec =
+    etaMs != null && etaMs > 0 && anchorMs != null
+      ? Math.max(0, Math.ceil((anchorMs + etaMs - now) / 1000))
+      : null;
+
+  // Progress bar prefers the server ETA, falls back to a static estimate.
+  let progress: number | undefined;
+  if (etaMs != null && etaMs > 0 && anchorMs != null) {
+    progress = Math.min((now - anchorMs) / etaMs, 1);
+  } else if (estimatedSeconds) {
+    progress = Math.min(elapsed / estimatedSeconds, 1);
+  }
+
+  const remainingDisplay =
+    remainingSec != null
+      ? remainingSec >= 60
+        ? `~${Math.ceil(remainingSec / 60)}m left`
+        : `~${remainingSec}s left`
+      : null;
 
   return (
     <div className={cn("inline-flex items-center gap-2 text-sm tabular-nums", className)}>
@@ -51,9 +97,14 @@ export function ElapsedTimer({
       </span>
 
       {/* Timer */}
-      <span className="font-mono text-muted-foreground">{display}</span>
+      <span className="font-mono text-muted-foreground">{elapsedDisplay}</span>
 
-      {/* Progress hint */}
+      {/* ETA hint */}
+      {remainingDisplay && (
+        <span className="text-xs text-muted-foreground">· {remainingDisplay}</span>
+      )}
+
+      {/* Progress bar */}
       {progress !== undefined && progress < 1 && (
         <div className="h-1 w-16 overflow-hidden rounded-full bg-muted">
           <div

--- a/src/components/molecules/elapsed-timer.tsx
+++ b/src/components/molecules/elapsed-timer.tsx
@@ -42,24 +42,33 @@ export function ElapsedTimer({
     return Number.isFinite(t) ? t : null;
   }, [startedAt]);
 
-  // Single `now` state drives both elapsed and remaining derivations —
-  // avoids the prior "setElapsed inside effect" pattern flagged by the
-  // old TODO and keeps the two values in lockstep.
+  // `now` ticks every second while running; `legacyStartAt` is the
+  // origin for callers that don't supply a server-side `startedAt`
+  // anchor. We re-stamp `legacyStartAt` on every running:false→true
+  // transition so consumers like strategist (which toggles generating
+  // multiple times within one component lifetime) get a fresh 0s start
+  // each run instead of accumulating from the first toggle. Both are
+  // updated from the effect — same pattern as the pre-refactor code.
   const [now, setNow] = useState(() => Date.now());
-  // Mount epoch — used as the elapsed origin only when there's no
-  // `startedAt` anchor (legacy callers). Lazy useState initialiser
-  // captures Date.now() exactly once and stays stable across renders.
-  const [mountAt] = useState(() => Date.now());
+  const [legacyStartAt, setLegacyStartAt] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!running) return;
+    if (!running) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLegacyStartAt(null);
+      return;
+    }
+    setLegacyStartAt(Date.now());
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
   }, [running]);
 
   if (!running) return null;
 
-  const origin = anchorMs ?? mountAt;
+  // Origin precedence: server-supplied anchor → fresh per-run legacy
+  // anchor → `now` (covers the first render after running flips true,
+  // before the effect populates legacyStartAt; resolves to 0s elapsed).
+  const origin = anchorMs ?? legacyStartAt ?? now;
   const elapsed = Math.max(0, Math.floor((now - origin) / 1000));
 
   const mins = Math.floor(elapsed / 60);
@@ -74,15 +83,20 @@ export function ElapsedTimer({
       : null;
 
   // Progress bar prefers the server ETA, falls back to a static estimate.
+  // Clamp to [0, 1] — `now < anchorMs` from clock skew would otherwise
+  // produce a negative value.
   let progress: number | undefined;
   if (etaMs != null && etaMs > 0 && anchorMs != null) {
-    progress = Math.min((now - anchorMs) / etaMs, 1);
+    progress = Math.min(Math.max((now - anchorMs) / etaMs, 0), 1);
   } else if (estimatedSeconds) {
     progress = Math.min(elapsed / estimatedSeconds, 1);
   }
 
+  // Suppress "~0s left" once we overshoot the ETA — the elapsed counter
+  // continues to convey "still working", and a stuck "~0s left" beside
+  // a ticking elapsed is just noise.
   const remainingDisplay =
-    remainingSec != null
+    remainingSec != null && remainingSec > 0
       ? remainingSec >= 60
         ? `~${Math.ceil(remainingSec / 60)}m left`
         : `~${remainingSec}s left`

--- a/src/components/molecules/elapsed-timer.tsx
+++ b/src/components/molecules/elapsed-timer.tsx
@@ -47,9 +47,15 @@ export function ElapsedTimer({
   // anchor. We re-stamp `legacyStartAt` on every running:false→true
   // transition so consumers like strategist (which toggles generating
   // multiple times within one component lifetime) get a fresh 0s start
-  // each run instead of accumulating from the first toggle. Both are
-  // updated from the effect — same pattern as the pre-refactor code.
-  const [now, setNow] = useState(() => Date.now());
+  // each run instead of accumulating from the first toggle.
+  //
+  // SSR safety: `now` starts at 0 (deterministic) instead of Date.now()
+  // so server-rendered HTML matches the first client render. The mount
+  // effect immediately calls setNow(Date.now()) to populate real time
+  // — a sub-frame transition the user can't perceive. Without this,
+  // any future caller that renders ElapsedTimer with running=true on
+  // first paint would trigger a Next.js hydration mismatch warning.
+  const [now, setNow] = useState(0);
   const [legacyStartAt, setLegacyStartAt] = useState<number | null>(null);
 
   useEffect(() => {
@@ -58,7 +64,9 @@ export function ElapsedTimer({
       setLegacyStartAt(null);
       return;
     }
-    setLegacyStartAt(Date.now());
+    const t = Date.now();
+    setLegacyStartAt(t);
+    setNow(t);
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
   }, [running]);
@@ -69,16 +77,21 @@ export function ElapsedTimer({
   // anchor → `now` (covers the first render after running flips true,
   // before the effect populates legacyStartAt; resolves to 0s elapsed).
   const origin = anchorMs ?? legacyStartAt ?? now;
-  const elapsed = Math.max(0, Math.floor((now - origin) / 1000));
+  // Clamp to 0 — covers (a) the SSR/pre-mount render where now=0 and
+  // anchorMs is in the past (would otherwise produce a huge negative)
+  // and (b) clock skew between server-stamped createdAt and Date.now().
+  const elapsed = now > 0 ? Math.max(0, Math.floor((now - origin) / 1000)) : 0;
 
   const mins = Math.floor(elapsed / 60);
   const secs = elapsed % 60;
   const elapsedDisplay = mins > 0 ? `${mins}:${secs.toString().padStart(2, "0")}` : `${secs}s`;
 
   // Server ETA: only meaningful with an anchor — without one we can't
-  // infer "how long until done" from a duration alone.
+  // infer "how long until done" from a duration alone. Also gated on
+  // now>0 so the SSR/pre-mount render (now=0) doesn't compute a wildly
+  // wrong "~Xs left" from `anchorMs + etaMs - 0`.
   const remainingSec =
-    etaMs != null && etaMs > 0 && anchorMs != null
+    now > 0 && etaMs != null && etaMs > 0 && anchorMs != null
       ? Math.max(0, Math.ceil((anchorMs + etaMs - now) / 1000))
       : null;
 


### PR DESCRIPTION
## Summary

The /dashboard/tasks per-job timer was a client-side stopwatch — it captured `Date.now()` at component mount and ticked from 0 on every refresh. It conveyed nothing about the actual job: not how long it had been queued, not how long it had been running, not how much longer it would take.

`/v1/jobs` already returns `createdAt` and `progress.etaMs`; this PR pipes both through `ElapsedTimer` so:
- elapsed survives a refresh (anchored to `createdAt`)
- "~Xs left" / "~Nm left" appears beside elapsed when handlers populate `etaMs`
- progress bar fills from server ETA when available, static estimate fallback otherwise
- legacy mode (no `startedAt` prop) preserved for non-job callers like the strategist loading spinner

## Test plan

- [ ] Type-check + lint pass (already verified locally)
- [ ] Open `/dashboard/tasks` with at least one in-flight job; hard-refresh — timer should NOT reset to 0, should continue from "elapsed since `createdAt`"
- [ ] When a handler populates `progress.etaMs` (e.g. `content_analyse` mid-run), confirm "~Xs left" / "~Nm left" appears beside the elapsed value and counts down
- [ ] When `etaMs` is absent, confirm graceful fallback (just elapsed, no ETA hint)
- [ ] Strategist page (`/dashboard/strategist`): generate twice within the same page session — second run's elapsed counter should start at 0s, not continue from the first run's accumulated time
- [ ] After ETA overshoot, "~0s left" should NOT show (just elapsed continues ticking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)