### PR TITLE
fix(referral): route share link to /auth and credit inviter on signup

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -76,9 +76,11 @@ const TRUST_STATS = [
 ] as const;
 
 // Bounded length + character set so a tampered link can't smuggle
-// arbitrary strings into the waitlist payload. Matches the
-// referredByCode validator on /v1/waitlist/signup (min 4, max 32) and
-// the customAlphabet used to mint codes (0-9, A-Z minus I/L/O/U).
+// arbitrary strings into the waitlist payload. Mirrors the
+// referredByCode validator on /v1/waitlist/signup (string, min 4,
+// max 32). The mint alphabet is a stricter subset (0-9, A-Z minus
+// I/L/O/U/10 chars) — staying with the validator's bounds means a
+// mint-alphabet change doesn't require a client release.
 const REFERRAL_CODE_PATTERN = /^[0-9A-Z]{4,32}$/;
 
 export default function AuthPage() {
@@ -317,13 +319,18 @@ function AuthPageContent() {
       {/* Right panel — auth form */}
       <div className="flex flex-1 flex-col">
         {referralCode ? (
-          <div className="border-b bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+          // Avoid "skip 5 spots" copy: the backend's idempotent path
+          // (existing email on the waitlist) returns the prior row
+          // without recrediting the inviter, so the promise would be
+          // unbacked for recipients who are already in line. Backend
+          // fix tracked separately; copy stays honest until then.
+          <div
+            role="status"
+            className="border-b bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+          >
             <div className="mx-auto flex max-w-md items-center gap-2">
               <Sparkles className="size-4 shrink-0" />
-              <span>
-                You were invited by a friend. Sign up below to skip 5 spots on
-                the waitlist.
-              </span>
+              <span>You were invited by a friend. Sign up to claim your spot.</span>
             </div>
           </div>
         ) : null}

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Sparkles } from "lucide-react";
 import { sendMagicLink } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,7 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ApiError } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { SITE } from "@/lib/utils";
 
 /**
@@ -73,7 +75,36 @@ const TRUST_STATS = [
   { value: "24/7", label: "autonomous optimization" },
 ] as const;
 
+// Bounded length + character set so a tampered link can't smuggle
+// arbitrary strings into the waitlist payload. Matches the
+// referredByCode validator on /v1/waitlist/signup (min 4, max 32) and
+// the customAlphabet used to mint codes (0-9, A-Z minus I/L/O/U).
+const REFERRAL_CODE_PATTERN = /^[0-9A-Z]{4,32}$/;
+
 export default function AuthPage() {
+  // useSearchParams() requires a Suspense boundary for streaming —
+  // wrap the inner component so the page works whether SSR streams
+  // or fully hydrates first.
+  return (
+    <Suspense fallback={null}>
+      <AuthPageContent />
+    </Suspense>
+  );
+}
+
+function AuthPageContent() {
+  const searchParams = useSearchParams();
+  // Sanitised against REFERRAL_CODE_PATTERN — any value that doesn't
+  // match the inviter-code shape is dropped silently so the rest of
+  // the flow behaves as a plain sign-in. `null` here means "no
+  // inviter context for this session."
+  const referralCode = (() => {
+    const raw = searchParams?.get("ref") ?? null;
+    if (!raw) return null;
+    const upper = raw.toUpperCase();
+    return REFERRAL_CODE_PATTERN.test(upper) ? upper : null;
+  })();
+
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   // Tick once per second while a cooldown is running so the button
@@ -150,6 +181,24 @@ export default function AuthPage() {
         : Date.now() + RESEND_COOLDOWN_SECONDS * 1000;
 
     try {
+      // Referral credit fires alongside (not before) the magic link so
+      // that a transient signup error doesn't block sign-in. The
+      // waitlist endpoint is idempotent on (email, active status), so
+      // repeat resends with the same code are safe. Only attempted on
+      // the initial send — resends shouldn't keep re-firing it.
+      if (referralCode && mode === "send") {
+        api
+          .post("/v1/waitlist/signup", {
+            email: targetEmail,
+            intent: "general",
+            referredByCode: referralCode,
+            channel: "direct",
+          })
+          .catch(() => {
+            // Inviter credit is best-effort. Don't surface a toast or
+            // disrupt the auth flow — the user is here to sign in.
+          });
+      }
       await sendMagicLink(targetEmail);
       setStatus({
         kind: "sent",
@@ -267,6 +316,17 @@ export default function AuthPage() {
 
       {/* Right panel — auth form */}
       <div className="flex flex-1 flex-col">
+        {referralCode ? (
+          <div className="border-b bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+            <div className="mx-auto flex max-w-md items-center gap-2">
+              <Sparkles className="size-4 shrink-0" />
+              <span>
+                You were invited by a friend. Sign up below to skip 5 spots on
+                the waitlist.
+              </span>
+            </div>
+          </div>
+        ) : null}
         <div className="flex flex-1 items-center justify-center px-4 py-12">
           {isCoolingDown ? (
             <Card className="w-full max-w-md">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import { ArrowRight, Sparkles, Brain, Zap, BarChart3 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -88,7 +89,31 @@ const INTEGRATIONS = [
   { name: "X (Twitter)", icon: TwitterIcon, color: "bg-black", description: "Posts & promoted content" },
 ] as const;
 
-export default async function Home() {
+// Same validator as /auth — sanitises a tampered ?ref= so the
+// redirect target only ever carries a well-formed inviter code.
+const REFERRAL_CODE_PATTERN = /^[0-9A-Z]{4,32}$/;
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string | string[]; n?: string | string[] }>;
+}) {
+  // Back-compat redirect for waitlist share links that were minted
+  // with the old `/?ref=…` shape. Forward to /auth so the inviter
+  // code is captured by the auth page and credited on signup. We
+  // forward `n` only if present to preserve the cache-bust nonce.
+  const params = await searchParams;
+  const refRaw = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  const nRaw = Array.isArray(params.n) ? params.n[0] : params.n;
+  if (refRaw) {
+    const refUpper = refRaw.toUpperCase();
+    if (REFERRAL_CODE_PATTERN.test(refUpper)) {
+      const qs = new URLSearchParams({ ref: refUpper });
+      if (nRaw) qs.set("n", nRaw);
+      redirect(`/auth?${qs.toString()}`);
+    }
+  }
+
   // Country-aware pricing — resolves the visitor's country from the
   // Vercel edge geo header (set on every prod/preview request) and
   // fetches the corresponding pricing matrix from peakhour-api. The

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -173,7 +173,10 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
   function shareReferral() {
     if (!success) return;
     const base = typeof window !== "undefined" ? window.location.origin : "";
-    const url = `${base}/?ref=${success.referralCode}&n=${clientNonce()}`;
+    // /auth captures `ref` and stamps it onto the recipient's waitlist
+    // signup, crediting the inviter. The marketing root (`/`) ignores
+    // the param, so pointing referrals there silently drops attribution.
+    const url = `${base}/auth?ref=${success.referralCode}&n=${clientNonce()}`;
     if (navigator.share) {
       navigator.share({
         title: "Peakhour — early access",


### PR DESCRIPTION
## Summary

- Share URL in upgrade drawer was pointing at the marketing root (`/?ref=…&n=…`), which silently dropped the referral code because the home page never read query params. Recipients landed on a marketing page with no path to credit the inviter.
- Three coordinated changes route them to `/auth` instead and credit the inviter on the recipient's first signup.

## What changed

- **`src/components/upgrade/upgrade-drawer.tsx`** — share URL builder now produces `/auth?ref=…&n=…` instead of `/?ref=…&n=…`.
- **`src/app/auth/page.tsx`** — reads `?ref` via `useSearchParams()` (Suspense-wrapped), validates it against the backend `referredByCode` shape (`/^[0-9A-Z]{4,32}$/`), shows an inviter banner with `role=\"status\"`, and on initial magic-link send fires a best-effort `POST /v1/waitlist/signup` with `referredByCode`. Errors are swallowed so a transient signup hiccup doesn't block sign-in.
- **`src/app/page.tsx`** — server-side `redirect()` for `/?ref=…` so already-shared waitlist links keep crediting. Validator mirrors `/auth` so a tampered code can't smuggle a malformed string through the redirect.

## Known gap (followup, not in this PR)

When the recipient is already on the waitlist, `POST /v1/waitlist/signup` returns the existing row idempotently but does NOT retroactively set `referrer.inviterSignupId` or bump `referralCount` on the inviter. That's why the banner copy says \"claim your spot\" rather than \"skip 5 spots\" — the promise would be unbacked for existing waitlisters. Backend retroactive-credit fix tracked separately.

## Test plan

- [ ] Mint a referral code from a waitlist signup; share button now copies `/auth?ref=…&n=…`
- [ ] Visit `/auth?ref=VALID10CHR` → amber inviter banner renders, screen reader announces it
- [ ] Submit email from that page → `POST /v1/waitlist/signup` fires with `referredByCode`, magic link still sends
- [ ] Visit `/auth?ref=lowercase` → no banner (filtered by uppercase + regex)
- [ ] Visit `/auth?ref=<script>` → no banner, no API call
- [ ] Visit `/?ref=VALID10CHR&n=rxwm` → 307 redirect to `/auth?ref=VALID10CHR&n=rxwm`
- [ ] Visit `/?ref=invalid!&n=x` → renders home page normally, no redirect
- [ ] Resend magic link → does NOT re-fire the waitlist signup (gated to `mode === \"send\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)