### PR TITLE
feat(dashboard): navbar PlanBadge + billing trial/feature info

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/sidebar";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { BusinessSwitcher } from "@/components/dashboard/business-switcher";
+import { PlanBadge } from "@/components/dashboard/plan-badge";
 import { CommandMenu } from "@/components/molecules/command-menu";
 import { FeedbackWidget } from "@/components/molecules/feedback-widget";
 import { ChatPanel } from "@/components/molecules/chat-panel";
@@ -389,7 +390,8 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
       <SidebarInset>
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-3">
+            <PlanBadge />
             <FeedbackWidget />
           </div>
         </header>

--- a/src/app/dashboard/settings/billing/page.tsx
+++ b/src/app/dashboard/settings/billing/page.tsx
@@ -13,12 +13,43 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface OrgBilling {
   name?: string;
+  /** Backward-compat alias on /v1/dashboard/org — `plan` is derived from
+   *  subscription.plan. New surfaces should consume `subscription`
+   *  directly (richer shape including trial state). */
   billing?: { plan?: string };
+  subscription?: {
+    plan?: string;
+    planVersion?: number;
+    trialEndsAt?: string | null;
+    trialActive?: boolean;
+    trialDaysRemaining?: number;
+  };
+  entitlements?: {
+    plan?: string;
+    planVersion?: number;
+    computedAt?: string | null;
+    features?: string[];
+  } | null;
   createdAt?: string;
 }
+
+// Mirrors the navbar PlanBadge tier accents so plan presentation stays
+// consistent across surfaces.
+const PLAN_STYLES: Record<string, string> = {
+  free: "bg-muted text-muted-foreground",
+  starter:
+    "bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300",
+  growth:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300",
+  agency:
+    "bg-violet-100 text-violet-700 dark:bg-violet-950/60 dark:text-violet-300",
+  enterprise:
+    "bg-amber-100 text-amber-800 dark:bg-amber-950/60 dark:text-amber-300",
+};
 
 export default function BillingPage() {
   const { org } = useAuth();
@@ -43,7 +74,17 @@ export default function BillingPage() {
     );
   }
 
-  const plan = details?.billing?.plan || "free";
+  // Prefer subscription.plan (canonical); fall back to billing.plan
+  // (legacy alias from the endpoint, also derived from subscription
+  // but kept on the response for old consumers).
+  const plan = details?.subscription?.plan ?? details?.billing?.plan ?? "free";
+  const planClass = PLAN_STYLES[plan] ?? PLAN_STYLES.free;
+  const trialActive = details?.subscription?.trialActive === true;
+  const trialDays = details?.subscription?.trialDaysRemaining ?? 0;
+  const trialEndsAt = details?.subscription?.trialEndsAt
+    ? new Date(details.subscription.trialEndsAt)
+    : null;
+  const features = details?.entitlements?.features ?? [];
 
   return (
     <div className="space-y-6">
@@ -60,9 +101,17 @@ export default function BillingPage() {
           <div className="flex flex-col justify-between gap-2 sm:flex-row sm:items-center mb-4">
             <div className="flex items-center gap-2">
               <h3 className="font-semibold">Current Plan</h3>
-              <Badge variant="secondary" className="bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400">
+              <Badge
+                variant="secondary"
+                className={cn("font-medium capitalize", planClass)}
+              >
                 {plan}
               </Badge>
+              {trialActive && trialDays > 0 ? (
+                <Badge variant="outline" className="font-medium">
+                  Trial · {trialDays}d left
+                </Badge>
+              ) : null}
             </div>
             <Button variant="outline" size="sm" asChild>
               <a href="mailto:hello@peakhour.ai">Upgrade plan</a>
@@ -80,8 +129,14 @@ export default function BillingPage() {
               </p>
             </div>
             <div>
-              <p className="text-xs text-muted-foreground">Billing cycle</p>
-              <p className="text-sm font-medium">Monthly</p>
+              <p className="text-xs text-muted-foreground">
+                {trialActive ? "Trial ends" : "Billing cycle"}
+              </p>
+              <p className="text-sm font-medium">
+                {trialActive && trialEndsAt
+                  ? formatDate(trialEndsAt.toISOString())
+                  : "Monthly"}
+              </p>
             </div>
           </div>
         </div>
@@ -106,12 +161,41 @@ export default function BillingPage() {
             <p className="font-semibold mb-1">Ad platforms</p>
             <p className="text-sm text-muted-foreground">
               <span className="text-foreground font-medium">
-                {plan === "pro" ? "All" : plan === "growth" ? "2" : "Preview only"}
+                {plan === "enterprise" || plan === "agency"
+                  ? "All"
+                  : plan === "growth"
+                    ? "2"
+                    : "Preview only"}
               </span>
               {" "}included
             </p>
           </div>
         </div>
+
+        {/* Features unlocked on this plan — sourced from the entitlements
+            snapshot so it reflects whatever cfg_plans currently grants,
+            not a hardcoded enumeration that would drift from the seed. */}
+        {features.length > 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Features included</CardTitle>
+              <CardDescription>
+                Resolved from your plan + any add-ons or platform grants.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="flex flex-wrap gap-1.5">
+                {features.map((f) => (
+                  <li key={f}>
+                    <Badge variant="outline" className="font-mono text-[11px]">
+                      {f}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ) : null}
 
         {/* Payment method */}
         <Card>

--- a/src/components/dashboard/plan-badge.tsx
+++ b/src/components/dashboard/plan-badge.tsx
@@ -97,8 +97,13 @@ export function PlanBadge() {
       >
         {planLabel(plan)}
       </Badge>
+      {/* Trial countdown + Upgrade CTA collapse on narrow viewports —
+          below sm the header would otherwise wrap (badge + countdown +
+          button + FeedbackWidget all competing for the same row). The
+          plan-tier chip alone communicates the most important state on
+          mobile; the rest is reachable via the badge route to billing. */}
       {trialActive && trialDays > 0 ? (
-        <span className="text-xs text-muted-foreground">
+        <span className="hidden text-xs text-muted-foreground sm:inline">
           {trialDays}d trial
         </span>
       ) : null}
@@ -107,7 +112,7 @@ export function PlanBadge() {
           variant="outline"
           size="sm"
           asChild
-          className="h-7 gap-1 px-2 text-xs"
+          className="hidden h-7 gap-1 px-2 text-xs sm:inline-flex"
         >
           <Link href="/dashboard/settings/billing">
             Upgrade

--- a/src/components/dashboard/plan-badge.tsx
+++ b/src/components/dashboard/plan-badge.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useAuth } from "@/providers/auth-provider";
+import { api } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PlanSummary {
+  subscription?: {
+    plan?: string;
+    planVersion?: number;
+    trialEndsAt?: string | null;
+    trialActive?: boolean;
+    trialDaysRemaining?: number;
+  };
+}
+
+/** Plans where an upgrade is meaningful. agency + enterprise hide the
+ *  CTA (they're already at/near the top of the price ladder; surfacing
+ *  "Upgrade" to those users is noise). */
+const UPGRADABLE = new Set(["free", "starter", "growth"]);
+
+/** Plan-tier accent colors. Tailwind class strings only — kept narrow
+ *  so a designer can tune without touching component logic. */
+const PLAN_STYLES: Record<string, string> = {
+  free: "bg-muted text-muted-foreground",
+  starter:
+    "bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300",
+  growth:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300",
+  agency:
+    "bg-violet-100 text-violet-700 dark:bg-violet-950/60 dark:text-violet-300",
+  enterprise:
+    "bg-amber-100 text-amber-800 dark:bg-amber-950/60 dark:text-amber-300",
+};
+
+function planLabel(key: string): string {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+/**
+ * Compact plan/trial indicator for the dashboard top bar.
+ *
+ * Reads `/v1/dashboard/org` which derives the plan from the canonical
+ * `subscription.plan` (see peakhour-api dashboard/index.ts). Renders:
+ *   - a colored badge with the plan name
+ *   - "Xd trial" subtle text when a trial is active
+ *   - a small "Upgrade" CTA linking to /dashboard/settings/billing when
+ *     the plan is upgradable (free/starter/growth); hidden for
+ *     agency/enterprise
+ *
+ * No fetch fires until the user is authenticated and has an active org
+ * — guards prevent the cold-render flash on the auth page and dodge a
+ * redundant request when /me has not resolved yet.
+ */
+export function PlanBadge() {
+  const { org, isAuthenticated } = useAuth();
+  const [summary, setSummary] = useState<PlanSummary | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !org?._id) return;
+    let cancelled = false;
+    api
+      .get<PlanSummary>("/v1/dashboard/org")
+      .then((d) => {
+        if (!cancelled) setSummary(d);
+      })
+      // Swallow — the badge is decorative; a failed fetch should not
+      // surface as a UI error. If the plan never lands the badge
+      // simply stays absent (handled by the early return below).
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // org._id is the right dep — switching orgs should refetch the
+    // badge so an agency operator who flips between client orgs sees
+    // each one's plan.
+  }, [isAuthenticated, org?._id]);
+
+  if (!summary?.subscription?.plan) return null;
+
+  const plan = summary.subscription.plan;
+  const planClass = PLAN_STYLES[plan] ?? PLAN_STYLES.free;
+  const trialActive = summary.subscription.trialActive === true;
+  const trialDays = summary.subscription.trialDaysRemaining ?? 0;
+  const showUpgrade = UPGRADABLE.has(plan);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Badge
+        variant="secondary"
+        className={cn("font-medium capitalize", planClass)}
+      >
+        {planLabel(plan)}
+      </Badge>
+      {trialActive && trialDays > 0 ? (
+        <span className="text-xs text-muted-foreground">
+          {trialDays}d trial
+        </span>
+      ) : null}
+      {showUpgrade ? (
+        <Button
+          variant="outline"
+          size="sm"
+          asChild
+          className="h-7 gap-1 px-2 text-xs"
+        >
+          <Link href="/dashboard/settings/billing">
+            Upgrade
+            <ArrowUpRight className="size-3" />
+          </Link>
+        </Button>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Companion to peakhour-api PR #274 (which fixed /v1/dashboard/org to expose canonical subscription + entitlements; was reading legacy billing.plan and defaulting to "free" universally).

- **PlanBadge** in dashboard top bar: tier-colored chip (free/starter/growth/agency/enterprise), trial-days-remaining text when active, "Upgrade" CTA for upgradable tiers linking to /dashboard/settings/billing. Trial text + Upgrade button collapse on narrow viewports (<640px) to avoid overflow; chip stays visible.
- **Billing page** now reads subscription.plan (with billing.plan as backward-compat fallback), surfaces trial status as a "Trial · Xd left" badge inline with the plan, swaps the "Billing cycle" cell for the trial-end date when trialing, and adds a "Features included" card sourced from entitlements.features (so it reflects whatever cfg_plans currently grants instead of drifting).
- Tier color palette shared between PlanBadge and billing page so the same plan looks the same everywhere.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Manual + subagent review (mobile overflow caught + fixed in review-1 commit)
- [ ] After deploy: confirm Quests.travel shows "Enterprise" badge (not Free). Reproduce via /dashboard/settings/billing.
- [ ] Set up a starter/growth org via CMS + confirm Upgrade CTA appears and links to billing.
- [ ] Test header layout at 375px (mobile) — only the tier chip should be visible alongside SidebarTrigger and FeedbackWidget.

## Deferred follow-ups
- react-query dedup of /v1/dashboard/org across PlanBadge + billing page
- cfg_features.displayName mapping so feature keys render human-readable
- Replace hardcoded usage limits with `entitlements.limits` once per-plan-per-feature-limits ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)