### PR TITLE
fix(auth): inFlightRef guard against double-submit — parity with cms PR #20

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { sendMagicLink } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
@@ -83,6 +83,14 @@ export default function AuthPage() {
   // isCoolingDown so the interval stops once status leaves the
   // cooldown states (sent / resending) or the component unmounts.
   const [now, setNow] = useState<number>(() => Date.now());
+  // Guards against fast double-submits — Enter-key mashing or
+  // duplicate click events during the click → render gap can fire
+  // two parallel sendMagicLink() calls before the disabled prop
+  // takes effect on the next paint, which results in two magic-link
+  // emails. The ref is mutated synchronously inside submit() so the
+  // second entry returns immediately. Cleared in a finally so a
+  // network failure still re-enables future submissions.
+  const inFlightRef = useRef(false);
 
   const isCoolingDown =
     status.kind === "sent" || status.kind === "resending";
@@ -109,6 +117,8 @@ export default function AuthPage() {
   }, [isCoolingDown]);
 
   async function submit(targetEmail: string, mode: "send" | "resend") {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     if (mode === "send") {
       setStatus({ kind: "submitting" });
     } else {
@@ -184,6 +194,8 @@ export default function AuthPage() {
       }
 
       setStatus({ kind: "error", message });
+    } finally {
+      inFlightRef.current = false;
     }
   }
 

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -142,8 +142,10 @@ export default function AuthPage() {
     // Remember the cooldown anchor BEFORE the await — `status` reads
     // inside the catch are stale closures over the pre-submit value,
     // but we want the cooldown that was active when the user clicked.
+    // Only meaningful for resends; on initial send we never read it.
     const cooldownAtAttempt =
-      status.kind === "sent" || status.kind === "resending"
+      mode === "resend" &&
+      (status.kind === "sent" || status.kind === "resending")
         ? status.cooldownEndsAt
         : Date.now() + RESEND_COOLDOWN_SECONDS * 1000;
 


### PR DESCRIPTION
## Summary

Byte-for-byte parity port of the inFlightRef fix that landed on [peakhour-cms PR #20](https://github.com/travelxp/peakhour-cms/pull/20) after that PR's round-2 review caught a real double-submit bug in the auth flow:

The Send button's \`disabled\` prop is gated on \`status.kind === \"submitting\"\`, but the disable only takes effect on the next paint. Between the synthetic click event firing and React committing the next render, a second event (Enter-key spam, mobile fast-tap, browser autofill+enter) can deliver another handleSubmit call → two parallel \`sendMagicLink()\` in-flight → two magic-link emails to the same user.

Same risk on Resend, though tighter (the button has additional cooldown gating).

Fix: \`useRef<boolean>\` mutated synchronously inside \`submit()\` before any await. The second entry returns immediately. Cleared in a finally so network failures still re-enable future submissions.

## Why this is a separate PR

PR #178 landed before round 2 of the CMS port surfaced this bug. The fix applies identically to both surfaces.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [ ] Mash Enter rapidly on the auth form — only one magic-link request fires
- [ ] Double-click Resend at cooldown end — only one request fires
- [ ] Network error during submit → next click still works (finally clears the ref)

🤖 Generated with [Claude Code](https://claude.com/claude-code)