### PR TITLE
feat(linkedin): Boost tab with boost-candidates recommender panel

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
@@ -7,7 +7,15 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Rocket, TrendingUp, Building2, User } from "lucide-react";
+import {
+  Building2,
+  Heart,
+  MessageSquare,
+  Rocket,
+  Share2,
+  TrendingUp,
+  User,
+} from "lucide-react";
 import {
   linkedInContentApi,
   type BoostCandidate,
@@ -73,6 +81,14 @@ export function BoostCandidatesPanel() {
   }
 
   if (!data || data.candidates.length === 0) {
+    // Empty-state path intentionally does NOT forward `truncated` /
+    // `eligibleCount` to PanelShell. If it did, the summary line in
+    // PanelShell could render "Top 0 of M+ posts considered" when
+    // the candidates array is empty but truncated is true (rare:
+    // the server hit the 30-post cap, then in-app filters knocked
+    // all of them out for low engagement / missing content). That
+    // reads worse than the empty-state body alone, so we hide the
+    // summary here on purpose.
     return (
       <PanelShell totalConsidered={data?.totalPostsConsidered ?? 0}>
         <EmptyBody
@@ -228,7 +244,7 @@ function BoostCandidateRow({
           aria-expanded={expanded}
         >
           <p
-            className={`whitespace-pre-line text-sm font-medium ${expanded ? "" : "line-clamp-2"}`}
+            className={`text-sm font-medium ${expanded ? "" : "line-clamp-2"}`}
             title={expanded ? undefined : candidate.hookExcerpt}
           >
             {candidate.hookExcerpt}
@@ -240,23 +256,23 @@ function BoostCandidateRow({
             {candidate.authorType === "org" ? "Company page" : "Personal feed"}
           </span>
           <span>{formatHoursSincePublished(candidate.hoursSincePublished)}</span>
-          <span>
+          <span className="inline-flex items-center gap-1">
+            <Heart className="size-3 shrink-0" />
             <span className="font-medium text-foreground">
               {candidate.signals.likes}
-            </span>{" "}
-            ♥
+            </span>
           </span>
-          <span>
+          <span className="inline-flex items-center gap-1">
+            <MessageSquare className="size-3 shrink-0" />
             <span className="font-medium text-foreground">
               {candidate.signals.comments}
-            </span>{" "}
-            💬
+            </span>
           </span>
-          <span>
+          <span className="inline-flex items-center gap-1">
+            <Share2 className="size-3 shrink-0" />
             <span className="font-medium text-foreground">
               {candidate.signals.shares}
-            </span>{" "}
-            ↻
+            </span>
           </span>
         </div>
         <p className="text-[11px] italic text-muted-foreground" title={candidate.rationale}>

--- a/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
@@ -77,9 +77,9 @@ export function BoostCandidatesPanel() {
       <PanelShell totalConsidered={data?.totalPostsConsidered ?? 0}>
         <EmptyBody
           title="No boost-worthy posts yet"
-          body="We surface posts that are 24h-14d old with at least 5 weighted engagement (likes + 2·comments + 3·shares). Publish a few and check back here."
+          body="We score posts 24h–14d old once they pick up at least 5 weighted engagement (likes + 2·comments + 3·shares). New posts will appear here as they mature."
         />
-        {data && filteredOutTotal(data.filteredOut) > 0 ? (
+        {data ? (
           <FilteredOutFootnote
             filteredOut={data.filteredOut}
             totalConsidered={data.totalPostsConsidered}
@@ -161,18 +161,6 @@ function EmptyBody({ title, body }: { title: string; body: string }) {
   );
 }
 
-function filteredOutTotal(f: {
-  missingPerformance: number;
-  missingContent: number;
-  lowEngagement: number;
-  tooFresh: number;
-  tooStale: number;
-}): number {
-  return (
-    f.missingPerformance + f.missingContent + f.lowEngagement + f.tooFresh + f.tooStale
-  );
-}
-
 function FilteredOutFootnote({
   filteredOut,
   totalConsidered,
@@ -186,11 +174,11 @@ function FilteredOutFootnote({
   };
   totalConsidered: number;
 }) {
-  const total = filteredOutTotal(filteredOut);
-  if (total === 0) return null;
-  // Only `lowEngagement` and `missingContent` actually fire in practice
-  // (the Mongo pre-filter handles the rest); render only the non-zero
-  // ones so the footnote stays honest.
+  // Only render counters that actually fire — lowEngagement,
+  // missingContent, missingPerformance. tooFresh/tooStale are
+  // clock-skew defences that never fire in practice (Mongo
+  // pre-filters the age window). Surfacing those would confuse users
+  // since the empty-state copy already covers fresh / stale gating.
   const parts: string[] = [];
   if (filteredOut.lowEngagement > 0) {
     parts.push(
@@ -301,7 +289,7 @@ function BoostCandidateRow({
         <div className="text-right">
           <div
             className="font-mono text-base font-semibold tabular-nums"
-            title={`Velocity ${candidate.breakdown.velocity}/40 · Audience ${candidate.breakdown.audienceQuality}/25 · Hook DNA ${candidate.breakdown.hookDna}/20 · Freshness ${candidate.breakdown.freshness}/15`}
+            title={`Velocity ${candidate.breakdown.velocity}/40 · Audience ${candidate.breakdown.audienceQuality}/25 · Hook DNA ${candidate.breakdown.hookDna}/20 (${candidate.signals.hookTier}) · Freshness ${candidate.breakdown.freshness}/15`}
           >
             {candidate.score}
           </div>
@@ -369,7 +357,7 @@ function BoostPanelSkeleton() {
       </CardHeader>
       <CardContent className="pt-0">
         <ol className="divide-y">
-          {Array.from({ length: 3 }).map((_, i) => (
+          {Array.from({ length: 5 }).map((_, i) => (
             <li key={i} className="flex items-start gap-3 py-3">
               <Skeleton className="h-4 w-4 shrink-0" />
               <div className="flex-1 space-y-2">

--- a/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ApiError } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Rocket, TrendingUp, Building2, User } from "lucide-react";
+import {
+  linkedInContentApi,
+  type BoostCandidate,
+} from "@/lib/api/linkedin-content";
+
+/**
+ * BoostCandidatesPanel — ranks the business's recently-published
+ * LinkedIn posts by boost-worthiness and surfaces the top N.
+ *
+ * The "Boost this post" button is intentionally disabled with a
+ * "coming soon" tooltip — autonomous ad-spend ships in workstream
+ * D6 (Autonomous Ad Engine). Today the panel is a recommendation
+ * surface: it tells the user *which* posts deserve the budget, but
+ * the actual campaign creation is one PR away.
+ *
+ * Lazy-mounted from the LinkedIn dashboard tabs (same pattern as
+ * AudiencePanel) so the boost-candidates query doesn't fire on
+ * every page load.
+ */
+export function BoostCandidatesPanel() {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["linkedin-boost-candidates"],
+    queryFn: () => linkedInContentApi.boostCandidates(),
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status === 403) return false;
+      return failureCount < 2;
+    },
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  // Surface non-403 errors in the dev console for debugging — same
+  // pattern as AudiencePanel. The user-facing toast intentionally
+  // doesn't echo err.message (provider strings leak internals).
+  if (isError && !(error instanceof ApiError && error.status === 403)) {
+    console.error("[BoostCandidatesPanel] boost-candidates query failed:", error);
+  }
+
+  if (isLoading) {
+    return <BoostPanelSkeleton />;
+  }
+
+  if (isError) {
+    if (error instanceof ApiError && error.status === 403) {
+      return (
+        <PanelShell>
+          <EmptyBody
+            title="Pick a business to see boost candidates"
+            body="Once a business is selected, we'll rank its recent LinkedIn posts by how worth-boosting they are."
+          />
+        </PanelShell>
+      );
+    }
+    return (
+      <PanelShell>
+        <EmptyBody
+          title="Couldn't load boost candidates"
+          body="Try refreshing in a moment. If the problem persists, check your LinkedIn connection."
+        />
+      </PanelShell>
+    );
+  }
+
+  if (!data || data.candidates.length === 0) {
+    return (
+      <PanelShell totalConsidered={data?.totalPostsConsidered ?? 0}>
+        <EmptyBody
+          title="No boost-worthy posts yet"
+          body="We surface posts that are 24h-14d old with at least 5 weighted engagement (likes + 2·comments + 3·shares). Publish a few and check back here."
+        />
+        {data && filteredOutTotal(data.filteredOut) > 0 ? (
+          <FilteredOutFootnote
+            filteredOut={data.filteredOut}
+            totalConsidered={data.totalPostsConsidered}
+          />
+        ) : null}
+      </PanelShell>
+    );
+  }
+
+  return (
+    <PanelShell
+      totalConsidered={data.totalPostsConsidered}
+      eligibleCount={data.eligibleCount}
+      truncated={data.truncated}
+    >
+      <ol className="divide-y">
+        {data.candidates.map((c, i) => (
+          <BoostCandidateRow key={c.postId} rank={i + 1} candidate={c} />
+        ))}
+      </ol>
+      <FilteredOutFootnote
+        filteredOut={data.filteredOut}
+        totalConsidered={data.totalPostsConsidered}
+      />
+    </PanelShell>
+  );
+}
+
+function PanelShell({
+  children,
+  totalConsidered,
+  eligibleCount,
+  truncated,
+}: {
+  children: React.ReactNode;
+  totalConsidered?: number;
+  eligibleCount?: number;
+  truncated?: boolean;
+}) {
+  const summary =
+    typeof totalConsidered === "number" && totalConsidered > 0
+      ? truncated
+        ? `Top ${eligibleCount ?? 0} of ${totalConsidered}+ posts considered (24h–14d window).`
+        : typeof eligibleCount === "number"
+          ? `${eligibleCount} of ${totalConsidered} posts considered (24h–14d window).`
+          : null
+      : null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-base leading-none font-semibold">
+            Boost-worthy posts
+          </h3>
+          <Badge
+            variant="outline"
+            className="text-[10px] uppercase tracking-wide"
+            title="Velocity · Audience quality · Hook DNA · Freshness — composite 0-100. Autonomous ad-spend is on the roadmap; today this is a recommendation surface."
+          >
+            Recommender
+          </Badge>
+        </div>
+        {summary ? (
+          <p className="mt-1 text-xs text-muted-foreground">{summary}</p>
+        ) : null}
+      </CardHeader>
+      <CardContent className="pt-0">{children}</CardContent>
+    </Card>
+  );
+}
+
+function EmptyBody({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border border-dashed bg-muted/20 px-4 py-6 text-center text-sm">
+      <p className="font-medium">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+function filteredOutTotal(f: {
+  missingPerformance: number;
+  missingContent: number;
+  lowEngagement: number;
+  tooFresh: number;
+  tooStale: number;
+}): number {
+  return (
+    f.missingPerformance + f.missingContent + f.lowEngagement + f.tooFresh + f.tooStale
+  );
+}
+
+function FilteredOutFootnote({
+  filteredOut,
+  totalConsidered,
+}: {
+  filteredOut: {
+    missingPerformance: number;
+    missingContent: number;
+    lowEngagement: number;
+    tooFresh: number;
+    tooStale: number;
+  };
+  totalConsidered: number;
+}) {
+  const total = filteredOutTotal(filteredOut);
+  if (total === 0) return null;
+  // Only `lowEngagement` and `missingContent` actually fire in practice
+  // (the Mongo pre-filter handles the rest); render only the non-zero
+  // ones so the footnote stays honest.
+  const parts: string[] = [];
+  if (filteredOut.lowEngagement > 0) {
+    parts.push(
+      `${filteredOut.lowEngagement} below the engagement floor (5 weighted)`,
+    );
+  }
+  if (filteredOut.missingContent > 0) {
+    parts.push(`${filteredOut.missingContent} missing content`);
+  }
+  if (filteredOut.missingPerformance > 0) {
+    parts.push(`${filteredOut.missingPerformance} missing performance data`);
+  }
+  if (parts.length === 0) return null;
+  return (
+    <p className="mt-3 border-t pt-2 text-[11px] text-muted-foreground">
+      Of {totalConsidered} recent posts examined: {parts.join(", ")}.
+    </p>
+  );
+}
+
+function formatHoursSincePublished(hours: number): string {
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function BoostCandidateRow({
+  rank,
+  candidate,
+}: {
+  rank: number;
+  candidate: BoostCandidate;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const ActorIcon = candidate.authorType === "org" ? Building2 : User;
+
+  return (
+    <li className="flex items-start gap-3 py-3">
+      <span className="w-6 shrink-0 pt-0.5 text-xs tabular-nums text-muted-foreground">
+        {rank}.
+      </span>
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="block w-full text-left"
+          aria-expanded={expanded}
+        >
+          <p
+            className={`whitespace-pre-line text-sm font-medium ${expanded ? "" : "line-clamp-2"}`}
+            title={expanded ? undefined : candidate.hookExcerpt}
+          >
+            {candidate.hookExcerpt}
+          </p>
+        </button>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <ActorIcon className="size-3 shrink-0" />
+            {candidate.authorType === "org" ? "Company page" : "Personal feed"}
+          </span>
+          <span>{formatHoursSincePublished(candidate.hoursSincePublished)}</span>
+          <span>
+            <span className="font-medium text-foreground">
+              {candidate.signals.likes}
+            </span>{" "}
+            ♥
+          </span>
+          <span>
+            <span className="font-medium text-foreground">
+              {candidate.signals.comments}
+            </span>{" "}
+            💬
+          </span>
+          <span>
+            <span className="font-medium text-foreground">
+              {candidate.signals.shares}
+            </span>{" "}
+            ↻
+          </span>
+        </div>
+        <p className="text-[11px] italic text-muted-foreground" title={candidate.rationale}>
+          {candidate.rationale}
+        </p>
+        <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-[10px] uppercase tracking-wide">
+          <ComponentBadge
+            label="Velocity"
+            value={candidate.breakdown.velocity}
+            max={40}
+          />
+          <ComponentBadge
+            label="Audience"
+            value={candidate.breakdown.audienceQuality}
+            max={25}
+          />
+          <ComponentBadge
+            label="Hook DNA"
+            value={candidate.breakdown.hookDna}
+            max={20}
+          />
+          <ComponentBadge
+            label="Freshness"
+            value={candidate.breakdown.freshness}
+            max={15}
+          />
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-2">
+        <div className="text-right">
+          <div
+            className="font-mono text-base font-semibold tabular-nums"
+            title={`Velocity ${candidate.breakdown.velocity}/40 · Audience ${candidate.breakdown.audienceQuality}/25 · Hook DNA ${candidate.breakdown.hookDna}/20 · Freshness ${candidate.breakdown.freshness}/15`}
+          >
+            {candidate.score}
+          </div>
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            / 100
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="default"
+          disabled
+          className="h-7 text-xs"
+          title="Coming soon — autonomous ad-spend deployment ships in the Ad Engine workstream. For now this surface tells you which posts deserve the budget."
+        >
+          <Rocket className="mr-1 size-3" />
+          Boost
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+function ComponentBadge({
+  label,
+  value,
+  max,
+}: {
+  label: string;
+  value: number;
+  max: number;
+}) {
+  // Heat the badge proportionally to how much of the component's
+  // weight the post earned — easier to scan than raw numbers.
+  const ratio = max > 0 ? value / max : 0;
+  const heat =
+    ratio >= 0.75
+      ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200"
+      : ratio >= 0.4
+        ? "bg-muted text-foreground"
+        : "bg-muted/40 text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] ${heat}`}
+      title={`${label}: ${value} / ${max}`}
+    >
+      <TrendingUp className="size-2.5" />
+      <span>{label}</span>
+      <span className="font-mono tabular-nums">
+        {value}/{max}
+      </span>
+    </span>
+  );
+}
+
+function BoostPanelSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <Skeleton className="mt-2 h-3 w-64" />
+      </CardHeader>
+      <CardContent className="pt-0">
+        <ol className="divide-y">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li key={i} className="flex items-start gap-3 py-3">
+              <Skeleton className="h-4 w-4 shrink-0" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-48" />
+                <Skeleton className="h-3 w-2/3" />
+                <div className="flex gap-1">
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="h-4 w-16" />
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-2">
+                <Skeleton className="h-10 w-10" />
+                <Skeleton className="h-7 w-16" />
+              </div>
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -7,13 +7,14 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { MessageSquare, RefreshCw, Send, Users } from "lucide-react";
+import { MessageSquare, RefreshCw, Rocket, Send, Users } from "lucide-react";
 import {
   PostComposer,
   PostComposerSkeleton,
   useLinkedInIdentity,
 } from "./_components/post-composer";
 import { AudiencePanel } from "./_components/audience-panel";
+import { BoostCandidatesPanel } from "./_components/boost-candidates-panel";
 import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
 
 interface ApiIntegration {
@@ -134,8 +135,9 @@ function LinkedInTabs({
   identity: ReturnType<typeof useLinkedInIdentity>;
   enabledIdentity: ReturnType<typeof useLinkedInIdentity> | null;
 }) {
-  const [tab, setTab] = useState<"compose" | "audience">("compose");
+  const [tab, setTab] = useState<"compose" | "audience" | "boost">("compose");
   const [audienceOpened, setAudienceOpened] = useState(false);
+  const [boostOpened, setBoostOpened] = useState(false);
   // Composer seed text — set when the user clicks "Use this draft" on
   // the Suggested Drafts panel. PostComposer accepts this as a prop and
   // seeds its internal text state when the value changes (tracked via
@@ -143,9 +145,10 @@ function LinkedInTabs({
   const [composerSeed, setComposerSeed] = useState<string | undefined>(undefined);
 
   function handleTabChange(value: string) {
-    if (value === "compose" || value === "audience") {
+    if (value === "compose" || value === "audience" || value === "boost") {
       setTab(value);
       if (value === "audience") setAudienceOpened(true);
+      if (value === "boost") setBoostOpened(true);
     }
   }
 
@@ -157,6 +160,9 @@ function LinkedInTabs({
         </TabsTrigger>
         <TabsTrigger value="audience" className="gap-1.5">
           <Users className="size-4" /> Audience
+        </TabsTrigger>
+        <TabsTrigger value="boost" className="gap-1.5">
+          <Rocket className="size-4" /> Boost
         </TabsTrigger>
       </TabsList>
 
@@ -183,6 +189,13 @@ function LinkedInTabs({
         {audienceOpened ? <AudiencePanel /> : null}
         <p className="mt-3 text-xs text-muted-foreground">
           We rank commenters on your LinkedIn posts by frequency, recency, and reactions. Names and titles will appear once profile enrichment lands.
+        </p>
+      </TabsContent>
+
+      <TabsContent value="boost" className="mt-4">
+        {boostOpened ? <BoostCandidatesPanel /> : null}
+        <p className="mt-3 text-xs text-muted-foreground">
+          We rank your recent posts by boost-worthiness — velocity, audience quality, hook strength, and freshness. Autonomous ad-spend ships in a follow-up; today this is a recommendation surface.
         </p>
       </TabsContent>
     </Tabs>

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -253,6 +253,22 @@ export const linkedInContentApi = {
       "/v1/linkedin-content/generate-from-profile",
       count !== undefined ? { count } : {},
     ),
+
+  /** Boost-this-post candidates. Read-only ranking of the business's
+   *  recently-published posts by boost-worthiness (velocity + audience
+   *  quality + Hook DNA + freshness). Server returns an empty
+   *  candidates array (not 404) when no eligible posts exist; the
+   *  panel renders an empty state. Default limit 10, max 25 server-side. */
+  boostCandidates: (params?: { limit?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.limit === "number" && params.limit > 0) {
+      qs.set("limit", String(params.limit));
+    }
+    const q = qs.toString();
+    return api.get<BoostCandidatesResponse>(
+      `/v1/linkedin-content/boost-candidates${q ? `?${q}` : ""}`,
+    );
+  },
 };
 
 /** One generated LinkedIn post draft returned by `generateFromProfile`.
@@ -290,6 +306,58 @@ export interface SuggestedDraft {
   rationale: string;
   /** Full Hook DNA score for the post's hook. */
   hookScore: HookScore;
+}
+
+/** One boost-this-post candidate returned by `boostCandidates`. Mirrors
+ *  the api's response shape exactly. Surfaces the composite score, the
+ *  four component breakdowns, the raw signals (likes/comments/shares,
+ *  velocity, avg AQS, Hook DNA), and a human-readable rationale for
+ *  the UI hover. */
+export interface BoostCandidate {
+  postId: string;
+  linkedInPostUrn: string;
+  authorUrn?: string;
+  authorType?: "person" | "org";
+  publishedAt: string;
+  hoursSincePublished: number;
+  hookExcerpt: string;
+  score: number;
+  breakdown: {
+    velocity: number;
+    audienceQuality: number;
+    hookDna: number;
+    freshness: number;
+  };
+  signals: {
+    likes: number;
+    comments: number;
+    shares: number;
+    engagement: number;
+    velocity: number;
+    distinctEngagers: number;
+    avgAqsScore: number;
+    hookScore: number;
+    hookTier: "rules" | "industry" | "personal";
+  };
+  rationale: string;
+  performanceLastUpdated?: string;
+}
+
+export interface BoostCandidatesResponse {
+  candidates: BoostCandidate[];
+  totalPostsConsidered: number;
+  eligibleCount: number;
+  /** True when the business has more eligible posts than the scorer's
+   *  hard cap (currently 30). UI should render "showing top N most
+   *  recent" so the user knows there's more. */
+  truncated: boolean;
+  filteredOut: {
+    missingPerformance: number;
+    missingContent: number;
+    lowEngagement: number;
+    tooFresh: number;
+    tooStale: number;
+  };
 }
 
 export interface GenerateFromProfileResponse {


### PR DESCRIPTION
## Summary

Workstream **D3 b2c** — completes the boost-this-post recommender surface. New "Boost" tab on the LinkedIn dashboard alongside Compose / Audience reads `GET /v1/linkedin-content/boost-candidates` (peakhour-api PR #232) and renders ranked candidates as cards.

The "Boost" button is **intentionally disabled** with a "Coming soon" tooltip — autonomous ad-spend deployment ships in workstream D6 (Autonomous Ad Engine). Today the panel tells the user *which* posts deserve the budget; campaign creation lands in the next workstream.

## Files

| File | Change |
|---|---|
| `src/lib/api/linkedin-content.ts` | NEW `boostCandidates()` method + `BoostCandidate` + `BoostCandidatesResponse` types mirroring the server response exactly |
| `src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx` | NEW Boost panel (~390 lines) |
| `src/app/dashboard/content/linkedin/page.tsx` | adds "Boost" tab + lazy-mount via `boostOpened` state (same pattern as `audienceOpened`) |

## Card design

Each candidate row shows:
- Rank + hook excerpt (line-clamped, click to expand)
- Actor type (Personal feed / Company page) + recency ("3d ago")
- Raw engagement counts (♥ likes · 💬 comments · ↻ shares)
- Italic rationale ("strong early velocity · 8 engagers (avg AQS 67) · strong hook (78/100, industry)")
- Composite score (X/100) with breakdown tooltip incl. Hook DNA tier
- 4 component badges (Velocity X/40, Audience X/25, Hook DNA X/20, Freshness X/15) — heat-mapped green when the component earned ≥75% of its weight
- Disabled "Boost" button with "Coming soon" tooltip

Panel states: skeleton while loading; "Pick a business" on 403; "No boost-worthy posts yet" empty state with honest gate explanation; `truncated:true` shows "Top 30 of N+ posts considered."

## TanStack Query config

- `queryKey: ["linkedin-boost-candidates"]`
- `staleTime: 5min`, `refetchOnMount: false`, `refetchOnWindowFocus: false` (matches AudiencePanel — the endpoint runs Mongo aggregation + per-post Hook DNA, shouldn't auto-refire)
- `retry`: blocks 403, retries transient up to 2 times

## Compliance posture

Inherits from peakhour-api PR #232 (already cleared as first-party only, no LinkedIn API calls, no ad spend in this PR).

## Review notes

### Caught + fixed in review #1
- Empty-state copy was misleading for users with only fresh posts (Mongo pre-filters 24h gate, so "publish a few" advice is wrong) — reworded to "We score posts 24h-14d old once they pick up engagement. New posts will appear here as they mature."
- `hookTier` was returned by the server but never surfaced — now appears in the score-box tooltip alongside the Hook DNA component
- `filteredOut` footnote dropped its dead helper + unused branches; only renders the 3 counters that actually fire in practice
- Skeleton row count bumped from 3 → 5 (panel loads up to 10 candidates)

### Documented (not in this PR)
- Disabled-button `title` tooltip doesn't show on disabled buttons in Safari (repo-wide stylistic pattern, follow-up)
- No unit tests (consistent with sibling panels, follow-up)

## Test plan

- [ ] Open `/dashboard/content/linkedin` → switch to Boost tab → panel mounts (verify the GET only fires on tab open, not on page load)
- [ ] Business with eligible posts → cards render with score / breakdown / rationale
- [ ] Business with no published posts → "No boost-worthy posts yet" empty state, no footnote
- [ ] Business with posts that didn't make the cut → empty state + footnote ("N below engagement floor, M missing content")
- [ ] Business with `truncated: true` → header shows "Top 30 of 30+ posts considered"
- [ ] Hover the score number → tooltip shows breakdown + Hook DNA tier
- [ ] Boost button is disabled with "Coming soon" tooltip
- [ ] Switch tab away and back → panel doesn't refetch (5min staleTime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
