### PR TITLE
feat(linkedin): surface needs_reauth status in composer + status-badge

### DIFF
--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -37,7 +37,14 @@ export default function LinkedInDashboardPage() {
     () => integrations.data?.integrations.find((i) => i.provider === "linkedin_content"),
     [integrations.data]
   );
-  const isConnected = linkedInConnection?.connected === true;
+  // Treat `needs_reauth` as "set up, just stale" — the composer
+  // renders + surfaces the in-page banner. Without this, /v1/integrations'
+  // strict `connected = status === "active"` would bounce stale-scope
+  // users to the EmptyState, hiding the very banner that tells them to
+  // reconnect.
+  const isConnected =
+    linkedInConnection?.connected === true ||
+    linkedInConnection?.status === "needs_reauth";
 
   const identity = useLinkedInIdentity();
   const enabledIdentity = isConnected ? identity : null;

--- a/src/components/molecules/status-badge.tsx
+++ b/src/components/molecules/status-badge.tsx
@@ -56,6 +56,7 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   disconnected: "error",
   expired: "error",
   error: "error",
+  needs_reauth: "warning",
   // Background-job statuses (Tasks dashboard + /cms/jobs ops view)
   queued: "muted",
   pending: "info",

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -25,9 +25,13 @@ export interface LinkedInOrgPage {
 }
 
 export interface LinkedInIdentity {
-  /** Connection lifecycle status — `disconnected`/`expired` mean the
-   *  caller should render a Reconnect CTA, not treat this as "no LinkedIn". */
-  status: "active" | "disconnected" | "expired" | "error";
+  /** Connection lifecycle status — anything other than `active` means
+   *  the caller should render a Reconnect CTA / banner, not treat
+   *  this as "no LinkedIn". `needs_reauth` covers the case where
+   *  tokens still refresh but the stored scopes no longer cover what
+   *  the current provider config requires (refresh-token flow can't
+   *  upgrade scopes). */
+  status: "active" | "disconnected" | "expired" | "error" | "needs_reauth";
   /** Granted scopes from the last consent. Use to gate features —
    *  e.g. hide org-page authoring when `w_organization_social` is missing. */
   scopes: string[];


### PR DESCRIPTION
## Summary
B2C side of the needs_reauth chain (peakhour-mongodb #64 + peakhour-api #204).

- `LinkedInIdentity.status` widens to include `\"needs_reauth\"` (TS would otherwise reject `/me` responses now that the api type widened).
- LinkedIn page's `isConnected` gate now also passes when `status === \"needs_reauth\"`, so those rows reach the composer and the in-page needs-reauth banner fires.
- StatusBadge molecule maps `needs_reauth → warning` (was falling through to muted). Auto-labels as \"Needs Reauth\".

## Why
Once the api migration runs, affected LinkedIn connections land at `status: \"needs_reauth\"` — a value `/v1/integrations` represents as `connected: false`. Without this PR, the LinkedIn page would bounce those users to the EmptyState, hiding the very banner that tells them to reconnect.

The composer's banner copy and Reconnect link were already in place from peakhour-b2c #166 — keying off `status !== \"active\"` was deliberate exactly so this PR could land the schema piece without any composer change.

## Deferred follow-up (not blocking)
- `src/app/dashboard/integrations/page.tsx` — the connection card branches on `integration.connected`, which is `false` for `needs_reauth`. So those rows currently render with a generic \"Connect\" button instead of an amber \"Reconnect\" CTA. Touches several visual elements (badge, border, account info display, button label) — punted to a focused follow-up. UX isn't broken: the composer's banner already routes users to /dashboard/integrations where clicking \"Connect\" re-OAuths and refreshes the scope set.
- peakhour-cms's `status-badge.tsx` has the same gap — tiny standalone PR to add the same mapping.

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] On a `needs_reauth` LinkedIn connection: page renders the composer with the amber needs-reauth banner (not the EmptyState)
- [ ] StatusBadge with `status=\"needs_reauth\"` renders amber with label \"Needs Reauth\"
- [ ] No regressions on the X / X-Ads / Beehiiv pages (they don't use `needs_reauth` and keep strict `connected === true` gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)