### PR TITLE
feat(onboarding): surface Google Business listing as a supported link type

### DIFF
--- a/src/app/onboarding/add-business/page.tsx
+++ b/src/app/onboarding/add-business/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/card";
 import { Sparkles, Globe, ArrowRight } from "lucide-react";
 import {
+  GoogleIcon,
   InstagramIcon,
   LinkedinIcon,
   YoutubeIcon,
@@ -50,6 +51,7 @@ interface ExtractResponse {
 
 const URL_EXAMPLES = [
   { label: "yourcompany.com", icon: Globe },
+  { label: "google.com/maps/place/…", icon: GoogleIcon },
   { label: "instagram.com/you", icon: InstagramIcon },
   { label: "linkedin.com/in/you", icon: LinkedinIcon },
   { label: "youtube.com/@you", icon: YoutubeIcon },
@@ -170,8 +172,9 @@ function AddBusinessContent() {
           Tell us about you
         </h1>
         <p className="text-lg text-muted-foreground">
-          Paste any link — your website, social profile, or newsletter.
-          We&apos;ll figure out the rest.
+          Paste any link — your website, your Google Business listing,
+          a social profile, or a newsletter. We&apos;ll figure out the
+          rest.
         </p>
       </div>
 
@@ -260,7 +263,7 @@ function AddBusinessContent() {
         <p className="text-center text-xs uppercase tracking-wider text-muted-foreground">
           What kinds of links work
         </p>
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
           {URL_EXAMPLES.map((ex) => (
             <div
               key={ex.label}


### PR DESCRIPTION
## Summary

B2 b2c side. Surfaces Google Business listing as a supported link type on the onboarding wizard. The api already resolves Maps URLs end-to-end via the Places API (peakhour-api PR #233); this PR is purely the user-visible affordance for discoverability.

## Changes

- `URL_EXAMPLES` gains a `google.com/maps/place/…` chip with the existing `GoogleIcon` brand mark
- Subtitle reworded: "your website, your Google Business listing, a social profile, or a newsletter"
- Grid bumped from `sm:grid-cols-4` → `sm:grid-cols-5` so all 5 chips fit on one row on desktop (was orphaning a 4+1 layout)

## What was already in place

- `KIND_LABEL.google_business = "Google Business listing"` ✓
- Live-classify chip ("Looks like a Google Business listing") already fires for Maps URLs ✓
- `POST /v1/onboarding/extract` already dispatches Maps URLs through the Places API (peakhour-api PR #233) ✓

No new state, no new API calls — discovery polish only.

## Test plan

- [ ] Paste a Google Maps URL → live-classify chip shows "Looks like a Google Business listing"
- [ ] Click Continue → extract succeeds (assuming `GOOGLE_PLACES_API_KEY` is configured server-side; falls through cleanly when not)
- [ ] "What kinds of links work" grid renders all 5 chips in one row on desktop, 2+2+1 on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
