### PR TITLE
feat(sources): Trusted Sources b2c UI — Day 1/2 surface

### DIFF
--- a/src/app/dashboard/content/sources/api.ts
+++ b/src/app/dashboard/content/sources/api.ts
@@ -24,7 +24,10 @@ export async function listSources(params: ListParams = {}): Promise<ListResponse
   const query: Record<string, string> = {};
   if (params.status) query.status = params.status;
   if (params.type) query.type = params.type;
-  if (params.limit) query.limit = String(params.limit);
+  // `!== undefined` rather than truthy-check so a caller passing
+  // limit: 0 surfaces as a backend 400 (Zod min(1)) instead of being
+  // silently dropped here.
+  if (params.limit !== undefined) query.limit = String(params.limit);
   return api.get<ListResponse>("/v1/sources/trusted", query);
 }
 

--- a/src/app/dashboard/content/sources/api.ts
+++ b/src/app/dashboard/content/sources/api.ts
@@ -1,0 +1,52 @@
+import { api } from "@/lib/api";
+import type {
+  CreateSourceInput,
+  ListResponse,
+  PatchSourceInput,
+  SourceStatus,
+  SourceType,
+} from "./types";
+
+/**
+ * Thin client wrappers around `/v1/sources/trusted`. Kept as plain
+ * async functions (no react-query layer here) so consumers stay free
+ * to choose their own data-fetching strategy. The page uses
+ * @tanstack/react-query already; these are the queryFns it passes in.
+ */
+
+export interface ListParams {
+  status?: SourceStatus;
+  type?: SourceType;
+  limit?: number;
+}
+
+export async function listSources(params: ListParams = {}): Promise<ListResponse> {
+  const query: Record<string, string> = {};
+  if (params.status) query.status = params.status;
+  if (params.type) query.type = params.type;
+  if (params.limit) query.limit = String(params.limit);
+  return api.get<ListResponse>("/v1/sources/trusted", query);
+}
+
+export async function createSource(input: CreateSourceInput): Promise<{ _id: string }> {
+  return api.post<{ _id: string }>("/v1/sources/trusted", input);
+}
+
+export async function patchSource(
+  id: string,
+  input: PatchSourceInput,
+): Promise<{ _id: string; updated: number }> {
+  return api.patch<{ _id: string; updated: number }>(`/v1/sources/trusted/${id}`, input);
+}
+
+/**
+ * Soft-delete via the dedicated endpoint. The backend transitions
+ * the row to status:"inactive" and stamps inactivatedAt — it does
+ * NOT remove the document (cnt_source_usage rows reference the
+ * trustedSourceId; hard-delete would orphan audit trails).
+ */
+export async function deleteSource(
+  id: string,
+): Promise<{ _id: string; softDeleted: boolean }> {
+  return api.delete<{ _id: string; softDeleted: boolean }>(`/v1/sources/trusted/${id}`);
+}

--- a/src/app/dashboard/content/sources/components/add-source-drawer.tsx
+++ b/src/app/dashboard/content/sources/components/add-source-drawer.tsx
@@ -74,20 +74,27 @@ export function AddSourceDrawer() {
     setFetchFrequency("daily");
   }
 
+  // Mutation takes the snapshot of trimmed values explicitly via a
+  // `variables` arg so the success toast and any error context read
+  // the values that were submitted, not whatever the input fields
+  // happen to contain when the response arrives. (Inputs aren't
+  // disabled while pending — only the buttons are — so a slow
+  // network + a user who keeps typing would otherwise have the toast
+  // echo the newer text.)
+  interface CreateVars {
+    type: SourceType;
+    identifier: string;
+    displayName: string;
+    fetchFrequency: FetchFrequency;
+  }
   const mutation = useMutation({
-    mutationFn: () =>
-      createSource({
-        type,
-        identifier: identifier.trim(),
-        displayName: displayName.trim(),
-        fetchFrequency,
-      }),
-    onSuccess: () => {
+    mutationFn: (vars: CreateVars) => createSource(vars),
+    onSuccess: (_data, vars) => {
       // Reach all status filters so the new row appears in whichever
       // tab the user is on (always lands `active`, but the per-status
       // counts on every tab also need to refresh).
       queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
-      toast.success(`${displayName.trim() || "Source"} added`);
+      toast.success(`${vars.displayName || "Source"} added`);
       setOpen(false);
       // Reset after the close animation so the form doesn't visibly
       // clear while the sheet is fading out (~300ms).
@@ -107,11 +114,18 @@ export function AddSourceDrawer() {
 
   function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!identifier.trim() || !displayName.trim()) {
+    const trimmedIdentifier = identifier.trim();
+    const trimmedName = displayName.trim();
+    if (!trimmedIdentifier || !trimmedName) {
       toast.error("Identifier and name are required");
       return;
     }
-    mutation.mutate();
+    mutation.mutate({
+      type,
+      identifier: trimmedIdentifier,
+      displayName: trimmedName,
+      fetchFrequency,
+    });
   }
 
   return (

--- a/src/app/dashboard/content/sources/components/add-source-drawer.tsx
+++ b/src/app/dashboard/content/sources/components/add-source-drawer.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Plus } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ApiError } from "@/lib/api";
+import { createSource } from "../api";
+import {
+  FETCH_FREQUENCY_LABEL,
+  SOURCE_TYPE_LABEL,
+  type FetchFrequency,
+  type SourceType,
+} from "../types";
+
+/**
+ * Add Source drawer — Day-1 manual-add form. The plan calls for three
+ * input modes (manual, bulk paste with auto-detect, OPML import); this
+ * implementation ships the manual path. Bulk + OPML are tracked in the
+ * follow-up issue and add new tabs to this same drawer rather than a
+ * new component, so the call-site (`/dashboard/content/sources` FAB)
+ * doesn't change.
+ *
+ * The form deliberately uses controlled state instead of react-hook-form
+ * — four fields, no nested objects yet. Keeping the dep tree shallow
+ * lets the bulk-add tab share state via the same hook when it ships.
+ */
+
+const SOURCE_TYPES: SourceType[] = [
+  "website",
+  "rss",
+  "newsletter",
+  "x_handle",
+  "instagram_handle",
+  "youtube_channel",
+  "podcast",
+  "uploaded_doc",
+];
+
+const FETCH_FREQUENCIES: FetchFrequency[] = ["hourly", "daily", "weekly", "manual"];
+
+export function AddSourceDrawer() {
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<SourceType>("website");
+  const [identifier, setIdentifier] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [fetchFrequency, setFetchFrequency] = useState<FetchFrequency>("daily");
+
+  const queryClient = useQueryClient();
+
+  function reset() {
+    setType("website");
+    setIdentifier("");
+    setDisplayName("");
+    setFetchFrequency("daily");
+  }
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createSource({
+        type,
+        identifier: identifier.trim(),
+        displayName: displayName.trim(),
+        fetchFrequency,
+      }),
+    onSuccess: () => {
+      // Reach all status filters so the new row appears in whichever
+      // tab the user is on (always lands `active`, but the per-status
+      // counts on every tab also need to refresh).
+      queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
+      toast.success(`${displayName.trim() || "Source"} added`);
+      setOpen(false);
+      // Reset after the close animation so the form doesn't visibly
+      // clear while the sheet is fading out (~300ms).
+      setTimeout(reset, 350);
+    },
+    onError: (err) => {
+      // The backend's POST returns 409 with a copy-friendly message
+      // ("Source already exists for this business at <identifier>") —
+      // surface it verbatim instead of the generic "create failed".
+      if (err instanceof ApiError) {
+        toast.error(err.message);
+      } else {
+        toast.error("Could not add source");
+      }
+    },
+  });
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!identifier.trim() || !displayName.trim()) {
+      toast.error("Identifier and name are required");
+      return;
+    }
+    mutation.mutate();
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button size="sm">
+          <Plus className="mr-1.5 size-4" />
+          Add source
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="flex flex-col sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Add a trusted source</SheetTitle>
+          <SheetDescription>
+            Sources ground every brief, idea, and post in your brand&apos;s voice. Active sources are picked up by the next 15-minute fetch.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form onSubmit={onSubmit} className="flex flex-1 flex-col gap-5 overflow-auto px-4">
+          <div className="grid gap-2">
+            <Label htmlFor="source-type">Type</Label>
+            <Select value={type} onValueChange={(v) => setType(v as SourceType)}>
+              <SelectTrigger id="source-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SOURCE_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {SOURCE_TYPE_LABEL[t]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="source-identifier">
+              {type === "x_handle" || type === "instagram_handle"
+                ? "Handle (e.g. @example)"
+                : type === "uploaded_doc"
+                  ? "Document key"
+                  : "URL"}
+            </Label>
+            <Input
+              id="source-identifier"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              placeholder={
+                type === "rss"
+                  ? "https://example.com/feed.xml"
+                  : type === "x_handle"
+                    ? "@example"
+                    : "https://example.com"
+              }
+              autoComplete="off"
+              autoFocus
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Stored normalised — handles lowercase, URLs preserve path case.
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="source-name">Display name</Label>
+            <Input
+              id="source-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="What you'd call this source in the team chat"
+              maxLength={256}
+              required
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="source-frequency">Fetch frequency</Label>
+            <Select
+              value={fetchFrequency}
+              onValueChange={(v) => setFetchFrequency(v as FetchFrequency)}
+            >
+              <SelectTrigger id="source-frequency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {FETCH_FREQUENCIES.map((f) => (
+                  <SelectItem key={f} value={f}>
+                    {FETCH_FREQUENCY_LABEL[f]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Daily is right for almost everything; pick weekly for slow-moving sites and manual for archival material.
+            </p>
+          </div>
+        </form>
+
+        <SheetFooter>
+          <Button
+            variant="outline"
+            type="button"
+            onClick={() => setOpen(false)}
+            disabled={mutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={onSubmit} disabled={mutation.isPending}>
+            {mutation.isPending ? (
+              <>
+                <Loader2 className="mr-1.5 size-4 animate-spin" />
+                Adding…
+              </>
+            ) : (
+              "Add source"
+            )}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/dashboard/content/sources/components/source-row.tsx
+++ b/src/app/dashboard/content/sources/components/source-row.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Check,
+  Globe,
+  Headphones,
+  Loader2,
+  Mail,
+  MoreHorizontal,
+  Pause,
+  Play,
+  Rss,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import {
+  InstagramIcon,
+  TwitterIcon,
+  YoutubeIcon,
+} from "@/components/ui/brand-icons";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ApiError } from "@/lib/api";
+import { deleteSource, patchSource } from "../api";
+import {
+  SOURCE_TYPE_LABEL,
+  type SourceStatus,
+  type SourceType,
+  type TrustedSource,
+} from "../types";
+
+/**
+ * Single source row — visual language adapted from
+ * @shadcnblocks/settings-integrations9 (large icon + name on left,
+ * meta in the middle, status badge + actions menu on right). Scaled
+ * to dashboard density (single row per card, p-4) instead of the
+ * block's marketing-page padding.
+ *
+ * The action set varies by status:
+ *   active     → Pause, Delete
+ *   suggested  → Accept, Reject
+ *   inactive   → Resume, Delete
+ *   rejected   → (no actions; rejected is terminal in the UI — ops
+ *                can hard-delete via CMS)
+ */
+
+/**
+ * Mix of lucide icons (most types) and the codebase's hand-rolled
+ * brand SVGs (Twitter/Instagram/Youtube — lucide-react doesn't ship
+ * trademarked brand marks). Both honor a `className` prop, so the
+ * component contract is unified as `(props: { className?: string })
+ * => JSX` rather than `LucideIcon`.
+ */
+type IconComponent = React.ComponentType<{ className?: string }>;
+
+const TYPE_ICON: Record<SourceType, IconComponent> = {
+  website: Globe,
+  rss: Rss,
+  x_handle: TwitterIcon,
+  instagram_handle: InstagramIcon,
+  youtube_channel: YoutubeIcon,
+  newsletter: Mail,
+  podcast: Headphones,
+  uploaded_doc: Upload,
+};
+
+const STATUS_VARIANT: Record<SourceStatus, "default" | "secondary" | "outline" | "destructive"> = {
+  active: "default",
+  suggested: "secondary",
+  inactive: "outline",
+  rejected: "destructive",
+};
+
+interface SourceRowProps {
+  source: TrustedSource;
+}
+
+export function SourceRow({ source }: SourceRowProps) {
+  const queryClient = useQueryClient();
+
+  function invalidate() {
+    queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
+  }
+
+  function handleApiError(err: unknown, fallback: string) {
+    if (err instanceof ApiError) toast.error(err.message);
+    else toast.error(fallback);
+  }
+
+  const pauseMutation = useMutation({
+    mutationFn: () => patchSource(source._id, { status: "inactive" }),
+    onSuccess: () => {
+      toast.success(`${source.displayName} paused`);
+      invalidate();
+    },
+    onError: (e) => handleApiError(e, "Could not pause source"),
+  });
+
+  const resumeMutation = useMutation({
+    mutationFn: () => patchSource(source._id, { status: "active" }),
+    onSuccess: () => {
+      toast.success(`${source.displayName} resumed — fetching shortly`);
+      invalidate();
+    },
+    onError: (e) => handleApiError(e, "Could not resume source"),
+  });
+
+  const acceptMutation = useMutation({
+    mutationFn: () => patchSource(source._id, { status: "active" }),
+    onSuccess: () => {
+      toast.success(`${source.displayName} added to active sources`);
+      invalidate();
+    },
+    onError: (e) => handleApiError(e, "Could not accept source"),
+  });
+
+  const rejectMutation = useMutation({
+    // Reason is required by the backend — sending a static value
+    // until the UI for capturing a reason ships (a small dialog with
+    // a textarea + radio of canned reasons). Until then this rejection
+    // path is intentionally rare; the dropdown copy makes that clear.
+    mutationFn: () =>
+      patchSource(source._id, { status: "rejected", rejectionReason: "Rejected from dashboard" }),
+    onSuccess: () => {
+      toast.success(`${source.displayName} rejected`);
+      invalidate();
+    },
+    onError: (e) => handleApiError(e, "Could not reject source"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteSource(source._id),
+    onSuccess: () => {
+      toast.success(`${source.displayName} removed`);
+      invalidate();
+    },
+    onError: (e) => handleApiError(e, "Could not remove source"),
+  });
+
+  const Icon = TYPE_ICON[source.type] ?? Globe;
+  const isPending =
+    pauseMutation.isPending ||
+    resumeMutation.isPending ||
+    acceptMutation.isPending ||
+    rejectMutation.isPending ||
+    deleteMutation.isPending;
+
+  return (
+    <div className="flex items-center gap-4 rounded-lg border bg-card p-4">
+      <div
+        aria-hidden="true"
+        className="flex size-10 shrink-0 items-center justify-center rounded-md border text-muted-foreground"
+      >
+        <Icon className="size-5" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate text-sm font-medium">{source.displayName}</h3>
+          <Badge variant="outline" className="shrink-0 text-[10px]">
+            {SOURCE_TYPE_LABEL[source.type]}
+          </Badge>
+        </div>
+        <p className="truncate font-mono text-xs text-muted-foreground" title={source.identifier}>
+          {source.identifier}
+        </p>
+        <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+          <span>{source.fetchFrequency}</span>
+          <span aria-hidden="true">•</span>
+          <span>Trust {(source.trustScore * 100).toFixed(0)}</span>
+          {typeof source.usageCount === "number" && source.usageCount > 0 && (
+            <>
+              <span aria-hidden="true">•</span>
+              <span>{source.usageCount} citation{source.usageCount === 1 ? "" : "s"}</span>
+            </>
+          )}
+          <LastFetched source={source} />
+        </div>
+      </div>
+
+      <Badge variant={STATUS_VARIANT[source.status]} className="shrink-0 capitalize">
+        {source.status}
+      </Badge>
+
+      <div className="shrink-0">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" disabled={isPending} aria-label="Source actions">
+              {isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <MoreHorizontal className="size-4" />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {source.status === "suggested" && (
+              <>
+                <DropdownMenuItem onClick={() => acceptMutation.mutate()}>
+                  <Check className="mr-2 size-4" />
+                  Accept
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => rejectMutation.mutate()}>
+                  <X className="mr-2 size-4" />
+                  Reject
+                </DropdownMenuItem>
+              </>
+            )}
+            {source.status === "active" && (
+              <DropdownMenuItem onClick={() => pauseMutation.mutate()}>
+                <Pause className="mr-2 size-4" />
+                Pause
+              </DropdownMenuItem>
+            )}
+            {source.status === "inactive" && (
+              <DropdownMenuItem onClick={() => resumeMutation.mutate()}>
+                <Play className="mr-2 size-4" />
+                Resume
+              </DropdownMenuItem>
+            )}
+            {(source.status === "active" || source.status === "inactive") && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => deleteMutation.mutate()}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="mr-2 size-4" />
+                  Remove
+                </DropdownMenuItem>
+              </>
+            )}
+            {source.status === "rejected" && (
+              <DropdownMenuItem disabled>
+                Rejected · contact support to restore
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact "last fetched" string — shows the most informative
+ * timestamp available. `lastSuccessfulFetchAt` is the canonical
+ * "we got data" signal; `lastFetchedAt` is "we tried." If neither
+ * exists yet (source just added, scheduler hasn't ticked), surface
+ * the fetch as queued.
+ *
+ * `Date.now()` is impure, so the time anchor is captured in state
+ * via a lazy initializer (React-pure-render rule). A 60-second tick
+ * keeps the "5m ago" label moving without forcing a parent re-render
+ * — the interval is cheap, and the cleanup unmounts the cycle when
+ * the row scrolls off.
+ */
+function LastFetched({ source }: { source: TrustedSource }) {
+  const ts = source.lastSuccessfulFetchAt ?? source.lastFetchedAt;
+  // Hooks must be called unconditionally — initialize even when
+  // there's no timestamp; the early-return below handles the "no
+  // ticks needed" case after the hook calls.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!ts) return;
+    const id = window.setInterval(() => setNow(Date.now()), 60_000);
+    return () => window.clearInterval(id);
+  }, [ts]);
+
+  if (!ts) {
+    return (
+      <>
+        <span aria-hidden="true">•</span>
+        <span>Queued for next fetch</span>
+      </>
+    );
+  }
+  const date = new Date(ts);
+  const diffMs = now - date.getTime();
+  const minutes = Math.round(diffMs / 60_000);
+  let label: string;
+  if (minutes < 1) label = "just now";
+  else if (minutes < 60) label = `${minutes}m ago`;
+  else if (minutes < 60 * 24) label = `${Math.round(minutes / 60)}h ago`;
+  else if (minutes < 60 * 24 * 7) label = `${Math.round(minutes / (60 * 24))}d ago`;
+  else label = date.toLocaleDateString();
+  return (
+    <>
+      <span aria-hidden="true">•</span>
+      <span>Fetched {label}</span>
+    </>
+  );
+}

--- a/src/app/dashboard/content/sources/components/source-row.tsx
+++ b/src/app/dashboard/content/sources/components/source-row.tsx
@@ -126,12 +126,17 @@ export function SourceRow({ source }: SourceRowProps) {
   });
 
   const rejectMutation = useMutation({
-    // Reason is required by the backend — sending a static value
+    // Reason is required by the backend — sending a sentinel value
     // until the UI for capturing a reason ships (a small dialog with
     // a textarea + radio of canned reasons). Until then this rejection
     // path is intentionally rare; the dropdown copy makes that clear.
+    // Sentinel chosen so future analytics can filter "rejected without
+    // a captured reason" rows out of any reason-distribution chart.
     mutationFn: () =>
-      patchSource(source._id, { status: "rejected", rejectionReason: "Rejected from dashboard" }),
+      patchSource(source._id, {
+        status: "rejected",
+        rejectionReason: "[ui-rejected: no reason captured]",
+      }),
     onSuccess: () => {
       toast.success(`${source.displayName} rejected`);
       invalidate();
@@ -196,7 +201,12 @@ export function SourceRow({ source }: SourceRowProps) {
       <div className="shrink-0">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" disabled={isPending} aria-label="Source actions">
+            <Button
+              variant="ghost"
+              size="icon"
+              disabled={isPending}
+              aria-label={`Actions for ${source.displayName}`}
+            >
               {isPending ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : (

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Activity, BookMarked, FileSearch, Sparkles } from "lucide-react";
+import { Activity, AlertCircle, BookMarked, FileSearch, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,6 +11,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { KpiCard } from "@/components/molecules/kpi-card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
+import { ApiError } from "@/lib/api";
 import { listSources } from "./api";
 import { AddSourceDrawer } from "./components/add-source-drawer";
 import { SourceRow } from "./components/source-row";
@@ -65,9 +66,16 @@ function TrustedSourcesSurface() {
   // the in-memory split below; saves four sequential round-trips
   // every time the page mounts. If a tenant grows past 200 sources
   // the Day-5 server-side pagination tab handles it.
-  const { data, isLoading } = useQuery({
+  //
+  // `retry: false` so a 401 from a not-yet-ready session or a 400
+  // from a missing-business principal surfaces immediately instead
+  // of looking like a slow load. The auth-provider is the right
+  // place to wait on session boot; this page just renders what we
+  // know.
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ["trusted-sources", { limit: 200 }],
     queryFn: () => listSources({ limit: 200 }),
+    retry: false,
   });
 
   const [tab, setTab] = useState<StatusTab>("active");
@@ -144,6 +152,8 @@ function TrustedSourcesSurface() {
         <div className="mt-4">
           {isLoading ? (
             <RowSkeletons />
+          ) : isError ? (
+            <ErrorCard error={error} />
           ) : visibleRows.length === 0 ? (
             <EmptyState tab={tab} hasAnySources={rows.length > 0} hasSearch={Boolean(search.trim())} />
           ) : (
@@ -216,6 +226,41 @@ function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }
         icon={Sparkles}
       />
     </div>
+  );
+}
+
+/**
+ * Error card for the listing fetch — distinguishes the most common
+ * failure modes (no active business / unauthenticated) from generic
+ * errors so the user sees an actionable message instead of "0
+ * sources" with no explanation.
+ */
+function ErrorCard({ error }: { error: unknown }) {
+  const isApi = error instanceof ApiError;
+  const status = isApi ? error.status : 0;
+  const message = isApi ? error.message : "Could not load trusted sources.";
+
+  // 400 + scope mention from the backend = no business selected
+  // (the route's principal-narrowing branch returns
+  // "Missing principal scope"). Surface a switcher hint instead of
+  // dumping the raw API message.
+  const hint =
+    status === 400 && /scope/i.test(message)
+      ? "Pick a business from the switcher to see its sources."
+      : status === 401
+        ? "Your session expired. Refresh the page to sign back in."
+        : null;
+
+  return (
+    <Card>
+      <CardContent className="flex items-start gap-3 py-6">
+        <AlertCircle aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-destructive" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Couldn&apos;t load sources</p>
+          <p className="text-sm text-muted-foreground">{hint ?? message}</p>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Activity, BookMarked, FileSearch, Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { KpiCard } from "@/components/molecules/kpi-card";
+import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { UpgradeButton } from "@/components/upgrade/upgrade-button";
+import { listSources } from "./api";
+import { AddSourceDrawer } from "./components/add-source-drawer";
+import { SourceRow } from "./components/source-row";
+import type { TrustedSource } from "./types";
+
+/**
+ * Trusted Sources — Phase 0 priority per the LinkedIn 360 plan §3.
+ *
+ * Ships the Day-1/2 surface: Active tab fully wired against
+ * /v1/sources/trusted, status-tab counts, search filter, KPI strip
+ * with the metrics computable from the listing payload alone, and
+ * the manual Add Source drawer. Suggested + Insights tabs render
+ * when data lands but the dedicated Suggested ranker UI + Insights
+ * timeline ship in Day-3/4 follow-ups.
+ *
+ * Gating: behind `content.sources` feature key. Today no plan grants
+ * this — the FeatureGate fallback opens the waitlist drawer pre-tagged
+ * so signups become signal for the rollout order.
+ */
+
+const FEATURE_KEY = "content.sources";
+const FEATURE_NAME = "Trusted Sources";
+const FEATURE_TAGLINE =
+  "Ground every brief, idea, and post in your brand's voice. Add the sites, feeds, channels, and creators your AI should read, watch, and cite.";
+
+type StatusTab = "active" | "suggested" | "rejected" | "inactive";
+
+const TABS: { value: StatusTab; label: string }[] = [
+  { value: "active", label: "Active" },
+  { value: "suggested", label: "Suggested" },
+  { value: "rejected", label: "Rejected" },
+  { value: "inactive", label: "Inactive" },
+];
+
+export default function TrustedSourcesPage() {
+  return (
+    <FeatureGate
+      feature={FEATURE_KEY}
+      featureName={FEATURE_NAME}
+      featureTagline={FEATURE_TAGLINE}
+      mode="hide"
+      fallback={<TrustedSourcesLockedFallback />}
+    >
+      <TrustedSourcesSurface />
+    </FeatureGate>
+  );
+}
+
+function TrustedSourcesSurface() {
+  // Pull all rows up front (cap at 200 — current schema validation
+  // ceiling on the listing endpoint). Per-status counts come from
+  // the in-memory split below; saves four sequential round-trips
+  // every time the page mounts. If a tenant grows past 200 sources
+  // the Day-5 server-side pagination tab handles it.
+  const { data, isLoading } = useQuery({
+    queryKey: ["trusted-sources", { limit: 200 }],
+    queryFn: () => listSources({ limit: 200 }),
+  });
+
+  const [tab, setTab] = useState<StatusTab>("active");
+  const [search, setSearch] = useState("");
+
+  // Memoize the row list against `data` directly so the deps array
+  // for `byStatus` doesn't change on every render (a fresh `?? []`
+  // expression yields a new array reference each call).
+  const rows = useMemo<TrustedSource[]>(() => data?.rows ?? [], [data]);
+
+  const byStatus = useMemo(() => {
+    const groups: Record<StatusTab, TrustedSource[]> = {
+      active: [],
+      suggested: [],
+      rejected: [],
+      inactive: [],
+    };
+    for (const r of rows) {
+      // The schema enum matches our tab values 1:1, but a future
+      // status would silently land in the wrong bucket without this
+      // narrow check.
+      if (r.status === "active" || r.status === "suggested" || r.status === "rejected" || r.status === "inactive") {
+        groups[r.status].push(r);
+      }
+    }
+    return groups;
+  }, [rows]);
+
+  const visibleRows = useMemo(() => {
+    const list = byStatus[tab];
+    if (!search.trim()) return list;
+    const q = search.trim().toLowerCase();
+    return list.filter(
+      (r) =>
+        r.displayName.toLowerCase().includes(q) ||
+        r.identifier.toLowerCase().includes(q),
+    );
+  }, [byStatus, tab, search]);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Trusted Sources</h2>
+          <p className="text-muted-foreground">
+            What your AI reads, watches, and cites.
+          </p>
+        </div>
+        <AddSourceDrawer />
+      </header>
+
+      <KpiStrip rows={rows} loading={isLoading} />
+
+      <Tabs value={tab} onValueChange={(v) => setTab(v as StatusTab)}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList>
+            {TABS.map((t) => (
+              <TabsTrigger key={t.value} value={t.value} className="gap-1.5">
+                {t.label}
+                <Badge variant="secondary" className="rounded-sm px-1.5 text-[10px]">
+                  {byStatus[t.value].length}
+                </Badge>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search name or URL"
+            className="h-9 w-full sm:w-72"
+          />
+        </div>
+
+        <div className="mt-4">
+          {isLoading ? (
+            <RowSkeletons />
+          ) : visibleRows.length === 0 ? (
+            <EmptyState tab={tab} hasAnySources={rows.length > 0} hasSearch={Boolean(search.trim())} />
+          ) : (
+            <div className="space-y-2">
+              {visibleRows.map((r) => (
+                <SourceRow key={r._id} source={r} />
+              ))}
+            </div>
+          )}
+        </div>
+      </Tabs>
+    </div>
+  );
+}
+
+/**
+ * KPI strip — four cards per the §3.4 spec. Two metrics are derivable
+ * from the listing payload and ship live; two need backend telemetry
+ * surfaces that don't exist yet (citations-30d depends on a count
+ * over `cnt_source_usage`; coverage-score is a proprietary scoring
+ * surface — see plan §3.4 + §6 algo #4) and ship as `—` placeholders
+ * with a tooltip-eligible muted state until the endpoint lands.
+ */
+function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }) {
+  const activeCount = rows.filter((r) => r.status === "active").length;
+
+  // 24h fetch health — ratio of recent-success vs recent-failure on
+  // active sources. consecutiveFetchFailures resets to 0 on success,
+  // so a non-zero value across active sources is the "needs attention"
+  // signal. Display as "{healthy}/{total}" so a dropping ratio is
+  // visible at a glance.
+  const active = rows.filter((r) => r.status === "active");
+  const healthy = active.filter((r) => (r.consecutiveFetchFailures ?? 0) === 0).length;
+  const fetchHealth = active.length === 0 ? "—" : `${healthy}/${active.length}`;
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <KpiCard
+        title="Active sources"
+        value={activeCount}
+        description="Currently feeding the AI"
+        icon={BookMarked}
+      />
+      <KpiCard
+        title="Fetch health"
+        value={fetchHealth}
+        description="Active sources fetched without failure"
+        icon={Activity}
+      />
+      <KpiCard
+        title="Citations (30d)"
+        value="—"
+        description="Lands when usage telemetry ships"
+        icon={FileSearch}
+      />
+      <KpiCard
+        title="Coverage score"
+        value="—"
+        description="Proprietary; algo in design"
+        icon={Sparkles}
+      />
+    </div>
+  );
+}
+
+function RowSkeletons() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Skeleton key={i} className="h-20" />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({
+  tab,
+  hasAnySources,
+  hasSearch,
+}: {
+  tab: StatusTab;
+  hasAnySources: boolean;
+  hasSearch: boolean;
+}) {
+  if (hasSearch) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          No sources match that search in this tab.
+        </CardContent>
+      </Card>
+    );
+  }
+  if (tab === "active" && !hasAnySources) {
+    // First-time empty state per the §3.4 spec — soft nudge ("explore
+    // first"), not a blocking modal. Per the open-questions log in
+    // §14, this lean was already chosen.
+    return (
+      <Card>
+        <CardContent className="space-y-2 py-12 text-center">
+          <p className="text-sm font-medium">Your AI is using only platform-default sources.</p>
+          <p className="text-sm text-muted-foreground">
+            Add 5–10 trusted sources to ground every brief in your brand&apos;s voice.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+  const copy: Record<StatusTab, string> = {
+    active: "Nothing active yet — add a source to start grounding briefs.",
+    suggested: "No suggested sources right now. The recommender adds candidates as your content grows.",
+    rejected: "Nothing rejected. Sources you reject from the Suggested tab show up here.",
+    inactive: "No paused sources.",
+  };
+  return (
+    <Card>
+      <CardContent className="py-12 text-center text-sm text-muted-foreground">
+        {copy[tab]}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TrustedSourcesLockedFallback() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-2xl font-bold tracking-tight">Trusted Sources</h2>
+        <p className="text-muted-foreground">
+          What your AI reads, watches, and cites.
+        </p>
+      </header>
+      <Card className="border-amber-200 bg-linear-to-br from-amber-50/60 to-white dark:border-amber-900/40 dark:from-amber-950/30 dark:to-transparent">
+        <CardContent className="space-y-3 p-8 text-center">
+          <Sparkles aria-hidden="true" className="mx-auto size-8 text-amber-600 dark:text-amber-400" />
+          <h3 className="text-lg font-semibold tracking-tight">Trusted Sources is rolling out</h3>
+          <p className="mx-auto max-w-md text-sm text-muted-foreground">
+            {FEATURE_TAGLINE}
+          </p>
+          <div className="pt-1">
+            <UpgradeButton
+              featureKey={FEATURE_KEY}
+              featureName={FEATURE_NAME}
+              featureTagline={FEATURE_TAGLINE}
+            >
+              Join waitlist
+            </UpgradeButton>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -15,7 +15,7 @@ import { ApiError } from "@/lib/api";
 import { listSources } from "./api";
 import { AddSourceDrawer } from "./components/add-source-drawer";
 import { SourceRow } from "./components/source-row";
-import type { TrustedSource } from "./types";
+import type { SourceStatus, TrustedSource } from "./types";
 
 /**
  * Trusted Sources — Phase 0 priority per the LinkedIn 360 plan §3.
@@ -37,7 +37,14 @@ const FEATURE_NAME = "Trusted Sources";
 const FEATURE_TAGLINE =
   "Ground every brief, idea, and post in your brand's voice. Add the sites, feeds, channels, and creators your AI should read, watch, and cite.";
 
-type StatusTab = "active" | "suggested" | "rejected" | "inactive";
+/**
+ * Tabs are 1:1 with SourceStatus. Aliasing instead of duplicating
+ * the union means a future schema addition (e.g., "archived") will
+ * TS-error at the `Record<StatusTab, ...>` exhaustiveness check on
+ * `byStatus` AND at the `TABS` const below — closing the silent-drop
+ * gap where a runtime `||` chain would have ignored the new value.
+ */
+type StatusTab = SourceStatus;
 
 const TABS: { value: StatusTab; label: string }[] = [
   { value: "active", label: "Active" },
@@ -72,10 +79,15 @@ function TrustedSourcesSurface() {
   // of looking like a slow load. The auth-provider is the right
   // place to wait on session boot; this page just renders what we
   // know.
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, isFetching, isError, error } = useQuery({
     queryKey: ["trusted-sources", { limit: 200 }],
     queryFn: () => listSources({ limit: 200 }),
     retry: false,
+    // Trusted sources change at 15-minute fetcher cadence at most;
+    // 30s of staleness avoids the tab-switch refetch storm that
+    // would otherwise rebuild every memo and remount the per-row
+    // "Xm ago" intervals.
+    staleTime: 30_000,
   });
 
   const [tab, setTab] = useState<StatusTab>("active");
@@ -93,13 +105,13 @@ function TrustedSourcesSurface() {
       rejected: [],
       inactive: [],
     };
+    // StatusTab is aliased to SourceStatus, so every r.status is a
+    // valid groups[] key by construction. If the schema gains a new
+    // status, the Record<StatusTab,…> initialiser above will fail
+    // exhaustiveness — that's the desired error surface, not this
+    // loop.
     for (const r of rows) {
-      // The schema enum matches our tab values 1:1, but a future
-      // status would silently land in the wrong bucket without this
-      // narrow check.
-      if (r.status === "active" || r.status === "suggested" || r.status === "rejected" || r.status === "inactive") {
-        groups[r.status].push(r);
-      }
+      groups[r.status].push(r);
     }
     return groups;
   }, [rows]);
@@ -149,7 +161,11 @@ function TrustedSourcesSurface() {
           />
         </div>
 
-        <div className="mt-4">
+        {/* aria-busy on the list region so screen-reader users learn
+            when a background revalidation (post-mutation invalidate
+            or focus refetch) is in flight — the visual list goes
+            stale for ~1s with no indicator without this. */}
+        <div className="mt-4" aria-busy={isFetching && !isLoading}>
           {isLoading ? (
             <RowSkeletons />
           ) : isError ? (

--- a/src/app/dashboard/content/sources/types.ts
+++ b/src/app/dashboard/content/sources/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Trusted-source types — mirrors the row shape returned by
+ * `GET /v1/sources/trusted` on peakhour-api.
+ *
+ * Source of truth for the field set: cnt_trusted_sources.schema.json
+ * + the projection in routes/sources/trusted.ts (the listing route
+ * strips `rejectionTopicEmbedding` from the response).
+ *
+ * Intentionally not all schema fields are typed here — only the ones
+ * the UI renders or mutates. Adding a new field requires touching this
+ * file so a "renamed in schema, forgotten in UI" drift is harder to
+ * miss in code review.
+ */
+
+export type SourceType =
+  | "website"
+  | "rss"
+  | "x_handle"
+  | "instagram_handle"
+  | "youtube_channel"
+  | "newsletter"
+  | "podcast"
+  | "uploaded_doc";
+
+export type SourceStatus = "active" | "suggested" | "rejected" | "inactive";
+
+export type SourceOrigin = "user_suggested" | "ai_suggested";
+
+export type FetchFrequency = "hourly" | "daily" | "weekly" | "manual";
+
+export interface TrustedSourceMetadata {
+  followerCount?: number;
+  description?: string;
+  domainAuthority?: number;
+  avgPostFrequency?: string;
+  language?: string;
+  region?: string;
+}
+
+export interface TrustedSource {
+  _id: string;
+  orgId: string;
+  businessId: string;
+  type: SourceType;
+  identifier: string;
+  displayName: string;
+  origin: SourceOrigin;
+  status: SourceStatus;
+  trustScore: number;
+  topicTags?: string[];
+  usageCount?: number;
+  fetchFrequency: FetchFrequency;
+  consecutiveFetchFailures?: number;
+  // Date strings come back ISO-formatted from Hono's JSON serializer.
+  createdAt?: string;
+  updatedAt?: string;
+  acceptedAt?: string;
+  rejectedAt?: string;
+  inactivatedAt?: string;
+  lastUsedAt?: string;
+  lastFetchedAt?: string;
+  lastSuccessfulFetchAt?: string;
+  nextFetchDue?: string;
+  rejectionReason?: string;
+  suggestedReason?: string;
+  metadata?: TrustedSourceMetadata;
+}
+
+export interface ListResponse {
+  rows: TrustedSource[];
+  total: number;
+}
+
+export interface CreateSourceInput {
+  type: SourceType;
+  identifier: string;
+  displayName: string;
+  fetchFrequency?: FetchFrequency;
+  metadata?: TrustedSourceMetadata;
+}
+
+export interface PatchSourceInput {
+  status?: "active" | "inactive" | "rejected";
+  rejectionReason?: string;
+  displayName?: string;
+  fetchFrequency?: FetchFrequency;
+  metadata?: TrustedSourceMetadata;
+}
+
+/**
+ * UI labels for source types. Kept here (not in the API helper) so
+ * copy lives next to the components that render it. Map keyed by the
+ * exact schema-enum string to make bad keys a TS error.
+ */
+export const SOURCE_TYPE_LABEL: Record<SourceType, string> = {
+  website: "Website",
+  rss: "RSS feed",
+  x_handle: "X handle",
+  instagram_handle: "Instagram handle",
+  youtube_channel: "YouTube channel",
+  newsletter: "Newsletter",
+  podcast: "Podcast",
+  uploaded_doc: "Uploaded document",
+};
+
+export const FETCH_FREQUENCY_LABEL: Record<FetchFrequency, string> = {
+  hourly: "Hourly",
+  daily: "Daily",
+  weekly: "Weekly",
+  manual: "Manual",
+};

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -80,8 +80,12 @@ const NAV_GROUPS: NavGroup[] = [
         href: "/dashboard/content",
         label: "Content",
         icon: FileText,
+        // Order encodes the mental model: Library → Sources → Strategist
+        // → Calendar = ingest → ground → plan → publish. Per the
+        // LinkedIn 360 plan §3.3 IA decision.
         subItems: [
           { href: "/dashboard/content", label: "Library" },
+          { href: "/dashboard/content/sources", label: "Sources" },
           { href: "/dashboard/strategist", label: "Strategist" },
           { href: "/dashboard/calendar", label: "Calendar" },
         ],


### PR DESCRIPTION
## Summary

Phase 0 priority per the LinkedIn 360 plan §3 + §13. Backend (CRUD + hybrid retrieval + 15-min fetch scheduler + citation audit + schemas) has been live with no UI to surface it; this PR ships the day-1/2 deliverable from §3.7 — page skeleton with CRUD wired, manual Add Source drawer, status tabs with counts, and a searchable Active list.

## What ships

- **Page** at \`/dashboard/content/sources\` (sub-nav: Library → **Sources** → Strategist → Calendar — encodes the §3.3 ingest → ground → plan → publish mental model).
- **KPI strip** with the two metrics derivable from the listing payload alone — Active count and fetch-health ratio (active sources without recent fetch failures). Citations 30d and Coverage score render \`—\` placeholders until their backend telemetry surfaces ship.
- **Status tabs** with live counts (Active / Suggested / Rejected / Inactive) — pattern from \`@shadcnblocks/data-table13\` (tabbed status filters with badges). Search box filters within the active tab.
- **Source rows** — pattern adapted from \`@shadcnblocks/settings-integrations9\` (icon left, name + meta middle, status badge + actions dropdown right). Dashboard-density rescale (single rounded-lg row, p-4) instead of the marketing-page card cluster.
- **Add Source drawer** — manual-add form (type, identifier, displayName, fetchFrequency). Surfaces the backend's 409 conflict copy verbatim. Bulk paste + OPML import slot into this same drawer as additional tabs in the day-4 follow-up.
- **FeatureGate** at \`content.sources\` — no plan grants this today, so the page locked-fallback opens the waitlist drawer pre-tagged. Same primitive used by \`/dashboard/optimizer\` (PR #160 / #161).
- **Action set varies by status**: Active → Pause + Delete; Suggested → Accept + Reject; Inactive → Resume + Delete; Rejected → terminal (no actions). Mirrors the state machine in [peakhour-api/src/v1/routes/sources/trusted.ts](peakhour-api/src/v1/routes/sources/trusted.ts).
- **Error UI** — distinguishes "no business selected" (400 + scope) and "session expired" (401) from generic errors so the user sees an actionable message instead of "0 sources".

## What doesn't (followups)

Tracked as day-3/4 work per §3.7:
- Suggested-tab ranker UI with similarity rationale + bulk Approve/Reject.
- Insights tab (top-cited sources, drift alerts, coverage heatmap, citation timeline using \`@shadcnblocks Timeline\` blocks).
- Bulk paste with auto-detect + OPML import in the Add drawer.
- "Suggest from competitor" tab in the drawer.
- CMS twin at \`/admin/sources\` for read-mostly ops (linking failure dashboards, push platform-defaults).
- Reject-with-reason dialog (today's static sentinel reason works for backend validation; proper UX needs textarea + canned-reason radios).
- Citations-30d + Coverage score KPI surfaces (depend on a \`cnt_source_usage\` aggregate endpoint and the §6 algo #4 coverage scorer — neither exists yet).

## Test plan

- [ ] Sign in as a free-tier user on a business with no sources — verify \`/dashboard/content/sources\` redirects through the FeatureGate fallback (locked card → waitlist drawer when clicked).
- [ ] Grant the org \`content.sources\` via \`platformOverrides.grantedFeatures\` in the CMS — verify the unlocked page renders with empty-state copy ("Your AI is using only platform-default sources…").
- [ ] Click \"Add source\", submit a website URL — verify it lands in Active tab, fetch-health KPI shows 1/1, toast confirms.
- [ ] Re-submit the same URL — verify the 409 conflict surfaces verbatim.
- [ ] Action menu: Pause, Resume, Delete each toast and refresh the list.
- [ ] Sign out and visit the URL — verify the 401 branch on the error card surfaces the "Refresh to sign back in" hint.
- [ ] Drop the active business via the switcher — verify the 400 scope branch renders "Pick a business from the switcher".
- [ ] Sub-nav: \"Sources\" appears between Library and Strategist under Content; clicking lights it up exclusively.
- [ ] Mobile responsive: tab list wraps gracefully; KPI strip collapses to 2-col then 1-col.
- [ ] Dark mode: all amber tokens + status badges hold contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)