### PR TITLE
feat(dashboard): self-serve trial extension UX (banner + button)

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -35,6 +35,7 @@ import {
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { BusinessSwitcher } from "@/components/dashboard/business-switcher";
 import { PlanBadge } from "@/components/dashboard/plan-badge";
+import { TrialExpiryBanner } from "@/components/dashboard/trial-expiry-banner";
 import { CommandMenu } from "@/components/molecules/command-menu";
 import { FeedbackWidget } from "@/components/molecules/feedback-widget";
 import { ChatPanel } from "@/components/molecules/chat-panel";
@@ -395,7 +396,16 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
             <FeedbackWidget />
           </div>
         </header>
-        <div className="flex-1 overflow-auto p-6">{children}</div>
+        <div className="flex-1 overflow-auto p-6">
+          {/* Trial-expiry warning slot — sits above the route content
+              only when a trial is within the final 3 days. Component
+              renders nothing in all other states (no trial, plenty of
+              days left, dismissed). */}
+          <div className="mb-4">
+            <TrialExpiryBanner />
+          </div>
+          {children}
+        </div>
       </SidebarInset>
 
       {/* ── AI Chat FAB ──────────────────────────────────── */}

--- a/src/app/dashboard/settings/billing/page.tsx
+++ b/src/app/dashboard/settings/billing/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { useDashboardOrg, useExtendTrial } from "@/hooks/use-dashboard-org";
 import { Badge } from "@/components/ui/badge";
@@ -62,8 +63,8 @@ export default function BillingPage() {
           description: `New end date: ${new Date(res.trialEndsAt).toLocaleDateString()}`,
         });
       },
-      onError: (err: Error & { code?: string }) => {
-        const code = (err as { code?: string }).code;
+      onError: (err: ApiError) => {
+        const code = err.code;
         if (code === "EXTENSION_ALREADY_USED") {
           toast.error("Extension already used", {
             description: "Reach out to hello@peakhour.ai for further help.",

--- a/src/app/dashboard/settings/billing/page.tsx
+++ b/src/app/dashboard/settings/billing/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useAuth } from "@/providers/auth-provider";
+import { toast } from "sonner";
 import { useLocale } from "@/hooks/use-locale";
-import { api } from "@/lib/api";
+import { useDashboardOrg, useExtendTrial } from "@/hooks/use-dashboard-org";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -14,28 +13,6 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-
-interface OrgBilling {
-  name?: string;
-  /** Backward-compat alias on /v1/dashboard/org — `plan` is derived from
-   *  subscription.plan. New surfaces should consume `subscription`
-   *  directly (richer shape including trial state). */
-  billing?: { plan?: string };
-  subscription?: {
-    plan?: string;
-    planVersion?: number;
-    trialEndsAt?: string | null;
-    trialActive?: boolean;
-    trialDaysRemaining?: number;
-  };
-  entitlements?: {
-    plan?: string;
-    planVersion?: number;
-    computedAt?: string | null;
-    features?: string[];
-  } | null;
-  createdAt?: string;
-}
 
 // Mirrors the navbar PlanBadge tier accents so plan presentation stays
 // consistent across surfaces.
@@ -52,21 +29,11 @@ const PLAN_STYLES: Record<string, string> = {
 };
 
 export default function BillingPage() {
-  const { org } = useAuth();
   const { formatDate } = useLocale();
-  const [details, setDetails] = useState<OrgBilling | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { data: details, isLoading } = useDashboardOrg();
+  const extend = useExtendTrial();
 
-  useEffect(() => {
-    if (!org?._id) return;
-    api
-      .get<OrgBilling>("/v1/dashboard/org")
-      .then(setDetails)
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, [org?._id]);
-
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex justify-center py-12">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
@@ -84,7 +51,39 @@ export default function BillingPage() {
   const trialEndsAt = details?.subscription?.trialEndsAt
     ? new Date(details.subscription.trialEndsAt)
     : null;
+  const selfServeExtensionUsed =
+    details?.subscription?.selfServeExtensionUsed === true;
   const features = details?.entitlements?.features ?? [];
+
+  const handleExtend = () => {
+    extend.mutate(undefined, {
+      onSuccess: (res) => {
+        toast.success(`Trial extended by ${res.addedDays} days`, {
+          description: `New end date: ${new Date(res.trialEndsAt).toLocaleDateString()}`,
+        });
+      },
+      onError: (err: Error & { code?: string }) => {
+        const code = (err as { code?: string }).code;
+        if (code === "EXTENSION_ALREADY_USED") {
+          toast.error("Extension already used", {
+            description: "Reach out to hello@peakhour.ai for further help.",
+          });
+        } else if (code === "NOT_TRIALING") {
+          toast.error("Trial ended", {
+            description: "Contact hello@peakhour.ai to discuss next steps.",
+          });
+        } else if (code === "EXTENSION_RACE") {
+          toast.info("State changed", {
+            description: "Refreshing the latest trial state…",
+          });
+        } else {
+          toast.error("Could not extend trial", {
+            description: err.message ?? "Try again or contact support.",
+          });
+        }
+      },
+    });
+  };
 
   return (
     <div className="space-y-6">
@@ -113,9 +112,25 @@ export default function BillingPage() {
                 </Badge>
               ) : null}
             </div>
-            <Button variant="outline" size="sm" asChild>
-              <a href="mailto:hello@peakhour.ai">Upgrade plan</a>
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Self-serve trial extension — visible only while the
+                  trial is active AND the customer hasn't burned their
+                  one-shot. After use, the button disappears; the dashboard
+                  banner shows a contact link in that window. */}
+              {trialActive && !selfServeExtensionUsed ? (
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={handleExtend}
+                  disabled={extend.isPending}
+                >
+                  {extend.isPending ? "Extending…" : "Extend trial 7 days"}
+                </Button>
+              ) : null}
+              <Button variant="outline" size="sm" asChild>
+                <a href="mailto:hello@peakhour.ai">Upgrade plan</a>
+              </Button>
+            </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-3">
             <div>

--- a/src/components/dashboard/plan-badge.tsx
+++ b/src/components/dashboard/plan-badge.tsx
@@ -1,23 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { useAuth } from "@/providers/auth-provider";
-import { api } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-interface PlanSummary {
-  subscription?: {
-    plan?: string;
-    planVersion?: number;
-    trialEndsAt?: string | null;
-    trialActive?: boolean;
-    trialDaysRemaining?: number;
-  };
-}
+import { useDashboardOrg } from "@/hooks/use-dashboard-org";
 
 /** Plans where an upgrade is meaningful. agency + enterprise hide the
  *  CTA (they're already at/near the top of the price ladder; surfacing
@@ -58,28 +46,11 @@ function planLabel(key: string): string {
  * redundant request when /me has not resolved yet.
  */
 export function PlanBadge() {
-  const { org, isAuthenticated } = useAuth();
-  const [summary, setSummary] = useState<PlanSummary | null>(null);
-
-  useEffect(() => {
-    if (!isAuthenticated || !org?._id) return;
-    let cancelled = false;
-    api
-      .get<PlanSummary>("/v1/dashboard/org")
-      .then((d) => {
-        if (!cancelled) setSummary(d);
-      })
-      // Swallow — the badge is decorative; a failed fetch should not
-      // surface as a UI error. If the plan never lands the badge
-      // simply stays absent (handled by the early return below).
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-    // org._id is the right dep — switching orgs should refetch the
-    // badge so an agency operator who flips between client orgs sees
-    // each one's plan.
-  }, [isAuthenticated, org?._id]);
+  // Reads through the shared dashboard/org cache so this badge, the
+  // trial-expiry banner, and the billing page all hit one network
+  // round-trip per org. After self-serve trial extension, the mutation
+  // invalidates the cache and the badge's trial countdown updates.
+  const { data: summary } = useDashboardOrg();
 
   if (!summary?.subscription?.plan) return null;
 

--- a/src/components/dashboard/trial-expiry-banner.tsx
+++ b/src/components/dashboard/trial-expiry-banner.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { Clock, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useDashboardOrg, useExtendTrial } from "@/hooks/use-dashboard-org";
+
+/**
+ * Surfaces when a trial is within the final 3 days. Includes a single
+ * one-click "Extend by 7 days" CTA when the customer's self-serve
+ * allowance is unused; falls back to a Contact-us link once that
+ * one-shot has been spent. Dismissible per session — the dismissal
+ * lives in component state only (not persisted) so it returns on the
+ * next dashboard mount; a sticky "remind me tomorrow" would need
+ * localStorage + a TTL and isn't worth the complexity yet.
+ *
+ * Hidden completely when:
+ *   - no trial active
+ *   - trial active but more than 3 days remain
+ *   - user has dismissed it in this session
+ *   - data is still loading (no flash)
+ */
+const WARNING_WINDOW_DAYS = 3;
+
+export function TrialExpiryBanner() {
+  const { data, isLoading } = useDashboardOrg();
+  const extend = useExtendTrial();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (isLoading || dismissed) return null;
+  const sub = data?.subscription;
+  if (!sub?.trialActive) return null;
+  const days = sub.trialDaysRemaining ?? 0;
+  if (days > WARNING_WINDOW_DAYS) return null;
+
+  const alreadyExtended = sub.selfServeExtensionUsed === true;
+
+  const handleExtend = () => {
+    extend.mutate(undefined, {
+      onSuccess: (res) => {
+        toast.success(
+          `Trial extended by ${res.addedDays} days`,
+          {
+            description: `New end date: ${new Date(res.trialEndsAt).toLocaleDateString()}`,
+          }
+        );
+      },
+      onError: (err: Error & { code?: string }) => {
+        // The api client wraps error responses with a `code` field
+        // mirroring the server's machine-readable code. Map known codes
+        // to user-facing messages; fall through to a generic fallback
+        // so a new server-side code never produces a silent failure.
+        const code = (err as { code?: string }).code;
+        if (code === "EXTENSION_ALREADY_USED") {
+          toast.error("Extension already used", {
+            description: "Reach out to hello@peakhour.ai for further help.",
+          });
+        } else if (code === "NOT_TRIALING") {
+          toast.error("Trial ended", {
+            description:
+              "Your trial has ended — contact hello@peakhour.ai to discuss next steps.",
+          });
+        } else if (code === "EXTENSION_RACE") {
+          toast.info("State changed", {
+            description: "Refreshing the latest trial state…",
+          });
+        } else {
+          toast.error("Could not extend trial", {
+            description: err.message ?? "Try again or contact support.",
+          });
+        }
+      },
+    });
+  };
+
+  // Tier-up the visual urgency as days run out. Day 3 = soft amber;
+  // days ≤1 = stronger red so the warning isn't easy to ignore on the
+  // last day.
+  const critical = days <= 1;
+  const wrapClass = critical
+    ? "border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200"
+    : "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200";
+
+  return (
+    <div
+      className={`flex flex-col gap-2 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:gap-3 ${wrapClass}`}
+      role="status"
+    >
+      {critical ? (
+        <AlertTriangle className="size-4 shrink-0" />
+      ) : (
+        <Clock className="size-4 shrink-0" />
+      )}
+      <div className="flex-1 text-sm">
+        <span className="font-medium">
+          Your trial ends in {days} day{days === 1 ? "" : "s"}.
+        </span>{" "}
+        {alreadyExtended ? (
+          <span>
+            You&apos;ve used your one-time extension —{" "}
+            <a
+              href="mailto:hello@peakhour.ai"
+              className="underline underline-offset-2"
+            >
+              contact us
+            </a>{" "}
+            to continue.
+          </span>
+        ) : (
+          <span>Extend by 7 days, no questions asked.</span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {!alreadyExtended ? (
+          <Button
+            size="sm"
+            variant="default"
+            onClick={handleExtend}
+            disabled={extend.isPending}
+          >
+            {extend.isPending ? "Extending…" : "Extend 7 days"}
+          </Button>
+        ) : null}
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+        >
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/trial-expiry-banner.tsx
+++ b/src/components/dashboard/trial-expiry-banner.tsx
@@ -4,16 +4,19 @@ import { useState } from "react";
 import { Clock, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api";
 import { useDashboardOrg, useExtendTrial } from "@/hooks/use-dashboard-org";
 
 /**
  * Surfaces when a trial is within the final 3 days. Includes a single
  * one-click "Extend by 7 days" CTA when the customer's self-serve
  * allowance is unused; falls back to a Contact-us link once that
- * one-shot has been spent. Dismissible per session — the dismissal
- * lives in component state only (not persisted) so it returns on the
- * next dashboard mount; a sticky "remind me tomorrow" would need
- * localStorage + a TTL and isn't worth the complexity yet.
+ * one-shot has been spent. Dismissible — the dismissal lives in
+ * component state. The dashboard layout in Next.js app-router
+ * persists across in-app navigations, so dismissal effectively holds
+ * for the rest of the browser session and returns on full page reload
+ * / re-login. A sticky "remind me tomorrow" with TTL would need
+ * localStorage and is deliberately out-of-scope for v1.
  *
  * Hidden completely when:
  *   - no trial active
@@ -46,12 +49,12 @@ export function TrialExpiryBanner() {
           }
         );
       },
-      onError: (err: Error & { code?: string }) => {
-        // The api client wraps error responses with a `code` field
-        // mirroring the server's machine-readable code. Map known codes
-        // to user-facing messages; fall through to a generic fallback
-        // so a new server-side code never produces a silent failure.
-        const code = (err as { code?: string }).code;
+      onError: (err: ApiError) => {
+        // ApiError carries a server-side `code` string mirroring the
+        // backend's error taxonomy. Map known codes to user-facing
+        // messages; fall through to a generic fallback so a new
+        // server-side code never produces a silent failure.
+        const code = err.code;
         if (code === "EXTENSION_ALREADY_USED") {
           toast.error("Extension already used", {
             description: "Reach out to hello@peakhour.ai for further help.",
@@ -83,9 +86,14 @@ export function TrialExpiryBanner() {
     : "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200";
 
   return (
+    // Critical (≤1 day) bumps the ARIA role to `alert` so assistive
+    // tech announces it immediately; the soft amber band (2-3 days
+    // remaining) stays at `status` to avoid interrupting users who
+    // are mid-flow but still benefit from a visible heads-up.
     <div
       className={`flex flex-col gap-2 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:gap-3 ${wrapClass}`}
-      role="status"
+      role={critical ? "alert" : "status"}
+      aria-live={critical ? "assertive" : "polite"}
     >
       {critical ? (
         <AlertTriangle className="size-4 shrink-0" />

--- a/src/hooks/use-dashboard-org.ts
+++ b/src/hooks/use-dashboard-org.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/** Shape of `/v1/dashboard/org` as relevant to plan/trial surfaces.
+ *  Other fields (taxonomy, integrations, business meta) are returned by
+ *  the endpoint but consumers of this hook only need plan/trial state. */
+export interface DashboardOrgPlanSummary {
+  name?: string;
+  subscription?: {
+    plan?: string;
+    planVersion?: number;
+    trialEndsAt?: string | null;
+    trialActive?: boolean;
+    trialDaysRemaining?: number;
+    selfServeExtensionUsed?: boolean;
+  };
+  entitlements?: {
+    plan?: string;
+    planVersion?: number;
+    computedAt?: string | null;
+    features?: string[];
+  } | null;
+  billing?: { plan?: string };
+  createdAt?: string;
+}
+
+export interface TrialExtendResponse {
+  trialEndsAt: string;
+  addedDays: number;
+}
+
+/** Shared cache key — every consumer of /v1/dashboard/org reads through
+ *  this so a single fetch (and the extend mutation's invalidation)
+ *  refreshes the badge, the banner, and the billing page atomically. */
+const DASHBOARD_ORG_KEY = "/v1/dashboard/org";
+
+/**
+ * Read `/v1/dashboard/org` via react-query so the PlanBadge, the
+ * trial-expiry banner, and the billing page share one network round-trip
+ * + one cache entry. Refetched on org-id change (agency operators
+ * flipping between client orgs see each one's plan).
+ *
+ * `enabled` guards prevent the fetch from firing before /me resolves
+ * — the auth context's org is the gate for "we know which org to fetch
+ * for."
+ */
+export function useDashboardOrg() {
+  const { org, isAuthenticated } = useAuth();
+  return useQuery<DashboardOrgPlanSummary>({
+    queryKey: [DASHBOARD_ORG_KEY, org?._id ?? null],
+    queryFn: () => api.get<DashboardOrgPlanSummary>("/v1/dashboard/org"),
+    enabled: isAuthenticated && !!org?._id,
+    // 60s staleTime — plan/trial state changes infrequently. Banner +
+    // badge re-render against the cached value; the extend mutation
+    // invalidates the cache to force a fresh fetch immediately after
+    // the grant lands.
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Self-serve trial extension. POST /v1/dashboard/trial/extend.
+ * Invalidates the dashboard/org cache on success so the badge, banner,
+ * and billing page all re-render with the new trialEndsAt +
+ * selfServeExtensionUsed flag.
+ */
+export function useExtendTrial() {
+  const queryClient = useQueryClient();
+  return useMutation<TrialExtendResponse, Error>({
+    mutationFn: () => api.post<TrialExtendResponse>("/v1/dashboard/trial/extend", {}),
+    onSuccess: () => {
+      // Drop every cached dashboard/org regardless of org-id suffix —
+      // an agency operator with multiple orgs in cache shouldn't keep
+      // stale state for the org they just extended. The key is shared
+      // by prefix; predicate matches that.
+      queryClient.invalidateQueries({
+        predicate: (q) => q.queryKey[0] === DASHBOARD_ORG_KEY,
+      });
+    },
+  });
+}

--- a/src/hooks/use-dashboard-org.ts
+++ b/src/hooks/use-dashboard-org.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/providers/auth-provider";
 
 /** Shape of `/v1/dashboard/org` as relevant to plan/trial surfaces.
@@ -69,7 +69,11 @@ export function useDashboardOrg() {
  */
 export function useExtendTrial() {
   const queryClient = useQueryClient();
-  return useMutation<TrialExtendResponse, Error>({
+  // Tight error generic: api.post() throws ApiError with a `code` field
+  // mirroring the server's error taxonomy
+  // (EXTENSION_ALREADY_USED / NOT_TRIALING / EXTENSION_RACE / generic).
+  // Consumers map by `err.code` without unsafe casts.
+  return useMutation<TrialExtendResponse, ApiError>({
     mutationFn: () => api.post<TrialExtendResponse>("/v1/dashboard/trial/extend", {}),
     onSuccess: () => {
       // Drop every cached dashboard/org regardless of org-id suffix —


### PR DESCRIPTION
## Summary

Customer-facing trial extension landing across three surfaces, fed by one shared react-query cache so the cache lands fresh data everywhere the moment the mutation resolves.

**New:**
- `src/hooks/use-dashboard-org.ts` — `useDashboardOrg()` + `useExtendTrial()` via @tanstack/react-query. Single cache entry keyed on org id; mutation invalidates by prefix so a multi-org agency view refreshes the right entry.
- `src/components/dashboard/trial-expiry-banner.tsx` — surfaces when trial is within 3 days. Day 3 = soft amber (`role="status"` / polite); day ≤1 = stronger red (`role="alert"` / assertive). One-click "Extend 7 days" CTA while `selfServeExtensionUsed=false`; falls back to a Contact-us link after the one-shot. Dismissible (holds for the browser session).

**Refactored:**
- `PlanBadge` reads from the shared hook (was its own useEffect+api.get). Deduplicates against banner + billing-page reads.
- Billing page reads from the shared hook and renders an "Extend trial 7 days" button in the plan card when trialing + not extended.

**Wiring:** Banner sits above the main route content in dashboard/layout.tsx; renders nothing when not applicable.

Backend: peakhour-api #275 + peakhour-mongodb #85 shipped earlier in the same session.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Manual + subagent review (error types, dismissal-comment accuracy, a11y role caught + fixed)
- [ ] Trial active >3d: banner hidden, billing-page button hidden, badge shows countdown
- [ ] Trial active <=3d: banner visible (amber), Extend button on banner + billing page
- [ ] Click Extend: toast success, trialDaysRemaining bumps by 7, button disappears (used flag set)
- [ ] Click Extend again from second tab: 409 EXTENSION_RACE → info toast → refresh shows correct state
- [ ] Trial active <=1d: banner red + role=alert
- [ ] Ops re-sets plan with trialDays=14: self-serve allowance resets, Extend button reappears next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)