### PR TITLE
fix(linkedin): point composer at /v1/linkedin/content/* (was 404)

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -438,7 +438,7 @@ const HOOK_SCORE_DEBOUNCE_MS = 400;
 const HOOK_SCORE_MIN_CHARS = 8;
 
 /**
- * Debounced hook scorer. Fires `POST /v1/linkedin-content/score-hook`
+ * Debounced hook scorer. Fires `POST /v1/linkedin/content/score-hook`
  * 400ms after the user stops typing. Pure-server function (no AI),
  * so the cost of getting it wrong is just a request, not a token bill.
  *

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -25,7 +25,7 @@ interface ApiIntegration {
 
 export default function LinkedInDashboardPage() {
   // Mirror the X hub's pattern — read /v1/integrations once for the
-  // top-level connect gate, then defer to /linkedin-content/me for
+  // top-level connect gate, then defer to /linkedin/content/me for
   // the picker data. Two queries because the integrations endpoint
   // gives us the lifecycle truth that lets us render an EmptyState
   // before /me would 404.

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -104,7 +104,7 @@ export interface RewriteHookResponse {
 
 /**
  * LinkedIn voice card surfaced to the composer. Narrow shape served by
- * `GET /v1/linkedin-content/voice-card` — audit fields + internal signals
+ * `GET /v1/linkedin/content/voice-card` — audit fields + internal signals
  * stripped server-side; this is exactly what the panel needs.
  */
 export interface LinkedInVoiceCard {
@@ -202,17 +202,17 @@ export interface EngagersResponse {
 export const SUGGESTED_DRAFTS_QUERY_KEY = ["linkedin-suggested-drafts"] as const;
 
 export const linkedInContentApi = {
-  me: () => api.get<LinkedInIdentity>("/v1/linkedin-content/me"),
+  me: () => api.get<LinkedInIdentity>("/v1/linkedin/content/me"),
 
   publish: (body: PublishLinkedInPostInput) =>
-    api.post<{ postId: string }>("/v1/linkedin-content/publish", body),
+    api.post<{ postId: string }>("/v1/linkedin/content/publish", body),
 
   scoreHook: (hook: string) =>
-    api.post<HookScore>("/v1/linkedin-content/score-hook", { hook }),
+    api.post<HookScore>("/v1/linkedin/content/score-hook", { hook }),
 
   rewriteHook: (hook: string, count?: number) =>
     api.post<RewriteHookResponse>(
-      "/v1/linkedin-content/rewrite-hook",
+      "/v1/linkedin/content/rewrite-hook",
       count !== undefined ? { hook, count } : { hook },
     ),
 
@@ -220,7 +220,7 @@ export const linkedInContentApi = {
    *  `code: "NOT_FOUND"` (404) means "no card yet" — caller should
    *  render an empty state, not surface an error. */
   voiceCard: () =>
-    api.get<LinkedInVoiceCard>("/v1/linkedin-content/voice-card"),
+    api.get<LinkedInVoiceCard>("/v1/linkedin/content/voice-card"),
 
   /** AQS-ranked recent engagers for the active business. Server returns
    *  an empty `engagers` array (not 404) when no comments have been
@@ -238,7 +238,7 @@ export const linkedInContentApi = {
     }
     const q = qs.toString();
     return api.get<EngagersResponse>(
-      `/v1/linkedin-content/engagers${q ? `?${q}` : ""}`,
+      `/v1/linkedin/content/engagers${q ? `?${q}` : ""}`,
     );
   },
 
@@ -250,7 +250,7 @@ export const linkedInContentApi = {
    *  [1, 10]; defaults to 5 when omitted. */
   generateFromProfile: (count?: number) =>
     api.post<GenerateFromProfileResponse>(
-      "/v1/linkedin-content/generate-from-profile",
+      "/v1/linkedin/content/generate-from-profile",
       count !== undefined ? { count } : {},
     ),
 
@@ -266,7 +266,7 @@ export const linkedInContentApi = {
     }
     const q = qs.toString();
     return api.get<BoostCandidatesResponse>(
-      `/v1/linkedin-content/boost-candidates${q ? `?${q}` : ""}`,
+      `/v1/linkedin/content/boost-candidates${q ? `?${q}` : ""}`,
     );
   },
 };


### PR DESCRIPTION
## Summary
- All 8 \`linkedInContentApi\` endpoints were hitting \`/v1/linkedin-content/*\` (hyphen). The API mounts at \`/v1/linkedin/content/*\` (slash) — see peakhour-api [routes/index.ts:104](https://github.com/travelxp/peakhour-api/blob/master/src/v1/routes/index.ts#L104). Every call 404'd.
- Find-and-replace \`/v1/linkedin-content/\` → \`/v1/linkedin/content/\` across 3 files (1 api client, 2 docstring/comment references)
- Sibling integrations (\`/v1/x/content/*\`, \`/v1/x/ads/*\`) already use slash — this brings linkedin_content in line

## Why this didn't bite until now
peakhour-api PR #238 (today) was the first time a linkedin_content OAuth attempt actually succeeded — prior consent attempts all failed at LinkedIn because of the OIDC vs Community Management API scope clash. Without a successful connection, the Content > LinkedIn page short-circuits to the EmptyState and never calls these endpoints. Once Vanshita got past consent, every composer call 404'd, surfacing as \"LinkedIn needs a quick reconnect\" — the /me 404 trips the identity error branch that assumes the connection is stale.

## Test plan
- [ ] Vanshita reloads \`/dashboard/content/linkedin\` — Reconnect prompt is gone
- [ ] /v1/linkedin/content/me returns 200 with her person + pages
- [ ] Composer renders with author picker populated (personal + any org Pages she admins)
- [ ] Posting to personal feed works
- [ ] Posting to Quests Page works (once she reconnects with Super Admin role per peakhour-api thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)