### PR TITLE
chore(scripts): npm run errors:ai passthrough to peakhour-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "errors:ai": "npm --prefix ../peakhour-api run errors:ai --",
+    "errors:ai:1d": "npm --prefix ../peakhour-api run errors:ai:1d",
+    "errors:ai:7d": "npm --prefix ../peakhour-api run errors:ai:7d"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Adds `npm run errors:ai`, `errors:ai:1d`, `errors:ai:7d` as passthroughs to peakhour-api (where MongoDB access lives).

The passthrough uses `npm --prefix ../peakhour-api run errors:ai` and depends on the sibling repo being checked out. Will fail with a clear "Missing script: errors:ai" until peakhour-api master has the script (peakhour-api PR #177).

## Test plan
- [ ] After peakhour-api#177 merges, run `npm run errors:ai:1d` from this repo — should print last-24h error clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)