### PR TITLE
feat(linkedin): surface Tier B archetype match in composer

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -508,14 +508,18 @@ function HookScoreCard({
   }
   const band = bandForScore(score.score);
   const topSuggestions = score.suggestions.slice(0, 3);
+  const tierMeta = tierBadgeMeta(score.tier);
   return (
     <div className={`space-y-2 rounded-md border px-3 py-2.5 text-sm ${band.className}`}>
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Sparkles className="size-4" />
           <span className="font-medium">{band.label}</span>
-          <span className="rounded-sm border border-current/30 px-1.5 py-0 text-[10px] uppercase tracking-wide opacity-80">
-            Tier: {score.tier}
+          <span
+            className="rounded-sm border border-current/30 px-1.5 py-0 text-[10px] uppercase tracking-wide opacity-80"
+            title={tierMeta.tooltip}
+          >
+            {tierMeta.label}
           </span>
         </div>
         <div className="flex items-center gap-2">
@@ -543,6 +547,15 @@ function HookScoreCard({
           </span>
         </div>
       </div>
+      {score.archetypeMatch && (
+        <div className="text-[11px] opacity-80">
+          Matched{" "}
+          <span className="font-mono">{score.archetypeMatch.cohortId}</span>{" "}
+          archetype · cosine{" "}
+          {score.archetypeMatch.cosineSimilarity.toFixed(2)} · scored
+          against {score.archetypeMatch.exampleCount} examples
+        </div>
+      )}
       {topSuggestions.length > 0 && (
         <ul className="ml-4 list-disc space-y-0.5 text-xs opacity-90">
           {topSuggestions.map((s, i) => (
@@ -552,6 +565,36 @@ function HookScoreCard({
       )}
     </div>
   );
+}
+
+/**
+ * Friendlier copy for the tier badge. "Rules" / "Industry" / "Personal"
+ * reads more meaningful than the raw enum value, with a hover tooltip
+ * that explains what produced the score so the badge isn't a mystery
+ * abbreviation.
+ */
+function tierBadgeMeta(tier: HookScore["tier"]): { label: string; tooltip: string } {
+  switch (tier) {
+    case "industry":
+      return {
+        label: "Tier: industry",
+        tooltip:
+          "Blended score: 60% cosine similarity to your industry archetype + 40% craft rules. Higher confidence than the rules-only floor.",
+      };
+    case "personal":
+      return {
+        label: "Tier: personal",
+        tooltip:
+          "Blended score: cosine similarity to your own top-performing hooks + craft rules. Most personalised tier.",
+      };
+    case "rules":
+    default:
+      return {
+        label: "Tier: rules",
+        tooltip:
+          "Score from craft rules only (length, opener, specific data, audience naming, active voice, line rhythm). No archetype available yet for your cohort.",
+      };
+  }
 }
 
 /**

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -44,13 +44,15 @@ export interface LinkedInIdentity {
   pages: LinkedInOrgPage[];
 }
 
-/** Hook DNA score — `tier: "rules"` is the v0 floor; v1+ may add
- *  "personal" (per-business cosine) and "industry" (archetype cosine)
- *  as the embedding pipeline lands. The badge surfaces the tier so
- *  users see when they're getting the floor vs personalised tiers. */
+/** Hook DNA score. Tier badge:
+ *    "rules"    — Tier C floor (deterministic craft rules only)
+ *    "industry" — Tier B blend (Tier C + cosine to industry archetype centroid)
+ *    "personal" — Tier A blend (Tier C + cosine to per-business archetype; future)
+ *  The composer surfaces the tier so users see when they're
+ *  getting the floor vs personalised tiers. */
 export interface HookScore {
   score: number;
-  tier: "rules";
+  tier: "rules" | "industry" | "personal";
   breakdown: {
     length: number;
     opener: number;
@@ -69,6 +71,16 @@ export interface HookScore {
     firstLineChars: number;
   };
   suggestions: string[];
+  /** Archetype match diagnostic — populated when Tier B / A fires.
+   *  Surface in the composer hover so curious users can see
+   *  "matched bfsi_india archetype, cosine 0.78 across 142 examples". */
+  archetypeMatch?: {
+    archetypeId: string;
+    cohortId: string;
+    cosineSimilarity: number;
+    archetypeScore: number;
+    exampleCount: number;
+  };
 }
 
 /** Hook rewrite variant — matches `rewrite_hook_variants` skill output.


### PR DESCRIPTION
## Summary
Wires peakhour-api #213's Tier B blended score into the LinkedIn composer. Widens the type union, adds the archetypeMatch diagnostic, and renders a friendlier tier badge + match-info line when Tier B fires.

## Files
- `src/lib/api/linkedin-content.ts` — `tier: \"rules\" | \"industry\" | \"personal\"` + `archetypeMatch?` field
- `_components/post-composer.tsx` — \`tierBadgeMeta()\` for friendlier labels w/ tooltips; renders \"Matched cohort archetype · cosine X · N examples\" when archetypeMatch present

## Behaviour
- Until corpus is curated: composer shows Tier C as before, no visible change
- When Tier B fires: badge updates to \"Tier: industry\" with the archetype match line beneath

## Test plan
- [ ] Type a hook with no business connected → Tier C as before
- [ ] Type a hook with business + cohort + populated archetype → Tier B badge + match line
- [ ] Hover the tier badge → tooltip explains what produced the score

🤖 Generated with [Claude Code](https://claude.com/claude-code)