### PR TITLE
feat(linkedin): Audience tab with AQS Tier C engagers panel

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -39,7 +39,22 @@ export function AudiencePanel() {
       return failureCount < 2;
     },
     staleTime: 5 * 60_000,
+    // The engagers endpoint runs a Mongo aggregation per call. Match
+    // the heavier insights panels' convention: don't auto-refetch on
+    // tab refocus or component remount — the 5min staleTime is the
+    // honest refresh cadence here, and the user can hard-refresh if
+    // they want a fresher view.
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
+
+  // Surface transient errors in the dev console so we can debug
+  // network/parse failures (raw TypeError from fetch, PARSE_ERROR from
+  // a 500 with non-JSON body). The user-facing toast intentionally
+  // doesn't echo err.message — provider/network strings leak internals.
+  if (isError && !(error instanceof ApiError && error.status === 403)) {
+    console.error("[AudiencePanel] engagers query failed:", error);
+  }
 
   if (isLoading) {
     return <AudiencePanelSkeleton />;

--- a/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { ApiError } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Building2, Users } from "lucide-react";
+import {
+  linkedInContentApi,
+  type EngagerScore,
+} from "@/lib/api/linkedin-content";
+
+/**
+ * AudiencePanel — surfaces the AQS Tier C ranking of recent LinkedIn
+ * engagers (people who commented on the business's posts).
+ *
+ * Tier C is the deterministic floor — frequency × recency × reactions
+ * — that ships without LinkedIn People Search enrichment. The badge
+ * shows "AQS · rules" so the user can tell when the score is the
+ * deterministic floor; when Tier B (profile enrichment) lands, the
+ * badge will read "AQS · enriched" without any code change to this
+ * panel beyond rendering the resolved name/title instead of the URN.
+ *
+ * No deep-link to the engager's LinkedIn profile yet — the raw URN's
+ * id-portion isn't a vanity handle, so a constructed link would land
+ * on a "not found" most of the time. The link unlocks with Tier B
+ * enrichment (which returns the public profile URL alongside the
+ * name).
+ */
+export function AudiencePanel() {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["linkedin-engagers"],
+    queryFn: () => linkedInContentApi.engagers(),
+    retry: (failureCount, err) => {
+      // 403 (no business selected) is expected — render the empty
+      // state. Transient errors get the default retry.
+      if (err instanceof ApiError && err.status === 403) return false;
+      return failureCount < 2;
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  if (isLoading) {
+    return <AudiencePanelSkeleton />;
+  }
+
+  if (isError) {
+    if (error instanceof ApiError && error.status === 403) {
+      return (
+        <PanelShell>
+          <EmptyBody
+            title="Pick a business to see your top engagers"
+            body="Once a business is selected, we'll rank the people who've been commenting on its LinkedIn posts."
+          />
+        </PanelShell>
+      );
+    }
+    return (
+      <PanelShell>
+        <EmptyBody
+          title="Couldn't load engagers"
+          body="Try refreshing in a moment. If the problem persists, check your LinkedIn connection."
+        />
+      </PanelShell>
+    );
+  }
+
+  if (!data || data.engagers.length === 0) {
+    return (
+      <PanelShell>
+        <EmptyBody
+          title="No engagers yet"
+          body="Once your LinkedIn posts attract comments, we'll surface your top engagers here, ranked by how often and how recently they engage."
+        />
+      </PanelShell>
+    );
+  }
+
+  return (
+    <PanelShell
+      summary={`${data.totalComments} comment${data.totalComments === 1 ? "" : "s"} across ${data.distinctActors} engager${data.distinctActors === 1 ? "" : "s"} in the last ${data.lookbackDays} days`}
+    >
+      <ol className="divide-y">
+        {data.engagers.map((engager, i) => (
+          <EngagerRow key={engager.actorUrn} engager={engager} rank={i + 1} />
+        ))}
+      </ol>
+    </PanelShell>
+  );
+}
+
+function PanelShell({
+  children,
+  summary,
+}: {
+  children: React.ReactNode;
+  summary?: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-base leading-none font-semibold">
+            Top engagers
+          </h3>
+          <Badge
+            variant="outline"
+            className="text-[10px] uppercase tracking-wide"
+            title="Tier C floor — frequency, recency, and comment reactions. Profile enrichment (job title, seniority, ICP match) ships next."
+          >
+            AQS · rules
+          </Badge>
+        </div>
+        {summary ? (
+          <p className="mt-1 text-xs text-muted-foreground">{summary}</p>
+        ) : null}
+      </CardHeader>
+      <CardContent className="pt-0">{children}</CardContent>
+    </Card>
+  );
+}
+
+function EmptyBody({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border border-dashed bg-muted/20 px-4 py-6 text-center text-sm">
+      <p className="font-medium">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+function EngagerRow({ engager, rank }: { engager: EngagerScore; rank: number }) {
+  const ActorIcon = engager.actorType === "org" ? Building2 : Users;
+  const actorLabel =
+    engager.actorType === "org" ? "Company page" : "Person";
+  // URN tail is the LinkedIn-internal member/org id. Not a vanity
+  // handle and not displayable as a name today — but a short suffix
+  // gives the user something to distinguish duplicate "Person" rows
+  // until Tier B enrichment lands with real names.
+  const urnTail = engager.actorUrn.split(":").pop() ?? "";
+  const shortId = urnTail.length > 12 ? `${urnTail.slice(0, 4)}…${urnTail.slice(-4)}` : urnTail;
+
+  const recencyLabel = formatRecency(engager.signals.daysSinceLastComment);
+
+  return (
+    <li className="flex items-start gap-3 py-3">
+      <span className="w-6 shrink-0 pt-0.5 text-xs tabular-nums text-muted-foreground">
+        {rank}.
+      </span>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2">
+          <ActorIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="text-sm font-medium">{actorLabel}</span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            · {shortId}
+          </span>
+        </div>
+        {engager.signals.lastCommentText ? (
+          <p
+            className="line-clamp-2 text-xs text-muted-foreground"
+            title={engager.signals.lastCommentText}
+          >
+            “{engager.signals.lastCommentText}”
+          </p>
+        ) : null}
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+          <span>
+            <span className="font-medium text-foreground">
+              {engager.signals.commentCount}
+            </span>{" "}
+            comment{engager.signals.commentCount === 1 ? "" : "s"}
+          </span>
+          {engager.signals.totalReactions > 0 ? (
+            <span>
+              <span className="font-medium text-foreground">
+                {engager.signals.totalReactions}
+              </span>{" "}
+              reaction{engager.signals.totalReactions === 1 ? "" : "s"}
+            </span>
+          ) : null}
+          <span>last · {recencyLabel}</span>
+        </div>
+      </div>
+      <div className="shrink-0 text-right">
+        <div
+          className="font-mono text-base font-semibold tabular-nums"
+          title={`Frequency ${engager.breakdown.frequency} / 40 · Recency ${engager.breakdown.recency} / 30 · Reactions ${engager.breakdown.reactions} / 30`}
+        >
+          {engager.score}
+        </div>
+        <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          / 100
+        </div>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Friendly relative time for last-comment recency. Granularity matches
+ * what the user reasons about ("3 days ago" not "73 hours ago"). The
+ * server already gives us `daysSinceLastComment` so we don't re-derive
+ * the wall clock here.
+ */
+function formatRecency(daysSinceLast: number): string {
+  if (daysSinceLast <= 0) return "today";
+  if (daysSinceLast === 1) return "yesterday";
+  if (daysSinceLast < 7) return `${daysSinceLast}d ago`;
+  if (daysSinceLast < 30) {
+    const weeks = Math.floor(daysSinceLast / 7);
+    return `${weeks}w ago`;
+  }
+  if (daysSinceLast < 365) {
+    const months = Math.floor(daysSinceLast / 30);
+    return `${months}mo ago`;
+  }
+  const years = Math.floor(daysSinceLast / 365);
+  return `${years}y ago`;
+}
+
+function AudiencePanelSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <Skeleton className="mt-2 h-3 w-64" />
+      </CardHeader>
+      <CardContent className="pt-0">
+        <ol className="divide-y">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i} className="flex items-start gap-3 py-3">
+              <Skeleton className="h-4 w-4 shrink-0" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-full max-w-md" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+              <Skeleton className="h-10 w-10 shrink-0" />
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
@@ -111,39 +111,71 @@ export default function LinkedInDashboardPage() {
         </Card>
       )}
 
-      <Tabs defaultValue="compose">
-        <TabsList>
-          <TabsTrigger value="compose" className="gap-1.5">
-            <Send className="size-4" /> Compose
-          </TabsTrigger>
-          <TabsTrigger value="audience" className="gap-1.5">
-            <Users className="size-4" /> Audience
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="compose" className="mt-4">
-          <Card>
-            <CardContent className="p-5">
-              {identity.isLoading || !enabledIdentity?.data ? (
-                <PostComposerSkeleton />
-              ) : (
-                <PostComposer identity={enabledIdentity.data} />
-              )}
-            </CardContent>
-          </Card>
-          <p className="mt-3 text-xs text-muted-foreground">
-            Text + link posts only for now — carousels, polls, and scheduling are coming.
-          </p>
-        </TabsContent>
-
-        <TabsContent value="audience" className="mt-4">
-          <AudiencePanel />
-          <p className="mt-3 text-xs text-muted-foreground">
-            We rank commenters on your LinkedIn posts by frequency, recency, and reactions. Names and titles will appear once profile enrichment lands.
-          </p>
-        </TabsContent>
-      </Tabs>
+      <LinkedInTabs identity={identity} enabledIdentity={enabledIdentity} />
     </PageShell>
+  );
+}
+
+/**
+ * Tabs shell — lifts the Tabs state into React so we can lazy-mount
+ * the Audience tab. Radix's <TabsContent> eagerly mounts every child
+ * (just toggles `hidden`), which would fire the engagers query on
+ * every page load even for users who never open the tab. Tracking
+ * "has the user ever opened Audience" in state lets us skip the
+ * mount until the user actually asks for it; on subsequent switches
+ * the mounted-once component handles its own visibility (and TanStack
+ * Query keeps the data warm via staleTime).
+ */
+function LinkedInTabs({
+  identity,
+  enabledIdentity,
+}: {
+  identity: ReturnType<typeof useLinkedInIdentity>;
+  enabledIdentity: ReturnType<typeof useLinkedInIdentity> | null;
+}) {
+  const [tab, setTab] = useState<"compose" | "audience">("compose");
+  const [audienceOpened, setAudienceOpened] = useState(false);
+
+  function handleTabChange(value: string) {
+    if (value === "compose" || value === "audience") {
+      setTab(value);
+      if (value === "audience") setAudienceOpened(true);
+    }
+  }
+
+  return (
+    <Tabs value={tab} onValueChange={handleTabChange}>
+      <TabsList>
+        <TabsTrigger value="compose" className="gap-1.5">
+          <Send className="size-4" /> Compose
+        </TabsTrigger>
+        <TabsTrigger value="audience" className="gap-1.5">
+          <Users className="size-4" /> Audience
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="compose" className="mt-4">
+        <Card>
+          <CardContent className="p-5">
+            {identity.isLoading || !enabledIdentity?.data ? (
+              <PostComposerSkeleton />
+            ) : (
+              <PostComposer identity={enabledIdentity.data} />
+            )}
+          </CardContent>
+        </Card>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Text + link posts only for now — carousels, polls, and scheduling are coming.
+        </p>
+      </TabsContent>
+
+      <TabsContent value="audience" className="mt-4">
+        {audienceOpened ? <AudiencePanel /> : null}
+        <p className="mt-3 text-xs text-muted-foreground">
+          We rank commenters on your LinkedIn posts by frequency, recency, and reactions. Names and titles will appear once profile enrichment lands.
+        </p>
+      </TabsContent>
+    </Tabs>
   );
 }
 

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -7,12 +7,13 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { MessageSquare, RefreshCw, Send } from "lucide-react";
+import { MessageSquare, RefreshCw, Send, Users } from "lucide-react";
 import {
   PostComposer,
   PostComposerSkeleton,
   useLinkedInIdentity,
 } from "./_components/post-composer";
+import { AudiencePanel } from "./_components/audience-panel";
 
 interface ApiIntegration {
   provider: string;
@@ -115,6 +116,9 @@ export default function LinkedInDashboardPage() {
           <TabsTrigger value="compose" className="gap-1.5">
             <Send className="size-4" /> Compose
           </TabsTrigger>
+          <TabsTrigger value="audience" className="gap-1.5">
+            <Users className="size-4" /> Audience
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="compose" className="mt-4">
@@ -129,6 +133,13 @@ export default function LinkedInDashboardPage() {
           </Card>
           <p className="mt-3 text-xs text-muted-foreground">
             Text + link posts only for now — carousels, polls, and scheduling are coming.
+          </p>
+        </TabsContent>
+
+        <TabsContent value="audience" className="mt-4">
+          <AudiencePanel />
+          <p className="mt-3 text-xs text-muted-foreground">
+            We rank commenters on your LinkedIn posts by frequency, recency, and reactions. Names and titles will appear once profile enrichment lands.
           </p>
         </TabsContent>
       </Tabs>

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -216,11 +216,17 @@ export const linkedInContentApi = {
   /** AQS-ranked recent engagers for the active business. Server returns
    *  an empty `engagers` array (not 404) when no comments have been
    *  ingested yet, so the panel renders an empty state instead of an
-   *  error. Defaults match the server's defaults (days=90, limit=25). */
+   *  error. Omitting the params (or passing 0 / negative values) lets
+   *  the server fall back to its own defaults (days=90, limit=25);
+   *  only positive values are serialised. */
   engagers: (params?: { days?: number; limit?: number }) => {
     const qs = new URLSearchParams();
-    if (params?.days !== undefined) qs.set("days", String(params.days));
-    if (params?.limit !== undefined) qs.set("limit", String(params.limit));
+    if (typeof params?.days === "number" && params.days > 0) {
+      qs.set("days", String(params.days));
+    }
+    if (typeof params?.limit === "number" && params.limit > 0) {
+      qs.set("limit", String(params.limit));
+    }
     const q = qs.toString();
     return api.get<EngagersResponse>(
       `/v1/linkedin-content/engagers${q ? `?${q}` : ""}`,

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -148,6 +148,50 @@ export interface LinkedInVoiceCard {
   lastGeneratedAt: string;
 }
 
+/**
+ * Audience Quality Score (AQS) result for one engager.
+ * Tier badge:
+ *   "rules"    — Tier C floor (frequency + recency + reactions; deterministic)
+ *   "enriched" — Tier B (Tier C + LinkedIn People Search enrichment;
+ *                 job title × seniority × ICP match; future)
+ * Today every engager comes back tier:"rules". The panel renders the
+ * badge so users see when the score is the deterministic floor vs the
+ * enriched tier.
+ */
+export interface EngagerScore {
+  actorUrn: string;
+  actorType: "person" | "org";
+  score: number;
+  tier: "rules" | "enriched";
+  breakdown: {
+    frequency: number;
+    recency: number;
+    reactions: number;
+  };
+  signals: {
+    commentCount: number;
+    topLevelCount: number;
+    totalReactions: number;
+    daysSinceLastComment: number;
+    lastCommentedAt: string;
+    firstCommentedAt: string;
+    lastCommentText: string;
+    lastParentPostUrn: string;
+  };
+}
+
+export interface EngagersResponse {
+  engagers: EngagerScore[];
+  /** Sum of commentCount across returned engagers — feeds the panel
+   *  header's "N comments across M people" line. */
+  totalComments: number;
+  /** = engagers.length, surfaced so the UI doesn't recompute. */
+  distinctActors: number;
+  /** Echo of the lookback window the server actually used (after
+   *  clamping the ?days query param). */
+  lookbackDays: number;
+}
+
 export const linkedInContentApi = {
   me: () => api.get<LinkedInIdentity>("/v1/linkedin-content/me"),
 
@@ -168,4 +212,18 @@ export const linkedInContentApi = {
    *  render an empty state, not surface an error. */
   voiceCard: () =>
     api.get<LinkedInVoiceCard>("/v1/linkedin-content/voice-card"),
+
+  /** AQS-ranked recent engagers for the active business. Server returns
+   *  an empty `engagers` array (not 404) when no comments have been
+   *  ingested yet, so the panel renders an empty state instead of an
+   *  error. Defaults match the server's defaults (days=90, limit=25). */
+  engagers: (params?: { days?: number; limit?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.days !== undefined) qs.set("days", String(params.days));
+    if (params?.limit !== undefined) qs.set("limit", String(params.limit));
+    const q = qs.toString();
+    return api.get<EngagersResponse>(
+      `/v1/linkedin-content/engagers${q ? `?${q}` : ""}`,
+    );
+  },
 };


### PR DESCRIPTION
## Summary

- Adds an **Audience** tab to `/dashboard/content/linkedin` alongside Compose. Renders the AQS Tier C ranking of recent engagers — people who've commented on the active business's LinkedIn posts — using the new `GET /v1/linkedin-content/engagers` endpoint (peakhour-api #229, merged).
- Each row shows: rank, actor type (Person / Company page) + short URN suffix, last comment excerpt (line-clamped), comment count, total reactions, recency ("3d ago", "2w ago"), and the 0-100 AQS score with a tooltip breakdown.
- Honest tier badge `AQS · rules` surfaces today; will read `AQS · enriched` when LinkedIn People Search profile enrichment lands. The panel auto-promotes — no code change needed beyond rendering the resolved name/headline.
- Empty / 403 / transient-error states render friendly messages, not raw errors.
- AudiencePanel is **lazy-mounted** — Radix `<TabsContent>` eagerly mounts every child, so a naive integration would fire the engagers query on every Compose-tab visit. Tabs is lifted into controlled state with a one-shot `audienceOpened` flag so the query only fires when the user actually opens the tab.

## Files

- `src/lib/api/linkedin-content.ts` — `EngagerScore` + `EngagersResponse` interfaces + `linkedInContentApi.engagers()` method.
- `src/app/dashboard/content/linkedin/_components/audience-panel.tsx` — new component (`AudiencePanel`, `EngagerRow`, `AudiencePanelSkeleton`).
- `src/app/dashboard/content/linkedin/page.tsx` — new Audience tab + lazy-mount logic.

## Test plan

- [ ] Open `/dashboard/content/linkedin` with a connected business that has comments — switch to Audience tab, verify ranked list renders with scores 0-100.
- [ ] Hover the score number — verify breakdown tooltip shows `Frequency X / 40 · Recency Y / 30 · Reactions Z / 30`.
- [ ] Hover the `AQS · rules` badge — verify tier-explanation tooltip.
- [ ] Verify lazy-mount: open page on Compose, watch Network tab, confirm `/v1/linkedin-content/engagers` is NOT requested until Audience tab is clicked.
- [ ] Empty-state path: business with zero ingested comments — renders "No engagers yet" message, not an error.
- [ ] Skeleton path: throttle network, open Audience tab, verify skeleton renders.
- [ ] Tab persistence: switch tabs back and forth — verify the panel doesn't refetch on every switch (TanStack staleTime).

## Depends on

- peakhour-api #229 (merged) — `GET /v1/linkedin-content/engagers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
