### PR TITLE
feat(marketing): country-aware /pricing + landing pricing section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { ArrowRight, Sparkles, Brain, Zap, BarChart3, Check } from "lucide-react";
+import { headers } from "next/headers";
+import { ArrowRight, Sparkles, Brain, Zap, BarChart3 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,6 +12,8 @@ import {
 } from "@/components/ui/card";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
+import { PricingGrid } from "@/components/marketing/pricing-grid";
+import { getPricing } from "@/lib/pricing";
 import {
   LinkedinIcon,
   FacebookIcon,
@@ -85,50 +88,18 @@ const INTEGRATIONS = [
   { name: "X (Twitter)", icon: TwitterIcon, color: "bg-black", description: "Posts & promoted content" },
 ] as const;
 
-const PLANS = [
-  {
-    name: "Free",
-    price: "0",
-    description: "See what AI can do with your content",
-    features: [
-      "50 content pieces tagged",
-      "Ad creative preview",
-      "Content gap analysis",
-    ],
-    cta: "Start free",
-    highlighted: false,
-  },
-  {
-    name: "Growth",
-    price: "7,499",
-    description: "Full AI marketing engine for growing businesses",
-    features: [
-      "Unlimited content tagging",
-      "2 ad platforms",
-      "Full optimization engine",
-      "Pattern mining & insights",
-      "Lead tracking",
-    ],
-    cta: "Get started",
-    highlighted: true,
-  },
-  {
-    name: "Pro",
-    price: "19,999",
-    description: "For businesses ready to scale aggressively",
-    features: [
-      "Everything in Growth",
-      "All ad platforms",
-      "Subscriber enrichment",
-      "Custom taxonomy",
-      "API access",
-    ],
-    cta: "Get started",
-    highlighted: false,
-  },
-] as const;
-
-export default function Home() {
+export default async function Home() {
+  // Country-aware pricing — resolves the visitor's country from the
+  // Vercel edge geo header (set on every prod/preview request) and
+  // fetches the corresponding pricing matrix from peakhour-api. The
+  // /pricing page uses the same helper; both surfaces stay in sync.
+  const h = await headers();
+  const vercelCountry = h.get("x-vercel-ip-country");
+  const country =
+    vercelCountry && /^[A-Za-z]{2}$/.test(vercelCountry)
+      ? vercelCountry.toUpperCase()
+      : "DEFAULT";
+  const pricing = await getPricing(country);
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
@@ -277,67 +248,29 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Pricing */}
+        {/* Pricing — country-aware, fetched server-side from
+            /v1/platform/pricing. Falls back to a CTA-only block when
+            the API is unreachable so the landing page never breaks
+            because pricing data is unavailable. */}
         <section id="pricing" className="py-20">
           <div className="container">
-            <div className="mx-auto max-w-5xl">
-              <div className="text-center">
-                <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
-                  Simple, transparent pricing
-                </h2>
-                <p className="mt-3 text-muted-foreground">
-                  Start free. Upgrade when you&apos;re ready to launch ads.
-                </p>
-              </div>
-              <div className="mt-12 grid gap-6 md:grid-cols-3">
-                {PLANS.map((plan) => (
-                  <Card
-                    key={plan.name}
-                    className={`relative transition-shadow hover:shadow-md ${
-                      plan.highlighted
-                        ? "border-primary shadow-lg ring-1 ring-primary/20"
-                        : ""
-                    }`}
-                  >
-                    {plan.highlighted && (
-                      <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground">
-                        Most popular
-                      </div>
-                    )}
-                    <CardHeader>
-                      <CardTitle className="text-lg">{plan.name}</CardTitle>
-                      <div className="mt-2 flex items-baseline gap-1">
-                        <span className="text-3xl font-bold">
-                          &#8377;{plan.price}
-                        </span>
-                        {plan.price !== "0" && (
-                          <span className="text-sm text-muted-foreground">
-                            /month
-                          </span>
-                        )}
-                      </div>
-                      <CardDescription>{plan.description}</CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <ul className="space-y-2.5 text-sm">
-                        {plan.features.map((feature) => (
-                          <li key={feature} className="flex items-start gap-2.5">
-                            <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                            {feature}
-                          </li>
-                        ))}
-                      </ul>
-                      <Button
-                        asChild
-                        className="w-full"
-                        variant={plan.highlighted ? "default" : "outline"}
-                      >
-                        <Link href="/auth">{plan.cta}</Link>
-                      </Button>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
+            <div className="mx-auto max-w-6xl">
+              {pricing && pricing.plans.length > 0 ? (
+                <PricingGrid plans={pricing.plans} />
+              ) : (
+                <div className="text-center">
+                  <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
+                    Simple, transparent pricing
+                  </h2>
+                  <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+                    Free tier and three paid plans. See full details on the
+                    pricing page.
+                  </p>
+                  <Button asChild size="lg" className="mt-6">
+                    <Link href="/pricing">View pricing</Link>
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,38 +1,35 @@
-import Link from "next/link";
-import { Check } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { headers } from "next/headers";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
+import { PricingGrid } from "@/components/marketing/pricing-grid";
+import { getPricing } from "@/lib/pricing";
 
-const PLANS = [
-  {
-    name: "Free",
-    price: "0",
-    description: "See what AI can do with your content",
-    features: ["50 content pieces tagged", "Ad creative preview", "Content gap analysis"],
-    cta: "Start free",
-    highlighted: false,
-  },
-  {
-    name: "Growth",
-    price: "7,499",
-    description: "Full AI marketing engine for growing businesses",
-    features: ["Unlimited content tagging", "2 ad platforms", "Full optimization engine", "Pattern mining & insights", "Lead tracking"],
-    cta: "Get started",
-    highlighted: true,
-  },
-  {
-    name: "Pro",
-    price: "19,999",
-    description: "For businesses ready to scale aggressively",
-    features: ["Everything in Growth", "All ad platforms", "Subscriber enrichment", "Custom taxonomy", "API access"],
-    cta: "Get started",
-    highlighted: false,
-  },
-] as const;
+/**
+ * /pricing — public marketing pricing page. Server-rendered with the
+ * visitor's country resolved from the Vercel edge geo header
+ * (`x-vercel-ip-country`). The peakhour-api `/v1/platform/pricing`
+ * endpoint resolves the country-specific entry per plan (INR for IN,
+ * USD via DEFAULT for everyone else in MVP) so the page renders with
+ * the right currency without any client-side flicker.
+ *
+ * Falls back to "DEFAULT" (USD) when the header is missing — local dev
+ * and non-Vercel deploys both hit that path; the page still renders.
+ *
+ * Pricing is cached server-side for 5 minutes via the
+ * `platform-pricing` tag (see `getPricing` in lib/pricing.ts). A CMS
+ * supersede can trigger a future revalidate by calling
+ * `revalidateTag("platform-pricing")` once that hook is wired.
+ */
+export default async function PricingPage() {
+  const h = await headers();
+  const vercelCountry = h.get("x-vercel-ip-country");
+  const country =
+    vercelCountry && /^[A-Za-z]{2}$/.test(vercelCountry)
+      ? vercelCountry.toUpperCase()
+      : "DEFAULT";
 
-export default function PricingPage() {
+  const pricing = await getPricing(country);
+
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
@@ -40,42 +37,29 @@ export default function PricingPage() {
       <main>
         <section className="py-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
-            <h1 className="text-center text-3xl font-bold">Simple, transparent pricing</h1>
-            <p className="mx-auto mt-3 max-w-xl text-center text-muted-foreground">
-              Start free. Upgrade when you&apos;re ready to launch ads.
-            </p>
-            <div className="mt-12 grid gap-6 md:grid-cols-3">
-              {PLANS.map((plan) => (
-                <Card key={plan.name} className={plan.highlighted ? "relative border-primary shadow-lg" : undefined}>
-                  {plan.highlighted && (
-                    <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground">
-                      Most popular
-                    </div>
-                  )}
-                  <CardHeader>
-                    <CardTitle className="text-lg">{plan.name}</CardTitle>
-                    <div className="mt-2 flex items-baseline gap-1">
-                      <span className="text-3xl font-bold">&#8377;{plan.price}</span>
-                      {plan.price !== "0" && <span className="text-sm text-muted-foreground">/month</span>}
-                    </div>
-                    <CardDescription>{plan.description}</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <ul className="space-y-2 text-sm">
-                      {plan.features.map((f) => (
-                        <li key={f} className="flex items-start gap-2">
-                          <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                          {f}
-                        </li>
-                      ))}
-                    </ul>
-                    <Button asChild className="w-full" variant={plan.highlighted ? "default" : "outline"}>
-                      <Link href="/auth">{plan.cta}</Link>
-                    </Button>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
+            {pricing && pricing.plans.length > 0 ? (
+              <PricingGrid plans={pricing.plans} />
+            ) : (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-6 text-sm text-amber-700 dark:text-amber-400">
+                Pricing is temporarily unavailable. Please refresh in a
+                moment, or contact{" "}
+                <a
+                  href="mailto:sales@peakhour.ai"
+                  className="font-medium underline underline-offset-2"
+                >
+                  sales@peakhour.ai
+                </a>{" "}
+                if the problem persists.
+              </div>
+            )}
+
+            {pricing && pricing.country !== "DEFAULT" && (
+              <p className="mt-8 text-center text-[11px] text-muted-foreground">
+                Prices shown for{" "}
+                <code className="font-mono">{pricing.country}</code>. Detected
+                from your IP — contact sales for a custom-currency invoice.
+              </p>
+            )}
           </div>
         </section>
       </main>

--- a/src/components/marketing/pricing-grid.tsx
+++ b/src/components/marketing/pricing-grid.tsx
@@ -1,0 +1,163 @@
+import Link from "next/link";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  formatMonthly,
+  formatYearly,
+  PLAN_BULLETS,
+  type PlanKey,
+  type ResolvedPlan,
+} from "@/lib/pricing";
+
+/**
+ * Country-aware pricing grid — renders the API-resolved pricing
+ * entries with marketing-grade bullets per tier. Used both on the
+ * dedicated /pricing page and the landing-page Pricing section.
+ *
+ * Rendered as a server component — pricing data comes pre-fetched
+ * from the caller (the page reads the Vercel IP country header and
+ * passes it to `getPricing`). No client-side state, no currency-toggle
+ * UI in MVP — the API picks the right entry by country.
+ *
+ * Enterprise renders below the comparison row as a contact-sales
+ * banner instead of a fifth narrow column.
+ */
+export function PricingGrid({
+  plans,
+  showHeader = true,
+}: {
+  plans: ResolvedPlan[];
+  showHeader?: boolean;
+}) {
+  const comparisonPlans = plans.filter((p) => p.key !== "enterprise");
+  const enterprise = plans.find((p) => p.key === "enterprise");
+
+  return (
+    <div className="space-y-8">
+      {showHeader && (
+        <div className="text-center">
+          <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
+            Simple, transparent pricing
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+            Start free. Upgrade when you&apos;re ready. Prices shown in your
+            local currency.
+          </p>
+        </div>
+      )}
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {comparisonPlans.map((plan) => (
+          <PlanCard key={plan.key} plan={plan} />
+        ))}
+      </div>
+
+      {enterprise ? <EnterpriseBanner plan={enterprise} /> : null}
+    </div>
+  );
+}
+
+function PlanCard({ plan }: { plan: ResolvedPlan }) {
+  const bullets = PLAN_BULLETS[plan.key as PlanKey] ?? [];
+  const showFreeTagline = plan.pricing.monthly === 0 && plan.pricing.tagline;
+
+  return (
+    <Card
+      className={`relative flex flex-col transition-shadow hover:shadow-md ${
+        plan.highlightAsRecommended
+          ? "border-primary shadow-lg ring-1 ring-primary/20"
+          : ""
+      }`}
+    >
+      {plan.highlightAsRecommended && (
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground">
+          Most popular
+        </div>
+      )}
+      <CardHeader>
+        <CardTitle className="text-lg capitalize">{plan.name}</CardTitle>
+        <div className="mt-2 flex items-baseline gap-1">
+          {showFreeTagline ? (
+            <span className="text-3xl font-bold">
+              {plan.pricing.tagline}
+            </span>
+          ) : (
+            <>
+              <span className="text-3xl font-bold">
+                {formatMonthly(plan.pricing)}
+              </span>
+              <span className="text-sm text-muted-foreground">/month</span>
+            </>
+          )}
+        </div>
+        {!showFreeTagline && plan.pricing.yearly > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {formatYearly(plan.pricing)} billed yearly · 2 months free
+          </p>
+        )}
+        {plan.tagline && (
+          <CardDescription className="mt-2">{plan.tagline}</CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        <ul className="flex-1 space-y-2.5 text-sm">
+          {bullets.map((b) => (
+            <li key={b} className="flex items-start gap-2.5">
+              <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+              {b}
+            </li>
+          ))}
+        </ul>
+        <Button
+          asChild
+          className="w-full"
+          variant={plan.highlightAsRecommended ? "default" : "outline"}
+        >
+          <Link href="/auth">
+            {plan.key === "free" ? "Start free" : `Try ${plan.name}`}
+          </Link>
+        </Button>
+        {plan.pricing.trialDays > 0 && plan.pricing.monthly > 0 && (
+          <p className="text-center text-[11px] text-muted-foreground">
+            {plan.pricing.trialDays}-day free trial · no credit card needed
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function EnterpriseBanner({ plan }: { plan: ResolvedPlan }) {
+  return (
+    <Card className="border-violet-300/60 bg-gradient-to-br from-violet-50 to-background dark:from-violet-950/30">
+      <CardContent className="flex flex-col items-start gap-6 p-8 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <h3 className="text-xl font-semibold">{plan.name}</h3>
+          {plan.tagline && (
+            <p className="text-sm text-muted-foreground">{plan.tagline}</p>
+          )}
+          <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {(PLAN_BULLETS.enterprise ?? []).map((b) => (
+              <li key={b} className="flex items-center gap-1.5">
+                <Check className="size-3 text-primary" />
+                {b}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <Button asChild size="lg">
+          <Link href="mailto:sales@peakhour.ai?subject=Enterprise%20plan%20inquiry">
+            {plan.pricing.tagline ?? "Contact sales"}
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,148 @@
+/**
+ * Server-side helper for fetching country-resolved pricing from the
+ * peakhour-api `/v1/platform/pricing` endpoint. Used by the marketing
+ * /pricing page and the landing-page pricing section so both render
+ * with the same currency for a given visitor.
+ *
+ * Country precedence on the API side:
+ *   1. `?country=XX` query — passed explicitly when we already know it.
+ *   2. Authenticated org subscription — N/A here (these pages are public).
+ *   3. Vercel `x-vercel-ip-country` header — set on every request when
+ *      deployed; absent in local dev.
+ *   4. `"DEFAULT"` sentinel → USD via stripe.
+ *
+ * To keep the marketing surface fast, we pass the detected country
+ * explicitly (read by the caller from `headers()`) AND fall back to
+ * letting the API resolve it via its own header chain if the b2c is
+ * called from somewhere that didn't pass `country`.
+ */
+
+import { unstable_cache as cache } from "next/cache";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+export type PlanKey = "free" | "starter" | "growth" | "agency" | "enterprise";
+
+export interface PricingEntry {
+  currency: string;
+  monthly: number;
+  yearly: number;
+  trialDays: number;
+  foundingDiscountPct: number;
+  billingProviderKey: string;
+  taxIncluded: boolean;
+  gstApplicable: boolean;
+  vatApplicable: boolean;
+  displayPrefix?: string;
+  tagline?: string;
+}
+
+export interface ResolvedPlan {
+  key: PlanKey;
+  name: string;
+  tagline?: string;
+  description?: string;
+  features: string[];
+  limits: Record<string, number | undefined>;
+  highlightAsRecommended: boolean;
+  version: number;
+  pricing: PricingEntry;
+}
+
+export interface PricingResponse {
+  country: string;
+  plans: ResolvedPlan[];
+}
+
+/**
+ * Cached server fetch — pricing changes infrequently (every supersede
+ * via the CMS FormWizard), so a 5-minute revalidate window is plenty.
+ * Cache key includes the country so an IN visitor and a US visitor
+ * don't share each other's pricing.
+ */
+async function fetchPricing(country: string): Promise<PricingResponse | null> {
+  if (!API_URL) return null;
+  try {
+    const res = await fetch(
+      `${API_URL}/v1/platform/pricing?country=${encodeURIComponent(country)}`,
+      { next: { revalidate: 300, tags: ["platform-pricing"] } },
+    );
+    if (!res.ok) return null;
+    const json = (await res.json()) as { ok?: boolean; data?: PricingResponse };
+    if (!json.ok || !json.data) return null;
+    return json.data;
+  } catch {
+    return null;
+  }
+}
+
+export const getPricing = cache(
+  fetchPricing,
+  ["platform-pricing"],
+  // Tag-based revalidate — pricing surfaces use this so a future
+  // /v1/cms/plans supersede can invalidate via revalidateTag().
+  { revalidate: 300, tags: ["platform-pricing"] },
+);
+
+/**
+ * Format a pricing entry as "₹3,499" or "$49" — leans on the entry's
+ * `displayPrefix` for the currency symbol so the API stays in charge
+ * of i18n strings rather than the b2c hardcoding rupee vs dollar.
+ *
+ * Free / Enterprise both ship `monthly: 0` — they're differentiated by
+ * the entry's `tagline` ("Free forever" / "Contact sales") which the
+ * caller decides whether to render in place of the price.
+ */
+export function formatMonthly(p: PricingEntry): string {
+  if (p.monthly === 0) return `${p.displayPrefix ?? ""}0`;
+  return `${p.displayPrefix ?? ""}${p.monthly.toLocaleString()}`;
+}
+
+export function formatYearly(p: PricingEntry): string {
+  if (p.yearly === 0) return `${p.displayPrefix ?? ""}0`;
+  return `${p.displayPrefix ?? ""}${p.yearly.toLocaleString()}`;
+}
+
+/**
+ * Per-tier marketing bullets. Keys mirror `PlanKey`. Kept here (not in
+ * cfg_features.tagline) so marketing can tune the comparison copy
+ * without a DB write — these are the punchy "what you get on this
+ * tier" lines, not the technical feature descriptions.
+ */
+export const PLAN_BULLETS: Record<PlanKey, string[]> = {
+  free: [
+    "1 LinkedIn page",
+    "10 AI-generated posts / month",
+    "Basic content engine",
+  ],
+  starter: [
+    "3 LinkedIn pages",
+    "100 posts / month",
+    "Voice card synthesis",
+    "Full content engine",
+    "14-day trial",
+  ],
+  growth: [
+    "5 LinkedIn pages",
+    "500 posts / month",
+    "Hook DNA rewrite + AQS engager scoring",
+    "Boost recommender",
+    "Multi-business workspace",
+    "14-day trial",
+  ],
+  agency: [
+    "25 LinkedIn pages × 25 businesses",
+    "2,000 posts / month",
+    "Client labels & permissions",
+    "SSO + audit log",
+    "Everything in Growth",
+    "14-day trial",
+  ],
+  enterprise: [
+    "Unlimited everything",
+    "White-label",
+    "Custom AI model keys (BYOK)",
+    "Dedicated success manager",
+    "SSO + audit log",
+  ],
+};


### PR DESCRIPTION
## Summary

Closes the India-pricing workstream — replaces hardcoded INR-only pricing on \`/pricing\` + the landing-page Pricing section with the country-aware data from \`GET /v1/platform/pricing\` (peakhour-api#249).

- New \`src/lib/pricing.ts\` server module: types + \`getPricing(country)\` with \`unstable_cache\` (300s revalidate, \`platform-pricing\` tag for future CMS-driven flushes) + format helpers + per-tier marketing bullets.
- New \`src/components/marketing/pricing-grid.tsx\` server component — 4-tier comparison grid + Enterprise banner with \`mailto:sales\` CTA.
- \`src/app/pricing/page.tsx\` rewritten as async server component, reads \`x-vercel-ip-country\` header, calls the API, renders with the right currency.
- \`src/app/page.tsx\` landing-page Pricing section: drops the stale 3-tier hardcoded \`PLANS\` array (Free/Growth/Pro/INR), uses the same \`<PricingGrid>\`.

## Test plan

- [ ] \`npx tsc --noEmit\` clean (verified).
- [ ] Visit \`/pricing\` from India (or send \`x-vercel-ip-country: IN\` header) → see ₹ prices on Starter/Growth/Agency.
- [ ] Visit \`/pricing\` from any other country (or no header) → see \$ prices.
- [ ] Visit \`/\` landing-page Pricing section → same 4-tier + Enterprise banner.
- [ ] Click "Try Growth" on the highlighted card → routes to \`/auth\`.
- [ ] Enterprise banner mailto opens \`sales@peakhour.ai\`.

## Out of scope

- Currency-toggle UI (server picks based on IP; manual override is a follow-up).
- Per-plan-per-feature restrictions (the cfg_plans.features\[] array is boolean today; structured limits per feature is a planned workstream).
- Tagline / name rewrites for jargon-heavy feature keys (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)