### PR TITLE
feat(onboarding): wire launch -> generate-from-profile + Suggested Drafts panel on LinkedIn dashboard

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -48,11 +48,30 @@ const HAS_ORG_SCOPE = "w_organization_social";
 
 interface Props {
   identity: LinkedInIdentity;
+  /** When set to a non-empty string, the composer loads it as the
+   *  current text. Used by the Suggested Drafts panel above the
+   *  composer to populate "Use this draft." The composer only seeds on
+   *  *value change* (tracked via a ref) so re-renders with the same
+   *  string don't blow away user edits. Empty/undefined values are
+   *  ignored entirely. */
+  seedText?: string;
 }
 
-export function PostComposer({ identity }: Props) {
+export function PostComposer({ identity, seedText }: Props) {
   const queryClient = useQueryClient();
   const [text, setText] = useState("");
+
+  // Seed the composer when the parent passes a fresh seedText (e.g.,
+  // the user clicked "Use this draft" on the Suggested Drafts panel).
+  // A ref tracks the last seed we applied so we don't overwrite the
+  // user's in-progress edits on every parent re-render.
+  const lastSeedRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (seedText && seedText !== lastSeedRef.current) {
+      lastSeedRef.current = seedText;
+      setText(seedText);
+    }
+  }, [seedText]);
   const [visibility, setVisibility] = useState<LinkedInVisibility>("PUBLIC");
   const [showLink, setShowLink] = useState(false);
   const [linkUrl, setLinkUrl] = useState("");

--- a/src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDown, Sparkles, X } from "lucide-react";
+import type {
+  GenerateFromProfileResponse,
+  SuggestedDraft,
+} from "@/lib/api/linkedin-content";
+
+/**
+ * SUGGESTED_DRAFTS_QUERY_KEY — the cache key shared with the onboarding
+ * launch page. The launch page writes the generate-from-profile result
+ * via `queryClient.setQueryData(SUGGESTED_DRAFTS_QUERY_KEY, response)`;
+ * this panel reads it back via `useQuery` with the same key + a
+ * `queryFn` that resolves to `null` when no data is in cache yet
+ * (no network call — this is pure in-memory state coordination).
+ *
+ * Page refresh clears the cache, which is intentional for v1: the
+ * suggested-drafts surface is a "just-onboarded" affordance, not a
+ * persistent queue. The drafts themselves persist in `cnt_drafts`
+ * (status="ready", source="ai_generated") and a future iteration will
+ * fetch them from `/v1/content/library` so the panel survives reloads.
+ */
+export const SUGGESTED_DRAFTS_QUERY_KEY = ["linkedin-suggested-drafts"] as const;
+
+interface Props {
+  /** Called when the user clicks "Use this draft" — the parent threads
+   *  the post text into the PostComposer's seedText prop. */
+  onUseDraft: (text: string) => void;
+}
+
+/**
+ * SuggestedDraftsPanel — surfaces the LinkedIn post drafts generated
+ * at onboarding completion. Empty state (no cached drafts) renders
+ * nothing — the panel just disappears, the composer takes the full
+ * width. After the user clicks "Use this draft" on a card, the card
+ * is dismissed (locally) and the composer receives the text.
+ *
+ * The panel is intentionally non-modal — the user can browse drafts
+ * while typing in the composer. Side-by-side suggestion + authoring
+ * matches how the user actually works.
+ */
+export function SuggestedDraftsPanel({ onUseDraft }: Props) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(true);
+  // Locally-dismissed draftIds — once a user picks a draft (or X's it),
+  // it disappears from this panel but stays in cnt_drafts so it's still
+  // discoverable from the broader Drafts list (when that surface lands).
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+
+  // staleTime: Infinity — the cache is populated synchronously by the
+  // launch page; we never refetch in this panel (no network query to
+  // make — the data is hand-fed). Empty initialData lets the panel
+  // render the "no drafts" branch cleanly before anything's stashed.
+  const { data } = useQuery<GenerateFromProfileResponse | null>({
+    queryKey: SUGGESTED_DRAFTS_QUERY_KEY,
+    queryFn: () => null,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  const drafts = (data?.posts ?? []).filter((d) => !dismissedIds.has(d.draftId));
+  if (drafts.length === 0) return null;
+
+  function dismiss(draftId: string) {
+    setDismissedIds((prev) => {
+      const next = new Set(prev);
+      next.add(draftId);
+      return next;
+    });
+    // If the user dismisses everything, drop the cache entry so the
+    // panel doesn't reappear on next tab switch via stale cache.
+    if (drafts.length === 1) {
+      queryClient.setQueryData(SUGGESTED_DRAFTS_QUERY_KEY, null);
+    }
+  }
+
+  function use(draft: SuggestedDraft) {
+    const composed = `${draft.hook}\n\n${draft.body}`;
+    onUseDraft(composed);
+    dismiss(draft.draftId);
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <Card className="border-primary/20 bg-primary/5">
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer flex-row items-center justify-between gap-3 space-y-0 py-3">
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-4 text-primary" />
+              <h3 className="text-base leading-none font-semibold">
+                Suggested for you
+              </h3>
+              <Badge
+                variant="outline"
+                className="border-primary/40 text-[10px] uppercase tracking-wide"
+              >
+                {drafts.length} draft{drafts.length === 1 ? "" : "s"}
+              </Badge>
+            </div>
+            <ChevronDown
+              className={`size-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
+            />
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent className="pt-0 pb-4">
+            <p className="mb-3 text-xs text-muted-foreground">
+              We drafted these from your business profile. Click <em>Use this draft</em> to load one into the composer; you can edit, then publish.
+            </p>
+            <ol className="space-y-2">
+              {drafts.map((draft, i) => (
+                <SuggestedDraftCard
+                  key={draft.draftId}
+                  rank={i + 1}
+                  draft={draft}
+                  onUse={() => use(draft)}
+                  onDismiss={() => dismiss(draft.draftId)}
+                />
+              ))}
+            </ol>
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
+  );
+}
+
+const ANGLE_LABEL: Record<SuggestedDraft["angle"], string> = {
+  industry_insight: "Industry insight",
+  customer_story: "Customer story",
+  thought_leadership: "Thought leadership",
+  product_or_service_highlight: "Product highlight",
+  behind_the_scenes: "Behind the scenes",
+  trend_observation: "Trend observation",
+  founder_personal: "Founder personal",
+  data_point: "Data point",
+  lessons_learned: "Lessons learned",
+  how_to_practical: "How-to",
+};
+
+function SuggestedDraftCard({
+  rank,
+  draft,
+  onUse,
+  onDismiss,
+}: {
+  rank: number;
+  draft: SuggestedDraft;
+  onUse: () => void;
+  onDismiss: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const tierBadgeText =
+    draft.hookScore.tier === "rules"
+      ? "rules"
+      : draft.hookScore.tier === "industry"
+        ? "industry"
+        : "personal";
+
+  return (
+    <li className="rounded-md border bg-card">
+      <div className="flex items-start gap-3 p-3">
+        <span className="w-5 shrink-0 pt-0.5 text-xs tabular-nums text-muted-foreground">
+          {rank}.
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="block w-full text-left"
+            aria-expanded={expanded}
+          >
+            <p
+              className={`whitespace-pre-line text-sm font-medium ${expanded ? "" : "line-clamp-2"}`}
+            >
+              {draft.hook}
+            </p>
+          </button>
+          {expanded && (
+            <p className="whitespace-pre-line text-xs text-muted-foreground">
+              {draft.body}
+            </p>
+          )}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+            <Badge
+              variant="secondary"
+              className="text-[10px] uppercase tracking-wide"
+            >
+              {ANGLE_LABEL[draft.angle]}
+            </Badge>
+            {draft.audienceSegment ? (
+              <span>for {draft.audienceSegment}</span>
+            ) : null}
+            <span
+              title={`Frequency ${draft.hookScore.breakdown.length} / Opener ${draft.hookScore.breakdown.opener} / Specific ${draft.hookScore.breakdown.specificData} / Audience ${draft.hookScore.breakdown.audienceNoun} / Active ${draft.hookScore.breakdown.activeVoice} / Rhythm ${draft.hookScore.breakdown.rhythm}`}
+            >
+              Hook DNA {draft.hookScore.score}/100 ·{" "}
+              <span className="uppercase">{tierBadgeText}</span>
+            </span>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            onClick={onUse}
+            className="h-7 text-xs"
+          >
+            Use this draft
+          </Button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Dismiss this suggestion"
+            title="Dismiss this suggestion"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </div>
+      {draft.rationale ? (
+        <p
+          className="border-t px-3 py-2 text-[11px] italic text-muted-foreground"
+          title={draft.rationale}
+        >
+          {draft.rationale}
+        </p>
+      ) : null}
+    </li>
+  );
+}

--- a/src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx
@@ -11,26 +11,28 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ChevronDown, Sparkles, X } from "lucide-react";
-import type {
-  GenerateFromProfileResponse,
-  SuggestedDraft,
+import {
+  SUGGESTED_DRAFTS_QUERY_KEY,
+  type GenerateFromProfileResponse,
+  type SuggestedDraft,
 } from "@/lib/api/linkedin-content";
 
 /**
- * SUGGESTED_DRAFTS_QUERY_KEY — the cache key shared with the onboarding
- * launch page. The launch page writes the generate-from-profile result
- * via `queryClient.setQueryData(SUGGESTED_DRAFTS_QUERY_KEY, response)`;
- * this panel reads it back via `useQuery` with the same key + a
- * `queryFn` that resolves to `null` when no data is in cache yet
- * (no network call — this is pure in-memory state coordination).
- *
- * Page refresh clears the cache, which is intentional for v1: the
- * suggested-drafts surface is a "just-onboarded" affordance, not a
- * persistent queue. The drafts themselves persist in `cnt_drafts`
- * (status="ready", source="ai_generated") and a future iteration will
- * fetch them from `/v1/content/library` so the panel survives reloads.
+ * Cache lifecycle for the SuggestedDraftsPanel:
+ *   • Launch page writes the generate-from-profile response into the
+ *     TanStack cache under SUGGESTED_DRAFTS_QUERY_KEY (re-exported from
+ *     the api-client module so launch + panel share a neutral source).
+ *   • This panel reads from the cache via useQuery with enabled:false +
+ *     initialData:null — pure cache reader, no queryFn invocation.
+ *   • Dismissals are persisted into the cache itself (mutated via
+ *     setQueryData) so the dismissed state survives tab switches and
+ *     route navigation within the session. Page refresh clears the
+ *     cache entirely — intentional for v1; the suggested-drafts surface
+ *     is a "just-onboarded" affordance, not a persistent queue. The
+ *     drafts themselves persist in cnt_drafts (status="ready",
+ *     source="ai_generated") and a future iteration will fetch them
+ *     from /v1/content/library so the panel survives reloads.
  */
-export const SUGGESTED_DRAFTS_QUERY_KEY = ["linkedin-suggested-drafts"] as const;
 
 interface Props {
   /** Called when the user clicks "Use this draft" — the parent threads
@@ -52,36 +54,39 @@ interface Props {
 export function SuggestedDraftsPanel({ onUseDraft }: Props) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(true);
-  // Locally-dismissed draftIds — once a user picks a draft (or X's it),
-  // it disappears from this panel but stays in cnt_drafts so it's still
-  // discoverable from the broader Drafts list (when that surface lands).
-  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
 
-  // staleTime: Infinity — the cache is populated synchronously by the
-  // launch page; we never refetch in this panel (no network query to
-  // make — the data is hand-fed). Empty initialData lets the panel
-  // render the "no drafts" branch cleanly before anything's stashed.
+  // Pure cache reader — no network call, no queryFn invocation. The
+  // launch page populates the cache via setQueryData; this panel only
+  // reads from it. enabled:false + initialData:null means useQuery
+  // never runs a fetch and renders the "no drafts" branch cleanly on
+  // first mount before the launch page has stashed anything.
   const { data } = useQuery<GenerateFromProfileResponse | null>({
     queryKey: SUGGESTED_DRAFTS_QUERY_KEY,
-    queryFn: () => null,
+    enabled: false,
+    initialData: null,
     staleTime: Infinity,
     gcTime: Infinity,
   });
 
-  const drafts = (data?.posts ?? []).filter((d) => !dismissedIds.has(d.draftId));
+  const drafts = data?.posts ?? [];
   if (drafts.length === 0) return null;
 
+  // Dismissals mutate the cache directly so they survive tab switches
+  // and route navigation within the session (component-local useState
+  // would reset on remount, re-showing dismissed drafts). One source
+  // of truth: the TanStack cache.
   function dismiss(draftId: string) {
-    setDismissedIds((prev) => {
-      const next = new Set(prev);
-      next.add(draftId);
-      return next;
-    });
-    // If the user dismisses everything, drop the cache entry so the
-    // panel doesn't reappear on next tab switch via stale cache.
-    if (drafts.length === 1) {
-      queryClient.setQueryData(SUGGESTED_DRAFTS_QUERY_KEY, null);
-    }
+    queryClient.setQueryData<GenerateFromProfileResponse | null>(
+      SUGGESTED_DRAFTS_QUERY_KEY,
+      (prev) => {
+        if (!prev) return prev;
+        const remaining = prev.posts.filter((p) => p.draftId !== draftId);
+        // Last draft dismissed → null the cache so the panel hides
+        // permanently for this session.
+        if (remaining.length === 0) return null;
+        return { ...prev, posts: remaining };
+      },
+    );
   }
 
   function use(draft: SuggestedDraft) {
@@ -160,12 +165,10 @@ function SuggestedDraftCard({
   onDismiss: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const tierBadgeText =
-    draft.hookScore.tier === "rules"
-      ? "rules"
-      : draft.hookScore.tier === "industry"
-        ? "industry"
-        : "personal";
+  // Fallback to a humanised version of the raw angle key if the server
+  // returns an angle that isn't in our local map (schema drift safety).
+  const angleLabel =
+    ANGLE_LABEL[draft.angle] ?? draft.angle.replace(/_/g, " ");
 
   return (
     <li className="rounded-md border bg-card">
@@ -196,16 +199,16 @@ function SuggestedDraftCard({
               variant="secondary"
               className="text-[10px] uppercase tracking-wide"
             >
-              {ANGLE_LABEL[draft.angle]}
+              {angleLabel}
             </Badge>
             {draft.audienceSegment ? (
               <span>for {draft.audienceSegment}</span>
             ) : null}
             <span
-              title={`Frequency ${draft.hookScore.breakdown.length} / Opener ${draft.hookScore.breakdown.opener} / Specific ${draft.hookScore.breakdown.specificData} / Audience ${draft.hookScore.breakdown.audienceNoun} / Active ${draft.hookScore.breakdown.activeVoice} / Rhythm ${draft.hookScore.breakdown.rhythm}`}
+              title={`Length ${draft.hookScore.breakdown.length} / Opener ${draft.hookScore.breakdown.opener} / Specific ${draft.hookScore.breakdown.specificData} / Audience ${draft.hookScore.breakdown.audienceNoun} / Active ${draft.hookScore.breakdown.activeVoice} / Rhythm ${draft.hookScore.breakdown.rhythm}`}
             >
               Hook DNA {draft.hookScore.score}/100 ·{" "}
-              <span className="uppercase">{tierBadgeText}</span>
+              <span className="uppercase">{draft.hookScore.tier}</span>
             </span>
           </div>
         </div>

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -14,6 +14,7 @@ import {
   useLinkedInIdentity,
 } from "./_components/post-composer";
 import { AudiencePanel } from "./_components/audience-panel";
+import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
 
 interface ApiIntegration {
   provider: string;
@@ -135,6 +136,11 @@ function LinkedInTabs({
 }) {
   const [tab, setTab] = useState<"compose" | "audience">("compose");
   const [audienceOpened, setAudienceOpened] = useState(false);
+  // Composer seed text — set when the user clicks "Use this draft" on
+  // the Suggested Drafts panel. PostComposer accepts this as a prop and
+  // seeds its internal text state when the value changes (tracked via
+  // ref inside the composer so re-renders don't blow away edits).
+  const [composerSeed, setComposerSeed] = useState<string | undefined>(undefined);
 
   function handleTabChange(value: string) {
     if (value === "compose" || value === "audience") {
@@ -154,17 +160,21 @@ function LinkedInTabs({
         </TabsTrigger>
       </TabsList>
 
-      <TabsContent value="compose" className="mt-4">
+      <TabsContent value="compose" className="mt-4 space-y-4">
+        <SuggestedDraftsPanel onUseDraft={setComposerSeed} />
         <Card>
           <CardContent className="p-5">
             {identity.isLoading || !enabledIdentity?.data ? (
               <PostComposerSkeleton />
             ) : (
-              <PostComposer identity={enabledIdentity.data} />
+              <PostComposer
+                identity={enabledIdentity.data}
+                seedText={composerSeed}
+              />
             )}
           </CardContent>
         </Card>
-        <p className="mt-3 text-xs text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           Text + link posts only for now — carousels, polls, and scheduling are coming.
         </p>
       </TabsContent>

--- a/src/app/onboarding/launch/page.tsx
+++ b/src/app/onboarding/launch/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/providers/auth-provider";
 import { api, ApiError } from "@/lib/api";
+import { linkedInContentApi } from "@/lib/api/linkedin-content";
+import { SUGGESTED_DRAFTS_QUERY_KEY } from "@/app/dashboard/content/linkedin/_components/suggested-drafts-panel";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -132,6 +135,42 @@ export default function LaunchPage() {
       refreshUser().catch(() => { /* non-critical */ });
     }
   }, [isDone, isFailed, refreshUser]);
+
+  // Fire-and-forget the LinkedIn suggested-drafts generation when
+  // discovery finishes successfully. The result is stashed in the
+  // TanStack Query cache under SUGGESTED_DRAFTS_QUERY_KEY so the
+  // SuggestedDraftsPanel on the LinkedIn dashboard renders the drafts
+  // immediately when the user navigates there.
+  //
+  // A ref tracks whether we've already fired so polling-driven
+  // re-renders of isDone (refreshUser → user-doc state churn → status
+  // re-renders) don't accidentally fire generate twice.
+  //
+  // No toast / no progress UI on this page — keeping it silent because
+  // the dashboard is the better place to surface the result, and a
+  // mid-flight toast on the launch page distracts from the "you're
+  // all set" hero.
+  const queryClient = useQueryClient();
+  const generateFiredRef = useRef(false);
+  useEffect(() => {
+    if (!isDone) return;
+    if (generateFiredRef.current) return;
+    generateFiredRef.current = true;
+    linkedInContentApi
+      .generateFromProfile()
+      .then((response) => {
+        queryClient.setQueryData(SUGGESTED_DRAFTS_QUERY_KEY, response);
+      })
+      .catch((err) => {
+        // Non-blocking — the rest of onboarding completes regardless.
+        // Drafts are a nice-to-have at launch; the user can ask for
+        // fresh drafts later from the LinkedIn dashboard.
+        console.warn(
+          "[onboarding/launch] generateFromProfile failed:",
+          err instanceof Error ? err.message : err,
+        );
+      });
+  }, [isDone, queryClient]);
 
   const completedSet = useMemo(
     () => new Set(status?.phasesCompleted ?? []),

--- a/src/app/onboarding/launch/page.tsx
+++ b/src/app/onboarding/launch/page.tsx
@@ -5,8 +5,7 @@ import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/providers/auth-provider";
 import { api, ApiError } from "@/lib/api";
-import { linkedInContentApi } from "@/lib/api/linkedin-content";
-import { SUGGESTED_DRAFTS_QUERY_KEY } from "@/app/dashboard/content/linkedin/_components/suggested-drafts-panel";
+import { linkedInContentApi, SUGGESTED_DRAFTS_QUERY_KEY } from "@/lib/api/linkedin-content";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -142,9 +141,19 @@ export default function LaunchPage() {
   // SuggestedDraftsPanel on the LinkedIn dashboard renders the drafts
   // immediately when the user navigates there.
   //
+  // No LinkedIn OAuth required for this call — the server-side endpoint
+  // generates from BusinessContext + voice card alone. Drafts persist
+  // in cnt_drafts regardless of whether the user has connected
+  // LinkedIn; they're publishable once the connection lands.
+  //
   // A ref tracks whether we've already fired so polling-driven
   // re-renders of isDone (refreshUser → user-doc state churn → status
   // re-renders) don't accidentally fire generate twice.
+  //
+  // Gated on `org` being defined — the user's currently-selected
+  // business is read from the session on the server side, but if the
+  // AuthProvider's session refresh hasn't propagated yet, a 403 is the
+  // worst case and is swallowed by the catch below.
   //
   // No toast / no progress UI on this page — keeping it silent because
   // the dashboard is the better place to surface the result, and a
@@ -154,6 +163,7 @@ export default function LaunchPage() {
   const generateFiredRef = useRef(false);
   useEffect(() => {
     if (!isDone) return;
+    if (!org?._id) return;
     if (generateFiredRef.current) return;
     generateFiredRef.current = true;
     linkedInContentApi
@@ -170,7 +180,7 @@ export default function LaunchPage() {
           err instanceof Error ? err.message : err,
         );
       });
-  }, [isDone, queryClient]);
+  }, [isDone, org?._id, queryClient]);
 
   const completedSet = useMemo(
     () => new Set(status?.phasesCompleted ?? []),

--- a/src/app/onboarding/launch/page.tsx
+++ b/src/app/onboarding/launch/page.tsx
@@ -54,7 +54,7 @@ const POLL_INTERVAL_MS = 3000;
 
 export default function LaunchPage() {
   const router = useRouter();
-  const { org, refreshUser } = useAuth();
+  const { org, business, refreshUser } = useAuth();
   // Read sessionStorage in the initializer so we don't render the
   // "We're working on it" hero for one tick before redirecting a
   // returning user. Guard `typeof window` for SSR safety even though
@@ -150,10 +150,18 @@ export default function LaunchPage() {
   // re-renders of isDone (refreshUser → user-doc state churn → status
   // re-renders) don't accidentally fire generate twice.
   //
-  // Gated on `org` being defined — the user's currently-selected
-  // business is read from the session on the server side, but if the
-  // AuthProvider's session refresh hasn't propagated yet, a 403 is the
-  // worst case and is swallowed by the catch below.
+  // Gated on `business?._id` (not just `org`). The api endpoint requires
+  // a selected businessId on the server-side principal; the AuthProvider
+  // auto-resolves single-business users by calling switchBusiness AFTER
+  // refreshUser returns, and switchBusiness in turn calls
+  // queryClient.clear() to wipe stale cache. If we fire generate before
+  // business?._id has stabilised, we hit two races:
+  //   1. The api 403s with FORBIDDEN ("Active business required")
+  //   2. Even on success, the in-flight setQueryData lands BEFORE the
+  //      auto-resolve's queryClient.clear(), which then wipes the cache
+  //      and the LinkedIn dashboard sees nothing.
+  // Gating on business?._id ensures the auto-resolve has completed
+  // before we fire — both races avoided.
   //
   // No toast / no progress UI on this page — keeping it silent because
   // the dashboard is the better place to surface the result, and a
@@ -163,7 +171,7 @@ export default function LaunchPage() {
   const generateFiredRef = useRef(false);
   useEffect(() => {
     if (!isDone) return;
-    if (!org?._id) return;
+    if (!business?._id) return;
     if (generateFiredRef.current) return;
     generateFiredRef.current = true;
     linkedInContentApi
@@ -180,7 +188,7 @@ export default function LaunchPage() {
           err instanceof Error ? err.message : err,
         );
       });
-  }, [isDone, org?._id, queryClient]);
+  }, [isDone, business?._id, queryClient]);
 
   const completedSet = useMemo(
     () => new Set(status?.phasesCompleted ?? []),

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -192,6 +192,15 @@ export interface EngagersResponse {
   lookbackDays: number;
 }
 
+/** Shared TanStack Query cache key for the LinkedIn suggested-drafts
+ *  surface. Producer: `onboarding/launch/page.tsx` writes the
+ *  generate-from-profile response via `queryClient.setQueryData`.
+ *  Consumer: `SuggestedDraftsPanel` on the LinkedIn dashboard reads
+ *  from the same key. Lives in the api-client module so both
+ *  consumers reach a neutral location (not a Next.js `_components`
+ *  private folder). */
+export const SUGGESTED_DRAFTS_QUERY_KEY = ["linkedin-suggested-drafts"] as const;
+
 export const linkedInContentApi = {
   me: () => api.get<LinkedInIdentity>("/v1/linkedin-content/me"),
 

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -257,9 +257,10 @@ export const linkedInContentApi = {
 
 /** One generated LinkedIn post draft returned by `generateFromProfile`.
  *  Mirrors the api's response shape exactly — `draftId` is the
- *  cnt_drafts._id the server inserted; the b2c reads it back via the
- *  drafts list endpoint once the user navigates away from the in-memory
- *  cache. */
+ *  cnt_drafts._id the server inserted. A future drafts-list endpoint
+ *  will let the b2c re-fetch persisted drafts after the in-memory
+ *  cache clears (page refresh); for now the panel only surfaces drafts
+ *  during the session in which they were generated. */
 export interface SuggestedDraft {
   /** ObjectId hex of the cnt_drafts row the server persisted. */
   draftId: string;

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -232,4 +232,66 @@ export const linkedInContentApi = {
       `/v1/linkedin-content/engagers${q ? `?${q}` : ""}`,
     );
   },
+
+  /** Generate N initial LinkedIn post drafts grounded in the active
+   *  business's profile + voice card + cohort archetype. Persists each
+   *  as a cnt_drafts row server-side and returns them in the response.
+   *  Designed to fire once on onboarding completion (and on-demand
+   *  from a "generate more" button later). Server clamps count to
+   *  [1, 10]; defaults to 5 when omitted. */
+  generateFromProfile: (count?: number) =>
+    api.post<GenerateFromProfileResponse>(
+      "/v1/linkedin-content/generate-from-profile",
+      count !== undefined ? { count } : {},
+    ),
 };
+
+/** One generated LinkedIn post draft returned by `generateFromProfile`.
+ *  Mirrors the api's response shape exactly — `draftId` is the
+ *  cnt_drafts._id the server inserted; the b2c reads it back via the
+ *  drafts list endpoint once the user navigates away from the in-memory
+ *  cache. */
+export interface SuggestedDraft {
+  /** ObjectId hex of the cnt_drafts row the server persisted. */
+  draftId: string;
+  /** First 1-3 lines of the post (above the See-more cut). */
+  hook: string;
+  /** Remainder of the post body. */
+  body: string;
+  /** Generator-picked angle — narrow enum on the server. */
+  angle:
+    | "industry_insight"
+    | "customer_story"
+    | "thought_leadership"
+    | "product_or_service_highlight"
+    | "behind_the_scenes"
+    | "trend_observation"
+    | "founder_personal"
+    | "data_point"
+    | "lessons_learned"
+    | "how_to_practical";
+  /** Optional audience segment from the business's taxonomy this post
+   *  was tuned for. Surface in a card subtitle when present. */
+  audienceSegment?: string;
+  /** Optional CTA the generator suggests appending. Kept out of body
+   *  so the user can pick whether to include it without re-editing. */
+  suggestedCta?: string;
+  /** One-sentence reason the post fits — surfaces in a hover/tooltip. */
+  rationale: string;
+  /** Full Hook DNA score for the post's hook. */
+  hookScore: HookScore;
+}
+
+export interface GenerateFromProfileResponse {
+  posts: SuggestedDraft[];
+  metadata: {
+    usedVoiceCard: boolean;
+    voiceCardVersion?: number;
+    /** Cohort IDs the business is currently matched to. Each post's
+     *  hookScore.archetypeMatch.cohortId tells which one Tier B
+     *  actually used for THAT post (may differ across posts in the
+     *  batch). */
+    businessCohortIds: string[];
+    usedBusinessContext: boolean;
+  };
+}


### PR DESCRIPTION
## Summary

Closes the **onboarding-to-content loop**. After discovery completes on `/onboarding/launch`, the b2c fires `POST /v1/linkedin-content/generate-from-profile` (peakhour-api #231). The response stashes in TanStack cache; the LinkedIn dashboard renders a new **Suggested for you** panel above the composer with the freshly generated posts. Click "Use this draft" → text loads into the composer → user edits + publishes.

**Workstream G1 from `linkedin-end-to-end-phase-2-plan.md`.**

## What ships

| File | Change |
|---|---|
| `src/lib/api/linkedin-content.ts` | NEW `generateFromProfile()` method + `SuggestedDraft` / `GenerateFromProfileResponse` types + `SUGGESTED_DRAFTS_QUERY_KEY` (shared cache key) |
| `src/app/onboarding/launch/page.tsx` | Fires `generateFromProfile` once when discovery transitions to `done` AND `org?._id` exists; caches the result via `setQueryData`. Non-blocking — failures swallowed with a `console.warn`. |
| `src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx` | NEW collapsible panel. Pure cache reader (`enabled:false` + `initialData:null`). Renders cards: hook, angle badge, audience segment, Hook DNA score+tier. Actions: "Use this draft" (loads into composer), X dismiss (mutates cache so it survives tab switches), expand to read body + rationale. |
| `src/app/dashboard/content/linkedin/_components/post-composer.tsx` | Accepts new optional `seedText` prop. `useRef`-tracked apply so re-renders with the same string don't blow away in-progress edits. |
| `src/app/dashboard/content/linkedin/page.tsx` | Compose tab renders `SuggestedDraftsPanel` above `PostComposer`; threads `composerSeed` state between them. |

## Cache lifecycle

In-memory only for v1. Page refresh clears the panel; the drafts persist in `cnt_drafts` (`status="ready"`, `source="ai_generated"`). A future iteration will fetch from `/v1/content/library` so the panel survives reloads.

Dismissals mutate the cache itself (not component-local state), so dismissed drafts survive tab switches and route navigation within the session.

## Compliance posture

Customer's own content, drafted for their own approval, on their own LinkedIn account. The panel surfaces only drafts generated from the connected business's own `BusinessContext` + voice card. No third-party LinkedIn data is touched. (Inherits the api endpoint's compliance posture from peakhour-api #231.)

## Review notes

### Caught + fixed in review #1
- Dismiss state didn't survive remount — now persisted in cache via `setQueryData`
- Cross-route private-folder import — `SUGGESTED_DRAFTS_QUERY_KEY` moved to `lib/api/linkedin-content.ts`
- Wasteful `queryFn:()=>null` — switched to `enabled:false + initialData:null`
- Launch generate didn't gate on `org?._id` — now gated
- ANGLE_LABEL undefined fallback for schema-drift safety
- "Frequency" mislabel in score tooltip — fixed to "Length"
- Redundant tier-label ternary removed

### Documented (not in this PR)
- Silent failure UX — `console.warn` only on generate failure. Acceptable v1; a follow-up can surface a retry CTA on the LinkedIn page when cache is empty and onboarding recently completed.
- Pre-existing `effectiveVisibility` controlled-Select drift in PostComposer (flagged by review #1, not introduced here).

## Test plan

- [ ] Fresh user signs up + completes onboarding (URL/prompt/etc) → lands on launch page → polls discovery → status:"done" → console shows generate-from-profile fired
- [ ] Click "Open my dashboard" → navigate to `/dashboard/content/linkedin` → Suggested for you panel renders with 5 cards
- [ ] Click "Use this draft" on a card → composer textarea populates with hook + body; card disappears from panel
- [ ] Click X on a different card → card disappears; remaining cards stay
- [ ] Switch to Audience tab → back to Compose → panel still shows the not-dismissed remainder (cache persistence)
- [ ] Dismiss all cards → panel disappears; subsequent tab switches don't bring it back
- [ ] Refresh page → panel is gone (in-memory cache cleared, intentional for v1)
- [ ] User who completes onboarding without LinkedIn connection → generate still fires (no LinkedIn OAuth required); drafts visible in panel; publish button gated by composer's identity check (existing behaviour)
- [ ] Re-completed onboarding (rare) → ref-guarded fire-once doesn't double-trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
