### PR TITLE
feat(optimizer): wire FeatureGate to /dashboard/optimizer waitlist

### DIFF
--- a/src/app/dashboard/optimizer/page.tsx
+++ b/src/app/dashboard/optimizer/page.tsx
@@ -6,7 +6,7 @@ import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
 
 const FEATURE_KEY = "growth.optimizer";
-const FEATURE_NAME = "AI Optimizer";
+const FEATURE_NAME = "Optimizer";
 const FEATURE_TAGLINE =
   "An always-on optimizer that auto-promotes winning posts, kills underperformers, and reallocates budget against your stated KPI.";
 
@@ -38,7 +38,7 @@ export default function OptimizerPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">AI Optimizer</h2>
+        <h2 className="text-2xl font-bold tracking-tight">Optimizer</h2>
         <p className="text-muted-foreground">
           An autonomous teammate for paid + organic — running the dials so you don&apos;t have to.
         </p>
@@ -51,10 +51,12 @@ export default function OptimizerPage() {
         mode="hide"
         fallback={<OptimizerWaitlistCard />}
       >
-        {/* Unlocked branch — until the live optimizer ships, the
-            preview pillars double as the surface and the small
-            confirmation banner below tells the user the feature is
-            reserved for their account. */}
+        {/* Unlocked branch — only reachable once an org has
+            growth.optimizer entitled (today: nobody, since the
+            feature is on no plan). Until the live agent ships, we
+            render the same pillar preview + a reservation banner so
+            entitled orgs see something stable instead of an empty
+            page. */}
         <OptimizerPreview />
         <Card>
           <CardContent className="flex items-center gap-3 py-5 text-sm">
@@ -121,12 +123,12 @@ function OptimizerWaitlistCard() {
               <h3 className="text-sm font-medium text-amber-950 dark:text-amber-100">
                 Reserve early access
               </h3>
-              {/* amber-on-amber palette guarantees ≥4.5:1 contrast on
-                  both gradient backgrounds (light + dark), where
-                  `text-muted-foreground` would dip below threshold on
-                  the amber-50/60 light background. */}
+              {/* amber-on-amber so contrast holds at the gradient's
+                  amber end (where `text-muted-foreground` is the
+                  weakest). The white end + the dark theme are both
+                  comfortably safe with this token pair. */}
               <p className="text-sm text-amber-900/80 dark:text-amber-200/80">
-                AI Optimizer rolls out to founding members first. Join the waitlist to lock in access + early-bird pricing.
+                Optimizer rolls out to founding members first. Join the waitlist to lock in access + early-bird pricing.
               </p>
             </div>
           </div>

--- a/src/app/dashboard/optimizer/page.tsx
+++ b/src/app/dashboard/optimizer/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Sparkles, Target, TrendingUp, Zap, Lock } from "lucide-react";
+import { Sparkles, Target, TrendingUp, Zap, Lock, type LucideIcon } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
-import { useFeature } from "@/hooks/use-feature";
 
 const FEATURE_KEY = "growth.optimizer";
 const FEATURE_NAME = "AI Optimizer";
@@ -12,7 +11,7 @@ const FEATURE_TAGLINE =
   "An always-on optimizer that auto-promotes winning posts, kills underperformers, and reallocates budget against your stated KPI.";
 
 interface Pillar {
-  icon: typeof Target;
+  icon: LucideIcon;
   title: string;
   body: string;
 }
@@ -36,19 +35,13 @@ const PILLARS: Pillar[] = [
 ];
 
 export default function OptimizerPage() {
-  // Surface the active plan label in the unlocked header so the page
-  // never feels like a placeholder once entitlements switch on.
-  const { plan } = useFeature(FEATURE_KEY);
-
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 className="text-2xl font-bold tracking-tight">AI Optimizer</h2>
-          <p className="text-muted-foreground">
-            An autonomous teammate for paid + organic — running the dials so you don&apos;t have to.
-          </p>
-        </div>
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">AI Optimizer</h2>
+        <p className="text-muted-foreground">
+          An autonomous teammate for paid + organic — running the dials so you don&apos;t have to.
+        </p>
       </div>
 
       <FeatureGate
@@ -58,16 +51,16 @@ export default function OptimizerPage() {
         mode="hide"
         fallback={<OptimizerWaitlistCard />}
       >
-        {/* Unlocked state — until the live optimizer ships, the
-            preview pillars double as the surface and a small banner
-            confirms the feature is reserved on this plan. */}
+        {/* Unlocked branch — until the live optimizer ships, the
+            preview pillars double as the surface and the small
+            confirmation banner below tells the user the feature is
+            reserved for their account. */}
         <OptimizerPreview />
         <Card>
           <CardContent className="flex items-center gap-3 py-5 text-sm">
-            <Sparkles className="size-4 text-amber-500 shrink-0" />
+            <Sparkles aria-hidden="true" className="size-4 text-amber-500 shrink-0" />
             <span className="text-muted-foreground">
-              Reserved on your <span className="font-medium text-foreground">{plan ?? "current"}</span> plan.
-              Live agents roll out as each Phase ships — you&apos;ll see them appear here automatically.
+              Access reserved on your account. Live agents roll out as each Phase ships — you&apos;ll see them appear here automatically.
             </span>
           </CardContent>
         </Card>
@@ -89,7 +82,7 @@ function OptimizerPreview() {
           <CardHeader className="pb-3">
             <div className="flex items-center gap-2">
               <div className="rounded-md bg-primary/10 p-1.5">
-                <Icon className="size-4 text-primary" />
+                <Icon aria-hidden="true" className="size-4 text-primary" />
               </div>
               <CardTitle className="text-base">{title}</CardTitle>
             </div>
@@ -119,11 +112,20 @@ function OptimizerWaitlistCard() {
         <CardContent className="flex flex-col gap-3 py-6 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-start gap-3">
             <div className="rounded-full bg-amber-100 p-2 dark:bg-amber-900/40">
-              <Lock className="size-4 text-amber-700 dark:text-amber-300" />
+              <Lock aria-hidden="true" className="size-4 text-amber-700 dark:text-amber-300" />
             </div>
             <div>
-              <p className="text-sm font-medium">Reserve early access</p>
-              <p className="text-sm text-muted-foreground">
+              {/* h3 (not p) so screen-reader users land on a real
+                  heading, and the locked card has a navigable title
+                  in the page outline. */}
+              <h3 className="text-sm font-medium text-amber-950 dark:text-amber-100">
+                Reserve early access
+              </h3>
+              {/* amber-on-amber palette guarantees ≥4.5:1 contrast on
+                  both gradient backgrounds (light + dark), where
+                  `text-muted-foreground` would dip below threshold on
+                  the amber-50/60 light background. */}
+              <p className="text-sm text-amber-900/80 dark:text-amber-200/80">
                 AI Optimizer rolls out to founding members first. Join the waitlist to lock in access + early-bird pricing.
               </p>
             </div>

--- a/src/app/dashboard/optimizer/page.tsx
+++ b/src/app/dashboard/optimizer/page.tsx
@@ -1,22 +1,144 @@
-import { Sparkles } from "lucide-react";
+"use client";
 
-import { EmptyState } from "@/components/molecules/empty-state";
+import { Sparkles, Target, TrendingUp, Zap, Lock } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { UpgradeButton } from "@/components/upgrade/upgrade-button";
+import { useFeature } from "@/hooks/use-feature";
+
+const FEATURE_KEY = "growth.optimizer";
+const FEATURE_NAME = "AI Optimizer";
+const FEATURE_TAGLINE =
+  "An always-on optimizer that auto-promotes winning posts, kills underperformers, and reallocates budget against your stated KPI.";
+
+interface Pillar {
+  icon: typeof Target;
+  title: string;
+  body: string;
+}
+
+const PILLARS: Pillar[] = [
+  {
+    icon: Target,
+    title: "Outcome-driven",
+    body: "Set a KPI (CPL, MQLs, follower growth) — the optimizer chooses what to test, where to spend, and when to scale.",
+  },
+  {
+    icon: TrendingUp,
+    title: "Closed-loop creative",
+    body: "Winning organic posts auto-promote into ad variants. Winning ad creatives recycle into next week's content plan.",
+  },
+  {
+    icon: Zap,
+    title: "Auto-pause & reallocate",
+    body: "Underperforming creatives are paused at thresholds you set. Their budget moves to whatever is hitting the KPI.",
+  },
+];
 
 export default function OptimizerPage() {
+  // Surface the active plan label in the unlocked header so the page
+  // never feels like a placeholder once entitlements switch on.
+  const { plan } = useFeature(FEATURE_KEY);
+
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold">AI Optimizer</h2>
-        <p className="text-muted-foreground">
-          The AI continuously improves your marketing performance
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">AI Optimizer</h2>
+          <p className="text-muted-foreground">
+            An autonomous teammate for paid + organic — running the dials so you don&apos;t have to.
+          </p>
+        </div>
       </div>
 
-      <EmptyState
-        icon={Sparkles}
-        title="Coming Soon"
-        description="Think of it as a marketing team member who never sleeps — always testing, learning, and optimizing to get you more customers for less money."
-      />
+      <FeatureGate
+        feature={FEATURE_KEY}
+        featureName={FEATURE_NAME}
+        featureTagline={FEATURE_TAGLINE}
+        mode="hide"
+        fallback={<OptimizerWaitlistCard />}
+      >
+        {/* Unlocked state — until the live optimizer ships, the
+            preview pillars double as the surface and a small banner
+            confirms the feature is reserved on this plan. */}
+        <OptimizerPreview />
+        <Card>
+          <CardContent className="flex items-center gap-3 py-5 text-sm">
+            <Sparkles className="size-4 text-amber-500 shrink-0" />
+            <span className="text-muted-foreground">
+              Reserved on your <span className="font-medium text-foreground">{plan ?? "current"}</span> plan.
+              Live agents roll out as each Phase ships — you&apos;ll see them appear here automatically.
+            </span>
+          </CardContent>
+        </Card>
+      </FeatureGate>
+    </div>
+  );
+}
+
+/**
+ * Three-up benefit grid used by both the locked fallback and the
+ * (future) unlocked surface — keeps the visual weight identical so
+ * upgrading doesn't cause a layout shift.
+ */
+function OptimizerPreview() {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {PILLARS.map(({ icon: Icon, title, body }) => (
+        <Card key={title}>
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-2">
+              <div className="rounded-md bg-primary/10 p-1.5">
+                <Icon className="size-4 text-primary" />
+              </div>
+              <CardTitle className="text-base">{title}</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">{body}</CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Locked state — what every signed-in user sees today, since
+ * `growth.optimizer` is not yet on any plan. Renders the preview
+ * pillars so the value is visible, then a single waitlist CTA.
+ *
+ * Prefer mode="hide" + a fallback like this over mode="lock" for
+ * full-page features: an inert+muted preview reads like a broken
+ * page, while a deliberate "preview + reserve access" card reads
+ * like an opt-in.
+ */
+function OptimizerWaitlistCard() {
+  return (
+    <div className="space-y-4">
+      <OptimizerPreview />
+      <Card className="border-amber-200 bg-linear-to-br from-amber-50/60 to-white dark:border-amber-900/40 dark:from-amber-950/30 dark:to-transparent">
+        <CardContent className="flex flex-col gap-3 py-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-amber-100 p-2 dark:bg-amber-900/40">
+              <Lock className="size-4 text-amber-700 dark:text-amber-300" />
+            </div>
+            <div>
+              <p className="text-sm font-medium">Reserve early access</p>
+              <p className="text-sm text-muted-foreground">
+                AI Optimizer rolls out to founding members first. Join the waitlist to lock in access + early-bird pricing.
+              </p>
+            </div>
+          </div>
+          <div className="sm:ml-4">
+            <UpgradeButton
+              featureKey={FEATURE_KEY}
+              featureName={FEATURE_NAME}
+              featureTagline={FEATURE_TAGLINE}
+            >
+              Join waitlist
+            </UpgradeButton>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

First production wiring of the upgrade primitive (PR #159) on a real dashboard surface. Replaces the `Coming Soon` empty state on `/dashboard/optimizer` with a value-prop preview gated behind `cfg_features.key="growth.optimizer"`.

- **Locked** (every signed-in user today, since `growth.optimizer` is on no plan yet) — three-pillar preview renders normally above a `Reserve early access` card with an `UpgradeButton` that opens the waitlist drawer pre-tagged with `featureKey="growth.optimizer"`. Every signup recorded against this key becomes signal for whether to prioritize this in the autonomy roadmap.
- **Unlocked** (future Pro / founding members, or per-org `platformOverrides.grantedFeatures`) — same pillar grid renders with a small `Access reserved on your account` banner. No layout shift because the preview block is shared between both states.

## Why mode="hide" + fallback (not mode="lock")

For full-page features, an inert+muted preview reads like a broken page. A deliberate "preview + reserve access" card reads like an opt-in, which is the conversion ask. The other gating modes (`lock`, `passthrough`) remain right for individual rows and parent-controlled layouts.

## Followups (intentionally not bundled)

- `useFeature` doesn't expose `entitlementsError`; on a Mongo blip the page goes silently locked. Better fixed at the primitive level so every FeatureGate consumer benefits.
- `upgrade-button.tsx` still uses `bg-gradient-to-r` (Tailwind v3 legacy). Sweep on the upgrade primitive, not on this consumer.
- Operators should register `growth.optimizer` in `cfg_features` via the CMS admin (`/admin/features` once it lands) so the waitlist drawer can read its tagline + screenshot. Today the waitlist endpoint stores arbitrary `featureKey` strings, so no foreign-key dependency blocks shipping this PR.

## Test plan

- [ ] Sign in as any free-tier user — verify the locked card renders with `Reserve early access`, click `Join waitlist` → drawer opens with `Feature: AI Optimizer` and the tagline.
- [ ] Submit the waitlist form — verify `POST /v1/waitlist/signup` carries `featureKey: "growth.optimizer"` (Network tab) and the success card shows position + referral.
- [ ] On a CMS-granted org (`platformOverrides.grantedFeatures: ["growth.optimizer"]` via `/v1/cms/orgs/:id/grant-feature`), verify the unlocked branch renders the banner instead.
- [ ] Resize: card stacks on mobile, side-by-side from `sm:`.
- [ ] Keyboard: Tab order — pillar cards (none focusable), `Join waitlist` button reachable, drawer focus-traps inside, `Esc` closes.
- [ ] Dark mode: amber gradient + `text-amber-200/80` body remain ≥4.5:1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)