### PR TITLE
feat(sources): Day 4 — bulk paste + OPML import + competitor stub

### DIFF
--- a/src/app/dashboard/content/sources/components/add-source-drawer.tsx
+++ b/src/app/dashboard/content/sources/components/add-source-drawer.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, Trash2, Upload } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -16,6 +16,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -25,24 +28,33 @@ import {
 } from "@/components/ui/select";
 import { ApiError } from "@/lib/api";
 import { createSource } from "../api";
+import { defaultDisplayName, detectSourceType } from "../lib/detect-type";
+import { OpmlParseError, parseOpml } from "../lib/parse-opml";
 import {
   FETCH_FREQUENCY_LABEL,
   SOURCE_TYPE_LABEL,
+  type CreateSourceInput,
   type FetchFrequency,
   type SourceType,
 } from "../types";
 
 /**
- * Add Source drawer — Day-1 manual-add form. The plan calls for three
- * input modes (manual, bulk paste with auto-detect, OPML import); this
- * implementation ships the manual path. Bulk + OPML are tracked in the
- * follow-up issue and add new tabs to this same drawer rather than a
- * new component, so the call-site (`/dashboard/content/sources` FAB)
- * doesn't change.
+ * Add Source drawer — Day-4 surface per the LinkedIn 360 plan §3.4.
  *
- * The form deliberately uses controlled state instead of react-hook-form
- * — four fields, no nested objects yet. Keeping the dep tree shallow
- * lets the bulk-add tab share state via the same hook when it ships.
+ * Hosts four input modes via Tabs:
+ *   • Manual    — type-specific form (Day-1 ship; PR #162).
+ *   • Bulk      — paste one URL/handle per line, auto-detect type,
+ *                 review preview, batch-create.
+ *   • OPML      — upload an OPML/.xml export (Feedly, NetNewsWire,
+ *                 etc.), preview, batch-create.
+ *   • Compete   — paste a competitor URL, the AI proposes sources
+ *                 from their citation graph. STUBBED — depends on a
+ *                 backend AI endpoint that doesn't exist yet.
+ *
+ * Bulk + OPML share a preview/submit pattern via the inner
+ * BulkPreview component so a future input mode (CSV import,
+ * paste-from-Notion, etc.) doesn't duplicate the parallel-mutation
+ * + per-row outcome handling.
  */
 
 const SOURCE_TYPES: SourceType[] = [
@@ -58,8 +70,57 @@ const SOURCE_TYPES: SourceType[] = [
 
 const FETCH_FREQUENCIES: FetchFrequency[] = ["hourly", "daily", "weekly", "manual"];
 
+type DrawerTab = "manual" | "bulk" | "opml" | "compete";
+
 export function AddSourceDrawer() {
   const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<DrawerTab>("manual");
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button size="sm">
+          <Plus className="mr-1.5 size-4" />
+          Add source
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="flex flex-col sm:max-w-2xl">
+        <SheetHeader>
+          <SheetTitle>Add trusted sources</SheetTitle>
+          <SheetDescription>
+            Sources ground every brief, idea, and post in your brand&apos;s voice. Active sources are picked up by the next 15-minute fetch.
+          </SheetDescription>
+        </SheetHeader>
+
+        <Tabs value={tab} onValueChange={(v) => setTab(v as DrawerTab)} className="flex flex-1 flex-col overflow-hidden">
+          <TabsList className="mx-4">
+            <TabsTrigger value="manual">Manual</TabsTrigger>
+            <TabsTrigger value="bulk">Bulk paste</TabsTrigger>
+            <TabsTrigger value="opml">OPML</TabsTrigger>
+            <TabsTrigger value="compete">From competitor</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="manual" className="flex flex-1 flex-col overflow-hidden">
+            <ManualTab onClose={() => setOpen(false)} />
+          </TabsContent>
+          <TabsContent value="bulk" className="flex flex-1 flex-col overflow-hidden">
+            <BulkPasteTab onClose={() => setOpen(false)} />
+          </TabsContent>
+          <TabsContent value="opml" className="flex flex-1 flex-col overflow-hidden">
+            <OpmlTab onClose={() => setOpen(false)} />
+          </TabsContent>
+          <TabsContent value="compete" className="flex flex-1 flex-col overflow-hidden">
+            <CompetitorTab />
+          </TabsContent>
+        </Tabs>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/* ── Manual tab ──────────────────────────────────────────────── */
+
+function ManualTab({ onClose }: { onClose: () => void }) {
   const [type, setType] = useState<SourceType>("website");
   const [identifier, setIdentifier] = useState("");
   const [displayName, setDisplayName] = useState("");
@@ -77,25 +138,13 @@ export function AddSourceDrawer() {
   // Mutation takes the snapshot of trimmed values explicitly via a
   // `variables` arg so the success toast and any error context read
   // the values that were submitted, not whatever the input fields
-  // happen to contain when the response arrives. (Inputs aren't
-  // disabled while pending — only the buttons are — so a slow
-  // network + a user who keeps typing would otherwise have the toast
-  // echo the newer text.)
-  interface CreateVars {
-    type: SourceType;
-    identifier: string;
-    displayName: string;
-    fetchFrequency: FetchFrequency;
-  }
+  // happen to contain when the response arrives.
   const mutation = useMutation({
-    mutationFn: (vars: CreateVars) => createSource(vars),
+    mutationFn: (vars: CreateSourceInput) => createSource(vars),
     onSuccess: (_data, vars) => {
-      // Reach all status filters so the new row appears in whichever
-      // tab the user is on (always lands `active`, but the per-status
-      // counts on every tab also need to refresh).
       queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
       toast.success(`${vars.displayName || "Source"} added`);
-      setOpen(false);
+      onClose();
       // Reset after the close animation so the form doesn't visibly
       // clear while the sheet is fading out (~300ms).
       setTimeout(reset, 350);
@@ -104,11 +153,8 @@ export function AddSourceDrawer() {
       // The backend's POST returns 409 with a copy-friendly message
       // ("Source already exists for this business at <identifier>") —
       // surface it verbatim instead of the generic "create failed".
-      if (err instanceof ApiError) {
-        toast.error(err.message);
-      } else {
-        toast.error("Could not add source");
-      }
+      if (err instanceof ApiError) toast.error(err.message);
+      else toast.error("Could not add source");
     },
   });
 
@@ -129,122 +175,382 @@ export function AddSourceDrawer() {
   }
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger asChild>
-        <Button size="sm">
-          <Plus className="mr-1.5 size-4" />
-          Add source
-        </Button>
-      </SheetTrigger>
-      <SheetContent className="flex flex-col sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle>Add a trusted source</SheetTitle>
-          <SheetDescription>
-            Sources ground every brief, idea, and post in your brand&apos;s voice. Active sources are picked up by the next 15-minute fetch.
-          </SheetDescription>
-        </SheetHeader>
+    <>
+      <form onSubmit={onSubmit} className="flex flex-1 flex-col gap-5 overflow-auto px-4 pt-4">
+        <div className="grid gap-2">
+          <Label htmlFor="source-type">Type</Label>
+          <Select value={type} onValueChange={(v) => setType(v as SourceType)}>
+            <SelectTrigger id="source-type">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SOURCE_TYPES.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {SOURCE_TYPE_LABEL[t]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-        <form onSubmit={onSubmit} className="flex flex-1 flex-col gap-5 overflow-auto px-4">
-          <div className="grid gap-2">
-            <Label htmlFor="source-type">Type</Label>
-            <Select value={type} onValueChange={(v) => setType(v as SourceType)}>
-              <SelectTrigger id="source-type">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SOURCE_TYPES.map((t) => (
-                  <SelectItem key={t} value={t}>
-                    {SOURCE_TYPE_LABEL[t]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+        <div className="grid gap-2">
+          <Label htmlFor="source-identifier">
+            {type === "x_handle" || type === "instagram_handle"
+              ? "Handle (e.g. @example)"
+              : type === "uploaded_doc"
+                ? "Document key"
+                : "URL"}
+          </Label>
+          <Input
+            id="source-identifier"
+            value={identifier}
+            onChange={(e) => setIdentifier(e.target.value)}
+            placeholder={
+              type === "rss"
+                ? "https://example.com/feed.xml"
+                : type === "x_handle"
+                  ? "@example"
+                  : "https://example.com"
+            }
+            autoComplete="off"
+            autoFocus
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            Stored normalised — handles lowercase, URLs preserve path case.
+          </p>
+        </div>
 
-          <div className="grid gap-2">
-            <Label htmlFor="source-identifier">
-              {type === "x_handle" || type === "instagram_handle"
-                ? "Handle (e.g. @example)"
-                : type === "uploaded_doc"
-                  ? "Document key"
-                  : "URL"}
-            </Label>
-            <Input
-              id="source-identifier"
-              value={identifier}
-              onChange={(e) => setIdentifier(e.target.value)}
-              placeholder={
-                type === "rss"
-                  ? "https://example.com/feed.xml"
-                  : type === "x_handle"
-                    ? "@example"
-                    : "https://example.com"
-              }
-              autoComplete="off"
-              autoFocus
-              required
-            />
-            <p className="text-xs text-muted-foreground">
-              Stored normalised — handles lowercase, URLs preserve path case.
-            </p>
-          </div>
+        <div className="grid gap-2">
+          <Label htmlFor="source-name">Display name</Label>
+          <Input
+            id="source-name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="What you'd call this source in the team chat"
+            maxLength={256}
+            required
+          />
+        </div>
 
-          <div className="grid gap-2">
-            <Label htmlFor="source-name">Display name</Label>
-            <Input
-              id="source-name"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="What you'd call this source in the team chat"
-              maxLength={256}
-              required
-            />
-          </div>
-
-          <div className="grid gap-2">
-            <Label htmlFor="source-frequency">Fetch frequency</Label>
-            <Select
-              value={fetchFrequency}
-              onValueChange={(v) => setFetchFrequency(v as FetchFrequency)}
-            >
-              <SelectTrigger id="source-frequency">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {FETCH_FREQUENCIES.map((f) => (
-                  <SelectItem key={f} value={f}>
-                    {FETCH_FREQUENCY_LABEL[f]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground">
-              Daily is right for almost everything; pick weekly for slow-moving sites and manual for archival material.
-            </p>
-          </div>
-        </form>
-
-        <SheetFooter>
-          <Button
-            variant="outline"
-            type="button"
-            onClick={() => setOpen(false)}
-            disabled={mutation.isPending}
+        <div className="grid gap-2">
+          <Label htmlFor="source-frequency">Fetch frequency</Label>
+          <Select
+            value={fetchFrequency}
+            onValueChange={(v) => setFetchFrequency(v as FetchFrequency)}
           >
-            Cancel
+            <SelectTrigger id="source-frequency">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FETCH_FREQUENCIES.map((f) => (
+                <SelectItem key={f} value={f}>
+                  {FETCH_FREQUENCY_LABEL[f]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Daily is right for almost everything; pick weekly for slow-moving sites and manual for archival material.
+          </p>
+        </div>
+      </form>
+
+      <SheetFooter>
+        <Button variant="outline" type="button" onClick={onClose} disabled={mutation.isPending}>
+          Cancel
+        </Button>
+        <Button onClick={onSubmit} disabled={mutation.isPending}>
+          {mutation.isPending ? (
+            <>
+              <Loader2 className="mr-1.5 size-4 animate-spin" />
+              Adding…
+            </>
+          ) : (
+            "Add source"
+          )}
+        </Button>
+      </SheetFooter>
+    </>
+  );
+}
+
+/* ── Bulk paste tab ──────────────────────────────────────────── */
+
+function BulkPasteTab({ onClose }: { onClose: () => void }) {
+  const [text, setText] = useState("");
+
+  // Parse on every change. Cheap (regex + URL parse per line) and
+  // the live preview is half the value of this surface — typing a
+  // line and immediately seeing its detected type catches mistakes
+  // (twitter→x_handle vs status→website) before submit.
+  const parsed = useMemo<CreateSourceInput[]>(() => {
+    return text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => ({
+        type: detectSourceType(line),
+        identifier: line,
+        displayName: defaultDisplayName(line),
+        fetchFrequency: "daily" as FetchFrequency,
+      }));
+  }, [text]);
+
+  return (
+    <>
+      <div className="flex flex-1 flex-col gap-3 overflow-auto px-4 pt-4">
+        <div className="grid gap-2">
+          <Label htmlFor="bulk-paste">One URL or handle per line</Label>
+          <Textarea
+            id="bulk-paste"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={"https://example.com/blog\n@another-account\nhttps://news.example.com/feed.xml"}
+            rows={6}
+            className="font-mono text-xs"
+          />
+          <p className="text-xs text-muted-foreground">
+            Type is auto-detected per line. RSS feeds, X/Instagram/YouTube, Substack/Beehiiv newsletters all recognised. Plain URLs default to website.
+          </p>
+        </div>
+        <BulkPreview rows={parsed} />
+      </div>
+      <BulkSubmitFooter rows={parsed} onClose={onClose} />
+    </>
+  );
+}
+
+/* ── OPML tab ────────────────────────────────────────────────── */
+
+function OpmlTab({ onClose }: { onClose: () => void }) {
+  const [rows, setRows] = useState<CreateSourceInput[]>([]);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    try {
+      const xml = await file.text();
+      const parsed = parseOpml(xml);
+      // Drop the parser's `category` field — the backend doesn't
+      // model categories. Explicit field copy (vs spread+omit) so a
+      // future ParsedOpmlRow addition lands as a TS error here, not
+      // as silent leakage into the create payload. fetchFrequency
+      // defaults to "daily" since OPML doesn't carry one.
+      const ready: CreateSourceInput[] = parsed.map((row) => ({
+        type: row.type,
+        identifier: row.identifier,
+        displayName: row.displayName,
+        fetchFrequency: "daily",
+      }));
+      setRows(ready);
+      if (ready.length === 0) {
+        toast.warning("No feeds found in the OPML file");
+      } else {
+        toast.success(`Found ${ready.length} feed${ready.length === 1 ? "" : "s"}`);
+      }
+    } catch (err) {
+      if (err instanceof OpmlParseError) toast.error(err.message);
+      else toast.error("Could not read the OPML file");
+      setRows([]);
+    }
+  }
+
+  function clear() {
+    setRows([]);
+    setFileName(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  return (
+    <>
+      <div className="flex flex-1 flex-col gap-3 overflow-auto px-4 pt-4">
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="mr-1.5 size-4" />
+            {fileName ? "Replace file" : "Choose OPML file"}
           </Button>
-          <Button onClick={onSubmit} disabled={mutation.isPending}>
-            {mutation.isPending ? (
-              <>
-                <Loader2 className="mr-1.5 size-4 animate-spin" />
-                Adding…
-              </>
-            ) : (
-              "Add source"
-            )}
-          </Button>
-        </SheetFooter>
-      </SheetContent>
-    </Sheet>
+          {fileName && (
+            <span className="truncate text-sm text-muted-foreground" title={fileName}>
+              {fileName}
+            </span>
+          )}
+          {rows.length > 0 && (
+            <Button type="button" variant="ghost" size="sm" onClick={clear}>
+              <Trash2 className="mr-1.5 size-4" />
+              Clear
+            </Button>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".opml,.xml,application/xml,text/xml"
+            className="hidden"
+            onChange={onFile}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Export from Feedly, NetNewsWire, Inoreader, or any feed reader that supports OPML 2.0.
+        </p>
+        <BulkPreview rows={rows} />
+      </div>
+      <BulkSubmitFooter rows={rows} onClose={onClose} />
+    </>
+  );
+}
+
+/* ── Suggest from competitor (stubbed) ───────────────────────── */
+
+function CompetitorTab() {
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-auto px-4 pt-4">
+      <div className="rounded-lg border border-dashed bg-muted/30 p-6 text-center">
+        <p className="text-sm font-medium">Source recommendation by competitor</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Paste a competitor&apos;s URL → the AI parses their citations + linked sources and proposes a starter set scoped to your brand.
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Lands once the competitor-scrape + source-recommender agent ships.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ── Shared bulk preview + submit ────────────────────────────── */
+
+interface BulkOutcome {
+  succeeded: number;
+  duplicates: number;
+  failed: number;
+  errors: { identifier: string; message: string }[];
+}
+
+/** Run N create-source POSTs in parallel batches of 5. Returns an
+ *  aggregate outcome rather than throwing on partial failure — the
+ *  UI surfaces "3 added, 1 duplicate, 1 failed" rather than a hard
+ *  fail when one row hits a 409. */
+async function bulkCreateSources(rows: CreateSourceInput[]): Promise<BulkOutcome> {
+  const BATCH = 5;
+  const result: BulkOutcome = { succeeded: 0, duplicates: 0, failed: 0, errors: [] };
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const batch = rows.slice(i, i + BATCH);
+    const settled = await Promise.allSettled(batch.map((r) => createSource(r)));
+    settled.forEach((s, j) => {
+      const row = batch[j];
+      if (s.status === "fulfilled") {
+        result.succeeded += 1;
+      } else if (s.reason instanceof ApiError && s.reason.status === 409) {
+        result.duplicates += 1;
+      } else {
+        result.failed += 1;
+        const message = s.reason instanceof ApiError ? s.reason.message : "unknown error";
+        result.errors.push({ identifier: row.identifier, message });
+      }
+    });
+  }
+  return result;
+}
+
+function BulkPreview({ rows }: { rows: CreateSourceInput[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="rounded-lg border">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="text-xs font-medium">
+          {rows.length} {rows.length === 1 ? "row" : "rows"} ready
+        </span>
+        <span className="text-xs text-muted-foreground">All fetch daily</span>
+      </div>
+      <ul className="max-h-80 divide-y overflow-auto">
+        {rows.map((row, i) => (
+          <li key={`${row.identifier}-${i}`} className="flex items-center gap-3 px-3 py-2">
+            <Badge variant="outline" className="shrink-0 text-[10px]">
+              {SOURCE_TYPE_LABEL[row.type]}
+            </Badge>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs font-medium">{row.displayName}</p>
+              <p className="truncate font-mono text-[10px] text-muted-foreground" title={row.identifier}>
+                {row.identifier}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function BulkSubmitFooter({
+  rows,
+  onClose,
+}: {
+  rows: CreateSourceInput[];
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit() {
+    if (rows.length === 0) return;
+    setSubmitting(true);
+    try {
+      const outcome = await bulkCreateSources(rows);
+      // Refetch even on a partial outcome — any successes need to
+      // appear in the listing immediately.
+      queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
+      summarize(outcome);
+      // Close only when at least one row landed; on a hard zero
+      // (everything was a duplicate or failed), keep the drawer
+      // open so the user can amend without losing context.
+      if (outcome.succeeded > 0) onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function summarize(o: BulkOutcome) {
+    const parts: string[] = [];
+    if (o.succeeded) parts.push(`${o.succeeded} added`);
+    if (o.duplicates) parts.push(`${o.duplicates} already existed`);
+    if (o.failed) parts.push(`${o.failed} failed`);
+    const summary = parts.join(", ") || "Nothing to add";
+    if (o.failed > 0) toast.error(summary);
+    else if (o.duplicates > 0 && o.succeeded === 0) toast.warning(summary);
+    else toast.success(summary);
+    // Surface the first ~3 specific failure messages — useful to
+    // diagnose why a row didn't land. Don't dump the full error
+    // list (could be 50 rows). The summary toast above already
+    // names the count.
+    o.errors.slice(0, 3).forEach((e) => {
+      toast.error(`${e.identifier}: ${e.message}`);
+    });
+  }
+
+  return (
+    <SheetFooter>
+      <Button variant="outline" type="button" onClick={onClose} disabled={submitting}>
+        Cancel
+      </Button>
+      <Button onClick={submit} disabled={submitting || rows.length === 0}>
+        {submitting ? (
+          <>
+            <Loader2 className="mr-1.5 size-4 animate-spin" />
+            Adding {rows.length}…
+          </>
+        ) : rows.length === 0 ? (
+          "Add"
+        ) : (
+          `Add ${rows.length} source${rows.length === 1 ? "" : "s"}`
+        )}
+      </Button>
+    </SheetFooter>
   );
 }

--- a/src/app/dashboard/content/sources/components/add-source-drawer.tsx
+++ b/src/app/dashboard/content/sources/components/add-source-drawer.tsx
@@ -363,7 +363,14 @@ function OpmlTab({ onClose }: { onClose: () => void }) {
 
   function onFileInput(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
-    if (file) ingestFile(file);
+    // Reset the input value AFTER reading the file so re-picking
+    // the same file fires `change` again. Browsers (Chrome/Safari)
+    // suppress onChange when the user re-selects an identical
+    // FileList; clearing the value forces a fresh selection.
+    if (file) {
+      ingestFile(file);
+      e.target.value = "";
+    }
   }
 
   function onDrop(e: React.DragEvent<HTMLDivElement>) {
@@ -395,8 +402,23 @@ function OpmlTab({ onClose }: { onClose: () => void }) {
           tabIndex={0}
           aria-label="Drop an OPML file here, or click to browse"
           onClick={() => fileInputRef.current?.click()}
+          // WAI-ARIA pattern for role="button": activate Enter on
+          // keyDown but Space on keyUp. Some browsers (Firefox)
+          // synthesise a click on Space-up for role="button"; if
+          // we also fired the picker on Space-down the dialog
+          // would open twice. preventDefault on Space-down still
+          // suppresses the page-scroll that Space normally
+          // triggers.
           onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              fileInputRef.current?.click();
+            } else if (e.key === " ") {
+              e.preventDefault();
+            }
+          }}
+          onKeyUp={(e) => {
+            if (e.key === " ") {
               e.preventDefault();
               fileInputRef.current?.click();
             }

--- a/src/app/dashboard/content/sources/components/add-source-drawer.tsx
+++ b/src/app/dashboard/content/sources/components/add-source-drawer.tsx
@@ -176,7 +176,10 @@ function ManualTab({ onClose }: { onClose: () => void }) {
 
   return (
     <>
-      <form onSubmit={onSubmit} className="flex flex-1 flex-col gap-5 overflow-auto px-4 pt-4">
+      {/* Constrain Manual to a typical-form width even though the
+          parent Sheet is sm:max-w-2xl (sized for the bulk preview).
+          A four-field form at 2xl-width reads loose. */}
+      <form onSubmit={onSubmit} className="flex flex-1 flex-col gap-5 overflow-auto px-4 pt-4 sm:max-w-md">
         <div className="grid gap-2">
           <Label htmlFor="source-type">Type</Label>
           <Select value={type} onValueChange={(v) => setType(v as SourceType)}>
@@ -326,11 +329,10 @@ function BulkPasteTab({ onClose }: { onClose: () => void }) {
 function OpmlTab({ onClose }: { onClose: () => void }) {
   const [rows, setRows] = useState<CreateSourceInput[]>([]);
   const [fileName, setFileName] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  async function ingestFile(file: File) {
     setFileName(file.name);
     try {
       const xml = await file.text();
@@ -359,6 +361,18 @@ function OpmlTab({ onClose }: { onClose: () => void }) {
     }
   }
 
+  function onFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) ingestFile(file);
+  }
+
+  function onDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) ingestFile(file);
+  }
+
   function clear() {
     setRows([]);
     setFileName(null);
@@ -368,22 +382,60 @@ function OpmlTab({ onClose }: { onClose: () => void }) {
   return (
     <>
       <div className="flex flex-1 flex-col gap-3 overflow-auto px-4 pt-4">
-        <div className="flex items-center gap-3">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <Upload className="mr-1.5 size-4" />
-            {fileName ? "Replace file" : "Choose OPML file"}
-          </Button>
-          {fileName && (
-            <span className="truncate text-sm text-muted-foreground" title={fileName}>
-              {fileName}
-            </span>
-          )}
+        {/* Drop-or-click affordance — visual pattern adapted from
+            @shadcnblocks/file-upload-file-upload-dropzone-3 (compact
+            horizontal arrangement: icon + dual-line label). The
+            block depends on a third-party Dice UI primitive; we
+            keep the visual idiom but use HTML5 drag-and-drop
+            directly so no extra dep tree lands for one OPML upload.
+            Clicking the zone or pressing Enter/Space activates the
+            hidden file input. */}
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label="Drop an OPML file here, or click to browse"
+          onClick={() => fileInputRef.current?.click()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              fileInputRef.current?.click();
+            }
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={onDrop}
+          className={
+            "flex cursor-pointer items-center gap-3 rounded-lg border border-dashed px-4 py-3 transition-colors " +
+            (dragOver
+              ? "border-primary bg-primary/5"
+              : "hover:border-foreground/30 hover:bg-muted/40")
+          }
+        >
+          <Upload aria-hidden="true" className="size-5 text-muted-foreground" />
+          <div className="flex-1 text-left">
+            <p className="text-sm font-medium">
+              {fileName ? fileName : "Drop an OPML file here, or click to browse"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {fileName
+                ? `${rows.length} feed${rows.length === 1 ? "" : "s"} parsed — review below.`
+                : "Export from Feedly, NetNewsWire, Inoreader, or any reader that supports OPML 2.0."}
+            </p>
+          </div>
           {rows.length > 0 && (
-            <Button type="button" variant="ghost" size="sm" onClick={clear}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={(e) => {
+                // Don't trigger the wrapper's onClick file-picker.
+                e.stopPropagation();
+                clear();
+              }}
+            >
               <Trash2 className="mr-1.5 size-4" />
               Clear
             </Button>
@@ -393,12 +445,9 @@ function OpmlTab({ onClose }: { onClose: () => void }) {
             type="file"
             accept=".opml,.xml,application/xml,text/xml"
             className="hidden"
-            onChange={onFile}
+            onChange={onFileInput}
           />
         </div>
-        <p className="text-xs text-muted-foreground">
-          Export from Feedly, NetNewsWire, Inoreader, or any feed reader that supports OPML 2.0.
-        </p>
         <BulkPreview rows={rows} />
       </div>
       <BulkSubmitFooter rows={rows} onClose={onClose} />
@@ -433,12 +482,16 @@ interface BulkOutcome {
   errors: { identifier: string; message: string }[];
 }
 
-/** Run N create-source POSTs in parallel batches of 5. Returns an
+/** Run N create-source POSTs in parallel batches of 10. Returns an
  *  aggregate outcome rather than throwing on partial failure — the
  *  UI surfaces "3 added, 1 duplicate, 1 failed" rather than a hard
- *  fail when one row hits a 409. */
-async function bulkCreateSources(rows: CreateSourceInput[]): Promise<BulkOutcome> {
-  const BATCH = 5;
+ *  fail when one row hits a 409. Calls `onProgress` between batches
+ *  so the caller can render a progress counter without polling. */
+async function bulkCreateSources(
+  rows: CreateSourceInput[],
+  onProgress?: (done: number, total: number) => void,
+): Promise<BulkOutcome> {
+  const BATCH = 10;
   const result: BulkOutcome = { succeeded: 0, duplicates: 0, failed: 0, errors: [] };
   for (let i = 0; i < rows.length; i += BATCH) {
     const batch = rows.slice(i, i + BATCH);
@@ -455,6 +508,7 @@ async function bulkCreateSources(rows: CreateSourceInput[]): Promise<BulkOutcome
         result.errors.push({ identifier: row.identifier, message });
       }
     });
+    onProgress?.(Math.min(i + BATCH, rows.length), rows.length);
   }
   return result;
 }
@@ -497,22 +551,27 @@ function BulkSubmitFooter({
 }) {
   const queryClient = useQueryClient();
   const [submitting, setSubmitting] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
 
   async function submit() {
     if (rows.length === 0) return;
     setSubmitting(true);
+    setProgress({ done: 0, total: rows.length });
     try {
-      const outcome = await bulkCreateSources(rows);
+      const outcome = await bulkCreateSources(rows, (done, total) => setProgress({ done, total }));
       // Refetch even on a partial outcome — any successes need to
       // appear in the listing immediately.
       queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
       summarize(outcome);
-      // Close only when at least one row landed; on a hard zero
-      // (everything was a duplicate or failed), keep the drawer
-      // open so the user can amend without losing context.
-      if (outcome.succeeded > 0) onClose();
+      // Close only when there were no failures. On any failure
+      // (including "everything was a duplicate" or hard errors),
+      // keep the drawer open so the user can see the rows that
+      // didn't land + amend without losing context. Pure-success
+      // and pure-success-plus-no-op-duplicate paths close.
+      if (outcome.failed === 0 && outcome.succeeded > 0) onClose();
     } finally {
       setSubmitting(false);
+      setProgress(null);
     }
   }
 
@@ -534,22 +593,21 @@ function BulkSubmitFooter({
     });
   }
 
+  const buttonLabel =
+    submitting && progress
+      ? `Adding ${progress.done} / ${progress.total}…`
+      : rows.length === 0
+        ? "Add"
+        : `Add ${rows.length} source${rows.length === 1 ? "" : "s"}`;
+
   return (
     <SheetFooter>
       <Button variant="outline" type="button" onClick={onClose} disabled={submitting}>
         Cancel
       </Button>
       <Button onClick={submit} disabled={submitting || rows.length === 0}>
-        {submitting ? (
-          <>
-            <Loader2 className="mr-1.5 size-4 animate-spin" />
-            Adding {rows.length}…
-          </>
-        ) : rows.length === 0 ? (
-          "Add"
-        ) : (
-          `Add ${rows.length} source${rows.length === 1 ? "" : "s"}`
-        )}
+        {submitting ? <Loader2 className="mr-1.5 size-4 animate-spin" /> : null}
+        {buttonLabel}
       </Button>
     </SheetFooter>
   );

--- a/src/app/dashboard/content/sources/lib/detect-type.ts
+++ b/src/app/dashboard/content/sources/lib/detect-type.ts
@@ -4,13 +4,16 @@ import type { SourceType } from "../types";
  * Auto-detect a source type from a single line of user input.
  *
  * Heuristics, applied in order — first match wins:
- *   • starts with `@` or `https://(twitter|x).com/` → x_handle
- *   • starts with `https://(www\.)?instagram.com/` → instagram_handle
- *   • starts with `https://(www\.)?(youtube\.com|youtu\.be)/` → youtube_channel
- *   • URL ends in `.xml`, `.rss`, or contains `/feed` (RSS conventions) → rss
- *   • URL host matches known newsletter platforms (substack/beehiiv/kit) → newsletter
- *   • URL host contains common podcast platforms → podcast
- *   • otherwise treat as a generic website
+ *   • bare `@handle`                                     → x_handle
+ *   • URL-host check against (twitter|x).com excluding /status/ → x_handle
+ *   • URL-host check against instagram.com               → instagram_handle
+ *   • URL-host check against youtube.com / youtu.be / m.youtube.com / music.youtube.com
+ *                                                        → youtube_channel
+ *   • path ends in .xml/.rss/.atom OR has a feed/rss/atom segment
+ *                                                        → rss
+ *   • URL-host matches known newsletter platforms (substack/beehiiv/kit) → newsletter
+ *   • URL-host matches known podcast platforms (apple/spotify/anchor)    → podcast
+ *   • otherwise                                          → website
  *
  * Why heuristics + not a full parser: bulk-paste users are pasting
  * URLs they already know. Wrong-type detections are correctable on
@@ -22,6 +25,14 @@ import type { SourceType } from "../types";
  * implies a separately-uploaded file blob, which isn't a thing
  * bulk-paste callers can provide.
  */
+// Segment-anchored: matches `/feed`, `/rss`, `/atom` only as a
+// distinct path segment (not inside `feedback`, `feed-back`, etc.),
+// or as the basename of a `.xml`/`.rss`/`.atom` file. Tested against
+// example.com/feedback (no match), example.com/feed (match),
+// example.com/blog/feed.xml (match), example.com/posts/feed-back (no
+// match), example.com/atom (match).
+const FEED_PATH_RE = /(?:^|\/)(feed|rss|atom)(?:\/|\.xml|\.rss|\.atom|$)/;
+
 export function detectSourceType(raw: string): SourceType {
   const trimmed = raw.trim();
   if (!trimmed) return "website";
@@ -43,7 +54,7 @@ export function detectSourceType(raw: string): SourceType {
   const host = url.host.toLowerCase();
   const path = url.pathname.toLowerCase();
 
-  // Social handles — tighter check on hosts so a substack.com/
+  // Social handles — tighter check on hosts so a substack.com
   // article about Twitter doesn't fall into x_handle.
   if (host === "twitter.com" || host === "x.com" || host === "www.twitter.com" || host === "www.x.com") {
     // Don't classify a tweet permalink (twitter.com/{handle}/status/...)
@@ -54,15 +65,20 @@ export function detectSourceType(raw: string): SourceType {
   if (host === "instagram.com" || host === "www.instagram.com") {
     return "instagram_handle";
   }
-  if (host === "youtube.com" || host === "www.youtube.com" || host === "youtu.be") {
+  // youtube.com / www.youtube.com / m.youtube.com / music.youtube.com
+  // / youtu.be — `endsWith` keeps subdomain coverage open without
+  // letting `notyoutube.com` slip through (host has the leading
+  // dot).
+  if (host === "youtube.com" || host.endsWith(".youtube.com") || host === "youtu.be") {
     return "youtube_channel";
   }
 
-  // RSS — extension or `/feed` segment. Order matters: a substack
-  // RSS URL (.../feed) is still on a substack host and would
-  // otherwise classify as newsletter; RSS first means we capture
-  // the actual feed URL when the user pastes one.
-  if (path.endsWith(".xml") || path.endsWith(".rss") || path.includes("/feed")) {
+  // RSS — segment-anchored regex, plus extension fallback for the
+  // edge case where the path has no segment but ends in a feed
+  // file directly (e.g. `https://example.com/feed.xml` parses with
+  // pathname `/feed.xml`, which the regex covers; this kept as a
+  // belt-and-braces guard for future regex tweaks).
+  if (FEED_PATH_RE.test(path) || path.endsWith(".xml") || path.endsWith(".rss") || path.endsWith(".atom")) {
     return "rss";
   }
 
@@ -74,9 +90,10 @@ export function detectSourceType(raw: string): SourceType {
     return "newsletter";
   }
 
-  // Podcast platforms — Apple/Spotify show pages and Anchor RSS.
+  // Podcast platforms — Apple show pages (both bare and the m.
+  // mobile variant), Spotify shows, Anchor RSS.
+  if (host === "podcasts.apple.com" || host === "www.podcasts.apple.com") return "podcast";
   if (host.endsWith("apple.com") && path.includes("/podcast/")) return "podcast";
-  if (host === "podcasts.apple.com") return "podcast";
   if (host.endsWith("spotify.com") && path.includes("/show/")) return "podcast";
   if (host.endsWith("anchor.fm")) return "podcast";
 
@@ -101,9 +118,12 @@ export function defaultDisplayName(raw: string): string {
     const u = new URL(trimmed);
     let path = u.pathname;
     // Strip trailing slash and the common feed paths so the name
-    // reads as the publication, not the feed file.
+    // reads as the publication, not the feed file. The trailing
+    // `.atom` covers the third common feed extension; the segment
+    // matcher must be anchored to end-of-string to avoid eating
+    // `feedback` (cf. FEED_PATH_RE in detectSourceType).
     path = path.replace(/\/$/, "");
-    path = path.replace(/\/(feed|rss|atom)(\.xml|\.rss)?$/i, "");
+    path = path.replace(/\/(feed|rss|atom)(\.xml|\.rss|\.atom)?$/i, "");
     if (path === "" || path === "/") return u.host;
     return `${u.host}${path}`;
   } catch {

--- a/src/app/dashboard/content/sources/lib/detect-type.ts
+++ b/src/app/dashboard/content/sources/lib/detect-type.ts
@@ -1,0 +1,112 @@
+import type { SourceType } from "../types";
+
+/**
+ * Auto-detect a source type from a single line of user input.
+ *
+ * Heuristics, applied in order — first match wins:
+ *   • starts with `@` or `https://(twitter|x).com/` → x_handle
+ *   • starts with `https://(www\.)?instagram.com/` → instagram_handle
+ *   • starts with `https://(www\.)?(youtube\.com|youtu\.be)/` → youtube_channel
+ *   • URL ends in `.xml`, `.rss`, or contains `/feed` (RSS conventions) → rss
+ *   • URL host matches known newsletter platforms (substack/beehiiv/kit) → newsletter
+ *   • URL host contains common podcast platforms → podcast
+ *   • otherwise treat as a generic website
+ *
+ * Why heuristics + not a full parser: bulk-paste users are pasting
+ * URLs they already know. Wrong-type detections are correctable on
+ * the preview screen before submit. The list is intentionally
+ * conservative (a misclassification falls through to "website",
+ * which works for almost everything via the normal HTTP fetcher).
+ *
+ * `uploaded_doc` is never auto-detected — it's a CMS-only flow that
+ * implies a separately-uploaded file blob, which isn't a thing
+ * bulk-paste callers can provide.
+ */
+export function detectSourceType(raw: string): SourceType {
+  const trimmed = raw.trim();
+  if (!trimmed) return "website";
+
+  // Bare handle.
+  if (trimmed.startsWith("@")) return "x_handle";
+
+  // Try URL parsing for everything else; fall back to "website".
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    // Not a parseable URL and doesn't start with @ — treat as a
+    // domain-style website. The backend's normaliseIdentifier will
+    // fall back to the raw trimmed form for this case.
+    return "website";
+  }
+
+  const host = url.host.toLowerCase();
+  const path = url.pathname.toLowerCase();
+
+  // Social handles — tighter check on hosts so a substack.com/
+  // article about Twitter doesn't fall into x_handle.
+  if (host === "twitter.com" || host === "x.com" || host === "www.twitter.com" || host === "www.x.com") {
+    // Don't classify a tweet permalink (twitter.com/{handle}/status/...)
+    // as a handle — that's a single post, not a feed worth subscribing to.
+    if (path.includes("/status/")) return "website";
+    return "x_handle";
+  }
+  if (host === "instagram.com" || host === "www.instagram.com") {
+    return "instagram_handle";
+  }
+  if (host === "youtube.com" || host === "www.youtube.com" || host === "youtu.be") {
+    return "youtube_channel";
+  }
+
+  // RSS — extension or `/feed` segment. Order matters: a substack
+  // RSS URL (.../feed) is still on a substack host and would
+  // otherwise classify as newsletter; RSS first means we capture
+  // the actual feed URL when the user pastes one.
+  if (path.endsWith(".xml") || path.endsWith(".rss") || path.includes("/feed")) {
+    return "rss";
+  }
+
+  // Newsletter platforms — substack/beehiiv/kit/convertkit. The
+  // backend doesn't distinguish "newsletter from a known platform"
+  // vs a generic newsletter site, but the type keeps the UI label
+  // honest.
+  if (host.endsWith("substack.com") || host.endsWith("beehiiv.com") || host.endsWith("kit.com") || host.endsWith("convertkit.com")) {
+    return "newsletter";
+  }
+
+  // Podcast platforms — Apple/Spotify show pages and Anchor RSS.
+  if (host.endsWith("apple.com") && path.includes("/podcast/")) return "podcast";
+  if (host === "podcasts.apple.com") return "podcast";
+  if (host.endsWith("spotify.com") && path.includes("/show/")) return "podcast";
+  if (host.endsWith("anchor.fm")) return "podcast";
+
+  return "website";
+}
+
+/**
+ * Best-effort display name from a single line. Used as a fallback
+ * when bulk-paste callers don't supply a name. The drawer's preview
+ * lets the user override before submit.
+ *
+ *   @handle           → "@handle"
+ *   https://example.com/blog → "example.com/blog"
+ *   https://example.com      → "example.com"
+ *   https://example.com/feed → "example.com" (strip the /feed suffix
+ *                              so the row reads as the parent site)
+ */
+export function defaultDisplayName(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("@")) return trimmed;
+  try {
+    const u = new URL(trimmed);
+    let path = u.pathname;
+    // Strip trailing slash and the common feed paths so the name
+    // reads as the publication, not the feed file.
+    path = path.replace(/\/$/, "");
+    path = path.replace(/\/(feed|rss|atom)(\.xml|\.rss)?$/i, "");
+    if (path === "" || path === "/") return u.host;
+    return `${u.host}${path}`;
+  } catch {
+    return trimmed;
+  }
+}

--- a/src/app/dashboard/content/sources/lib/parse-opml.ts
+++ b/src/app/dashboard/content/sources/lib/parse-opml.ts
@@ -51,41 +51,49 @@ export function parseOpml(xml: string): ParsedOpmlRow[] {
     throw new OpmlParseError("Root element isn't <opml>");
   }
 
-  const out: ParsedOpmlRow[] = [];
+  // Dedupe by identifier — Feedly et al. export the same feed
+  // under multiple categories, and bulk-create would generate one
+  // 409 per duplicate. First occurrence wins so the breadcrumb
+  // reflects the primary category.
+  const seen = new Map<string, ParsedOpmlRow>();
   const root = doc.querySelector("body");
-  if (!root) return out;
-
-  walk(root, [], out);
-  return out;
+  if (root) walk(root, [], seen);
+  return Array.from(seen.values());
 }
 
-function walk(node: Element, breadcrumbs: string[], out: ParsedOpmlRow[]): void {
+function walk(node: Element, breadcrumbs: string[], seen: Map<string, ParsedOpmlRow>): void {
   for (const child of Array.from(node.children)) {
     if (child.tagName.toLowerCase() !== "outline") continue;
 
-    const xmlUrl = child.getAttribute("xmlUrl") || child.getAttribute("xmlurl");
-    const htmlUrl = child.getAttribute("htmlUrl") || child.getAttribute("htmlurl");
+    // OPML 2.0 spec: attribute names are case-sensitive `xmlUrl` /
+    // `htmlUrl`. All real-world exporters (Feedly, NetNewsWire,
+    // Inoreader) emit canonical casing; we read it directly.
+    const xmlUrl = child.getAttribute("xmlUrl");
+    const htmlUrl = child.getAttribute("htmlUrl");
     const text = child.getAttribute("text") || child.getAttribute("title") || "";
 
     // A leaf with at least one URL → emit a row. We favour xmlUrl
     // because feed-reader exports lean on it; htmlUrl is used as
-    // the displayName-target when both are present.
+    // the fallback when xmlUrl is absent.
     const url = xmlUrl || htmlUrl;
     if (url) {
-      const displayName = text.trim() || defaultDisplayName(url);
-      const type = xmlUrl ? "rss" : detectSourceType(url);
-      out.push({
-        type,
-        identifier: url.trim(),
-        displayName,
-        ...(breadcrumbs.length > 0 ? { category: breadcrumbs.join(" / ") } : {}),
-      });
+      const identifier = url.trim();
+      if (!seen.has(identifier)) {
+        const displayName = text.trim() || defaultDisplayName(url);
+        const type = xmlUrl ? "rss" : detectSourceType(url);
+        seen.set(identifier, {
+          type,
+          identifier,
+          displayName,
+          ...(breadcrumbs.length > 0 ? { category: breadcrumbs.join(" / ") } : {}),
+        });
+      }
       continue;
     }
 
     // Branch outline (no URL) — recurse with the breadcrumb. Use
     // the outline's text/title as the path segment.
     const segment = text.trim();
-    walk(child, segment ? [...breadcrumbs, segment] : breadcrumbs, out);
+    walk(child, segment ? [...breadcrumbs, segment] : breadcrumbs, seen);
   }
 }

--- a/src/app/dashboard/content/sources/lib/parse-opml.ts
+++ b/src/app/dashboard/content/sources/lib/parse-opml.ts
@@ -47,7 +47,13 @@ export function parseOpml(xml: string): ParsedOpmlRow[] {
   if (parserError) {
     throw new OpmlParseError("File doesn't look like valid XML/OPML");
   }
-  if (doc.documentElement.tagName.toLowerCase() !== "opml") {
+  // `localName` returns the un-namespaced element name (e.g.
+  // <opml:opml> → "opml"). Some legacy exporters wrap their OPML in
+  // a custom namespace; `tagName` would include the prefix and fail
+  // this check unnecessarily. Lowercase the compare since XML
+  // element names are technically case-sensitive (real OPML uses
+  // lowercase `<opml>`/`<outline>` per spec).
+  if (doc.documentElement.localName.toLowerCase() !== "opml") {
     throw new OpmlParseError("Root element isn't <opml>");
   }
 
@@ -63,7 +69,10 @@ export function parseOpml(xml: string): ParsedOpmlRow[] {
 
 function walk(node: Element, breadcrumbs: string[], seen: Map<string, ParsedOpmlRow>): void {
   for (const child of Array.from(node.children)) {
-    if (child.tagName.toLowerCase() !== "outline") continue;
+    // `localName` strips namespace prefixes — see the parseOpml
+    // header for why. Real OPML exporters emit lowercase
+    // `<outline>`; the case-fold is belt-and-braces.
+    if (child.localName.toLowerCase() !== "outline") continue;
 
     // OPML 2.0 spec: attribute names are case-sensitive `xmlUrl` /
     // `htmlUrl`. All real-world exporters (Feedly, NetNewsWire,

--- a/src/app/dashboard/content/sources/lib/parse-opml.ts
+++ b/src/app/dashboard/content/sources/lib/parse-opml.ts
@@ -1,0 +1,91 @@
+import type { CreateSourceInput } from "../types";
+import { detectSourceType, defaultDisplayName } from "./detect-type";
+
+/**
+ * Parse an OPML 2.0 document — the canonical export format for
+ * feed-readers (Feedly, NetNewsWire, Inoreader, etc.) — into a list
+ * of CreateSourceInput rows ready to feed bulk-create.
+ *
+ * Walks `<outline>` elements, including nested ones inside
+ * categorised exports (e.g., Feedly groups feeds under category
+ * outlines). For each leaf outline that has an `xmlUrl` attribute
+ * we treat it as an RSS feed; outlines with only `htmlUrl` fall
+ * through to the website type via the standard auto-detect.
+ *
+ * What we deliberately ignore:
+ *   • OPML categories themselves — we flatten. The Trusted Sources
+ *     UI doesn't model categories; if it ever does, this parser
+ *     can return `{ rows, groups }` instead.
+ *   • Versioned OPML 1.x — the element shape is the same; what
+ *     differs is the head metadata, which we don't read.
+ *   • Non-feed outlines without xmlUrl/htmlUrl — these are
+ *     organisational nodes; skipping them is correct.
+ *
+ * Errors thrown by this function bubble up to the caller's toast
+ * surface — DOMParser silently produces a `<parsererror>` document
+ * on malformed XML, so we look for that explicitly.
+ */
+export interface ParsedOpmlRow extends CreateSourceInput {
+  /** Optional category breadcrumb from nested OPML outlines.
+   *  Surfaced only for the preview UI, not sent to the backend
+   *  (cnt_trusted_sources has no category column today). */
+  category?: string;
+}
+
+export class OpmlParseError extends Error {}
+
+export function parseOpml(xml: string): ParsedOpmlRow[] {
+  if (typeof window === "undefined" || typeof DOMParser === "undefined") {
+    // Defensive: this util is intended for client use (file upload
+    // handlers). If it ever gets wired to a server route, the
+    // caller needs a node:xml parser instead.
+    throw new OpmlParseError("OPML parsing requires DOMParser; call from a client component");
+  }
+
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
+  const parserError = doc.querySelector("parsererror");
+  if (parserError) {
+    throw new OpmlParseError("File doesn't look like valid XML/OPML");
+  }
+  if (doc.documentElement.tagName.toLowerCase() !== "opml") {
+    throw new OpmlParseError("Root element isn't <opml>");
+  }
+
+  const out: ParsedOpmlRow[] = [];
+  const root = doc.querySelector("body");
+  if (!root) return out;
+
+  walk(root, [], out);
+  return out;
+}
+
+function walk(node: Element, breadcrumbs: string[], out: ParsedOpmlRow[]): void {
+  for (const child of Array.from(node.children)) {
+    if (child.tagName.toLowerCase() !== "outline") continue;
+
+    const xmlUrl = child.getAttribute("xmlUrl") || child.getAttribute("xmlurl");
+    const htmlUrl = child.getAttribute("htmlUrl") || child.getAttribute("htmlurl");
+    const text = child.getAttribute("text") || child.getAttribute("title") || "";
+
+    // A leaf with at least one URL → emit a row. We favour xmlUrl
+    // because feed-reader exports lean on it; htmlUrl is used as
+    // the displayName-target when both are present.
+    const url = xmlUrl || htmlUrl;
+    if (url) {
+      const displayName = text.trim() || defaultDisplayName(url);
+      const type = xmlUrl ? "rss" : detectSourceType(url);
+      out.push({
+        type,
+        identifier: url.trim(),
+        displayName,
+        ...(breadcrumbs.length > 0 ? { category: breadcrumbs.join(" / ") } : {}),
+      });
+      continue;
+    }
+
+    // Branch outline (no URL) — recurse with the breadcrumb. Use
+    // the outline's text/title as the path segment.
+    const segment = text.trim();
+    walk(child, segment ? [...breadcrumbs, segment] : breadcrumbs, out);
+  }
+}


### PR DESCRIPTION
## Summary

Day 4 of the LinkedIn 360 plan §3.4 + §3.7. Expands the Add Source drawer from one input mode to four via Tabs.

## Tabs

- **Manual** — extracted from the previous flat form. Constrained to \`sm:max-w-md\` so the wider Sheet (sm:max-w-2xl, sized for bulk preview) doesn't make the four-field form read loose.
- **Bulk paste** — textarea, one URL/handle per line, type auto-detected on every keystroke via \`detectSourceType\`. Live preview shows the parsed rows so users spot misclassifications before submit.
- **OPML import** — drag-and-drop or click drop-zone (visual pattern adapted from \`@shadcnblocks/file-upload-file-upload-dropzone-3\`; HTML5 drag-and-drop instead of pulling in the block's third-party Dice UI dep). Parses OPML 2.0 via DOMParser, walks nested category outlines depth-first, dedupes by identifier (Feed readers export the same feed under multiple categories), drops the category breadcrumb at submit (backend has no category column).
- **From competitor** — stub. Backend \"paste competitor URL → AI proposes sources\" endpoint hasn't shipped (separate workstream — competitor-scrape + recommender agent). Tab placeholder names the gate.

## Bulk-create behavior

- 10-row parallel batches via \`Promise.allSettled\` so one 409 doesn't tank the rest.
- Per-row outcome bucketing: succeeded / duplicates (409) / failed.
- Progress counter (\"Adding 17 / 200…\") fires between batches.
- Drawer closes only when \`failed === 0 && succeeded > 0\` — any failures keep it open so the user can see what didn't land.
- Summary toast (\"3 added, 1 already existed, 2 failed\") + first three specific failure messages so the user can diagnose without an error dump.

## New helpers

- [src/app/dashboard/content/sources/lib/detect-type.ts](src/app/dashboard/content/sources/lib/detect-type.ts) — first-match heuristic for type detection. Critical correctness fixes after review #1: \`/feed\` matcher tightened to a segment-anchored regex (was matching \`/feedback\`); youtube subdomain coverage via \`endsWith\`; apple-podcast subdomains; \`.atom\` added.
- [src/app/dashboard/content/sources/lib/parse-opml.ts](src/app/dashboard/content/sources/lib/parse-opml.ts) — OPML 2.0 parser via client-side DOMParser. Reads canonical \`xmlUrl\`/\`htmlUrl\` attribute casing only (spec is case-sensitive). Dedupes by identifier.

## Followups (not bundled)

- Per-row edit in the bulk preview (rename, change type, override fetch frequency) before submit. Day 4 ships read-only preview; edit is a Day-5 polish.
- \"Suggest from competitor\" backend (competitor-scrape + source-recommender agent) — separate workstream.
- Per-line fetch frequency override in bulk paste (today everything defaults to daily).

## Test plan

- [ ] Open the drawer, switch through all four tabs — Tabs render, Manual still works, Compete tab shows the placeholder.
- [ ] Manual tab: width is form-typical, not loose 2xl.
- [ ] Bulk paste: paste 3–5 mixed lines (URL, @handle, RSS feed URL). Verify each line's type badge in the preview matches expectation.
- [ ] Detection edge cases: paste \`https://example.com/feedback\` — should classify as \`website\`, NOT \`rss\` (was a regression pre-review).
- [ ] Detection edge cases: paste \`https://m.youtube.com/@channel\` — should classify as \`youtube_channel\`.
- [ ] OPML: drag a real Feedly OPML export onto the dropzone — verify drag-over visual state, drop ingests, dedupe works (Feedly typically duplicates feeds across categories).
- [ ] OPML: click the dropzone (no drag) — file picker opens.
- [ ] Bulk submit with 30+ rows — verify the \"Adding 17 / 30…\" progress counter increments.
- [ ] Bulk submit with one bad row + many good rows — drawer stays open after submit; bad row's error toast fires; good rows landed in the listing.
- [ ] Tab keyboard navigation: arrow keys cycle tabs; Tab moves into content; ESC closes the Sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)