### PR TITLE
feat(sources): RejectReasonDialog molecule + b2c wiring

### DIFF
--- a/src/app/dashboard/content/sources/components/source-row.tsx
+++ b/src/app/dashboard/content/sources/components/source-row.tsx
@@ -284,9 +284,10 @@ export function SourceRow({ source }: SourceRowProps) {
         open={rejectOpen}
         onOpenChange={setRejectOpen}
         targetLabel={source.displayName}
-        // Discard mutateAsync's return value — the dialog only cares
-        // about resolve-vs-reject (resolve closes, reject keeps it
-        // open). The patch result isn't useful at the dialog layer.
+        // We don't propagate the patch result up to the dialog — it
+        // only cares about resolve-vs-reject (resolve closes, reject
+        // keeps it open for retry). The mutation's onSuccess /
+        // onError handle the toast + invalidate.
         onSubmit={async (reason) => {
           await rejectMutation.mutateAsync(reason);
         }}

--- a/src/app/dashboard/content/sources/components/source-row.tsx
+++ b/src/app/dashboard/content/sources/components/source-row.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { RejectReasonDialog } from "@/components/molecules/reject-reason-dialog";
 import {
   Check,
   Globe,
@@ -125,17 +126,17 @@ export function SourceRow({ source }: SourceRowProps) {
     onError: (e) => handleApiError(e, "Could not accept source"),
   });
 
+  // Reject now goes through RejectReasonDialog; the mutation takes
+  // the captured reason as a variable rather than baking a sentinel.
+  // The dialog opens when the user picks "Reject" from the dropdown
+  // and closes on successful submit (or stays open + surfaces the
+  // toast on error).
+  const [rejectOpen, setRejectOpen] = useState(false);
   const rejectMutation = useMutation({
-    // Reason is required by the backend — sending a sentinel value
-    // until the UI for capturing a reason ships (a small dialog with
-    // a textarea + radio of canned reasons). Until then this rejection
-    // path is intentionally rare; the dropdown copy makes that clear.
-    // Sentinel chosen so future analytics can filter "rejected without
-    // a captured reason" rows out of any reason-distribution chart.
-    mutationFn: () =>
+    mutationFn: (reason: string) =>
       patchSource(source._id, {
         status: "rejected",
-        rejectionReason: "[ui-rejected: no reason captured]",
+        rejectionReason: reason,
       }),
     onSuccess: () => {
       toast.success(`${source.displayName} rejected`);
@@ -236,7 +237,7 @@ export function SourceRow({ source }: SourceRowProps) {
                   <Check className="mr-2 size-4" />
                   Accept
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => rejectMutation.mutate()}>
+                <DropdownMenuItem onClick={() => setRejectOpen(true)}>
                   <X className="mr-2 size-4" />
                   Reject
                 </DropdownMenuItem>
@@ -274,6 +275,22 @@ export function SourceRow({ source }: SourceRowProps) {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      {/* Reject dialog mounts inside the row so its open state is
+          row-scoped — each row has its own. The dialog throws if the
+          mutation rejects so it stays open for retry; it auto-closes
+          on success. */}
+      <RejectReasonDialog
+        open={rejectOpen}
+        onOpenChange={setRejectOpen}
+        targetLabel={source.displayName}
+        // Discard mutateAsync's return value — the dialog only cares
+        // about resolve-vs-reject (resolve closes, reject keeps it
+        // open). The patch result isn't useful at the dialog layer.
+        onSubmit={async (reason) => {
+          await rejectMutation.mutateAsync(reason);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/molecules/reject-reason-dialog.tsx
+++ b/src/components/molecules/reject-reason-dialog.tsx
@@ -57,20 +57,31 @@ export interface RejectReasonDialogProps {
   onSubmit: (reason: string) => Promise<void> | void;
   /** Canned-reason options shown in the dropdown. Pass [] to skip
    *  the picker and force free-text only. */
-  cannedReasons?: string[];
+  cannedReasons?: readonly string[];
   /** Override the title; defaults to "Reject {targetLabel}". */
   title?: string;
   /** Override the body description. */
   description?: string;
 }
 
-const DEFAULT_REASONS = [
+/** Sentinel for the "Other" canned option — when selected the
+ *  dialog requires a non-empty note (it'd otherwise read as
+ *  "selected the option that says 'use note below' and didn't
+ *  use the note"). Imported from the same const so the gate stays
+ *  in sync with the option list. */
+const OTHER_REASON = "Other (use note below)";
+
+const DEFAULT_REASONS: readonly string[] = [
   "Off-topic for our brand",
   "Low signal / poor quality",
   "Duplicate of an existing source",
   "Compliance / regulatory concern",
-  "Other (use note below)",
-] as const;
+  OTHER_REASON,
+];
+
+/** Backend cap on rejectionReason — keep in sync with PatchBody.zod
+ *  in peakhour-api/src/v1/routes/sources/trusted.ts. */
+const REASON_MAX_LENGTH = 1024;
 
 export function RejectReasonDialog(props: RejectReasonDialogProps) {
   // Mount the inner body only when open. Closed → unmounted → state
@@ -90,7 +101,7 @@ function RejectReasonDialogBody({
   onOpenChange,
   targetLabel,
   onSubmit,
-  cannedReasons = DEFAULT_REASONS as unknown as string[],
+  cannedReasons = DEFAULT_REASONS,
   title,
   description,
 }: RejectReasonDialogProps) {
@@ -99,19 +110,30 @@ function RejectReasonDialogBody({
   const [submitting, setSubmitting] = useState(false);
 
   const hasOptions = cannedReasons.length > 0;
-  // Submit is allowed when the user has either picked a canned
-  // reason OR typed at least 3 chars of detail. Pure-empty submits
-  // would surface as a backend 400 anyway; gating in the UI saves
-  // the round-trip and lets us disable the button instead of
-  // toasting an error.
+  const detailTrimmed = detail.trim();
+  // Submit gating:
+  //  • need a canned pick OR ≥3 chars of detail
+  //  • when the canned pick is the OTHER sentinel, the detail is
+  //    mandatory — submitting "Other (use note below)" alone reads
+  //    as "I picked the option that says 'use the note' and didn't
+  //    use the note." The backend would accept it; the UI shouldn't.
+  const otherWithoutDetail =
+    selected === OTHER_REASON && detailTrimmed.length < 3;
   const canSubmit =
-    !submitting && (Boolean(selected) || detail.trim().length >= 3);
+    !submitting &&
+    !otherWithoutDetail &&
+    (Boolean(selected) || detailTrimmed.length >= 3);
 
   function combineReason(): string {
     const left = selected.trim();
-    const right = detail.trim();
-    if (left && right) return `${left}: ${right}`;
-    return left || right;
+    const right = detailTrimmed;
+    const raw = left && right ? `${left}: ${right}` : left || right;
+    // Backend caps at REASON_MAX_LENGTH; truncate so the dialog can
+    // never round-trip to a VALIDATION_ERROR. Leaves a 1-char buffer
+    // for the ellipsis so the truncation is visible to the operator
+    // reading the audit trail later.
+    if (raw.length <= REASON_MAX_LENGTH) return raw;
+    return `${raw.slice(0, REASON_MAX_LENGTH - 1)}…`;
   }
 
   async function handleSubmit() {
@@ -167,14 +189,18 @@ function RejectReasonDialogBody({
               onChange={(e) => setDetail(e.target.value)}
               placeholder={
                 hasOptions
-                  ? "Add detail to the canned reason — useful when 'Other' is picked."
+                  ? "Add detail to the canned reason — required when 'Other' is picked."
                   : "Why is this being rejected?"
               }
-              maxLength={1024}
+              maxLength={REASON_MAX_LENGTH}
               rows={3}
             />
-            <p className="text-xs text-muted-foreground tabular-nums">
-              {detail.length} / 1024
+            <p
+              className={`text-xs tabular-nums ${otherWithoutDetail ? "text-amber-700 dark:text-amber-400" : "text-muted-foreground"}`}
+            >
+              {otherWithoutDetail
+                ? "Detail required when 'Other' is selected"
+                : `${detail.length} / ${REASON_MAX_LENGTH}`}
             </p>
           </div>
         </div>

--- a/src/components/molecules/reject-reason-dialog.tsx
+++ b/src/components/molecules/reject-reason-dialog.tsx
@@ -128,12 +128,19 @@ function RejectReasonDialogBody({
     const left = selected.trim();
     const right = detailTrimmed;
     const raw = left && right ? `${left}: ${right}` : left || right;
-    // Backend caps at REASON_MAX_LENGTH; truncate so the dialog can
-    // never round-trip to a VALIDATION_ERROR. Leaves a 1-char buffer
-    // for the ellipsis so the truncation is visible to the operator
-    // reading the audit trail later.
+    // Backend caps at REASON_MAX_LENGTH (UTF-16 code units). Truncate
+    // so the dialog can never round-trip to a VALIDATION_ERROR. Leaves
+    // a 1-unit buffer for the ellipsis (U+2026, single code unit) so
+    // the truncation is visible to whoever reads the audit trail.
     if (raw.length <= REASON_MAX_LENGTH) return raw;
-    return `${raw.slice(0, REASON_MAX_LENGTH - 1)}…`;
+    let cut = REASON_MAX_LENGTH - 1;
+    // Don't split a UTF-16 surrogate pair (emoji etc.) — would
+    // leave a lone high-surrogate that renders as U+FFFD and may
+    // fail strict UTF-8 validators. If the unit just before the cut
+    // is a high surrogate, back off by one.
+    const code = raw.charCodeAt(cut - 1);
+    if (code >= 0xd800 && code <= 0xdbff) cut -= 1;
+    return `${raw.slice(0, cut)}…`;
   }
 
   async function handleSubmit() {
@@ -155,8 +162,23 @@ function RejectReasonDialogBody({
     }
   }
 
+  // Block the dialog from dismissing via ESC / outside-click while
+  // a submit is in flight — Radix would otherwise unmount the
+  // dialog mid-mutation and the success toast would land over an
+  // unrelated screen. The Cancel button is already disabled via
+  // `submitting`; this closes the keyboard/pointer dismissal
+  // paths too.
+  function blockIfSubmitting(e: { preventDefault: () => void }) {
+    if (submitting) e.preventDefault();
+  }
+
   return (
-    <DialogContent className="sm:max-w-md">
+    <DialogContent
+      className="sm:max-w-md"
+      onEscapeKeyDown={blockIfSubmitting}
+      onPointerDownOutside={blockIfSubmitting}
+      onInteractOutside={blockIfSubmitting}
+    >
         <DialogHeader>
           <DialogTitle>{title ?? `Reject ${targetLabel}`}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}

--- a/src/components/molecules/reject-reason-dialog.tsx
+++ b/src/components/molecules/reject-reason-dialog.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * RejectReasonDialog — shared molecule for the "reject this thing,
+ * tell us why" pattern. Used today by the Trusted Sources reject
+ * action; built generic so future surfaces (rejecting AI-suggested
+ * voice cards, rejecting recommended ad creatives) reuse it.
+ *
+ * UX: the user picks a canned reason from a Select, optionally
+ * appends free-text detail in a Textarea. Submit emits the chosen
+ * label + (if present) the free-text — the caller decides how to
+ * combine them into the reason string sent to the backend (default:
+ * "{label}: {detail}" or just "{label}" / "{detail}" depending on
+ * what's provided). The dialog has no opinion on the API contract.
+ *
+ * Contract notes:
+ *   • `open` / `onOpenChange` — controlled. Always-controlled because
+ *     reject-this-row is always row-scoped and the parent already
+ *     tracks which row the user clicked.
+ *   • Provide either `cannedReasons` (the dropdown shows them) or
+ *     pass an empty array and rely on free-text only.
+ *   • `onSubmit(reason)` is called with the final string. Returning a
+ *     promise lets the dialog show a spinner while the network call
+ *     is in flight; resolving auto-closes, throwing keeps it open.
+ *   • `targetLabel` is the noun the heading shows (e.g. "Daring
+ *     Fireball" or "this source"). Keep it short.
+ */
+
+export interface RejectReasonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** What's being rejected, for the heading copy. */
+  targetLabel: string;
+  /** Submit handler — receives the formatted reason string. Throw to
+   *  keep the dialog open; resolve to close it. */
+  onSubmit: (reason: string) => Promise<void> | void;
+  /** Canned-reason options shown in the dropdown. Pass [] to skip
+   *  the picker and force free-text only. */
+  cannedReasons?: string[];
+  /** Override the title; defaults to "Reject {targetLabel}". */
+  title?: string;
+  /** Override the body description. */
+  description?: string;
+}
+
+const DEFAULT_REASONS = [
+  "Off-topic for our brand",
+  "Low signal / poor quality",
+  "Duplicate of an existing source",
+  "Compliance / regulatory concern",
+  "Other (use note below)",
+] as const;
+
+export function RejectReasonDialog(props: RejectReasonDialogProps) {
+  // Mount the inner body only when open. Closed → unmounted → state
+  // reset via remount on the next open. Avoids both the
+  // setState-in-effect lint rule AND the "old reason from previous
+  // row bleeds into next reject" bug, with no useEffect at all.
+  // Radix Dialog still owns the controlled open state on the outer
+  // shell so the parent's onOpenChange fires on outside-click / ESC.
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      {props.open ? <RejectReasonDialogBody {...props} /> : null}
+    </Dialog>
+  );
+}
+
+function RejectReasonDialogBody({
+  onOpenChange,
+  targetLabel,
+  onSubmit,
+  cannedReasons = DEFAULT_REASONS as unknown as string[],
+  title,
+  description,
+}: RejectReasonDialogProps) {
+  const [selected, setSelected] = useState<string>("");
+  const [detail, setDetail] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasOptions = cannedReasons.length > 0;
+  // Submit is allowed when the user has either picked a canned
+  // reason OR typed at least 3 chars of detail. Pure-empty submits
+  // would surface as a backend 400 anyway; gating in the UI saves
+  // the round-trip and lets us disable the button instead of
+  // toasting an error.
+  const canSubmit =
+    !submitting && (Boolean(selected) || detail.trim().length >= 3);
+
+  function combineReason(): string {
+    const left = selected.trim();
+    const right = detail.trim();
+    if (left && right) return `${left}: ${right}`;
+    return left || right;
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    const reason = combineReason();
+    if (!reason) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(reason);
+      // Resolve = close. The caller's onSubmit invalidates queries
+      // / fires toasts as it sees fit; the dialog only owns its
+      // own open state.
+      onOpenChange(false);
+    } catch {
+      // Caller threw — keep the dialog open so the user can retry
+      // or amend. The caller is responsible for surfacing the
+      // error toast; the dialog doesn't second-guess.
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title ?? `Reject ${targetLabel}`}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        <div className="space-y-4">
+          {hasOptions && (
+            <div className="grid gap-2">
+              <Label htmlFor="reject-reason-canned">Reason</Label>
+              <Select value={selected} onValueChange={setSelected}>
+                <SelectTrigger id="reject-reason-canned">
+                  <SelectValue placeholder="Pick a reason…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {cannedReasons.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {r}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          <div className="grid gap-2">
+            <Label htmlFor="reject-reason-detail">
+              {hasOptions ? "Note (optional)" : "Reason"}
+            </Label>
+            <Textarea
+              id="reject-reason-detail"
+              value={detail}
+              onChange={(e) => setDetail(e.target.value)}
+              placeholder={
+                hasOptions
+                  ? "Add detail to the canned reason — useful when 'Other' is picked."
+                  : "Why is this being rejected?"
+              }
+              maxLength={1024}
+              rows={3}
+            />
+            <p className="text-xs text-muted-foreground tabular-nums">
+              {detail.length} / 1024
+            </p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? (
+              <>
+                <Loader2 className="mr-1.5 size-4 animate-spin" />
+                Rejecting…
+              </>
+            ) : (
+              "Reject"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the gap PRs #162 + #163 left open: rejecting a suggested source from the b2c UI was sending a sentinel string (\`\"[ui-rejected: no reason captured]\"\`) to satisfy the backend's \`rejectionReason\` requirement, with no path to capture the actual reason. This PR ships the proper dialog and wires the b2c side; peakhour-cms wiring follows in a separate PR (replaces the \`window.prompt\` fallback there).

## New molecule

[src/components/molecules/reject-reason-dialog.tsx](src/components/molecules/reject-reason-dialog.tsx) — generic \"reject this thing, tell us why\" dialog.

- **UX**: canned-reason \`Select\` + optional free-text \`Textarea\`. Submit combines them as \`{label}: {detail}\` or just \`{label}\` / \`{detail}\` depending on what's filled.
- **Default canned reasons**: off-topic, low signal, duplicate, compliance, other-with-note. Caller can override with a custom list or pass \`[]\` for free-text-only.
- **Submit gating**: at least a canned pick OR ≥3 chars of detail. \`Other (use note below)\` requires the note (otherwise it'd read as \"picked the option that says 'use the note' and didn't use the note\").
- **Length cap**: \`combineReason()\` truncates to 1024 chars (matched to \`PatchBody.zod\` on peakhour-api) with a trailing ellipsis so a long combined string doesn't bounce off the backend as a non-actionable validation error.
- **Mount-on-open pattern** (\`{props.open ? <Body /> : null}\`): body state resets via remount on each new open, no useEffect-reset needed (and avoids the react-hooks/set-state-in-effect lint).
- **Resolve = close, throw = stay open**: caller's \`onSubmit\` returning a promise lets the dialog show a spinner + auto-close on resolve. Caller owns toasts.

## Wiring

[src/app/dashboard/content/sources/components/source-row.tsx](src/app/dashboard/content/sources/components/source-row.tsx):
- \`rejectMutation\` now takes the captured reason as a variable instead of baking the sentinel.
- Reject dropdown item now opens the dialog (per-row state).
- \`mutateAsync\` await chains correctly so the dialog only closes on backend confirm.

## Followups

- **peakhour-cms** \`/admin/sources\` will receive the same molecule (no shared package — single-file copy + adapt).
- **Future surfaces**: rejecting AI-suggested voice cards, rejecting recommended ad creatives. Same molecule, different \`cannedReasons\`.

## Test plan

- [ ] Suggested source: dropdown → Reject → dialog opens with \"Reject {name}\" heading.
- [ ] Submit without picking a canned reason and without typing → button stays disabled.
- [ ] Type 2 chars only → still disabled. Type 3 chars → enabled.
- [ ] Pick \"Other (use note below)\" with empty textarea → submit disabled, helper text shows \"Detail required when 'Other' is selected\".
- [ ] Pick a canned reason + add a note → backend receives \`{label}: {note}\`.
- [ ] Type a 1024-char note + pick a canned reason (would combine to >1024) → submit succeeds; backend receives the truncated string with trailing \`…\`.
- [ ] Mid-submit network failure → dialog stays open, error toast fires, user can retry.
- [ ] Cancel / outside-click / ESC → dialog closes, no mutation fires.
- [ ] Re-open the dialog on a different row → fresh state, no carry-over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)