### PR TITLE
feat(sources): Day 3 — Suggested rationale + Insights tab

### DIFF
--- a/src/app/dashboard/content/sources/components/insights-panel.tsx
+++ b/src/app/dashboard/content/sources/components/insights-panel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo } from "react";
+import { BookMarked, Sparkles, Trophy } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { KpiCard } from "@/components/molecules/kpi-card";
+import { PendingItemsCard } from "@/components/molecules/pending-items-card";
+import { ProportionListCard } from "@/components/molecules/proportion-list-card";
+import { RankedListCard } from "@/components/molecules/ranked-list-card";
+import { SOURCE_TYPE_LABEL, type SourceType, type TrustedSource } from "../types";
+
+/**
+ * Insights panel — Day-3 surface per the LinkedIn 360 plan §3.4.
+ *
+ * Composes generic molecules (KpiCard, RankedListCard,
+ * ProportionListCard, PendingItemsCard) so the same shapes can be
+ * reused for the X / LinkedIn / Beehiiv insights surfaces when they
+ * land. This module's only job is the trusted-sources-specific
+ * aggregate computation + the wiring to those molecules.
+ *
+ * Ships the aggregates derivable from the listing payload alone:
+ *   • Active count, total citations (sum of usageCount), avg trust
+ *     across active sources.
+ *   • Top 5 cited sources (by usageCount, ties broken by trustScore).
+ *   • Active sources by type (proportion list).
+ *
+ * Held back for follow-ups (depend on backend telemetry that doesn't
+ * exist yet — see PendingItemsCard items below):
+ *   • Citation timeline — needs `cnt_source_usage` time-series.
+ *   • Coverage heatmap — proprietary scorer (§6 algo #4).
+ *   • Drift alerts — rejection-topic embedding comparison cron.
+ */
+
+interface InsightsPanelProps {
+  rows: TrustedSource[];
+}
+
+export function InsightsPanel({ rows }: InsightsPanelProps) {
+  const stats = useMemo(() => computeStats(rows), [rows]);
+
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          Insights light up once you&apos;ve added sources and the AI starts citing them.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Top row: three KpiCards (existing molecule). Citations
+          shows a hint when 0 so a brand-new tenant doesn't read it
+          as "your AI doesn't cite anything" — it reads "you haven't
+          generated content yet." */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <KpiCard
+          title="Active sources"
+          value={stats.totalActive}
+          icon={BookMarked}
+        />
+        <KpiCard
+          title="Citations"
+          value={stats.totalCitations}
+          description={
+            stats.totalCitations === 0
+              ? "Once the AI cites a source, the count lands here"
+              : "All-time, across active sources"
+          }
+          icon={Sparkles}
+        />
+        <KpiCard
+          title="Avg trust"
+          value={stats.avgTrust === null ? "—" : `${Math.round(stats.avgTrust * 100)}`}
+          description="Active sources, 0–100"
+          icon={Trophy}
+        />
+      </div>
+
+      {/* Two-up: top cited + by-type breakdown. */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <RankedListCard
+          title="Top cited"
+          items={stats.topCited.map((s) => ({
+            id: s._id,
+            title: s.displayName,
+            subtitle: s.identifier,
+            value: s.usageCount ?? 0,
+          }))}
+          emptyMessage="No citations yet. The AI cites sources as it generates briefs and plans."
+        />
+        <ProportionListCard
+          title="Active sources by type"
+          items={stats.byType.map((b) => ({
+            id: b.type,
+            label: SOURCE_TYPE_LABEL[b.type],
+            count: b.count,
+          }))}
+          total={stats.totalActive}
+          emptyMessage="No active sources to break down."
+        />
+      </div>
+
+      <PendingItemsCard
+        items={[
+          { title: "Citation timeline", gatedOn: "cnt_source_usage time-series aggregate endpoint" },
+          { title: "Coverage heatmap", gatedOn: "proprietary scorer (algo in design)" },
+          { title: "Drift alerts", gatedOn: "rejection-topic embedding comparison cron" },
+        ]}
+      />
+    </div>
+  );
+}
+
+interface AggregateStats {
+  totalActive: number;
+  totalCitations: number;
+  avgTrust: number | null;
+  byType: Array<{ type: SourceType; count: number }>;
+  topCited: TrustedSource[];
+}
+
+/**
+ * Aggregate over **active** sources only. Including paused or
+ * rejected rows would inflate citation counts the user can't act on,
+ * and inflate the type breakdown with sources their AI is no longer
+ * reading.
+ */
+function computeStats(rows: TrustedSource[]): AggregateStats {
+  const active = rows.filter((r) => r.status === "active");
+
+  const totalCitations = active.reduce((sum, r) => sum + (r.usageCount ?? 0), 0);
+
+  const avgTrust =
+    active.length === 0
+      ? null
+      : active.reduce((sum, r) => sum + r.trustScore, 0) / active.length;
+
+  const typeCounts = new Map<SourceType, number>();
+  for (const r of active) {
+    typeCounts.set(r.type, (typeCounts.get(r.type) ?? 0) + 1);
+  }
+  const byType = Array.from(typeCounts.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Top cited — break ties by trustScore so a higher-trust source
+  // leads when two sources have the same usage count. The molecule
+  // caps display at 5; we still pre-filter and sort here.
+  const topCited = [...active]
+    .filter((r) => (r.usageCount ?? 0) > 0)
+    .sort((a, b) => {
+      const ua = a.usageCount ?? 0;
+      const ub = b.usageCount ?? 0;
+      if (ub !== ua) return ub - ua;
+      return b.trustScore - a.trustScore;
+    });
+
+  return {
+    totalActive: active.length,
+    totalCitations,
+    avgTrust,
+    byType,
+    topCited,
+  };
+}

--- a/src/app/dashboard/content/sources/components/insights-panel.tsx
+++ b/src/app/dashboard/content/sources/components/insights-panel.tsx
@@ -112,20 +112,19 @@ export function InsightsPanel({ rows }: InsightsPanelProps) {
         items={[
           {
             title: "Citation timeline",
-            gatedOn: "cnt_source_usage time-series aggregate endpoint",
+            gateNoun: "cnt_source_usage time-series aggregate endpoint",
           },
           {
-            // gatedOn is parsed by PendingItemsCard as the noun
-            // phrase between "Lands once the" and "ships." A
-            // parenthetical aside ("(algo in design)") would attach
-            // "ships" to the parenthetical, reading awkwardly — keep
-            // the phrase a clean noun.
+            // gateNoun must read as a clean noun ("Lands once the X
+            // ships.") — see PendingItem JSDoc. If a parenthetical
+            // ("(algo in design)") creeps back in, switch to the
+            // discriminated `caption` variant for full control.
             title: "Coverage heatmap",
-            gatedOn: "proprietary coverage scorer",
+            gateNoun: "proprietary coverage scorer",
           },
           {
             title: "Drift alerts",
-            gatedOn: "rejection-topic embedding comparison cron",
+            gateNoun: "rejection-topic embedding comparison cron",
           },
         ]}
       />

--- a/src/app/dashboard/content/sources/components/insights-panel.tsx
+++ b/src/app/dashboard/content/sources/components/insights-panel.tsx
@@ -60,13 +60,19 @@ export function InsightsPanel({ rows }: InsightsPanelProps) {
           value={stats.totalActive}
           icon={BookMarked}
         />
+        {/* "Active citations" so the active-only scope is on the
+            label, not buried in a description. A paused source's
+            historical citations are real but excluded here — the
+            user reads this number as "what's currently feeding the
+            AI's output," matching the rest of this panel which is
+            also active-only by design. */}
         <KpiCard
-          title="Citations"
+          title="Active citations"
           value={stats.totalCitations}
           description={
             stats.totalCitations === 0
               ? "Once the AI cites a source, the count lands here"
-              : "All-time, across active sources"
+              : "All-time, across currently-active sources"
           }
           icon={Sparkles}
         />
@@ -104,9 +110,23 @@ export function InsightsPanel({ rows }: InsightsPanelProps) {
 
       <PendingItemsCard
         items={[
-          { title: "Citation timeline", gatedOn: "cnt_source_usage time-series aggregate endpoint" },
-          { title: "Coverage heatmap", gatedOn: "proprietary scorer (algo in design)" },
-          { title: "Drift alerts", gatedOn: "rejection-topic embedding comparison cron" },
+          {
+            title: "Citation timeline",
+            gatedOn: "cnt_source_usage time-series aggregate endpoint",
+          },
+          {
+            // gatedOn is parsed by PendingItemsCard as the noun
+            // phrase between "Lands once the" and "ships." A
+            // parenthetical aside ("(algo in design)") would attach
+            // "ships" to the parenthetical, reading awkwardly — keep
+            // the phrase a clean noun.
+            title: "Coverage heatmap",
+            gatedOn: "proprietary coverage scorer",
+          },
+          {
+            title: "Drift alerts",
+            gatedOn: "rejection-topic embedding comparison cron",
+          },
         ]}
       />
     </div>

--- a/src/app/dashboard/content/sources/components/source-row.tsx
+++ b/src/app/dashboard/content/sources/components/source-row.tsx
@@ -176,10 +176,25 @@ export function SourceRow({ source }: SourceRowProps) {
           <Badge variant="outline" className="shrink-0 text-[10px]">
             {SOURCE_TYPE_LABEL[source.type]}
           </Badge>
+          {source.origin === "ai_suggested" && (
+            <Badge variant="secondary" className="shrink-0 text-[10px]">
+              AI suggested
+            </Badge>
+          )}
         </div>
         <p className="truncate font-mono text-xs text-muted-foreground" title={source.identifier}>
           {source.identifier}
         </p>
+        {/* Suggested rows lead with WHY the recommender flagged it —
+            that's the decision-relevant info for an Accept/Reject
+            click. Active/inactive/rejected rows show fetch + usage
+            stats instead. */}
+        {source.status === "suggested" && source.suggestedReason ? (
+          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground/80">Why: </span>
+            {source.suggestedReason}
+          </p>
+        ) : null}
         <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
           <span>{source.fetchFrequency}</span>
           <span aria-hidden="true">•</span>

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -14,6 +14,7 @@ import { UpgradeButton } from "@/components/upgrade/upgrade-button";
 import { ApiError } from "@/lib/api";
 import { listSources } from "./api";
 import { AddSourceDrawer } from "./components/add-source-drawer";
+import { InsightsPanel } from "./components/insights-panel";
 import { SourceRow } from "./components/source-row";
 import type { SourceStatus, TrustedSource } from "./types";
 
@@ -38,15 +39,21 @@ const FEATURE_TAGLINE =
   "Ground every brief, idea, and post in your brand's voice. Add the sites, feeds, channels, and creators your AI should read, watch, and cite.";
 
 /**
- * Tabs are 1:1 with SourceStatus. Aliasing instead of duplicating
- * the union means a future schema addition (e.g., "archived") will
- * TS-error at the `Record<StatusTab, ...>` exhaustiveness check on
- * `byStatus` AND at the `TABS` const below — closing the silent-drop
- * gap where a runtime `||` chain would have ignored the new value.
+ * Status-filtered list tabs are 1:1 with SourceStatus. Aliasing
+ * instead of duplicating the union means a future schema addition
+ * (e.g., "archived") will TS-error at the `Record<StatusTab, ...>`
+ * exhaustiveness check on `byStatus` AND at the `STATUS_TABS` const
+ * below — closing the silent-drop gap where a runtime `||` chain
+ * would have ignored the new value.
+ *
+ * `Tab` is the broader union including the Insights view; the
+ * Insights tab renders aggregates (not a filtered list) so it sits
+ * outside the SourceStatus alias.
  */
 type StatusTab = SourceStatus;
+type Tab = StatusTab | "insights";
 
-const TABS: { value: StatusTab; label: string }[] = [
+const STATUS_TABS: { value: StatusTab; label: string }[] = [
   { value: "active", label: "Active" },
   { value: "suggested", label: "Suggested" },
   { value: "rejected", label: "Rejected" },
@@ -90,7 +97,7 @@ function TrustedSourcesSurface() {
     staleTime: 30_000,
   });
 
-  const [tab, setTab] = useState<StatusTab>("active");
+  const [tab, setTab] = useState<Tab>("active");
   const [search, setSearch] = useState("");
 
   // Memoize the row list against `data` directly so the deps array
@@ -117,6 +124,7 @@ function TrustedSourcesSurface() {
   }, [rows]);
 
   const visibleRows = useMemo(() => {
+    if (tab === "insights") return [];
     const list = byStatus[tab];
     if (!search.trim()) return list;
     const q = search.trim().toLowerCase();
@@ -141,10 +149,10 @@ function TrustedSourcesSurface() {
 
       <KpiStrip rows={rows} loading={isLoading} />
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as StatusTab)}>
+      <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <TabsList>
-            {TABS.map((t) => (
+            {STATUS_TABS.map((t) => (
               <TabsTrigger key={t.value} value={t.value} className="gap-1.5">
                 {t.label}
                 <Badge variant="secondary" className="rounded-sm px-1.5 text-[10px]">
@@ -152,13 +160,18 @@ function TrustedSourcesSurface() {
                 </Badge>
               </TabsTrigger>
             ))}
+            <TabsTrigger value="insights">Insights</TabsTrigger>
           </TabsList>
-          <Input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search name or URL"
-            className="h-9 w-full sm:w-72"
-          />
+          {/* Search filters the row list — irrelevant on Insights, so
+              it hides there to avoid implying "search the aggregates". */}
+          {tab !== "insights" && (
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search name or URL"
+              className="h-9 w-full sm:w-72"
+            />
+          )}
         </div>
 
         {/* aria-busy on the list region so screen-reader users learn
@@ -170,6 +183,8 @@ function TrustedSourcesSurface() {
             <RowSkeletons />
           ) : isError ? (
             <ErrorCard error={error} />
+          ) : tab === "insights" ? (
+            <InsightsPanel rows={rows} />
           ) : visibleRows.length === 0 ? (
             <EmptyState tab={tab} hasAnySources={rows.length > 0} hasSearch={Boolean(search.trim())} />
           ) : (

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -60,6 +60,20 @@ const STATUS_TABS: { value: StatusTab; label: string }[] = [
   { value: "inactive", label: "Inactive" },
 ];
 
+/**
+ * Validate a string against the Tab union — Radix Tabs only emits
+ * values from the rendered triggers today, but accepting them via
+ * an unchecked cast would defeat the silent-drop guard the
+ * StatusTab/Tab split was introduced for. A future caller passing
+ * a stray query param into this state would silently land on
+ * `"active"` instead of crashing or rendering a broken layout.
+ */
+function parseTab(v: string): Tab {
+  if (v === "insights") return "insights";
+  if (STATUS_TABS.some((t) => t.value === v)) return v as StatusTab;
+  return "active";
+}
+
 export default function TrustedSourcesPage() {
   return (
     <FeatureGate
@@ -149,7 +163,7 @@ function TrustedSourcesSurface() {
 
       <KpiStrip rows={rows} loading={isLoading} />
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
+      <Tabs value={tab} onValueChange={(v) => setTab(parseTab(v))}>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <TabsList>
             {STATUS_TABS.map((t) => (

--- a/src/components/molecules/pending-items-card.tsx
+++ b/src/components/molecules/pending-items-card.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 /**
  * PendingItemsCard — a deliberate "what's coming, and what gates it"
@@ -10,17 +10,20 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
  * alerts, hook DNA, audience signals). Naming each gate explicitly
  * lets a future reader pattern-match against followup trackers
  * instead of guessing what's missing.
+ *
+ * Each item supplies either:
+ *   • `gateNoun` — a noun phrase the molecule splices into the
+ *     templated sentence "Lands once the {gateNoun} ships." Use this
+ *     for the common case (an endpoint, scorer, cron, etc.).
+ *   • `caption` — a full sentence rendered verbatim. Use this when
+ *     the templated sentence reads awkwardly (passive voice, future
+ *     tense, multi-clause). Caption wins if both are provided.
  */
 
-export interface PendingItem {
-  /** Item title, e.g. "Citation timeline". */
-  title: string;
-  /** What backend or data surface gates this item, e.g. "cnt_source_usage
-   *  time-series aggregate endpoint". The card prepends "Lands once the"
-   *  and appends "ships." so callers should write the *thing* that needs
-   *  to ship, not a full sentence. */
-  gatedOn: string;
-}
+export type PendingItem = { title: string } & (
+  | { gateNoun: string; caption?: never }
+  | { caption: string; gateNoun?: never }
+);
 
 export interface PendingItemsCardProps {
   title?: string;
@@ -31,13 +34,17 @@ export function PendingItemsCard({ title = "Coming soon", items }: PendingItemsC
   return (
     <Card className="border-dashed">
       <CardHeader>
-        <CardTitle className="text-base">{title}</CardTitle>
+        {/* Real <h3> for SR navigation — see ranked-list-card.tsx
+            for the rationale. Tokens mirror CardTitle's defaults. */}
+        <h3 className="text-base leading-none font-semibold">{title}</h3>
       </CardHeader>
       <CardContent className="space-y-2 text-sm text-muted-foreground">
         {items.map((item) => (
           <div key={item.title}>
             <p className="text-sm font-medium text-foreground">{item.title}</p>
-            <p className="text-xs">Lands once the {item.gatedOn} ships.</p>
+            <p className="text-xs">
+              {item.caption ?? `Lands once the ${item.gateNoun} ships.`}
+            </p>
           </div>
         ))}
       </CardContent>

--- a/src/components/molecules/pending-items-card.tsx
+++ b/src/components/molecules/pending-items-card.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * PendingItemsCard — a deliberate "what's coming, and what gates it"
+ * placeholder. Use when a panel has a designed slot for content that
+ * depends on a backend surface that hasn't shipped yet.
+ *
+ * Why this is a molecule and not a one-off: every analytics surface
+ * eventually has telemetry that lags the UI (citations 30d, drift
+ * alerts, hook DNA, audience signals). Naming each gate explicitly
+ * lets a future reader pattern-match against followup trackers
+ * instead of guessing what's missing.
+ */
+
+export interface PendingItem {
+  /** Item title, e.g. "Citation timeline". */
+  title: string;
+  /** What backend or data surface gates this item, e.g. "cnt_source_usage
+   *  time-series aggregate endpoint". The card prepends "Lands once the"
+   *  and appends "ships." so callers should write the *thing* that needs
+   *  to ship, not a full sentence. */
+  gatedOn: string;
+}
+
+export interface PendingItemsCardProps {
+  title?: string;
+  items: PendingItem[];
+}
+
+export function PendingItemsCard({ title = "Coming soon", items }: PendingItemsCardProps) {
+  return (
+    <Card className="border-dashed">
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm text-muted-foreground">
+        {items.map((item) => (
+          <div key={item.title}>
+            <p className="text-sm font-medium text-foreground">{item.title}</p>
+            <p className="text-xs">Lands once the {item.gatedOn} ships.</p>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/molecules/proportion-list-card.tsx
+++ b/src/components/molecules/proportion-list-card.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 
 /**
@@ -37,7 +37,9 @@ export function ProportionListCard({
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">{title}</CardTitle>
+        {/* Real <h3> for SR navigation — see ranked-list-card.tsx
+            for the rationale. Tokens mirror CardTitle's defaults. */}
+        <h3 className="text-base leading-none font-semibold">{title}</h3>
       </CardHeader>
       <CardContent>
         {items.length === 0 ? (

--- a/src/components/molecules/proportion-list-card.tsx
+++ b/src/components/molecules/proportion-list-card.tsx
@@ -54,7 +54,11 @@ export function ProportionListCard({
                 </div>
                 <Progress
                   value={total === 0 ? 0 : (item.count / total) * 100}
-                  aria-label={`${item.count} of ${total} are ${item.label}`}
+                  // Label puts the category name first so the AT
+                  // user hears the bar's meaning (the category) before
+                  // the proportion. "Newsletter: 3 of 12" is more
+                  // scannable than "3 of 12 are newsletter".
+                  aria-label={`${item.label}: ${item.count} of ${total}`}
                 />
               </li>
             ))}

--- a/src/components/molecules/proportion-list-card.tsx
+++ b/src/components/molecules/proportion-list-card.tsx
@@ -1,0 +1,66 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+
+/**
+ * ProportionListCard — "label + count of total" rows with a progress
+ * bar each, sorted however the caller likes. Used for breakdowns
+ * (sources by type, posts by channel, audience by industry) where a
+ * full chart is overkill but a list of plain counts is undersold.
+ *
+ * The molecule renders proportions strictly relative to `total` so
+ * the caller controls whether the denominator is "all rows" or "rows
+ * matching some filter" — a different denominator changes the bars'
+ * meaning, and shifting that decision into the molecule would couple
+ * it to a single use case.
+ */
+
+export interface ProportionListItem {
+  id: string;
+  label: string;
+  count: number;
+}
+
+export interface ProportionListCardProps {
+  title: string;
+  items: ProportionListItem[];
+  total: number;
+  /** Copy shown when items is empty. */
+  emptyMessage: string;
+}
+
+export function ProportionListCard({
+  title,
+  items,
+  total,
+  emptyMessage,
+}: ProportionListCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <li key={item.id} className="space-y-1">
+                <div className="flex items-baseline justify-between text-sm">
+                  <span>{item.label}</span>
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {item.count} / {total}
+                  </span>
+                </div>
+                <Progress
+                  value={total === 0 ? 0 : (item.count / total) * 100}
+                  aria-label={`${item.count} of ${total} are ${item.label}`}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/molecules/ranked-list-card.tsx
+++ b/src/components/molecules/ranked-list-card.tsx
@@ -1,0 +1,83 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+/**
+ * RankedListCard — generic top-N leaderboard pattern (numbered list,
+ * each row showing a primary label + optional secondary line + a
+ * trailing count/value badge).
+ *
+ * Used by Insights panels (Trusted Sources top-cited, future
+ * X/LinkedIn top posts, etc.). The molecule deliberately leaves
+ * domain-specific concerns (links, action menus, type-icons) to the
+ * composition site — keep the molecule renderer dumb so the same
+ * component renders top-cited sources and top-engaging posts without
+ * a switch.
+ */
+
+export interface RankedListItem {
+  /** Stable React key. */
+  id: string;
+  /** Primary label, e.g. a source's display name. */
+  title: string;
+  /** Optional secondary line (truncated if long), e.g. URL/identifier. */
+  subtitle?: string;
+  /** Trailing badge value — render as-is so callers can format
+   *  (e.g. "1.2k", "$420", "12 citations"). */
+  value: string | number;
+}
+
+export interface RankedListCardProps {
+  title: string;
+  items: RankedListItem[];
+  /** Copy shown when items is empty. Tailor per surface — the
+   *  molecule has no domain context to choose default copy. */
+  emptyMessage: string;
+  /** Cap the visible items. Defaults to 5 (the leaderboard sweet
+   *  spot). Pass `Infinity` to render everything. */
+  limit?: number;
+}
+
+export function RankedListCard({
+  title,
+  items,
+  emptyMessage,
+  limit = 5,
+}: RankedListCardProps) {
+  const visible = items.slice(0, limit);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {visible.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          <ol className="space-y-2">
+            {visible.map((item, i) => (
+              <li key={item.id} className="flex items-baseline gap-3 text-sm">
+                <span className="w-4 shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {i + 1}.
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium">{item.title}</p>
+                  {item.subtitle ? (
+                    <p
+                      className="truncate font-mono text-[11px] text-muted-foreground"
+                      title={item.subtitle}
+                    >
+                      {item.subtitle}
+                    </p>
+                  ) : null}
+                </div>
+                <Badge variant="secondary" className="shrink-0 text-xs tabular-nums">
+                  {item.value}
+                </Badge>
+              </li>
+            ))}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/molecules/ranked-list-card.tsx
+++ b/src/components/molecules/ranked-list-card.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 /**
@@ -47,7 +47,11 @@ export function RankedListCard({
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">{title}</CardTitle>
+        {/* Real <h3> (not CardTitle, which is a styled <div>) so the
+            section appears in the page outline and SR users
+            navigating by heading can land on it. Tailwind tokens
+            mirror CardTitle's defaults so the visual is unchanged. */}
+        <h3 className="text-base leading-none font-semibold">{title}</h3>
       </CardHeader>
       <CardContent>
         {visible.length === 0 ? (


### PR DESCRIPTION
## Summary

Day 3 of the LinkedIn 360 plan §3.4 + §3.7. Builds on PR #162 (Day 1/2) with two surfaces:

### Suggested-tab improvements

- **\"AI suggested\" badge** on rows with \`origin === \"ai_suggested\"\` so user-curated and AI-suggested sources are visually distinct regardless of which tab they land in.
- **\"Why\" rationale line** on suggested-status rows with a non-empty \`suggestedReason\`. Surfaced above the fetch/usage meta because it's the decision-relevant info for an Accept/Reject click — burying it in a tooltip would defeat the purpose.

### Insights tab

A new sibling tab to the four status filters. Renders aggregates over the listing payload alone — no new backend dependency:

- **3 KpiCards** at top: Active sources, Active citations (active-only scope on the label), Avg trust.
- **Top cited** (top 5 by usageCount, ties broken by trustScore).
- **Active sources by type** (proportion list with progress bars).
- **PendingItemsCard** naming the three telemetry-gated surfaces explicitly so a future reader pattern-matches against the followup tracker instead of guessing what's missing: citation timeline, coverage heatmap, drift alerts.

The page widens \`tab\` state from \`StatusTab\` (= SourceStatus) to \`Tab = StatusTab | \"insights\"\`. Search input hides on Insights since there's no row list to filter. Tab onValueChange goes through \`parseTab(v)\` instead of an unchecked cast — closes the silent-drop guard the StatusTab/Tab split was introduced for.

## New reusable molecules

Per the standing rule about reusability: searched shadcnblocks PRO for ranked-list / progress-breakdown / \"coming soon\" patterns first; nothing matched cleanly at dashboard density (registry stat blocks are full marketing-page scale). Extracted three new molecules so the future X / LinkedIn / Beehiiv insights surfaces reuse them:

- \`src/components/molecules/ranked-list-card.tsx\` — generic top-N leaderboard. Trailing value is \`string | number\` so callers format however they like.
- \`src/components/molecules/proportion-list-card.tsx\` — generic \"label + count of total\" breakdown rows with Progress bars. Caller controls the denominator so the bars' meaning stays at the call site.
- \`src/components/molecules/pending-items-card.tsx\` — the \"what's coming, what gates it\" placeholder. The molecule prepends \"Lands once the\" and appends \"ships.\" — callers write the dependency, not a full sentence.

The Insights panel composes these molecules + the existing KpiCard. No bespoke layout primitives invented for this surface.

## Test plan

- [ ] Sign in as a user with \`content.sources\` granted via \`platformOverrides.grantedFeatures\` — Insights tab appears as the rightmost tab.
- [ ] Switch to Insights with no active sources — empty card with \"Insights light up once you've added sources\" copy.
- [ ] Add 3+ sources, switch to Insights — all three KpiCards populate; type breakdown lists each type with a count and progress bar; top cited is empty until usageCount > 0.
- [ ] Verify the \"Active citations\" label clearly conveys the scope (vs the prior \"Citations\" which buried the scope in description copy).
- [ ] Switch to a recommender-suggested source (status: suggested with suggestedReason set) — \"AI suggested\" badge appears next to the type badge; \"Why: …\" line renders above the meta row.
- [ ] Search input hides on Insights tab; reappears when switching back to Active/Suggested/Rejected/Inactive.
- [ ] Keyboard tab order: tablist → first focusable inside panel.
- [ ] Screen reader: progress bars announce as \"{label}: {count} of {total}\" (Newsletter: 3 of 12).
- [ ] Mobile responsive: KPI grid collapses 3-col → 1-col; insights two-up collapses to stacked.

## Followups (not bundled)

- Bulk Approve/Reject from Suggested tab (per the §3.4 spec — out of scope for Day 3).
- Reject-with-reason dialog (still using the sentinel reason from PR #162).
- Citation timeline / Coverage heatmap / Drift alerts wiring once the backend surfaces ship (named explicitly in the PendingItemsCard).
- Day 4: bulk-paste + OPML import in the Add Source drawer.
- Day 5: CMS twin at \`/admin/sources\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)