### PR TITLE
feat(b2c): upgrade primitive (FeatureGate / UpgradeButton / UpgradeDrawer / useFeature)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,3 +125,21 @@
     @apply bg-background text-foreground;
   }
 }
+
+/*
+ * Animated conic-gradient ring used by <UpgradeButton variant="pill" />.
+ * @property is required so browsers can interpolate the custom angle
+ * value at the requested 60fps; without it the conic-gradient would
+ * snap from 0deg to 360deg without intermediate frames.
+ */
+@property --ring-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes gradient-ring-spin {
+  to {
+    --ring-angle: 360deg;
+  }
+}

--- a/src/components/upgrade/feature-gate.tsx
+++ b/src/components/upgrade/feature-gate.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useFeature } from "@/hooks/use-feature";
+import { cn } from "@/lib/utils";
+import { UpgradeBadge } from "./upgrade-badge";
+import { UpgradeButton } from "./upgrade-button";
+
+/**
+ * FeatureGate — wraps any UI subtree and gates it on a feature key
+ * from the org's entitlements snapshot.
+ *
+ * Modes:
+ *   "lock"  (default) — children render but are visually muted +
+ *           pointer-events-none, with an UpgradeBadge in the corner.
+ *           Clicking the wrapper opens the upgrade drawer. Best for
+ *           feature toggles and individual rows the user shouldn't
+ *           be allowed to interact with.
+ *   "hide"  — children don't render at all when locked. Use for
+ *           full-panel features where revealing-but-locking would be
+ *           noisy. The fallback (typically a card with an explainer
+ *           + UpgradeButton) renders in their place.
+ *   "passthrough" — when allowed, returns children directly with no
+ *           wrapper. When locked, renders fallback if provided, else
+ *           null. Use when the parent controls the layout.
+ *
+ * While entitlements are loading, the component renders children
+ * with reduced opacity (no flicker between "locked" and "allowed").
+ */
+export interface FeatureGateProps {
+  feature: string;
+  featureName?: string;
+  featureTagline?: string;
+  mode?: "lock" | "hide" | "passthrough";
+  /** Rendered in place of children when mode != "lock" and the
+   *  feature is locked. */
+  fallback?: React.ReactNode;
+  /** Wrapper className applied to the outer div in "lock" mode. */
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function FeatureGate({
+  feature,
+  featureName,
+  featureTagline,
+  mode = "lock",
+  fallback,
+  className,
+  children,
+}: FeatureGateProps) {
+  const { allowed, loading } = useFeature(feature);
+
+  if (loading) {
+    return <div className="opacity-70">{children}</div>;
+  }
+
+  if (allowed) {
+    return mode === "passthrough" ? <>{children}</> : <>{children}</>;
+  }
+
+  // Locked.
+  if (mode === "hide" || mode === "passthrough") {
+    return fallback ?? null;
+  }
+
+  // Lock mode (default): show children muted + an upgrade affordance.
+  return (
+    <div className={cn("relative", className)}>
+      <div className="pointer-events-none select-none opacity-50 [filter:saturate(0.8)]">
+        {children}
+      </div>
+      <UpgradeBadge />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <UpgradeButton
+          featureKey={feature}
+          featureName={featureName}
+          featureTagline={featureTagline}
+        >
+          Unlock
+        </UpgradeButton>
+      </div>
+    </div>
+  );
+}

--- a/src/components/upgrade/feature-gate.tsx
+++ b/src/components/upgrade/feature-gate.tsx
@@ -50,12 +50,14 @@ export function FeatureGate({
 }: FeatureGateProps) {
   const { allowed, loading } = useFeature(feature);
 
-  if (loading) {
-    return <div className="opacity-70">{children}</div>;
-  }
+  // While loading, render the locked treatment — never expose
+  // children fully interactive before entitlements resolve. A brief
+  // "locked" flash beats briefly granting access. Keeps the JSDoc
+  // promise above (locked-by-default semantics) honest.
+  const showLocked = loading || !allowed;
 
-  if (allowed) {
-    return mode === "passthrough" ? <>{children}</> : <>{children}</>;
+  if (!showLocked) {
+    return <>{children}</>;
   }
 
   // Locked.
@@ -63,21 +65,39 @@ export function FeatureGate({
     return fallback ?? null;
   }
 
-  // Lock mode (default): show children muted + an upgrade affordance.
+  // Lock mode (default): muted children + upgrade affordance over them.
+  // - `inert` disables pointer + keyboard interaction on the muted
+  //   subtree (React 19+ supports inert natively). Without it, a
+  //   focusable child (Switch, Input) stays tab-reachable and could
+  //   be activated via keyboard despite the visual lock.
+  // - The overlay container is `pointer-events-none` so empty space
+  //   in the centered flex layout doesn't intercept attempts to click
+  //   visible-but-muted children. Only the UpgradeButton itself
+  //   captures pointer events.
+  // - role="group" + aria-label give AT users a description of WHY
+  //   the region is locked instead of just announcing "Unlock".
+  const lockLabel = `Locked feature${featureName ? `: ${featureName}` : ""}. Upgrade required.`;
   return (
-    <div className={cn("relative", className)}>
-      <div className="pointer-events-none select-none opacity-50 [filter:saturate(0.8)]">
+    <div
+      className={cn("relative", className)}
+      role="group"
+      aria-label={lockLabel}
+    >
+      {/* @ts-expect-error -- React 19 supports the `inert` attribute, but TS DOM types haven't caught up everywhere. */}
+      <div inert="" className="select-none opacity-50 filter-[saturate(0.8)]">
         {children}
       </div>
       <UpgradeBadge />
-      <div className="absolute inset-0 flex items-center justify-center">
-        <UpgradeButton
-          featureKey={feature}
-          featureName={featureName}
-          featureTagline={featureTagline}
-        >
-          Unlock
-        </UpgradeButton>
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <span className="pointer-events-auto">
+          <UpgradeButton
+            featureKey={feature}
+            featureName={featureName}
+            featureTagline={featureTagline}
+          >
+            Unlock
+          </UpgradeButton>
+        </span>
       </div>
     </div>
   );

--- a/src/components/upgrade/gradient-ring.tsx
+++ b/src/components/upgrade/gradient-ring.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Animated conic-gradient ring used as an accent on locked UI.
+ * Tailwind-only — no Framer Motion dep — but motion-safe via
+ * `motion-reduce:animate-none`. The gradient revolves slowly (~8s);
+ * hovering speeds it to 4s so the user gets a subtle response without
+ * us shipping a JS animation library.
+ *
+ * Renders as a positioned overlay; the parent should be `position:
+ * relative` and have a sensible `border-radius`. The ring sits as a
+ * 1.5px outline over the parent's content via `inset-[-1.5px]`.
+ */
+interface GradientRingProps {
+  className?: string;
+  /** Speed up on hover. Defaults to true. */
+  hoverAccelerate?: boolean;
+}
+
+export function GradientRing({ className, hoverAccelerate = true }: GradientRingProps) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-[-1.5px] rounded-[inherit]",
+        "[background:conic-gradient(from_var(--ring-angle,0deg),#0A66C2_0deg,#7c3aed_120deg,#f59e0b_240deg,#0A66C2_360deg)]",
+        "[mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)]",
+        "[mask-composite:exclude] [-webkit-mask-composite:xor]",
+        "p-[1.5px] motion-safe:animate-[gradient-ring-spin_8s_linear_infinite] motion-reduce:animate-none",
+        hoverAccelerate
+          ? "group-hover/gradient-ring:motion-safe:[animation-duration:4s]"
+          : "",
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/upgrade/upgrade-badge.tsx
+++ b/src/components/upgrade/upgrade-badge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Small lock indicator pinned at the top-right of a gated control.
+ * Used inline next to a feature toggle, button, or selectable row when
+ * we want to mark the surface as Pro-gated without obscuring it.
+ *
+ * Pair with parent `position: relative` so the absolute-positioning
+ * lands inside the gated control's bounding box.
+ */
+export function UpgradeBadge({ className, label }: { className?: string; label?: string }) {
+  return (
+    <span
+      className={cn(
+        "absolute -top-2 -right-2 z-10 inline-flex items-center gap-1",
+        "rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5",
+        "text-[10px] font-medium text-amber-700 shadow-sm",
+        "dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300",
+        className,
+      )}
+    >
+      <Lock className="size-3" />
+      {label ?? "Pro"}
+    </span>
+  );
+}

--- a/src/components/upgrade/upgrade-button.tsx
+++ b/src/components/upgrade/upgrade-button.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type ButtonSize = "default" | "sm" | "lg" | "icon" | null | undefined;
+import { cn } from "@/lib/utils";
+import { GradientRing } from "./gradient-ring";
+import { UpgradeDrawer } from "./upgrade-drawer";
+
+/**
+ * UpgradeButton — single CTA the rest of the app uses to open the
+ * upgrade drawer. Renders a gradient-ringed Pro chip by default; pass
+ * `variant="inline-link"` for a low-emphasis text link, or
+ * `variant="ghost"` for a flat button.
+ *
+ * Owns its own drawer instance — clicking opens, closing resets form.
+ * No global mounting required for v1.
+ */
+export interface UpgradeButtonProps {
+  /** cfg_features.key — what the user clicked into. Surfaced in
+   *  drawer copy and tagged on every waitlist signup for analytics. */
+  featureKey?: string;
+  featureName?: string;
+  featureTagline?: string;
+  /** Default "pill" — the brand pill with rotating gradient ring.
+   *  "ghost" — flat secondary; "inline-link" — text link. */
+  variant?: "pill" | "ghost" | "inline-link";
+  size?: ButtonSize;
+  className?: string;
+  children?: React.ReactNode;
+  /** Override drawer mode. Defaults to "waitlist". */
+  mode?: "waitlist" | "checkout";
+  intent?: "plan_upgrade" | "addon" | "integration" | "general";
+  addonKey?: string;
+  integrationKey?: string;
+}
+
+export function UpgradeButton(props: UpgradeButtonProps) {
+  const [open, setOpen] = useState(false);
+  const {
+    featureKey,
+    featureName,
+    featureTagline,
+    variant = "pill",
+    size,
+    className,
+    children,
+    mode,
+    intent,
+    addonKey,
+    integrationKey,
+  } = props;
+
+  const label = children ?? "Upgrade";
+
+  return (
+    <>
+      {variant === "pill" ? (
+        <span className={cn("group/gradient-ring relative inline-block rounded-full", className)}>
+          <GradientRing />
+          <Button
+            type="button"
+            size={size ?? "sm"}
+            onClick={() => setOpen(true)}
+            className={cn(
+              "relative rounded-full gap-1.5",
+              "bg-gradient-to-r from-amber-50 to-amber-100 text-amber-900 hover:from-amber-100 hover:to-amber-200",
+              "dark:from-amber-950 dark:to-amber-900 dark:text-amber-200 dark:hover:from-amber-900 dark:hover:to-amber-800",
+              "border-0 shadow-sm",
+            )}
+          >
+            <Sparkles className="size-3.5" />
+            {label}
+          </Button>
+        </span>
+      ) : variant === "inline-link" ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={cn(
+            "inline-flex items-center gap-1 text-sm font-medium",
+            "text-primary underline-offset-2 hover:underline",
+            className,
+          )}
+        >
+          <Lock className="size-3.5" />
+          {label}
+        </button>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size={size}
+          onClick={() => setOpen(true)}
+          className={className}
+        >
+          <Lock className="size-3.5 mr-1.5" />
+          {label}
+        </Button>
+      )}
+
+      <UpgradeDrawer
+        open={open}
+        onOpenChange={setOpen}
+        featureKey={featureKey}
+        featureName={featureName}
+        featureTagline={featureTagline}
+        mode={mode}
+        intent={intent}
+        addonKey={addonKey}
+        integrationKey={integrationKey}
+      />
+    </>
+  );
+}

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { Sparkles, Mail, Loader2, Check, Send } from "lucide-react";
+import { Sparkles, Mail, Loader2, Check, Share2 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuth } from "@/providers/auth-provider";
 import {
@@ -57,12 +57,31 @@ export interface UpgradeDrawerProps {
 }
 
 /**
- * Cryptographically random-ish 4-char anti-collision suffix used in
- * the success card's share URL. Keeps the UTM stable while avoiding
- * exact-URL caching on retweets.
+ * Client-side random suffix used in the success card's share URL —
+ * defeats exact-URL caching on retweets. Non-security; Math.random
+ * is fine.
  */
 function clientNonce(): string {
   return Math.random().toString(36).slice(2, 6);
+}
+
+/**
+ * Pick the right `intent` for a waitlist signup based on which key
+ * the caller passed. Documents the precedence so callers passing
+ * BOTH addonKey AND featureKey (legitimate — an add-on unlocks a
+ * feature) know they'll be bucketed by add-on (the more specific of
+ * the two for analytics). Override via the explicit `intent` prop
+ * when the default is wrong.
+ */
+function inferIntent(args: {
+  addonKey?: string;
+  integrationKey?: string;
+  featureKey?: string;
+}): "plan_upgrade" | "addon" | "integration" | "general" {
+  if (args.addonKey) return "addon";
+  if (args.integrationKey) return "integration";
+  if (args.featureKey) return "plan_upgrade";
+  return "general";
 }
 
 export function UpgradeDrawer(props: UpgradeDrawerProps) {
@@ -77,7 +96,7 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
     addonKey,
     integrationKey,
   } = props;
-  const { user, org } = useAuth();
+  const { user } = useAuth();
 
   // Local form state — kept inside the drawer so closing-and-reopening
   // resets the form. Authenticated callers see their email auto-filled.
@@ -102,9 +121,11 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
   function handleClose(next: boolean) {
     onOpenChange(next);
     if (!next) {
-      // Defer reset to next tick so the close animation doesn't show
-      // the form clearing while the drawer is still visible.
-      setTimeout(reset, 200);
+      // Reset form once the Sheet's close animation has finished
+      // (Radix's default close transition is ~300ms in this build).
+      // Resetting earlier would visibly clear the form while the
+      // drawer is still fading out.
+      setTimeout(reset, 350);
     }
   }
 
@@ -117,13 +138,12 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
     try {
       const body: Record<string, unknown> = {
         email,
-        intent: intent ?? (addonKey ? "addon" : integrationKey ? "integration" : featureKey ? "plan_upgrade" : "general"),
+        intent: intent ?? inferIntent({ addonKey, integrationKey, featureKey }),
       };
       if (featureKey) body.featureKey = featureKey;
       if (addonKey) body.addonKey = addonKey;
       if (integrationKey) body.integrationKey = integrationKey;
       if (businessContext) body.businessContext = businessContext;
-      if (org?.slug) body.utmSource = org.slug;
 
       const r = await api.post<{
         _id: string;
@@ -161,7 +181,10 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
         url,
       }).catch(() => {/* user dismissed */});
     } else {
-      navigator.clipboard.writeText(url).then(() => toast.success("Referral link copied"));
+      navigator.clipboard
+        .writeText(url)
+        .then(() => toast.success("Referral link copied"))
+        .catch(() => toast.error("Could not copy link — copy it manually below"));
     }
   }
 
@@ -292,8 +315,8 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
                   <code className="flex-1 rounded bg-muted px-3 py-1.5 font-mono text-xs">
                     {success.referralCode}
                   </code>
-                  <Button size="sm" variant="outline" onClick={shareReferral}>
-                    <Send className="size-3.5 mr-1.5" />
+                  <Button size="sm" variant="outline" onClick={shareReferral} aria-label="Share referral link">
+                    <Share2 className="size-3.5 mr-1.5" />
                     Share
                   </Button>
                 </div>

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Sparkles, Mail, Loader2, Check, Send } from "lucide-react";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * UpgradeDrawer — reusable Sheet that opens on any plan-gated
+ * interaction. Operates in two modes (a third "limit-reached" mode
+ * for fair-use 429s lives in a separate component).
+ *
+ *   waitlist  — v1 GA default. No prices shown. Captures email +
+ *               business context for the Pro waiting list. Founding-
+ *               member badge for the first 500 signups.
+ *   checkout  — flips on once public pricing GA-s. Plan card +
+ *               Stripe/Razorpay handoff.
+ *
+ * The two modes share the same Sheet chrome, animated header, and
+ * telemetry tags so flipping `mode` is one config change at the call
+ * site (eventually a remote-config flag).
+ *
+ * Props pass `featureKey` so the body copy + waitlist signup know
+ * what triggered the drawer; that string is the single best dataset
+ * we'll have for pricing decisions later.
+ */
+type UpgradeDrawerMode = "waitlist" | "checkout";
+
+export interface UpgradeDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** cfg_features.key the user clicked into. */
+  featureKey?: string;
+  /** Display name of the locked feature, for the headline. */
+  featureName?: string;
+  /** One-line value prop shown under the headline. */
+  featureTagline?: string;
+  /** Drawer mode. Defaults to "waitlist" — the v1 production posture. */
+  mode?: UpgradeDrawerMode;
+  /** Optional intent override; defaults derived from featureKey/addonKey. */
+  intent?: "plan_upgrade" | "addon" | "integration" | "general";
+  addonKey?: string;
+  integrationKey?: string;
+}
+
+/**
+ * Cryptographically random-ish 4-char anti-collision suffix used in
+ * the success card's share URL. Keeps the UTM stable while avoiding
+ * exact-URL caching on retweets.
+ */
+function clientNonce(): string {
+  return Math.random().toString(36).slice(2, 6);
+}
+
+export function UpgradeDrawer(props: UpgradeDrawerProps) {
+  const {
+    open,
+    onOpenChange,
+    featureKey,
+    featureName,
+    featureTagline,
+    mode = "waitlist",
+    intent,
+    addonKey,
+    integrationKey,
+  } = props;
+  const { user, org } = useAuth();
+
+  // Local form state — kept inside the drawer so closing-and-reopening
+  // resets the form. Authenticated callers see their email auto-filled.
+  const [email, setEmail] = useState(user?.email ?? "");
+  const [businessContext, setBusinessContext] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<{
+    referralCode: string;
+    foundingMember: boolean;
+    position: number | null;
+  } | null>(null);
+
+  // Reset state when drawer closes — useEffect would also work but
+  // open/close gives a more deterministic UX.
+  function reset() {
+    setEmail(user?.email ?? "");
+    setBusinessContext("");
+    setSuccess(null);
+    setSubmitting(false);
+  }
+
+  function handleClose(next: boolean) {
+    onOpenChange(next);
+    if (!next) {
+      // Defer reset to next tick so the close animation doesn't show
+      // the form clearing while the drawer is still visible.
+      setTimeout(reset, 200);
+    }
+  }
+
+  async function submitWaitlist() {
+    if (!email || !email.includes("@")) {
+      toast.error("Please enter a valid email");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = {
+        email,
+        intent: intent ?? (addonKey ? "addon" : integrationKey ? "integration" : featureKey ? "plan_upgrade" : "general"),
+      };
+      if (featureKey) body.featureKey = featureKey;
+      if (addonKey) body.addonKey = addonKey;
+      if (integrationKey) body.integrationKey = integrationKey;
+      if (businessContext) body.businessContext = businessContext;
+      if (org?.slug) body.utmSource = org.slug;
+
+      const r = await api.post<{
+        _id: string;
+        referralCode: string;
+        foundingMember: boolean;
+        position: number | null;
+        idempotent?: boolean;
+      }>("/v1/waitlist/signup", body);
+
+      setSuccess({
+        referralCode: r.referralCode,
+        foundingMember: r.foundingMember,
+        position: r.position,
+      });
+      if (r.idempotent) {
+        toast.success("You're already on the waitlist");
+      } else {
+        toast.success("You're in");
+      }
+    } catch (err) {
+      toast.error((err as Error)?.message || "Could not join the waitlist");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function shareReferral() {
+    if (!success) return;
+    const base = typeof window !== "undefined" ? window.location.origin : "";
+    const url = `${base}/?ref=${success.referralCode}&n=${clientNonce()}`;
+    if (navigator.share) {
+      navigator.share({
+        title: "Peakhour — early access",
+        text: "I just joined the Peakhour waitlist. Skip the line:",
+        url,
+      }).catch(() => {/* user dismissed */});
+    } else {
+      navigator.clipboard.writeText(url).then(() => toast.success("Referral link copied"));
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent className="sm:max-w-md flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            {mode === "waitlist" ? (
+              <>
+                <Sparkles className="size-5 text-amber-500" />
+                Pro is opening soon
+              </>
+            ) : (
+              <>Unlock {featureName || "this feature"}</>
+            )}
+          </SheetTitle>
+          <SheetDescription>
+            {success
+              ? "You're in line. We'll email you when access opens."
+              : mode === "waitlist"
+                ? `Reserve your spot${featureName ? ` for ${featureName}` : ""}. Founding members lock in early-access perks.`
+                : (featureTagline ?? "Choose a plan to unlock this and the rest of Pro.")}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="px-4 flex-1 overflow-auto space-y-5">
+          {/* Locked-feature preview block */}
+          {!success && featureName ? (
+            <div className="rounded-lg border bg-card p-4">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Feature
+              </p>
+              <p className="mt-1 text-sm font-medium">{featureName}</p>
+              {featureTagline ? (
+                <p className="mt-1 text-sm text-muted-foreground">{featureTagline}</p>
+              ) : null}
+              {featureKey ? (
+                <p className="mt-2 font-mono text-[10px] text-muted-foreground">{featureKey}</p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {/* Waitlist form */}
+          {mode === "waitlist" && !success ? (
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (!submitting) submitWaitlist();
+              }}
+              className="space-y-4"
+            >
+              <div>
+                <Label htmlFor="upgrade-email">Email</Label>
+                <Input
+                  id="upgrade-email"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  readOnly={Boolean(user?.email)}
+                  className={user?.email ? "bg-muted" : undefined}
+                  required
+                />
+                {user?.email ? (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Signed-in email. Sign out and resubmit to use a different one.
+                  </p>
+                ) : null}
+              </div>
+              <div>
+                <Label htmlFor="upgrade-context">
+                  Tell us how you&apos;d use this
+                  <span className="text-xs font-normal text-muted-foreground ml-1">(optional, shapes what we ship first)</span>
+                </Label>
+                <Textarea
+                  id="upgrade-context"
+                  value={businessContext}
+                  onChange={(e) => setBusinessContext(e.target.value)}
+                  placeholder="e.g. We post on LinkedIn 3×/week and want a writer agent that picks up our brand voice."
+                  maxLength={2048}
+                  rows={4}
+                />
+              </div>
+            </form>
+          ) : null}
+
+          {/* Checkout-mode placeholder. The pricing matrix is wired
+              once we flip drawerMode globally — for now this is a
+              visible reminder that the path exists. */}
+          {mode === "checkout" && !success ? (
+            <div className="rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground">
+              Checkout mode renders the pricing matrix and Stripe/Razorpay
+              handoff. Until public pricing flips on, the drawer ships in
+              waitlist mode.
+            </div>
+          ) : null}
+
+          {/* Success card */}
+          {success ? (
+            <div className="space-y-4">
+              <div className="rounded-lg border bg-card p-4 flex items-start gap-3">
+                <div className="rounded-full bg-green-100 dark:bg-green-950 p-2 mt-0.5">
+                  <Check className="size-4 text-green-700 dark:text-green-400" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">You&apos;re in line</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {success.position
+                      ? `Position #${success.position.toLocaleString()}`
+                      : "Position will update on your next visit"}
+                  </p>
+                  {success.foundingMember ? (
+                    <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+                      <Sparkles className="size-3" />
+                      Founding Member — early-access perks locked in
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="rounded-lg border p-4 space-y-2">
+                <p className="text-sm font-medium">Skip 5 spots</p>
+                <p className="text-xs text-muted-foreground">
+                  Invite a friend with your code; both of you move up the line.
+                </p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 rounded bg-muted px-3 py-1.5 font-mono text-xs">
+                    {success.referralCode}
+                  </code>
+                  <Button size="sm" variant="outline" onClick={shareReferral}>
+                    <Send className="size-3.5 mr-1.5" />
+                    Share
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <SheetFooter>
+          {success ? (
+            <Button onClick={() => handleClose(false)}>Done</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => handleClose(false)} disabled={submitting}>
+                Maybe later
+              </Button>
+              <Button onClick={submitWaitlist} disabled={submitting || mode === "checkout"}>
+                {submitting ? (
+                  <>
+                    <Loader2 className="size-4 mr-2 animate-spin" />
+                    Saving…
+                  </>
+                ) : (
+                  <>
+                    <Mail className="size-4 mr-2" />
+                    {mode === "waitlist" ? "Reserve my spot" : "Continue to checkout"}
+                  </>
+                )}
+              </Button>
+            </>
+          )}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/hooks/use-feature.ts
+++ b/src/hooks/use-feature.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Feature flag hook backed by the org's entitlements snapshot from
+ * GET /v1/auth/me (populated on session boot + every org/business
+ * switch via the auth provider).
+ *
+ * Usage:
+ *   const { allowed, plan } = useFeature("linkedin.autonomy.l3");
+ *   if (!allowed) return <UpgradeButton feature="linkedin.autonomy.l3" />;
+ *
+ * Locked-by-default semantics:
+ *   - Returns `allowed: false` when entitlements are still loading.
+ *   - Returns `allowed: false` when entitlements is null (no active org,
+ *     or peakhour-api flagged entitlementsError on /me).
+ *   - Returns `allowed: true` when the feature key is present in
+ *     entitlements.features (cfg_features.key, dotted.snake_case).
+ *
+ * The conservative default is intentional: a brief flicker showing
+ * "locked" is better than briefly showing gated content while the
+ * snapshot loads.
+ */
+export interface UseFeatureResult {
+  /** True when the feature is unlocked for this org. */
+  allowed: boolean;
+  /** True while the entitlements snapshot is still loading. */
+  loading: boolean;
+  /** Active plan key (e.g., "free", "pro") — useful for upgrade-drawer copy. */
+  plan: string | null;
+  /** Active country (ISO 3166-1 alpha-2) — for region-aware plan cards. */
+  country: string | null;
+  /** Currency from the entitlements snapshot. */
+  currency: string | null;
+}
+
+export function useFeature(featureKey: string): UseFeatureResult {
+  const { entitlements, isLoading } = useAuth();
+  const allowed = !isLoading && Boolean(entitlements?.features?.includes(featureKey));
+  return {
+    allowed,
+    loading: isLoading,
+    plan: entitlements?.plan ?? null,
+    country: entitlements?.country ?? null,
+    currency: entitlements?.currency ?? null,
+  };
+}
+
+/**
+ * Variant — returns `true` when ANY of the listed feature keys is on.
+ * Useful for routes that accept multiple plan tiers.
+ */
+export function useAnyFeature(featureKeys: string[]): UseFeatureResult {
+  const { entitlements, isLoading } = useAuth();
+  const allowed =
+    !isLoading &&
+    Boolean(entitlements?.features) &&
+    featureKeys.some((k) => entitlements!.features.includes(k));
+  return {
+    allowed,
+    loading: isLoading,
+    plan: entitlements?.plan ?? null,
+    country: entitlements?.country ?? null,
+    currency: entitlements?.currency ?? null,
+  };
+}
+
+/**
+ * Lookup a numeric limit from entitlements. Returns null if not set
+ * (treat as "no quota explicitly defined" — caller decides default).
+ */
+export function useLimit(limitKey: keyof NonNullable<ReturnType<typeof useAuth>["entitlements"]>["limits"]): number | null {
+  const { entitlements } = useAuth();
+  const v = entitlements?.limits?.[limitKey];
+  return typeof v === "number" ? v : null;
+}

--- a/src/hooks/use-feature.ts
+++ b/src/hooks/use-feature.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { EntitlementLimits } from "@/lib/auth";
 import { useAuth } from "@/providers/auth-provider";
 
 /**
@@ -69,8 +70,11 @@ export function useAnyFeature(featureKeys: string[]): UseFeatureResult {
 /**
  * Lookup a numeric limit from entitlements. Returns null if not set
  * (treat as "no quota explicitly defined" — caller decides default).
+ *
+ * Typed via `keyof EntitlementLimits` directly so a refactor of the
+ * AuthState shape doesn't silently widen this surface.
  */
-export function useLimit(limitKey: keyof NonNullable<ReturnType<typeof useAuth>["entitlements"]>["limits"]): number | null {
+export function useLimit(limitKey: keyof EntitlementLimits): number | null {
   const { entitlements } = useAuth();
   const v = entitlements?.limits?.[limitKey];
   return typeof v === "number" ? v : null;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -54,12 +54,53 @@ export interface BusinessSummary {
   businessCategory?: string | null;
 }
 
+export interface EntitlementLimits {
+  maxPostsPerMonth?: number;
+  maxAgentRunsPerDay?: number;
+  maxConnectedChannels?: number;
+  maxBusinesses?: number;
+  maxSeats?: number;
+  monthlyAdSpendCap?: number;
+  maxStorageGb?: number;
+  maxAiTokensPerMonth?: number;
+}
+
+/**
+ * Computed entitlements snapshot for the active org. Mirrors
+ * peakhour-api's `ComputedEntitlements` shape (services/entitlements/
+ * compute.ts). Resolves features + integrations + limits from the
+ * org's plan + active add-ons.
+ *
+ * `features[]` keys follow the cfg_features dotted.snake_case convention
+ * (e.g., "linkedin.autonomy.l3", "audience.lookalike_pipe").
+ * `integrations[]` keys follow flat snake_case matching cfg_integrations.key.
+ */
+export interface Entitlements {
+  plan: string;
+  planVersion: number;
+  features: string[];
+  integrations: string[];
+  limits: EntitlementLimits;
+  country?: string;
+  currency?: string;
+  computedAt: string;
+}
+
 export interface MeResponse {
   user: AuthUser;
   org: AuthOrg | null;
   orgs: OrgSummary[];
   business: AuthBusiness | null;
   businesses: BusinessSummary[];
+  /**
+   * Active org's entitlements snapshot. Null when the user has no
+   * active org (pre-onboarding) — UI should treat as "no features".
+   * When the API has trouble computing (Mongo blip, missing plan
+   * row), the field is null AND `entitlementsError: true` is also
+   * set — gates stay locked, ops investigates via auth log.
+   */
+  entitlements: Entitlements | null;
+  entitlementsError?: boolean;
 }
 
 export interface VerifyMagicResponse {

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -16,6 +16,7 @@ import {
   type AuthBusiness,
   type OrgSummary,
   type BusinessSummary,
+  type Entitlements,
   getMe,
   logout as apiLogout,
   switchOrg as apiSwitchOrg,
@@ -28,6 +29,9 @@ interface AuthState {
   orgs: OrgSummary[];
   business: AuthBusiness | null;
   businesses: BusinessSummary[];
+  /** Active org's entitlements snapshot from /me. Null when unavailable
+   *  — every FeatureGate treats null as locked (correct safety posture). */
+  entitlements: Entitlements | null;
   isLoading: boolean;
   isAuthenticated: boolean;
 }
@@ -50,19 +54,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     orgs: [],
     business: null,
     businesses: [],
+    entitlements: null,
     isLoading: true,
     isAuthenticated: false,
   });
 
   const refreshUser = useCallback(async () => {
     try {
-      const { user, org, orgs, business, businesses } = await getMe();
+      const { user, org, orgs, business, businesses, entitlements } = await getMe();
       setState({
         user,
         org,
         orgs: orgs || [],
         business: business || null,
         businesses: businesses || [],
+        entitlements: entitlements ?? null,
         isLoading: false,
         isAuthenticated: true,
       });
@@ -73,6 +79,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         orgs: [],
         business: null,
         businesses: [],
+        entitlements: null,
         isLoading: false,
         isAuthenticated: false,
       });
@@ -156,6 +163,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       orgs: [],
       business: null,
       businesses: [],
+      entitlements: null,
       isLoading: false,
       isAuthenticated: false,
     });


### PR DESCRIPTION
## Summary

Reusable plan-gating UI consuming \`/me.entitlements\` (peakhour-api PR #198) and \`/v1/waitlist/signup\` (peakhour-api PR #194).

### Components (\`src/components/upgrade/\`)

| File | Purpose |
|---|---|
| \`feature-gate.tsx\` | Wraps any subtree; modes: lock (default — muted+badge+overlay CTA), hide (nullify), passthrough (caller controls) |
| \`upgrade-button.tsx\` | Standalone CTA. Variants: pill (animated gradient ring), ghost, inline-link |
| \`upgrade-drawer.tsx\` | Sheet — waitlist mode (v1 GA, no prices, captures email + business context, founding-member badge) and checkout mode (placeholder until pricing GAs) |
| \`upgrade-badge.tsx\` | Corner Pro lock chip |
| \`gradient-ring.tsx\` | Tailwind-only animated conic gradient (no Framer Motion); motion-reduce respected |

### Hook (\`src/hooks/use-feature.ts\`)

- \`useFeature(key)\` — returns \`{ allowed, loading, plan, country, currency }\` from auth provider's entitlements snapshot.
- \`useAnyFeature(keys)\`, \`useLimit(key)\` (typed via \`keyof EntitlementLimits\`).

Locked-by-default while loading — a brief "locked" flicker is correct safety posture vs briefly granting access.

### Wiring

- \`MeResponse\` + \`AuthState\` extended with \`entitlements: Entitlements | null\`.
- \`refreshUser\` populates from \`/me\`; logout clears.
- Each \`UpgradeButton\` owns its own drawer instance (singleton-mounted variant deferred).

### Globals.css

- \`@property --ring-angle\` + \`@keyframes gradient-ring-spin\` so the pill's ring revolves smoothly without Framer Motion. \`motion-safe:\` and \`motion-reduce:\` honored.

### Review trail (combined #1+2)

- Critical: focus-through locked children → fixed via React 19 \`inert\`; no semantic role on lock wrapper → \`role="group"\` + descriptive \`aria-label\`; overlay click-intercept → pointer-events-none container w/ auto button; loading flicker exposed real controls → FeatureGate now treats loading as locked.
- Important: brittle ternary intent inference → extracted to \`inferIntent()\` helper with documented precedence; \`utmSource: org.slug\` mis-tagging → dropped; reset timeout 200→350ms (matches Sheet animation); clipboard fallback rejection → user-visible toast; useLimit typed via \`EntitlementLimits\` directly.
- Nits: Share2 icon for Share button + aria-label, Math.random doc honesty, Tailwind canonical \`filter-[saturate(0.8)]\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] After merge: drop \`<UpgradeButton featureKey="audience.lookalike_pipe">\` anywhere in /dashboard → click → drawer opens with the feature key shown → submit email → /v1/waitlist/signup creates a row tagged with that featureKey → success card with referral code
- [ ] FeatureGate around a free-tier user's settings toggle → toggle is visually muted and \`inert\` (no Tab focus, no Space activation) → centered Unlock button is the only interactive surface
- [ ] Tab through a locked region with screen reader → hears "Locked feature: <name>. Upgrade required." before the Unlock button
- [ ] \`prefers-reduced-motion: reduce\` → gradient ring no longer rotates

## Companion PR

- peakhour-api PR #198 (merged) — added \`entitlements\` to \`/v1/auth/me\` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)