### PR TITLE
feat(linkedin): /dashboard/content/linkedin Compose tab + author picker

### DIFF
--- a/src/app/dashboard/content/channels.config.ts
+++ b/src/app/dashboard/content/channels.config.ts
@@ -107,7 +107,8 @@ export const CHANNELS: readonly ChannelConfig[] = [
     description: "Publish posts and articles, analyze reach.",
     category: "Social",
     providerKey: "linkedin_content",
-    status: "available",
+    status: "live",
+    dashboardPath: "/dashboard/content/linkedin",
     logoUrl: `${SHADCN_LOGOS}/linkedin-icon.svg`,
   },
   {

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Link2, Send, X } from "lucide-react";
+import {
+  linkedInContentApi,
+  type LinkedInAuthor,
+  type LinkedInVisibility,
+  type LinkedInIdentity,
+  type PublishLinkedInPostInput,
+} from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+
+const MAX_LEN = 3000;
+
+const HAS_ORG_SCOPE = "w_organization_social";
+
+interface Props {
+  identity: LinkedInIdentity;
+}
+
+export function PostComposer({ identity }: Props) {
+  const queryClient = useQueryClient();
+  const [text, setText] = useState("");
+  const [visibility, setVisibility] = useState<LinkedInVisibility>("PUBLIC");
+  const [showLink, setShowLink] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkTitle, setLinkTitle] = useState("");
+  const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
+
+  // Author picker — discriminated union string keys for the Select.
+  // "person" → user's personal feed. "org:<id>" → that org page.
+  const authorOptions = useMemo(() => {
+    const opts: Array<{ value: string; label: string; sublabel?: string }> = [
+      {
+        value: "person",
+        label: identity.person.name ?? "My personal feed",
+        sublabel: "Personal feed",
+      },
+    ];
+    const canPostAsOrg = identity.scopes.includes(HAS_ORG_SCOPE);
+    if (canPostAsOrg) {
+      for (const page of identity.pages) {
+        opts.push({
+          value: `org:${page.id}`,
+          label: page.name || `Page ${page.id}`,
+          sublabel: "Company page",
+        });
+      }
+    }
+    return opts;
+  }, [identity]);
+
+  const [authorKey, setAuthorKey] = useState<string>(authorOptions[0]?.value ?? "person");
+
+  const publish = useMutation({
+    mutationFn: (input: PublishLinkedInPostInput) => linkedInContentApi.publish(input),
+    onSuccess: () => {
+      setText("");
+      setLinkUrl("");
+      setLinkTitle("");
+      setShowLink(false);
+      setFeedback({ kind: "success", message: "Post published to LinkedIn." });
+      queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof ApiError ? err.message : "Failed to publish post.";
+      setFeedback({ kind: "error", message });
+    },
+  });
+
+  const remaining = MAX_LEN - text.length;
+  const tooLong = remaining < 0;
+  const empty = text.trim().length === 0;
+  const linkInvalid = showLink && linkUrl.trim().length > 0 && !isProbablyUrl(linkUrl);
+  const disabled = empty || tooLong || publish.isPending || linkInvalid;
+
+  function onSubmit() {
+    if (disabled) return;
+    setFeedback(null);
+
+    const author: LinkedInAuthor = authorKey.startsWith("org:")
+      ? { type: "org", pageId: authorKey.slice("org:".length) }
+      : { type: "person" };
+
+    const body: PublishLinkedInPostInput = {
+      author,
+      commentary: text.trim(),
+      visibility,
+    };
+
+    if (showLink && linkUrl.trim()) {
+      body.link = {
+        url: linkUrl.trim(),
+        title: linkTitle.trim() || undefined,
+      };
+    }
+
+    publish.mutate(body);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="li-author" className="text-xs uppercase tracking-wide text-muted-foreground">
+            Post as
+          </Label>
+          <Select value={authorKey} onValueChange={setAuthorKey}>
+            <SelectTrigger id="li-author">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {authorOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  <span className="flex flex-col">
+                    <span>{opt.label}</span>
+                    {opt.sublabel && (
+                      <span className="text-xs text-muted-foreground">{opt.sublabel}</span>
+                    )}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {!identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Reconnect LinkedIn to enable posting from your company pages.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="li-visibility" className="text-xs uppercase tracking-wide text-muted-foreground">
+            Visibility
+          </Label>
+          <Select value={visibility} onValueChange={(v) => setVisibility(v as LinkedInVisibility)}>
+            <SelectTrigger id="li-visibility">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="PUBLIC">Public — anyone on LinkedIn</SelectItem>
+              <SelectItem value="CONNECTIONS">Connections only</SelectItem>
+              <SelectItem value="LOGGED_IN">Signed-in members</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Share an update, story, or question…"
+        rows={6}
+        className="resize-none"
+        aria-label="LinkedIn post content"
+      />
+
+      {showLink && (
+        <div className="space-y-2 rounded-md border p-3">
+          <Label htmlFor="li-link-url" className="text-xs uppercase tracking-wide text-muted-foreground">
+            Attach link
+          </Label>
+          <Input
+            id="li-link-url"
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            placeholder="https://example.com/article"
+            aria-invalid={linkInvalid}
+          />
+          <Input
+            value={linkTitle}
+            onChange={(e) => setLinkTitle(e.target.value)}
+            placeholder="Link title (optional)"
+          />
+          <div className="flex items-center justify-between">
+            {linkInvalid ? (
+              <p className="text-xs text-destructive">Enter a valid http(s) URL.</p>
+            ) : (
+              <span />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowLink(false);
+                setLinkUrl("");
+                setLinkTitle("");
+              }}
+            >
+              <X className="size-3.5 mr-1" /> Remove
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <div className="flex gap-2">
+          {!showLink && (
+            <Button type="button" variant="ghost" size="sm" onClick={() => setShowLink(true)}>
+              <Link2 className="size-3.5 mr-1" /> Add link
+            </Button>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className={
+              tooLong
+                ? "text-sm font-medium text-destructive"
+                : remaining <= 100
+                  ? "text-sm font-medium text-amber-600"
+                  : "text-sm text-muted-foreground"
+            }
+            aria-live="polite"
+          >
+            {remaining}
+          </span>
+          <Button onClick={onSubmit} disabled={disabled} aria-busy={publish.isPending}>
+            <Send className="size-4 mr-1.5" />
+            {publish.isPending ? "Publishing…" : "Publish"}
+          </Button>
+        </div>
+      </div>
+
+      {feedback && (
+        <p
+          role="status"
+          className={
+            feedback.kind === "error"
+              ? "rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+              : "rounded-md border border-green-200 bg-green-50/60 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
+          }
+        >
+          {feedback.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function PostComposerSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+      <Skeleton className="h-32 w-full" />
+      <div className="flex justify-between">
+        <Skeleton className="h-8 w-24" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Use the linkedin-me query as the data source for the composer's
+ * picker. Re-exported here so the page can render the right shell
+ * (composer, EmptyState, or Reconnect CTA) based on the same query.
+ */
+export function useLinkedInIdentity() {
+  return useQuery({
+    queryKey: ["linkedin-me"],
+    queryFn: () => linkedInContentApi.me(),
+    retry: (failureCount, err) => {
+      // Don't keep retrying if LinkedIn isn't connected — the page
+      // will render its EmptyState. Other transient errors get the
+      // default retry behavior.
+      if (err instanceof ApiError && (err.code === "NOT_CONNECTED" || err.status === 404)) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+    staleTime: 60_000,
+  });
+}
+
+function isProbablyUrl(s: string): boolean {
+  try {
+    const u = new URL(s.trim());
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -66,6 +66,25 @@ export function PostComposer({ identity }: Props) {
 
   const [authorKey, setAuthorKey] = useState<string>(authorOptions[0]?.value ?? "person");
 
+  // Clamp the selected author back into the option list when identity
+  // shifts beneath us (scope reconnect drops org_social, page list
+  // shrinks, etc). Without this, Radix Select renders a controlled
+  // value with no matching item — blank trigger + console warning —
+  // and submit would happily ship a stale `org:<id>` to a page the
+  // user can no longer post to.
+  useEffect(() => {
+    if (!authorOptions.some((o) => o.value === authorKey)) {
+      setAuthorKey(authorOptions[0]?.value ?? "person");
+    }
+  }, [authorOptions, authorKey]);
+
+  // LinkedIn rejects non-PUBLIC visibility on org posts. Coerce to
+  // PUBLIC when the user picks a page so the submit doesn't surface
+  // the raw API error. Keeps the visibility selector simple — both
+  // org and person flows share the same control state.
+  const isOrgAuthor = authorKey.startsWith("org:");
+  const effectiveVisibility: LinkedInVisibility = isOrgAuthor ? "PUBLIC" : visibility;
+
   const publish = useMutation({
     mutationFn: (input: PublishLinkedInPostInput) => linkedInContentApi.publish(input),
     onSuccess: () => {
@@ -92,14 +111,16 @@ export function PostComposer({ identity }: Props) {
     if (disabled) return;
     setFeedback(null);
 
-    const author: LinkedInAuthor = authorKey.startsWith("org:")
+    const author: LinkedInAuthor = isOrgAuthor
       ? { type: "org", pageId: authorKey.slice("org:".length) }
       : { type: "person" };
 
     const body: PublishLinkedInPostInput = {
       author,
       commentary: text.trim(),
-      visibility,
+      visibility: effectiveVisibility,
+      // TODO: wire ideaId once the strategist→linkedin bridge ships,
+      // so org-grounded posts feed the source-usage audit pipeline.
     };
 
     if (showLink && linkUrl.trim()) {
@@ -137,6 +158,8 @@ export function PostComposer({ identity }: Props) {
             </SelectContent>
           </Select>
           {!identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length > 0 && (
+            // Suppressed when pages.length === 0 — a user with no admin
+            // pages has nothing to enable, so the hint would just confuse.
             <p className="text-xs text-muted-foreground">
               Reconnect LinkedIn to enable posting from your company pages.
             </p>
@@ -147,7 +170,11 @@ export function PostComposer({ identity }: Props) {
           <Label htmlFor="li-visibility" className="text-xs uppercase tracking-wide text-muted-foreground">
             Visibility
           </Label>
-          <Select value={visibility} onValueChange={(v) => setVisibility(v as LinkedInVisibility)}>
+          <Select
+            value={effectiveVisibility}
+            onValueChange={(v) => setVisibility(v as LinkedInVisibility)}
+            disabled={isOrgAuthor}
+          >
             <SelectTrigger id="li-visibility">
               <SelectValue />
             </SelectTrigger>
@@ -157,6 +184,11 @@ export function PostComposer({ identity }: Props) {
               <SelectItem value="LOGGED_IN">Signed-in members</SelectItem>
             </SelectContent>
           </Select>
+          {isOrgAuthor && (
+            <p className="text-xs text-muted-foreground">
+              Company page posts are always public.
+            </p>
+          )}
         </div>
       </div>
 

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -2,8 +2,7 @@
 
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api";
-import { ApiError } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { ApiError } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { MessageSquare, RefreshCw, Send } from "lucide-react";
+import {
+  PostComposer,
+  PostComposerSkeleton,
+  useLinkedInIdentity,
+} from "./_components/post-composer";
+
+interface ApiIntegration {
+  provider: string;
+  connected?: boolean;
+  status?: string;
+}
+
+export default function LinkedInDashboardPage() {
+  // Mirror the X hub's pattern — read /v1/integrations once for the
+  // top-level connect gate, then defer to /linkedin-content/me for
+  // the picker data. Two queries because the integrations endpoint
+  // gives us the lifecycle truth that lets us render an EmptyState
+  // before /me would 404.
+  const integrations = useQuery({
+    queryKey: ["content-hub-integrations"],
+    queryFn: () =>
+      api.get<{ integrations: ApiIntegration[] }>("/v1/integrations"),
+    staleTime: 30_000,
+  });
+
+  const linkedInConnection = useMemo(
+    () => integrations.data?.integrations.find((i) => i.provider === "linkedin_content"),
+    [integrations.data]
+  );
+  const isConnected = linkedInConnection?.connected === true;
+
+  const identity = useLinkedInIdentity();
+  const enabledIdentity = isConnected ? identity : null;
+
+  if (integrations.isLoading) {
+    return <PageShell loading />;
+  }
+
+  if (!isConnected) {
+    return (
+      <PageShell>
+        <EmptyState
+          icon={MessageSquare}
+          title="Connect LinkedIn to get started"
+          description="Once connected, you can publish to your personal feed or any company page you administer, all from here."
+          action={{ label: "Connect LinkedIn", href: "/dashboard/integrations" }}
+        />
+      </PageShell>
+    );
+  }
+
+  // Identity errors that aren't NOT_CONNECTED — surface a Reconnect prompt.
+  // (NOT_CONNECTED itself can't happen here: isConnected gated us in.)
+  if (identity.isError) {
+    const err = identity.error;
+    const code = err instanceof ApiError ? err.code : "UNKNOWN";
+    return (
+      <PageShell>
+        <EmptyState
+          icon={RefreshCw}
+          title="LinkedIn needs a quick reconnect"
+          description={
+            code === "NO_ACCOUNT"
+              ? "We're missing your LinkedIn member identity. Reconnect to repair the integration."
+              : "We couldn't read your LinkedIn identity. Reconnect to continue posting."
+          }
+          action={{ label: "Reconnect LinkedIn", href: "/dashboard/integrations" }}
+        />
+      </PageShell>
+    );
+  }
+
+  const needsReauth =
+    enabledIdentity?.data && enabledIdentity.data.status !== "active";
+
+  return (
+    <PageShell>
+      {needsReauth && (
+        <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-900 dark:bg-amber-950/30">
+          <CardContent className="flex items-center justify-between gap-4 p-4 text-sm">
+            <span>
+              Your LinkedIn connection is{" "}
+              <span className="font-medium">{enabledIdentity?.data?.status}</span>.
+              Reconnect to keep publishing.
+            </span>
+            <a
+              href="/dashboard/integrations"
+              className="font-medium text-amber-900 underline underline-offset-4 dark:text-amber-200"
+            >
+              Reconnect
+            </a>
+          </CardContent>
+        </Card>
+      )}
+
+      <Tabs defaultValue="compose">
+        <TabsList>
+          <TabsTrigger value="compose" className="gap-1.5">
+            <Send className="size-4" /> Compose
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="compose" className="mt-4">
+          <Card>
+            <CardContent className="p-5">
+              {identity.isLoading || !enabledIdentity?.data ? (
+                <PostComposerSkeleton />
+              ) : (
+                <PostComposer identity={enabledIdentity.data} />
+              )}
+            </CardContent>
+          </Card>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Text + link posts only for now — carousels, polls, and scheduling are coming.
+          </p>
+        </TabsContent>
+      </Tabs>
+    </PageShell>
+  );
+}
+
+function PageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">LinkedIn</h2>
+        <p className="text-muted-foreground">
+          Publish to your personal feed or any company page you administer.
+        </p>
+      </div>
+      {loading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -1,0 +1,48 @@
+import { api } from "@/lib/api";
+
+export type LinkedInVisibility = "PUBLIC" | "CONNECTIONS" | "LOGGED_IN";
+
+export type LinkedInAuthor =
+  | { type: "person" }
+  | { type: "org"; pageId: string };
+
+export interface PublishLinkedInPostInput {
+  author: LinkedInAuthor;
+  commentary: string;
+  visibility?: LinkedInVisibility;
+  link?: { url: string; title?: string; description?: string };
+  imageUrns?: string[];
+  /** Optional cnt_ideas pointer — wires the post into the source-usage
+   *  audit pipeline so retrieved-source citations + claim extraction
+   *  fire when this LinkedIn post ships. Omit for ad-hoc posts. */
+  ideaId?: string;
+}
+
+export interface LinkedInOrgPage {
+  id: string;
+  name: string;
+  role: string;
+}
+
+export interface LinkedInIdentity {
+  /** Connection lifecycle status — `disconnected`/`expired` mean the
+   *  caller should render a Reconnect CTA, not treat this as "no LinkedIn". */
+  status: "active" | "disconnected" | "expired" | "error";
+  /** Granted scopes from the last consent. Use to gate features —
+   *  e.g. hide org-page authoring when `w_organization_social` is missing. */
+  scopes: string[];
+  person: {
+    urn: string;
+    name: string | null;
+    avatarUrl?: string;
+    email?: string;
+  };
+  pages: LinkedInOrgPage[];
+}
+
+export const linkedInContentApi = {
+  me: () => api.get<LinkedInIdentity>("/v1/linkedin-content/me"),
+
+  publish: (body: PublishLinkedInPostInput) =>
+    api.post<{ postId: string }>("/v1/linkedin-content/publish", body),
+};


### PR DESCRIPTION
## Summary
- New `/dashboard/content/linkedin` page — first concrete LinkedIn surface in b2c. Three states: not-connected EmptyState, identity-error Reconnect CTA, connected composer with a needs-reauth banner when the LinkedIn row is `disconnected`/`expired`.
- `PostComposer` molecule — author picker (personal feed + each admin company page), visibility selector, optional link attachment, char counter, mutation feedback. Mirrors `TweetComposer` style.
- `src/lib/api/linkedin-content.ts` — typed client over peakhour-api #203's new `/v1/linkedin-content/me` and extended `/publish`.
- `channels.config.ts` — flag `linkedin` as `live` with `dashboardPath`.

## Why
PR #203 (peakhour-api) extended `/v1/linkedin-content/publish` to accept person|org authors and added `GET /me`, but had no consumer. This is that consumer — the LinkedIn 360 Phase 1 Compose-only hub from plan §10.

## Picker behavior
- \"Post as page\" entries hidden when the connection is missing `w_organization_social` (e.g. legacy connection from before PR #200/#201 expanded scopes), with a hint to reconnect when admin pages exist.
- LinkedIn rejects non-PUBLIC visibility on org posts → composer coerces visibility to PUBLIC and disables the selector when an org author is picked, with a hint.
- `authorKey` is clamped to the option list via `useEffect`, so a scope/page change beneath the composer can't leave a stale selection that 404s on submit.

## Test plan
- [ ] Disconnected LinkedIn → page shows Connect CTA pointing to /dashboard/integrations
- [ ] Connected with no org scope → composer shows only personal-feed in picker
- [ ] Connected with org scope + admin page → both options appear, page picker submits to org URN
- [ ] Selecting an org author disables the visibility selector and forces PUBLIC
- [ ] Disconnected/expired connection (status != active) → needs-reauth banner above tabs
- [ ] Channels Hub LinkedIn tile now routes to `/dashboard/content/linkedin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)