### PR TITLE
feat(linkedin): live Hook DNA score in composer

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -14,9 +14,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Link2, Send, X } from "lucide-react";
+import { Link2, Send, Sparkles, X } from "lucide-react";
 import {
   linkedInContentApi,
+  type HookScore,
   type LinkedInAuthor,
   type LinkedInVisibility,
   type LinkedInIdentity,
@@ -84,6 +85,13 @@ export function PostComposer({ identity }: Props) {
   // org and person flows share the same control state.
   const isOrgAuthor = authorKey.startsWith("org:");
   const effectiveVisibility: LinkedInVisibility = isOrgAuthor ? "PUBLIC" : visibility;
+
+  // Hook DNA score — debounced live scoring as the user types. Pure
+  // server function (no AI, no DB) so it's safe to fire on every
+  // 400ms keystroke pause. Score is the v0 Tier-C floor; the badge
+  // surfaces "rules" so users see when personalised tiers haven't
+  // shipped yet.
+  const hookScore = useHookScore(text);
 
   const publish = useMutation({
     mutationFn: (input: PublishLinkedInPostInput) => linkedInContentApi.publish(input),
@@ -200,6 +208,8 @@ export function PostComposer({ identity }: Props) {
         className="resize-none"
         aria-label="LinkedIn post content"
       />
+
+      <HookScoreCard score={hookScore} />
 
       {showLink && (
         <div className="space-y-2 rounded-md border p-3">
@@ -329,4 +339,127 @@ function isProbablyUrl(s: string): boolean {
   } catch {
     return false;
   }
+}
+
+// ── Hook DNA scoring ─────────────────────────────────────────────────
+
+const HOOK_SCORE_DEBOUNCE_MS = 400;
+const HOOK_SCORE_MIN_CHARS = 8;
+
+/**
+ * Debounced hook scorer. Fires `POST /v1/linkedin-content/score-hook`
+ * 400ms after the user stops typing. Pure-server function (no AI),
+ * so the cost of getting it wrong is just a request, not a token bill.
+ *
+ * Returns:
+ *   - `null` while text is too short to score meaningfully
+ *   - `undefined` while a debounce window is still open
+ *   - `HookScore` object otherwise
+ */
+function useHookScore(text: string): HookScore | null | undefined {
+  const [score, setScore] = useState<HookScore | null | undefined>(null);
+
+  useEffect(() => {
+    const trimmed = text.trim();
+    if (trimmed.length < HOOK_SCORE_MIN_CHARS) {
+      setScore(null);
+      return;
+    }
+    setScore(undefined); // pending
+    const handle = window.setTimeout(() => {
+      // Stale-response guard via `cancelled` — debounced calls can race
+      // with newer keystrokes; only the most-recent one wins. Without
+      // this, a slow network on the first call would clobber a faster
+      // second call's score.
+      let cancelled = false;
+      linkedInContentApi
+        .scoreHook(trimmed)
+        .then((s) => {
+          if (!cancelled) setScore(s);
+        })
+        .catch(() => {
+          if (!cancelled) setScore(null);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, HOOK_SCORE_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [text]);
+
+  return score;
+}
+
+interface HookScoreBand {
+  label: string;
+  className: string;
+}
+
+function bandForScore(score: number): HookScoreBand {
+  if (score >= 80)
+    return {
+      label: "Strong hook",
+      className:
+        "border-emerald-200 bg-emerald-50/60 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
+    };
+  if (score >= 55)
+    return {
+      label: "Decent hook",
+      className:
+        "border-blue-200 bg-blue-50/60 text-blue-800 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-300",
+    };
+  if (score >= 30)
+    return {
+      label: "Weak hook",
+      className:
+        "border-amber-200 bg-amber-50/60 text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
+    };
+  return {
+    label: "Rework the hook",
+    className:
+      "border-red-200 bg-red-50/60 text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300",
+  };
+}
+
+/**
+ * HookScore card — surfaces the v0 score, an honest tier badge, and
+ * up to 3 plain-English suggestions. Hidden until the user types
+ * enough characters to score (`null`); shows a light pending state
+ * while the debounced request is in flight (`undefined`).
+ */
+function HookScoreCard({ score }: { score: HookScore | null | undefined }) {
+  if (score === null) return null;
+  if (score === undefined) {
+    return (
+      <div className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        Scoring hook…
+      </div>
+    );
+  }
+  const band = bandForScore(score.score);
+  const topSuggestions = score.suggestions.slice(0, 3);
+  return (
+    <div className={`space-y-2 rounded-md border px-3 py-2.5 text-sm ${band.className}`}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-4" />
+          <span className="font-medium">{band.label}</span>
+          <span className="rounded-sm border border-current/30 px-1.5 py-0 text-[10px] uppercase tracking-wide opacity-80">
+            Tier: {score.tier}
+          </span>
+        </div>
+        <span className="font-mono text-base font-semibold tabular-nums">
+          {score.score}
+          <span className="ml-0.5 text-xs opacity-70">/100</span>
+        </span>
+      </div>
+      {topSuggestions.length > 0 && (
+        <ul className="ml-4 list-disc space-y-0.5 text-xs opacity-90">
+          {topSuggestions.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
 }

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -366,12 +366,16 @@ function useHookScore(text: string): HookScore | null | undefined {
       return;
     }
     setScore(undefined); // pending
+
+    // Stale-response guard MUST live at effect-scope so the cleanup
+    // closure can flip it. Hoisting it inside the setTimeout callback
+    // (a previous attempt) was a no-op — setTimeout ignores callback
+    // return values, so the cleanup function returned from there was
+    // discarded. A slow first request would silently clobber a faster
+    // second one. With the flag at effect-scope, the next text-change
+    // tick flips it to true before the in-flight promise can setScore.
+    let cancelled = false;
     const handle = window.setTimeout(() => {
-      // Stale-response guard via `cancelled` — debounced calls can race
-      // with newer keystrokes; only the most-recent one wins. Without
-      // this, a slow network on the first call would clobber a faster
-      // second call's score.
-      let cancelled = false;
       linkedInContentApi
         .scoreHook(trimmed)
         .then((s) => {
@@ -380,11 +384,11 @@ function useHookScore(text: string): HookScore | null | undefined {
         .catch(() => {
           if (!cancelled) setScore(null);
         });
-      return () => {
-        cancelled = true;
-      };
     }, HOOK_SCORE_DEBOUNCE_MS);
-    return () => window.clearTimeout(handle);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
   }, [text]);
 
   return score;

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -44,9 +44,39 @@ export interface LinkedInIdentity {
   pages: LinkedInOrgPage[];
 }
 
+/** Hook DNA score — `tier: "rules"` is the v0 floor; v1+ may add
+ *  "personal" (per-business cosine) and "industry" (archetype cosine)
+ *  as the embedding pipeline lands. The badge surfaces the tier so
+ *  users see when they're getting the floor vs personalised tiers. */
+export interface HookScore {
+  score: number;
+  tier: "rules";
+  breakdown: {
+    length: number;
+    opener: number;
+    specificData: number;
+    audienceNoun: number;
+    activeVoice: number;
+    rhythm: number;
+  };
+  signals: {
+    wordCount: number;
+    visibleChars: number;
+    opener: "number" | "question" | "contrarian" | "named_entity" | "generic";
+    hasSpecificNumber: boolean;
+    hasAudienceNoun: boolean;
+    isActiveOpening: boolean;
+    firstLineChars: number;
+  };
+  suggestions: string[];
+}
+
 export const linkedInContentApi = {
   me: () => api.get<LinkedInIdentity>("/v1/linkedin-content/me"),
 
   publish: (body: PublishLinkedInPostInput) =>
     api.post<{ postId: string }>("/v1/linkedin-content/publish", body),
+
+  scoreHook: (hook: string) =>
+    api.post<HookScore>("/v1/linkedin-content/score-hook", { hook }),
 };


### PR DESCRIPTION
## Summary
Wires peakhour-api #207's `POST /v1/linkedin-content/score-hook` into the LinkedIn composer. As the user types, a debounced (400ms) call fires and renders a colored score band card directly under the textarea: score 0-100 + tier badge (\"rules\" for v0) + up to three plain-English suggestions.

## Changes
- `src/lib/api/linkedin-content.ts` — typed `scoreHook()` wrapper + `HookScore` shape.
- `_components/post-composer.tsx` — `useHookScore` hook with debounce + stale-response guard. `HookScoreCard` renders band + badge + suggestion bullets. `bandForScore` maps 0/30/55/80 thresholds to four tones (red/amber/blue/emerald).

## UX choices
- Hidden when text is < 8 chars trimmed.
- Pending state (\"Scoring hook…\") during debounce window.
- Tier badge always visible — honest about v0 floor.
- Suggestions cap at 3.

## Smoke-tested band calibration (against api smoke set)
- 89 (canonical good) → emerald \"Strong hook\"
- 82 (contrarian) → emerald \"Strong hook\"
- 38 (weak generic) → amber \"Weak hook\"
- 27 (lone year) → red \"Rework the hook\"
- 13 (mid-typing) → suggestions suppressed by api

## Test plan
- [ ] Type \"Hello\" → no card (under 8 chars)
- [ ] Type \"47% of BFSI founders ignore one simple compliance step.\" → emerald 89 / Strong hook
- [ ] Type then erase quickly → no flicker, last-known-final state wins (debounce + race guard)
- [ ] api unreachable → card hides silently (acceptable degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)