### PR TITLE
feat(linkedin): Page-names loading state + auto-polling

### DIFF
--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -1013,28 +1013,37 @@ function LinkedInContentPages({
     pages.every(
       (p: { organizationName?: string }) => !p.organizationName,
     );
-  const attemptsRef = useRef(0);
+  const [attempts, setAttempts] = useState(0);
+
+  // Latest-ref pattern: the parent passes a fresh `onRefresh` closure
+  // on every render (it's an inline `() => handleRefresh(provider)`),
+  // so depending on it directly would re-fire the effect on every
+  // parent re-render and reset the polling timer forever. Hold the
+  // latest ref and keep the effect depending only on real state.
+  const onRefreshRef = useRef(onRefresh);
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  });
 
   useEffect(() => {
     // Reset attempt count once names land — if the user later
     // disconnects + reconnects, the pending state re-opens with a
     // fresh budget.
     if (!namesPending) {
-      attemptsRef.current = 0;
+      if (attempts !== 0) setAttempts(0);
       return;
     }
     if (refreshing) return; // don't pile on while a refresh is in-flight
-    if (attemptsRef.current >= NAMES_POLL_MAX_ATTEMPTS) return;
+    if (attempts >= NAMES_POLL_MAX_ATTEMPTS) return;
 
     const id = setTimeout(() => {
-      attemptsRef.current += 1;
-      onRefresh();
+      setAttempts((a) => a + 1);
+      onRefreshRef.current();
     }, NAMES_POLL_INTERVAL_MS);
     return () => clearTimeout(id);
-  }, [namesPending, refreshing, onRefresh]);
+  }, [namesPending, refreshing, attempts]);
 
-  const showPollGaveUp =
-    namesPending && attemptsRef.current >= NAMES_POLL_MAX_ATTEMPTS;
+  const showPollGaveUp = namesPending && attempts >= NAMES_POLL_MAX_ATTEMPTS;
 
   return (
     <div className="space-y-1.5 rounded-md border border-border/40 p-2">
@@ -1057,7 +1066,11 @@ function LinkedInContentPages({
       </div>
 
       {namesPending && (
-        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
+        >
           <Loader2 className="h-2.5 w-2.5 animate-spin" />
           <span>
             {showPollGaveUp

--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@/providers/auth-provider";
 import { useLocale } from "@/hooks/use-locale";
 import { api, ApiError, API_BASE_URL } from "@/lib/api";
@@ -980,6 +980,14 @@ function BeehiivSyncControls({
 // promoted to Super Admin on a new client Page after their initial
 // Connect; one click here picks it up without OAuth round-trip.
 
+// Auto-poll cadence for the names-pending state: 10 sec between
+// attempts, max ~8 attempts (~80 sec) before giving up. peakhour-api's
+// linkedin_post_sync background job typically hydrates names within
+// ~1 min of OAuth callback (depends on jobs-runner cron interval), so
+// 80 sec gives us a comfortable margin.
+const NAMES_POLL_INTERVAL_MS = 10_000;
+const NAMES_POLL_MAX_ATTEMPTS = 8;
+
 function LinkedInContentPages({
   extra,
   onRefresh,
@@ -991,6 +999,42 @@ function LinkedInContentPages({
   refreshing: boolean;
 }) {
   const pages = Array.isArray(extra?.pages) ? extra.pages : [];
+
+  // The OAuth callback skips per-Page name hydration to redirect fast
+  // (peakhour-api PR #247). Names land within ~1 min via a background
+  // job. Detect the "pages exist but all unnamed" state and:
+  //   1. Show a "Fetching Page names from LinkedIn…" indicator so the
+  //      user sees it's an in-progress operation, not a bug
+  //   2. Auto-poll /refresh every 10 sec until names arrive (capped at
+  //      ~80 sec to avoid hammering the API if the background job
+  //      stalls — user can still click Refresh manually after that)
+  const namesPending =
+    pages.length > 0 &&
+    pages.every(
+      (p: { organizationName?: string }) => !p.organizationName,
+    );
+  const attemptsRef = useRef(0);
+
+  useEffect(() => {
+    // Reset attempt count once names land — if the user later
+    // disconnects + reconnects, the pending state re-opens with a
+    // fresh budget.
+    if (!namesPending) {
+      attemptsRef.current = 0;
+      return;
+    }
+    if (refreshing) return; // don't pile on while a refresh is in-flight
+    if (attemptsRef.current >= NAMES_POLL_MAX_ATTEMPTS) return;
+
+    const id = setTimeout(() => {
+      attemptsRef.current += 1;
+      onRefresh();
+    }, NAMES_POLL_INTERVAL_MS);
+    return () => clearTimeout(id);
+  }, [namesPending, refreshing, onRefresh]);
+
+  const showPollGaveUp =
+    namesPending && attemptsRef.current >= NAMES_POLL_MAX_ATTEMPTS;
 
   return (
     <div className="space-y-1.5 rounded-md border border-border/40 p-2">
@@ -1011,6 +1055,17 @@ function LinkedInContentPages({
           {refreshing ? "Refreshing" : "Refresh"}
         </Button>
       </div>
+
+      {namesPending && (
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <Loader2 className="h-2.5 w-2.5 animate-spin" />
+          <span>
+            {showPollGaveUp
+              ? "Page names still loading — tap Refresh to retry."
+              : "Fetching Page names from LinkedIn…"}
+          </span>
+        </div>
+      )}
 
       {pages.length > 0 && (
         <ul className="space-y-0.5 text-[10px] text-muted-foreground">


### PR DESCRIPTION
## Summary
Pairs with peakhour-api PR #247 which deferred Page-name hydration into a background job. Right after Connect, the tile would show pages with empty names for ~30-60 sec; without UX feedback the user might think the integration is broken. This PR:

- Detects \"pages exist but all unnamed\" state
- Shows an inline \"Fetching Page names from LinkedIn…\" indicator with a spinner
- Auto-polls /refresh every 10 sec until names land (max 8 attempts ≈ 80 sec)
- After cap, switches to \"tap Refresh to retry\" so user has manual recovery
- Resets attempt count once names arrive (fresh budget on next reconnect)
- Refresh button always works for manual triggering
- Polling gated on \`refreshing\` flag (no pile-on)

## Patterns
- **Latest-ref for onRefresh**: parent passes a fresh closure each render — depending on it would re-fire the effect on every parent re-render. Latest-ref decouples.
- **useState for attempts** (not useRef): so the "tap Refresh to retry" message updates immediately at the cap without relying on parent-driven re-renders.
- **a11y**: \`role=\"status\"\` + \`aria-live=\"polite\"\` on the loading message.

## Test plan
- [ ] After deploy + peakhour-api #247 deploy, Vanshita reconnects LinkedIn — sees \"Fetching Page names…\" spinner immediately
- [ ] Within ~1 min, names appear and the spinner disappears
- [ ] If background job stalls beyond ~80 sec, fallback message appears + manual Refresh works
- [ ] No console errors / re-render loops while polling
- [ ] Screen reader announces the status changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)