### PR TITLE
fix(sources): rename FEATURE_KEY to content.trusted_sources

### DIFF
--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -28,11 +28,12 @@ import type { SourceStatus, TrustedSource } from "./types";
  * when data lands but the dedicated Suggested ranker UI + Insights
  * timeline ship in Day-3/4 follow-ups.
  *
- * Gating: behind `content.trusted_sources` feature key. Seeded into the
- * Starter / Growth / Agency / Enterprise plans via the cfg_features +
- * cfg_plans rollout in peakhour-mongodb; Free stays locked and sees the
- * waitlist fallback. The cfg_features row uses the same tagline string
- * below so the upgrade drawer copy stays consistent.
+ * Gating: behind `content.trusted_sources` feature key. Granted to
+ * Starter / Growth / Agency / Enterprise via the companion cfg_features
+ * + cfg_plans rollout in peakhour-mongodb; Free stays locked and sees
+ * the waitlist fallback. The cfg_features row reuses the same tagline
+ * string below so the upgrade drawer copy stays consistent — if you
+ * edit FEATURE_TAGLINE here, edit the seed row too.
  */
 
 const FEATURE_KEY = "content.trusted_sources";

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -28,12 +28,14 @@ import type { SourceStatus, TrustedSource } from "./types";
  * when data lands but the dedicated Suggested ranker UI + Insights
  * timeline ship in Day-3/4 follow-ups.
  *
- * Gating: behind `content.sources` feature key. Today no plan grants
- * this — the FeatureGate fallback opens the waitlist drawer pre-tagged
- * so signups become signal for the rollout order.
+ * Gating: behind `content.trusted_sources` feature key. Seeded into the
+ * Starter / Growth / Agency / Enterprise plans via the cfg_features +
+ * cfg_plans rollout in peakhour-mongodb; Free stays locked and sees the
+ * waitlist fallback. The cfg_features row uses the same tagline string
+ * below so the upgrade drawer copy stays consistent.
  */
 
-const FEATURE_KEY = "content.sources";
+const FEATURE_KEY = "content.trusted_sources";
 const FEATURE_NAME = "Trusted Sources";
 const FEATURE_TAGLINE =
   "Ground every brief, idea, and post in your brand's voice. Add the sites, feeds, channels, and creators your AI should read, watch, and cite.";


### PR DESCRIPTION
## Summary

Aligns the FeatureGate key with the cfg_features row being added in peakhour-mongodb and with the user-facing "Trusted Sources" name + the `cnt_trusted_sources` collection. The old key `content.sources` never had a matching cfg_features row, which is why every org saw the "Join the waitlist" fallback.

## Changes
- `src/app/dashboard/content/sources/page.tsx` — `FEATURE_KEY` rename + JSDoc updated to reflect the rollout state instead of the prior "no plan grants this" wording.

## Pairs with
- peakhour-mongodb: `feat/seed-content-sources-feature` — adds the cfg_features row + wires it into Starter/Growth/Agency/Enterprise plan rows. Merge that PR first so a recompute populates the entitlements snapshot before this rename lands in prod.

## Test plan
- [ ] Verify `useFeature("content.trusted_sources")` returns `allowed: true` for a Starter+ org after the mongodb PR migration runs and the entitlements snapshot recomputes.
- [ ] Verify Free-plan org still sees `TrustedSourcesLockedFallback` with the "Join waitlist" button (UpgradeButton receives the new key).
- [ ] Verify the upgrade drawer shows the same tagline string as `FEATURE_TAGLINE` in this file (single source of truth — cfg_features row tagline is a byte-match).
- [ ] Grep verifies zero remaining references to the old `content.sources` key in this repo.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)