### PR TITLE
feat(linkedin): retention disclosure — /help/data-retention + panel footnotes

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -10,6 +10,7 @@ import {
   linkedInContentApi,
   type EngagerScore,
 } from "@/lib/api/linkedin-content";
+import { RetentionFootnote } from "./retention-footnote";
 
 /**
  * AudiencePanel — surfaces the AQS Tier C ranking of recent LinkedIn
@@ -94,15 +95,31 @@ export function AudiencePanel() {
 
   return (
     <PanelShell
-      summary={`${data.totalComments} comment${data.totalComments === 1 ? "" : "s"} across ${data.distinctActors} engager${data.distinctActors === 1 ? "" : "s"} in the last ${data.lookbackDays} days`}
+      summary={`${data.totalComments} comment${data.totalComments === 1 ? "" : "s"} across ${data.distinctActors} engager${data.distinctActors === 1 ? "" : "s"} in the last ${formatLookback(data.lookbackDays)}`}
     >
       <ol className="divide-y">
         {data.engagers.map((engager, i) => (
           <EngagerRow key={engager.actorUrn} engager={engager} rank={i + 1} />
         ))}
       </ol>
+      <RetentionFootnote>
+        Comments are scored over the lookback window LinkedIn permits (48
+        hours by default).
+      </RetentionFootnote>
     </PanelShell>
   );
+}
+
+/** Render lookbackDays in the form a non-technical user reasons about.
+ *  2 = "48 hours" (the post-R1.2 default aligned with LinkedIn's 48h
+ *  Members' Social Activity ceiling); 1 is rendered as "24 hours" for
+ *  the corner case where ops overrides `?days=1`; everything else falls
+ *  through to "N days". Keeps the summary readable while letting ops
+ *  override the window without the UI claiming a different number. */
+function formatLookback(days: number): string {
+  if (days === 2) return "48 hours";
+  if (days === 1) return "24 hours";
+  return `${days} days`;
 }
 
 function PanelShell({
@@ -122,7 +139,7 @@ function PanelShell({
           <Badge
             variant="outline"
             className="text-[10px] uppercase tracking-wide"
-            title="Tier C floor — frequency, recency, and comment reactions. Profile enrichment (job title, seniority, ICP match) ships next."
+            title="Tier C floor — frequency, recency, and comment reactions, scored over the lookback window LinkedIn's data-retention rules permit (48 hours by default). Profile enrichment (job title, seniority, ICP match) ships next."
           >
             AQS · rules
           </Badge>

--- a/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
@@ -20,6 +20,7 @@ import {
   linkedInContentApi,
   type BoostCandidate,
 } from "@/lib/api/linkedin-content";
+import { RetentionFootnote } from "./retention-footnote";
 
 /**
  * BoostCandidatesPanel — ranks the business's recently-published
@@ -120,6 +121,11 @@ export function BoostCandidatesPanel() {
         filteredOut={data.filteredOut}
         totalConsidered={data.totalPostsConsidered}
       />
+      <RetentionFootnote>
+        Posts are scored 24h&ndash;14d after publication. Personal-feed
+        posts drop out at 48h under LinkedIn&apos;s Members&apos; Social
+        Activity rule; Company-Page posts run the full window.
+      </RetentionFootnote>
     </PanelShell>
   );
 }
@@ -154,7 +160,7 @@ function PanelShell({
           <Badge
             variant="outline"
             className="text-[10px] uppercase tracking-wide"
-            title="Velocity · Audience quality · Hook DNA · Freshness — composite 0-100. Autonomous ad-spend is on the roadmap; today this is a recommendation surface."
+            title="Velocity · Audience quality · Hook DNA · Freshness — composite 0-100. Posts are scored from 24 hours to 14 days after publication; for personal-feed posts the effective ceiling is 48 hours under LinkedIn's Members' Social Activity rule. Autonomous ad-spend is on the roadmap; today this is a recommendation surface."
           >
             Recommender
           </Badge>

--- a/src/app/dashboard/content/linkedin/_components/retention-footnote.tsx
+++ b/src/app/dashboard/content/linkedin/_components/retention-footnote.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+/**
+ * Shared retention-disclosure footnote for LinkedIn panels bounded by
+ * LinkedIn's Marketing API data-storage rules
+ * (https://learn.microsoft.com/en-us/linkedin/marketing/data-storage-requirements).
+ *
+ * The leading sentence varies per panel (engager scoring vs. boost
+ * scoring), so each call site supplies its own copy. The trailing
+ * "Why?" link is invariant — both panels point at /help/data-retention,
+ * which is the canonical user-facing explainer.
+ *
+ * Internal navigation uses `next/link` so the click stays on the
+ * dashboard shell (no full-page flash on the way to a static page).
+ */
+export function RetentionFootnote({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-3 border-t pt-2 text-[11px] text-muted-foreground">
+      {children}{" "}
+      <Link
+        href="/help/data-retention"
+        className="underline underline-offset-2 hover:text-foreground"
+      >
+        Why?
+      </Link>
+    </p>
+  );
+}

--- a/src/app/help/data-retention/page.tsx
+++ b/src/app/help/data-retention/page.tsx
@@ -1,0 +1,241 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE } from "@/lib/utils";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Data Retention - PeakHour",
+  description:
+    "How long PeakHour keeps the data it pulls from connected platforms, and why.",
+};
+
+/**
+ * Public /help/data-retention page. Surfaces LinkedIn's Marketing API
+ * data-storage rules in plain English so users can answer "why does
+ * this panel only show the last 48 hours?" without filing support.
+ * Updated whenever a new platform integration with its own retention
+ * windows ships — see the TODO marker on Section 5.
+ */
+export default function DataRetentionPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <h1 className="text-3xl font-bold">Data Retention</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: {SITE.legalLastUpdated}
+        </p>
+
+        <div className="mt-8 space-y-8 text-sm leading-relaxed text-muted-foreground">
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              1. Why some panels only show the last 48 hours
+            </h2>
+            <p className="mt-2">
+              Connected platforms (LinkedIn, Meta, X, and others) place limits
+              on how long partners are allowed to keep the data their APIs
+              return. PeakHour respects those limits. When a panel in your
+              dashboard says &ldquo;last 48 hours&rdquo; or &ldquo;last 2
+              days&rdquo;, that&apos;s not a product choice &mdash; it&apos;s
+              the platform&apos;s data-storage rule.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              2. LinkedIn retention windows
+            </h2>
+            <p className="mt-2">
+              LinkedIn&apos;s Marketing API rules
+              (
+              <a
+                href="https://learn.microsoft.com/en-us/linkedin/marketing/data-storage-requirements"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                published here
+              </a>
+              ) classify the data in three groups. PeakHour applies the
+              corresponding storage limit to each:
+            </p>
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full border-collapse text-left text-xs">
+                <thead>
+                  <tr className="border-b text-foreground">
+                    <th className="py-2 pr-4 font-medium">Data type</th>
+                    <th className="py-2 pr-4 font-medium">
+                      What it includes
+                    </th>
+                    <th className="py-2 font-medium">PeakHour retention</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  <tr>
+                    <td className="py-3 pr-4 align-top text-foreground">
+                      Members&apos; social activity
+                    </td>
+                    <td className="py-3 pr-4 align-top">
+                      Comments and reactions from individual LinkedIn members
+                      on your posts; personal-feed posts from members.
+                    </td>
+                    <td className="py-3 align-top">
+                      <span className="font-medium text-foreground">
+                        48 hours
+                      </span>{" "}
+                      after collection.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="py-3 pr-4 align-top text-foreground">
+                      Organization social activity
+                    </td>
+                    <td className="py-3 pr-4 align-top">
+                      Posts from a LinkedIn Company Page that you, the
+                      authenticated administrator, manage through PeakHour.
+                    </td>
+                    <td className="py-3 align-top">
+                      <span className="font-medium text-foreground">
+                        6 months
+                      </span>{" "}
+                      after collection (authenticated-organization
+                      allowance).
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="py-3 pr-4 align-top text-foreground">
+                      Aggregated marketing data
+                    </td>
+                    <td className="py-3 pr-4 align-top">
+                      Statistics derived from the data above &mdash; counts,
+                      scores, recency markers &mdash; alongside the stable
+                      LinkedIn URN identifiers needed to join those scores
+                      back to a person or page over time. We do not retain
+                      raw comment text or third-party profile fields under
+                      this allowance.
+                    </td>
+                    <td className="py-3 align-top">
+                      <span className="font-medium text-foreground">
+                        No fixed limit
+                      </span>{" "}
+                      (LinkedIn&apos;s aggregated-marketing-data
+                      exception).
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-4">
+              A platform-wide cleanup runs every 6 hours and deletes anything
+              past its window. Re-running the cleanup is safe; it never
+              touches data inside the window.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              3. What this means for your dashboard
+            </h2>
+            <ul className="mt-2 list-disc space-y-2 pl-6">
+              <li>
+                <span className="font-medium text-foreground">
+                  Top engagers (LinkedIn):
+                </span>{" "}
+                ranked from comments collected in the last 48 hours. People
+                who commented earlier are still counted in their aggregate
+                engager score (frequency, recency, reactions) &mdash; you
+                just don&apos;t see the raw comment text once it ages past
+                48 hours.
+              </li>
+              <li>
+                <span className="font-medium text-foreground">
+                  Boost-worthy posts (LinkedIn):
+                </span>{" "}
+                posts become eligible 24 hours after publication and are
+                scored for up to 14 days. Company Page posts run the full
+                window. Personal-feed posts have an effective ceiling of
+                48 hours under the Members&apos; Social Activity rule
+                above &mdash; they are dropped by the cleanup before the
+                14-day scoring window closes.
+              </li>
+              <li>
+                <span className="font-medium text-foreground">
+                  Long-term trends:
+                </span>{" "}
+                preserved through aggregated scores and counts that update
+                on every sync. The trend survives even though the raw
+                comment-by-comment trail does not.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              4. Disconnecting a LinkedIn account
+            </h2>
+            <p className="mt-2">
+              When you disconnect a LinkedIn account from PeakHour, we
+              stop calling the LinkedIn API on its behalf. The
+              social-activity rows we already collected drop out at the
+              next scheduled cleanup under the same retention rules
+              described above. Aggregated, derivative scores that
+              don&apos;t reveal member-level information may remain in
+              your business&apos;s analytics history.
+            </p>
+          </section>
+
+          {/*
+            TODO(retention-disclosure): When the next platform integration
+            (Meta, X, TikTok) ships a dashboard backed by its own
+            retention rules, add a per-platform section here with the same
+            three-row structure as §2. The Header/Footer chrome and the
+            §1 framing are intentionally platform-agnostic so only this
+            section needs to grow. Don't let this page silently rot —
+            check it on every platform-integration PR.
+          */}
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              5. Other platforms
+            </h2>
+            <p className="mt-2">
+              Today this page covers LinkedIn, the only platform whose
+              dashboard PeakHour ships to users. Meta, X, and other
+              platforms each publish their own data-retention rules. As
+              PeakHour adds dashboards for each platform, this page will
+              gain a section per platform with the same structure as the
+              LinkedIn table above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              6. Questions
+            </h2>
+            <p className="mt-2">
+              Anything unclear? Reach out through{" "}
+              <Link
+                href="/contact"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Contact
+              </Link>
+              . For the full picture of what PeakHour stores and why, see
+              the{" "}
+              <Link
+                href="/privacy-policy"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/help/data-retention/page.tsx
+++ b/src/app/help/data-retention/page.tsx
@@ -143,11 +143,9 @@ export default function DataRetentionPage() {
                 <span className="font-medium text-foreground">
                   Top engagers (LinkedIn):
                 </span>{" "}
-                ranked from comments collected in the last 48 hours. People
-                who commented earlier are still counted in their aggregate
-                engager score (frequency, recency, reactions) &mdash; you
-                just don&apos;t see the raw comment text once it ages past
-                48 hours.
+                ranked over the last 48 hours of comment activity. Once a
+                comment ages past the window it is deleted and no longer
+                contributes to the ranking.
               </li>
               <li>
                 <span className="font-medium text-foreground">
@@ -162,11 +160,13 @@ export default function DataRetentionPage() {
               </li>
               <li>
                 <span className="font-medium text-foreground">
-                  Long-term trends:
+                  Long-term trends (planned):
                 </span>{" "}
-                preserved through aggregated scores and counts that update
-                on every sync. The trend survives even though the raw
-                comment-by-comment trail does not.
+                under the aggregated-marketing-data allowance, PeakHour
+                will retain anonymous counts, scores, and recency markers
+                so the trend in engagement survives even after the raw
+                comment trail is deleted. The writer that populates this
+                aggregate ships in a follow-up release.
               </li>
             </ul>
           </section>

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -5,6 +5,7 @@ const FOOTER_LINKS = [
   { href: "/contact", label: "Contact" },
   { href: "/privacy-policy", label: "Privacy Policy" },
   { href: "/terms", label: "Terms of Service" },
+  { href: "/help/data-retention", label: "Data Retention" },
 ] as const;
 
 export function Footer() {


### PR DESCRIPTION
## Summary

R2 of the LinkedIn retention remediation. User-facing surface of the 48h / 6-month / aggregated-marketing-data classification that R1 wired into the cleanup cron (peakhour-api PR #235, peakhour-mongodb PRs #72/#73).

**New public page** `src/app/help/data-retention/page.tsx`:
- Same chrome as `/terms` and `/privacy-policy`. Linked from the global footer.
- §1 frames "why some panels only show the last 48h" for a non-technical reader.
- §2 maps LinkedIn's three data classes to PeakHour's storage limits, with a deep link to LinkedIn's published rules.
- §3 covers Audience + Boost panels — boost wording is the corrected "24h–14d window with an effective 48h ceiling on personal-feed posts" (review #1 caught that the recommender applies a uniform 24h–14d gate to both author types).
- §4 disconnect softened to what actually ships (next cleanup tick under the same rules; immediate on-disconnect cleanup is queued for a follow-up).
- §5 carries a `TODO(retention-disclosure)` marker for the next platform integration to add its own section.

**Shared component** `src/app/dashboard/content/linkedin/_components/retention-footnote.tsx`:
- Small "<lead sentence>  Why?" line pointing at `/help/data-retention` via `next/link`.
- Rendered under the populated state of `AudiencePanel` and `BoostCandidatesPanel`. Empty/error/loading states deliberately skip the footnote.

**Tooltip updates**:
- `AudiencePanel` AQS · rules badge — wording stays accurate when ops dial the window via `?days=`.
- `BoostCandidatesPanel` Recommender badge — corrected to the 24h–14d / 48h-ceiling phrasing.

**Footer** picks up `/help/data-retention` next to Privacy / Terms.

**No banner, no email.** No existing users on the platform yet; the public page + dashboard disclosure is the agreed-on surface.

## Review

Review #1 (subagent) caught one Critical (boost-window wording on the help page + boost panel) and six Suggested items — all applied in this PR before opening it:

- C1 — Section 3 + Recommender tooltip + footnote JSDoc rewritten to reflect the uniform 24h–14d window
- S2 — Aggregated-marketing-data row now says we keep the LinkedIn URN identifier alongside the derivative scores (honest about what's there)
- S3 — Disconnect section reflects the 6h cleanup pattern that actually shipped
- S4 — Internal anchors use `next/link` instead of `<a href>`
- S5 — `RetentionFootnote` lifted to a shared component
- S6 — TODO marker on §5 so the next platform integration doesn't silently rot the page
- N7 — AQS badge tooltip wording softened
- N8 — `formatLookback` JSDoc covers the `days===1` branch
- N9 — JSDoc on the page's default export

## Test plan

- [ ] Visit `/help/data-retention` directly — verify Header/Footer/`Last updated` stamp render and the LinkedIn retention table is readable on narrow viewports (overflow-x-auto)
- [ ] Click the new Data Retention link in the footer from a couple of pages (home, /pricing, /privacy-policy)
- [ ] Open `/dashboard/content/linkedin`, pick a business with LinkedIn data, confirm the AudiencePanel populated state shows the retention footnote and the "Why?" link client-routes (no flash) to the help page
- [ ] Same flow on the BoostCandidatesPanel populated state; confirm both `FilteredOutFootnote` and `RetentionFootnote` render under the candidate list when both apply
- [ ] Trigger the empty state in each panel (no comments / no boost-worthy posts) — confirm the retention footnote does NOT render there
- [ ] Hover both panel badges; confirm tooltip wording matches the corrected windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)