### PR TITLE
feat(sources): wire Citations (30d) KPI to live endpoint

### DIFF
--- a/src/app/dashboard/content/sources/api.ts
+++ b/src/app/dashboard/content/sources/api.ts
@@ -53,3 +53,24 @@ export async function deleteSource(
 ): Promise<{ _id: string; softDeleted: boolean }> {
   return api.delete<{ _id: string; softDeleted: boolean }>(`/v1/sources/trusted/${id}`);
 }
+
+export interface CitationsResponse {
+  count: number;
+  windowDays: number;
+  /** ISO of window start (asOf - windowDays) */
+  since: string;
+  /** ISO of response time */
+  asOf: string;
+}
+
+/**
+ * Rolling-window count of cnt_source_usage rows for the active
+ * business. Powers the "Citations (Nd)" KPI on the Trusted Sources
+ * page. Defaults to 30 days; capped at 365 by the backend.
+ */
+export async function getCitations(days = 30): Promise<CitationsResponse> {
+  return api.get<CitationsResponse>(
+    "/v1/sources/insights/citations",
+    { days: String(days) },
+  );
+}

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -12,7 +12,7 @@ import { KpiCard } from "@/components/molecules/kpi-card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
 import { ApiError } from "@/lib/api";
-import { listSources } from "./api";
+import { getCitations, listSources } from "./api";
 import { AddSourceDrawer } from "./components/add-source-drawer";
 import { InsightsPanel } from "./components/insights-panel";
 import { SourceRow } from "./components/source-row";
@@ -215,12 +215,16 @@ function TrustedSourcesSurface() {
 }
 
 /**
- * KPI strip — four cards per the §3.4 spec. Two metrics are derivable
- * from the listing payload and ship live; two need backend telemetry
- * surfaces that don't exist yet (citations-30d depends on a count
- * over `cnt_source_usage`; coverage-score is a proprietary scoring
- * surface — see plan §3.4 + §6 algo #4) and ship as `—` placeholders
- * with a tooltip-eligible muted state until the endpoint lands.
+ * KPI strip — four cards per the §3.4 spec. Three metrics ship live;
+ * Coverage score remains `—` until the proprietary scorer lands
+ * (plan §6 algo #4 — needs a `sector` field that doesn't exist yet).
+ *
+ * Citations (30d) reads from /v1/sources/insights/citations as its
+ * own query rather than being derived from the rows payload, since
+ * it aggregates the cnt_source_usage time-series across paused +
+ * active sources (the listing payload only carries per-source
+ * usageCount, which excludes any usage logged after a row went
+ * inactive).
  */
 function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }) {
   const activeCount = rows.filter((r) => r.status === "active").length;
@@ -234,6 +238,16 @@ function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }
   const healthy = active.filter((r) => (r.consecutiveFetchFailures ?? 0) === 0).length;
   const fetchHealth = active.length === 0 ? "—" : `${healthy}/${active.length}`;
 
+  // Citations is its own backend roundtrip — counts cnt_source_usage
+  // in a rolling 30d window. 5-min staleTime keeps tab-switches snappy
+  // without surfacing minute-stale numbers.
+  const citations = useQuery({
+    queryKey: ["citations", 30],
+    queryFn: () => getCitations(30),
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+
   if (loading) {
     return (
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -243,6 +257,18 @@ function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }
       </div>
     );
   }
+
+  // The KPI is honest about its lifecycle: still loading → "—",
+  // fetched → number, errored → "—" with a softer description so a
+  // transient backend blip doesn't read as "zero citations".
+  const citationsValue = citations.isLoading
+    ? "—"
+    : citations.isError
+      ? "—"
+      : citations.data?.count ?? 0;
+  const citationsDescription = citations.isError
+    ? "Couldn't load — refresh to retry"
+    : "AI citations across all sources, last 30 days";
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -260,8 +286,8 @@ function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }
       />
       <KpiCard
         title="Citations (30d)"
-        value="—"
-        description="Lands when usage telemetry ships"
+        value={citationsValue}
+        description={citationsDescription}
         icon={FileSearch}
       />
       <KpiCard

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -258,16 +258,14 @@ function KpiStrip({ rows, loading }: { rows: TrustedSource[]; loading: boolean }
     );
   }
 
-  // The KPI is honest about its lifecycle: still loading → "—",
-  // fetched → number, errored → "—" with a softer description so a
-  // transient backend blip doesn't read as "zero citations".
-  const citationsValue = citations.isLoading
-    ? "—"
-    : citations.isError
-      ? "—"
-      : citations.data?.count ?? 0;
+  // The KPI is honest about its lifecycle: loading and error both
+  // have undefined `data`, so a single `?? "—"` covers both — the
+  // softer description on error is what tells the user the value
+  // missing isn't "zero citations" but a transient backend blip.
+  // 5-min staleTime means a focus refetch retries automatically.
+  const citationsValue = citations.data?.count ?? "—";
   const citationsDescription = citations.isError
-    ? "Couldn't load — refresh to retry"
+    ? "Couldn't load — will retry shortly"
     : "AI citations across all sources, last 30 days";
 
   return (


### PR DESCRIPTION
## Summary
Replaces the `—` placeholder on the Trusted Sources \"Citations (30d)\" KPI with a real number sourced from peakhour-api #205.

- `src/app/dashboard/content/sources/api.ts` — typed `getCitations(days = 30)` + `CitationsResponse` shape.
- `page.tsx` `KpiStrip` — TanStack Query against the new endpoint, 5-min staleTime, `retry: false`. Loading and error both render `—`; error switches the description to \"Couldn't load — will retry shortly\" so a transient blip doesn't read as \"zero citations\".

## Why
Citations is its own backend roundtrip rather than derived from the listing payload because the listing only carries per-row `usageCount` for active sources; the KPI's intent (\"AI citations across all sources\") includes paused rows whose historical usage still counts.

Coverage score deliberately stays `—` — schema has no `sector` field, algo not locked.

## Tenant safety
The auth provider already calls `queryClient.clear()` on business switch, so the cached `[\"citations\", 30]` entry can't leak across tenants.

## Test plan
- [ ] Active business with publish history shows a non-zero citation count
- [ ] Brand-new business shows 0 (not `—`)
- [ ] Switching businesses refreshes the count
- [ ] Network 404 on the endpoint shows `—` with the error description (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)