### PR TITLE
chore(vercel): pin deploymentEnabled to fixed branch list

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,16 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "production": true,
+      "master": true,
+      "staging": true,
+      "feature-1": true,
+      "feature-2": true,
+      "feature-3": true,
+      "feature-4": true,
+      "*": false
+    }
+  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

Adds \`git.deploymentEnabled\` to vercel.json so Vercel only auto-builds the branches we actually want deployed, matching the config in peakhour-api / peakhour-cms:

- **production** → peakhour.ai
- **staging** → staging.peakhour.ai
- **master** → dev.peakhour.ai (development)
- **feature-1..4** → reusable preview slots
- \`"*": false\` blocks every other branch

Existing headers config preserved verbatim.

## Test plan

- [ ] Vercel project picks this up on next push to master and stops auto-building random branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)