### PR TITLE
refactor(optimizer): adopt @shadcnblocks/feature358 + cta36 patterns

### DIFF
--- a/src/app/dashboard/optimizer/page.tsx
+++ b/src/app/dashboard/optimizer/page.tsx
@@ -60,7 +60,7 @@ export default function OptimizerPage() {
         <OptimizerPreview />
         <Card>
           <CardContent className="flex items-center gap-3 py-5 text-sm">
-            <Sparkles aria-hidden="true" className="size-4 text-amber-500 shrink-0" />
+            <Sparkles aria-hidden="true" className="size-4 text-amber-600 dark:text-amber-400 shrink-0" />
             <span className="text-muted-foreground">
               Access reserved on your account. Live agents roll out as each Phase ships — you&apos;ll see them appear here automatically.
             </span>

--- a/src/app/dashboard/optimizer/page.tsx
+++ b/src/app/dashboard/optimizer/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Sparkles, Target, TrendingUp, Zap, Lock, type LucideIcon } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Sparkles, Target, TrendingUp, Zap, type LucideIcon } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
 
@@ -72,24 +72,29 @@ export default function OptimizerPage() {
 }
 
 /**
- * Three-up benefit grid used by both the locked fallback and the
- * (future) unlocked surface — keeps the visual weight identical so
- * upgrading doesn't cause a layout shift.
+ * Three-up benefit grid — visual language adapted from
+ * @shadcnblocks/feature358 (bordered-square icon badge above a
+ * stacked title + description). The block's defaults are
+ * landing-page scale (py-32, text-lg titles, p-8 cards); we drop the
+ * outer section + use shadcn Card (canonical container in this
+ * dashboard) at p-6 so the grid sits naturally inside a 6-padding
+ * dashboard layout.
  */
 function OptimizerPreview() {
   return (
     <div className="grid gap-4 md:grid-cols-3">
       {PILLARS.map(({ icon: Icon, title, body }) => (
         <Card key={title}>
-          <CardHeader className="pb-3">
-            <div className="flex items-center gap-2">
-              <div className="rounded-md bg-primary/10 p-1.5">
-                <Icon aria-hidden="true" className="size-4 text-primary" />
-              </div>
-              <CardTitle className="text-base">{title}</CardTitle>
+          <CardContent className="flex flex-col gap-3 p-6">
+            <div className="flex size-10 items-center justify-center rounded-md border">
+              <Icon aria-hidden="true" className="size-5" />
             </div>
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">{body}</CardContent>
+            {/* h3 so screen-reader users hit a heading per card; the
+                page <h2> sits above this grid so the outline reads
+                page-title → pillar-title without jumping levels. */}
+            <h3 className="text-base font-medium tracking-tight">{title}</h3>
+            <p className="text-sm text-muted-foreground">{body}</p>
+          </CardContent>
         </Card>
       ))}
     </div>
@@ -98,41 +103,38 @@ function OptimizerPreview() {
 
 /**
  * Locked state — what every signed-in user sees today, since
- * `growth.optimizer` is not yet on any plan. Renders the preview
- * pillars so the value is visible, then a single waitlist CTA.
+ * `growth.optimizer` is not yet on any plan.
  *
- * Prefer mode="hide" + a fallback like this over mode="lock" for
- * full-page features: an inert+muted preview reads like a broken
- * page, while a deliberate "preview + reserve access" card reads
- * like an opt-in.
+ * Layout adapted from @shadcnblocks/cta36 (horizontal split:
+ * heading + description left, action right; collapses to stacked on
+ * small screens). The block's defaults are landing-page scale
+ * (py-32, max-w-5xl, text-2xl/4xl); we drop the outer section, keep
+ * the pattern, and tone everything to dashboard scale (text-base
+ * heading, no oversized container).
+ *
+ * Why mode="hide" + this fallback (over mode="lock"): for full-page
+ * features, an inert+muted preview reads like a broken page; a
+ * deliberate "preview + reserve access" card reads like an opt-in.
  */
 function OptimizerWaitlistCard() {
   return (
     <div className="space-y-4">
       <OptimizerPreview />
       <Card className="border-amber-200 bg-linear-to-br from-amber-50/60 to-white dark:border-amber-900/40 dark:from-amber-950/30 dark:to-transparent">
-        <CardContent className="flex flex-col gap-3 py-6 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-start gap-3">
-            <div className="rounded-full bg-amber-100 p-2 dark:bg-amber-900/40">
-              <Lock aria-hidden="true" className="size-4 text-amber-700 dark:text-amber-300" />
-            </div>
-            <div>
-              {/* h3 (not p) so screen-reader users land on a real
-                  heading, and the locked card has a navigable title
-                  in the page outline. */}
-              <h3 className="text-sm font-medium text-amber-950 dark:text-amber-100">
-                Reserve early access
-              </h3>
-              {/* amber-on-amber so contrast holds at the gradient's
-                  amber end (where `text-muted-foreground` is the
-                  weakest). The white end + the dark theme are both
-                  comfortably safe with this token pair. */}
-              <p className="text-sm text-amber-900/80 dark:text-amber-200/80">
-                Optimizer rolls out to founding members first. Join the waitlist to lock in access + early-bird pricing.
-              </p>
-            </div>
+        <CardContent className="flex flex-col items-start justify-between gap-6 p-6 lg:flex-row lg:items-center">
+          <div className="flex flex-col gap-1.5">
+            <h3 className="text-base font-semibold tracking-tight text-amber-950 dark:text-amber-100">
+              Reserve early access to Optimizer
+            </h3>
+            {/* amber-on-amber so contrast holds at the gradient's
+                amber end (where `text-muted-foreground` is the
+                weakest). The white end + the dark theme are both
+                comfortably safe with this token pair. */}
+            <p className="max-w-xl text-sm text-amber-900/80 dark:text-amber-200/80">
+              Optimizer rolls out to founding members first. Join the waitlist to lock in access + early-bird pricing.
+            </p>
           </div>
-          <div className="sm:ml-4">
+          <div className="shrink-0">
             <UpgradeButton
               featureKey={FEATURE_KEY}
               featureName={FEATURE_NAME}

--- a/src/app/dashboard/optimizer/page.tsx
+++ b/src/app/dashboard/optimizer/page.tsx
@@ -85,7 +85,7 @@ function OptimizerPreview() {
     <div className="grid gap-4 md:grid-cols-3">
       {PILLARS.map(({ icon: Icon, title, body }) => (
         <Card key={title}>
-          <CardContent className="flex flex-col gap-3 p-6">
+          <CardContent className="flex flex-col gap-4 p-6">
             <div className="flex size-10 items-center justify-center rounded-md border">
               <Icon aria-hidden="true" className="size-5" />
             </div>


### PR DESCRIPTION
## Summary

Followup to PR #160 to honor the \"search shadcnblocks PRO first\" rule. The original PR built the pillar grid and waitlist card freehand without checking the registry; searching after the fact surfaced two on-point patterns:

- **@shadcnblocks/feature358** — three-column bordered cards with a bordered square icon badge above a stacked title + description.
- **@shadcnblocks/cta36** — horizontal-split CTA: heading + description left, action right; collapses stacked at <lg.

Neither block is a clean drop-in for an in-dashboard surface — both default to landing-page scale (\`py-32\`, \`max-w-5xl\`, \`text-2xl/4xl\` headings, \`p-8\` cards). This change adopts the *visual language* (bordered icon badge above stacked text; horizontal-split CTA) and keeps shadcn \`Card\` as the canonical container so the surface still reads as part of the dashboard, not a marketing inset.

## Diff vs PR #160

- **OptimizerPreview pillars**: bordered square icon badge (`size-10 rounded-md border`) above a stacked `h3` + `p` (was: side-by-side icon + title in a `CardHeader`, primary-tinted icon background).
- **OptimizerWaitlistCard**: horizontal split (heading + description left, button right; collapses to stacked at <lg). The visible Lock icon is dropped — the headline `Reserve early access to Optimizer` carries the gating signal, and removing the icon column gives the description more breathing room. Amber treatment kept (visually distinguishes the locked card from neutral pillars).
- All amber tokens preserved + the contrast comment kept honest.

## Why not \`npx shadcn add\` the blocks directly

Both blocks ship a landing-page \`<section className=\"py-32\">\` wrapper with their own typography scale. Installing them would mean ripping the wrapper out and re-toning the typography immediately — same delta as adapting their inner pattern by hand. We get registry-blessed visual language without the marketing-block overhead.

## Test plan

- [ ] Visit /dashboard/optimizer signed in as any free-tier user — pillar grid renders with bordered icon badges above stacked titles + bodies; locked card below renders horizontally on lg+ and stacked on mobile.
- [ ] Click \"Join waitlist\" — drawer opens, featureKey \`growth.optimizer\` carries through, signup succeeds.
- [ ] Granted org (\`platformOverrides.grantedFeatures: [\"growth.optimizer\"]\`) — sees the unlocked branch with the same pillar grid + a small \`Access reserved\` banner.
- [ ] Dark mode: amber gradient + amber-200/80 body remain ≥4.5:1.
- [ ] Resize lg→sm: locked card transitions horizontal → stacked cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)