### PR TITLE
feat(settings): Seasonal Events card + country edit

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -29,7 +29,16 @@ import {
   X,
   Check,
   Plus,
+  CalendarDays,
+  Globe2,
 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface OrgDetails {
   _id: string;
@@ -62,12 +71,42 @@ interface OrgDetails {
   taxonomy?: {
     sectors?: string[];
     generatedAt?: string;
+    seasonalEvents?: SeasonalEvent[];
+  } | null;
+  location?: {
+    country?: string;
   } | null;
   onboarding?: {
     completed?: boolean;
   };
   createdAt?: string;
 }
+
+interface SeasonalEvent {
+  name: string;
+  /** 1..12 */
+  month: number;
+  relevance?: string;
+  /** Year (YYYY) → ISO date (YYYY-MM-DD). Set by the seed for moving
+   *  holidays; read-only in v0 of this UI. Display only. */
+  dates?: Record<string, string>;
+}
+
+const MONTH_SHORT_NAMES = [
+  "",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
 
 export default function SettingsPage() {
   return (
@@ -101,6 +140,13 @@ function SettingsContent() {
   const [editType, setEditType] = useState("");
   const [editUrl, setEditUrl] = useState("");
   const [editSectors, setEditSectors] = useState<string[]>([]);
+  const [editCountry, setEditCountry] = useState("");
+
+  // Seasonal events edit state — kept independent of the Business
+  // Details card so an owner can edit one without touching the other.
+  const [editingSeasonal, setEditingSeasonal] = useState(false);
+  const [savingSeasonal, setSavingSeasonal] = useState(false);
+  const [editSeasonalEvents, setEditSeasonalEvents] = useState<SeasonalEvent[]>([]);
 
   async function handleSaveBusinessDetails() {
     setSaving(true);
@@ -112,6 +158,15 @@ function SettingsContent() {
       if (editUrl !== (orgDetails?.websiteUrl || "")) updates.websiteUrl = editUrl;
       if (JSON.stringify(editSectors) !== JSON.stringify(orgDetails?.taxonomy?.sectors || [])) {
         updates.taxonomy = { sectors: editSectors };
+      }
+      // Country drives onboarding's seasonal-pack lookup. Sending only
+      // when changed avoids overwriting with the same value (the api
+      // upper-cases before persistence, so a same-value send is a no-op
+      // but still bumps updatedAt).
+      const currentCountry = (orgDetails?.location?.country || "").toUpperCase();
+      const nextCountry = editCountry.trim().toUpperCase();
+      if (nextCountry && nextCountry !== currentCountry) {
+        updates.countryCode = nextCountry;
       }
 
       if (Object.keys(updates).length === 0) {
@@ -128,6 +183,39 @@ function SettingsContent() {
       else setError("Failed to save. Please try again.");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleSaveSeasonalEvents() {
+    setSavingSeasonal(true);
+    setError("");
+    try {
+      // Strip empty rows the owner left blank; preserve their existing
+      // `dates` map (seed-driven for moving holidays, read-only in v0).
+      const cleaned = editSeasonalEvents
+        .map((e) => ({
+          name: e.name.trim(),
+          month: e.month,
+          ...(e.relevance && e.relevance.trim()
+            ? { relevance: e.relevance.trim() }
+            : {}),
+          ...(e.dates && Object.keys(e.dates).length > 0
+            ? { dates: e.dates }
+            : {}),
+        }))
+        .filter((e) => e.name.length > 0);
+
+      await api.put("/v1/dashboard/org", {
+        taxonomy: { seasonalEvents: cleaned },
+      });
+      const updated = await api.get<OrgDetails>("/v1/dashboard/org");
+      setOrgDetails(updated);
+      setEditingSeasonal(false);
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.message);
+      else setError("Failed to save seasonal events. Please try again.");
+    } finally {
+      setSavingSeasonal(false);
     }
   }
 
@@ -194,6 +282,7 @@ function SettingsContent() {
                     setEditType(orgDetails?.businessType || "");
                     setEditUrl(orgDetails?.websiteUrl || "");
                     setEditSectors(orgDetails?.taxonomy?.sectors || []);
+                    setEditCountry(orgDetails?.location?.country || "");
                   }}
                 >
                   <Pencil className="h-3.5 w-3.5" />
@@ -221,6 +310,11 @@ function SettingsContent() {
                 <SettingRow label="Category" value={orgDetails?.businessCategory} />
                 <EditRow label="Type" value={editType} onChange={setEditType} />
                 <EditRow label="Website" value={editUrl} onChange={setEditUrl} type="url" />
+                <EditRow
+                  label="Country (ISO-2)"
+                  value={editCountry}
+                  onChange={(v) => setEditCountry(v.toUpperCase())}
+                />
                 <SettingRow
                   label="Plan"
                   value={
@@ -238,6 +332,21 @@ function SettingsContent() {
                 <SettingRow label="Category" value={orgDetails?.businessCategory} />
                 <SettingRow label="Type" value={orgDetails?.businessType} />
                 <SettingRow label="Website" value={orgDetails?.websiteUrl} />
+                <SettingRow
+                  label="Country"
+                  value={
+                    orgDetails?.location?.country ? (
+                      <span className="flex items-center gap-1.5">
+                        <Globe2 className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="font-mono">{orgDetails.location.country}</span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        Not set — seasonal events will be limited until you pick a country
+                      </span>
+                    )
+                  }
+                />
                 <SettingRow
                   label="Plan"
                   value={
@@ -260,6 +369,68 @@ function SettingsContent() {
                   </div>
                 )}
               </>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Seasonal Events */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="h-5 w-5 text-muted-foreground" />
+                <CardTitle>Seasonal Events</CardTitle>
+              </div>
+              {!editingSeasonal ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="gap-1.5 text-muted-foreground"
+                  onClick={() => {
+                    setEditingSeasonal(true);
+                    setEditSeasonalEvents(orgDetails?.taxonomy?.seasonalEvents || []);
+                  }}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                  Edit
+                </Button>
+              ) : (
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setEditingSeasonal(false)}
+                    disabled={savingSeasonal}
+                  >
+                    <X className="h-3.5 w-3.5" /> Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleSaveSeasonalEvents}
+                    disabled={savingSeasonal}
+                  >
+                    <Check className="h-3.5 w-3.5" />{" "}
+                    {savingSeasonal ? "Saving…" : "Save"}
+                  </Button>
+                </div>
+              )}
+            </div>
+            <CardDescription>
+              Cultural, national, and commercial moments the AI uses to plan
+              seasonal content. Onboarding seeds these from your country&apos;s
+              calendar; you can add, edit, or remove events here.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {editingSeasonal ? (
+              <EditableSeasonalEvents
+                events={editSeasonalEvents}
+                onChange={setEditSeasonalEvents}
+              />
+            ) : (
+              <ReadOnlySeasonalEvents
+                events={orgDetails?.taxonomy?.seasonalEvents || []}
+              />
             )}
           </CardContent>
         </Card>
@@ -406,6 +577,165 @@ function EditableSectors({ sectors, onChange }: { sectors: string[]; onChange: (
           <Plus className="h-3.5 w-3.5" /> Add
         </Button>
       </div>
+    </div>
+  );
+}
+
+function ReadOnlySeasonalEvents({ events }: { events: SeasonalEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No seasonal events yet. Click Edit to add holidays, festivals, or
+        commercial moments relevant to your audience.
+      </p>
+    );
+  }
+  // Sort by month for a calendar-ish read order. Same-month events
+  // preserve their declared sort order.
+  const sorted = [...events].sort((a, b) => a.month - b.month);
+  return (
+    <div className="space-y-1.5">
+      {sorted.map((e, i) => {
+        const movingYears = e.dates ? Object.keys(e.dates).sort() : [];
+        return (
+          <div
+            key={`${e.name}-${i}`}
+            className="rounded-md border bg-card p-2.5 text-sm"
+          >
+            <div className="flex flex-wrap items-baseline gap-2">
+              <span className="font-medium">{e.name}</span>
+              <Badge variant="outline" className="font-mono text-[10px]">
+                {MONTH_SHORT_NAMES[e.month] ?? `m${e.month}`}
+              </Badge>
+              {movingYears.length > 0 ? (
+                <Badge variant="secondary" className="text-[10px]">
+                  moving · {movingYears.length}y mapped
+                </Badge>
+              ) : null}
+            </div>
+            {e.relevance ? (
+              <p className="mt-1 text-xs text-muted-foreground">{e.relevance}</p>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EditableSeasonalEvents({
+  events,
+  onChange,
+}: {
+  events: SeasonalEvent[];
+  onChange: (events: SeasonalEvent[]) => void;
+}) {
+  function updateAt(index: number, patch: Partial<SeasonalEvent>) {
+    onChange(events.map((e, i) => (i === index ? { ...e, ...patch } : e)));
+  }
+  function removeAt(index: number) {
+    onChange(events.filter((_, i) => i !== index));
+  }
+  function addBlank() {
+    onChange([...events, { name: "", month: 1 }]);
+  }
+
+  return (
+    <div className="space-y-2">
+      {events.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No events yet. Add your first one below.
+        </p>
+      ) : (
+        events.map((e, i) => {
+          const movingYears = e.dates ? Object.keys(e.dates).sort() : [];
+          return (
+            <div
+              key={i}
+              className="rounded-md border bg-card p-2.5 space-y-2"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  type="text"
+                  value={e.name}
+                  placeholder="Event name (e.g. Diwali)"
+                  onChange={(ev) => updateAt(i, { name: ev.target.value })}
+                  className="h-8 text-sm flex-1 min-w-48"
+                />
+                <Select
+                  value={String(e.month)}
+                  onValueChange={(v) => updateAt(i, { month: parseInt(v, 10) })}
+                >
+                  <SelectTrigger className="h-8 w-22">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MONTH_SHORT_NAMES.slice(1).map((label, idx) => (
+                      <SelectItem key={label} value={String(idx + 1)}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {movingYears.length > 0 ? (
+                  <Badge variant="secondary" className="text-[10px]">
+                    {movingYears.length}y mapped
+                  </Badge>
+                ) : null}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => removeAt(i)}
+                  className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                  aria-label={`Remove ${e.name || "event"}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <Input
+                type="text"
+                value={e.relevance || ""}
+                placeholder="What does this event mean for your audience? (optional)"
+                onChange={(ev) => updateAt(i, { relevance: ev.target.value })}
+                className="h-8 text-sm"
+              />
+              {movingYears.length > 0 && e.dates ? (
+                // Read-only display of per-year dates for moving holidays
+                // (lunar / variable). Editing per-year dates from this UI
+                // is deferred to a v1 follow-up — the seed populates
+                // these and most owners won't need to override.
+                <div className="rounded bg-muted/30 px-2 py-1.5">
+                  <p className="text-[10px] font-medium text-muted-foreground mb-1">
+                    Per-year dates (read-only)
+                  </p>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-3 gap-y-0.5 text-[11px] font-mono">
+                    {movingYears.map((year) => (
+                      <div key={year} className="flex gap-1">
+                        <span className="text-muted-foreground">{year}:</span>
+                        <span>{e.dates![year]}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          );
+        })
+      )}
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={addBlank}
+        className="gap-1.5"
+        disabled={events.length >= 64}
+      >
+        <Plus className="h-3.5 w-3.5" /> Add event
+      </Button>
+      {events.length >= 64 ? (
+        <p className="text-[10px] text-muted-foreground">
+          Maximum of 64 events. Remove one to add another.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -92,6 +92,27 @@ interface SeasonalEvent {
   dates?: Record<string, string>;
 }
 
+/**
+ * Client-side row state during edit. Adds a stable `clientId` so React
+ * keys don't fall back to array index (which would drift focus + leak
+ * input values across rows after a middle remove). Stripped before
+ * sending to the api — the server's `.strict()` schema would reject it.
+ */
+interface EditableSeasonalEvent extends SeasonalEvent {
+  clientId: string;
+}
+
+function makeClientId() {
+  // crypto.randomUUID is available in all evergreen browsers + Node 19+.
+  return typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `e-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function attachClientIds(events: SeasonalEvent[]): EditableSeasonalEvent[] {
+  return events.map((e) => ({ ...e, clientId: makeClientId() }));
+}
+
 const MONTH_SHORT_NAMES = [
   "",
   "Jan",
@@ -144,9 +165,11 @@ function SettingsContent() {
 
   // Seasonal events edit state — kept independent of the Business
   // Details card so an owner can edit one without touching the other.
+  // `EditableSeasonalEvent` carries a stable `clientId` for React keys
+  // so removing a middle row doesn't drift input focus / values.
   const [editingSeasonal, setEditingSeasonal] = useState(false);
   const [savingSeasonal, setSavingSeasonal] = useState(false);
-  const [editSeasonalEvents, setEditSeasonalEvents] = useState<SeasonalEvent[]>([]);
+  const [editSeasonalEvents, setEditSeasonalEvents] = useState<EditableSeasonalEvent[]>([]);
 
   async function handleSaveBusinessDetails() {
     setSaving(true);
@@ -192,6 +215,8 @@ function SettingsContent() {
     try {
       // Strip empty rows the owner left blank; preserve their existing
       // `dates` map (seed-driven for moving holidays, read-only in v0).
+      // The api's SeasonalEventBody is .strict() — clientId MUST stay
+      // local and never reach the server.
       const cleaned = editSeasonalEvents
         .map((e) => ({
           name: e.name.trim(),
@@ -204,6 +229,22 @@ function SettingsContent() {
             : {}),
         }))
         .filter((e) => e.name.length > 0);
+
+      // Guard against accidentally clearing the whole array. If the
+      // original had events and the cleaned list is empty, prompt for
+      // confirmation before persisting.
+      const originalCount = orgDetails?.taxonomy?.seasonalEvents?.length ?? 0;
+      if (originalCount > 0 && cleaned.length === 0) {
+        const confirmed =
+          typeof window !== "undefined" &&
+          window.confirm(
+            `This will remove all ${originalCount} seasonal events from your business. Continue?`,
+          );
+        if (!confirmed) {
+          setSavingSeasonal(false);
+          return;
+        }
+      }
 
       await api.put("/v1/dashboard/org", {
         taxonomy: { seasonalEvents: cleaned },
@@ -388,7 +429,9 @@ function SettingsContent() {
                   className="gap-1.5 text-muted-foreground"
                   onClick={() => {
                     setEditingSeasonal(true);
-                    setEditSeasonalEvents(orgDetails?.taxonomy?.seasonalEvents || []);
+                    setEditSeasonalEvents(
+                      attachClientIds(orgDetails?.taxonomy?.seasonalEvents || []),
+                    );
                   }}
                 >
                   <Pencil className="h-3.5 w-3.5" />
@@ -408,9 +451,10 @@ function SettingsContent() {
                     size="sm"
                     onClick={handleSaveSeasonalEvents}
                     disabled={savingSeasonal}
+                    className="gap-1.5"
                   >
-                    <Check className="h-3.5 w-3.5" />{" "}
-                    {savingSeasonal ? "Saving…" : "Save"}
+                    <Check className="h-3.5 w-3.5" />
+                    {savingSeasonal ? "Saving..." : "Save"}
                   </Button>
                 </div>
               )}
@@ -627,17 +671,19 @@ function EditableSeasonalEvents({
   events,
   onChange,
 }: {
-  events: SeasonalEvent[];
-  onChange: (events: SeasonalEvent[]) => void;
+  events: EditableSeasonalEvent[];
+  onChange: (events: EditableSeasonalEvent[]) => void;
 }) {
-  function updateAt(index: number, patch: Partial<SeasonalEvent>) {
-    onChange(events.map((e, i) => (i === index ? { ...e, ...patch } : e)));
+  function updateById(clientId: string, patch: Partial<SeasonalEvent>) {
+    onChange(
+      events.map((e) => (e.clientId === clientId ? { ...e, ...patch } : e)),
+    );
   }
-  function removeAt(index: number) {
-    onChange(events.filter((_, i) => i !== index));
+  function removeById(clientId: string) {
+    onChange(events.filter((e) => e.clientId !== clientId));
   }
   function addBlank() {
-    onChange([...events, { name: "", month: 1 }]);
+    onChange([...events, { clientId: makeClientId(), name: "", month: 1 }]);
   }
 
   return (
@@ -649,9 +695,14 @@ function EditableSeasonalEvents({
       ) : (
         events.map((e, i) => {
           const movingYears = e.dates ? Object.keys(e.dates).sort() : [];
+          const rowLabel = e.name || `Event ${i + 1}`;
+          // Stable key via clientId keeps input focus + value bound to
+          // the row that owns them when middle entries are removed —
+          // an index key would visually leave stale text in the input
+          // that "moves up" after a removal.
           return (
             <div
-              key={i}
+              key={e.clientId}
               className="rounded-md border bg-card p-2.5 space-y-2"
             >
               <div className="flex flex-wrap items-center gap-2">
@@ -659,14 +710,22 @@ function EditableSeasonalEvents({
                   type="text"
                   value={e.name}
                   placeholder="Event name (e.g. Diwali)"
-                  onChange={(ev) => updateAt(i, { name: ev.target.value })}
+                  aria-label={`${rowLabel} — name`}
+                  onChange={(ev) =>
+                    updateById(e.clientId, { name: ev.target.value })
+                  }
                   className="h-8 text-sm flex-1 min-w-48"
                 />
                 <Select
                   value={String(e.month)}
-                  onValueChange={(v) => updateAt(i, { month: parseInt(v, 10) })}
+                  onValueChange={(v) =>
+                    updateById(e.clientId, { month: parseInt(v, 10) })
+                  }
                 >
-                  <SelectTrigger className="h-8 w-22">
+                  <SelectTrigger
+                    className="h-8 w-22"
+                    aria-label={`${rowLabel} — month`}
+                  >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -685,9 +744,9 @@ function EditableSeasonalEvents({
                 <Button
                   size="sm"
                   variant="ghost"
-                  onClick={() => removeAt(i)}
+                  onClick={() => removeById(e.clientId)}
                   className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                  aria-label={`Remove ${e.name || "event"}`}
+                  aria-label={`Remove ${rowLabel}`}
                 >
                   <X className="h-3.5 w-3.5" />
                 </Button>
@@ -696,7 +755,10 @@ function EditableSeasonalEvents({
                 type="text"
                 value={e.relevance || ""}
                 placeholder="What does this event mean for your audience? (optional)"
-                onChange={(ev) => updateAt(i, { relevance: ev.target.value })}
+                aria-label={`${rowLabel} — relevance`}
+                onChange={(ev) =>
+                  updateById(e.clientId, { relevance: ev.target.value })
+                }
                 className="h-8 text-sm"
               />
               {movingYears.length > 0 && e.dates ? (


### PR DESCRIPTION
## Summary

Final part of the per-business seasonal-events workstream ([api #309](https://github.com/travelxp/peakhour-api/pull/309)). Lets owners self-serve two fields previously editable only via ops re-running the seed.

**Country (ISO-2)** — added to the Business Details card. Read-only row shows the value with a Globe icon, or a clear "Not set — seasonal events will be limited until you pick a country" hint when undefined. Editable inline (auto-uppercased) so an owner whose onboarding didn't resolve a country can fix it without a support ticket.

**Seasonal Events** — new card under Business Details. Surfaces `taxonomy.seasonalEvents` from onboarding's deep-copy and lets owners add cultural / national / commercial moments the AI didn't extract.

- **Read view** — each event card shows the event name + 3-letter month badge + an optional `moving · Ny mapped` chip for lunar/variable holidays + the relevance string. Sorted by month.
- **Edit view** — inline name input + month dropdown + relevance text + remove button. Add-event button at the bottom; capped at 64 (matching the api validator).
- **Per-year `dates` map** is rendered read-only with a "managed by ops" hint. Editing per-year dates is deferred to a v1 follow-up since the seed already covers moving holidays.

## Commits

1. `c192c6f` — initial card + editor + country row + save handler
2. `ac04a77` — review #1 polish: stable `clientId` keys (fixes focus/value drift on middle-row remove), aria-labels on inputs, confirm-before-clear guard, cosmetic Save button consistency

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Live verification on Vercel preview after merge:
  - [ ] Empty seasonalEvents — read view shows the empty message; Edit shows "No events yet"
  - [ ] Existing seasonalEvents (e.g. Quests.Travel with 7 industry events) — read view sorts by month
  - [ ] Add event, fill name + month, save — appears in read view
  - [ ] Remove middle event in Edit — inputs of subsequent rows stay bound to their own values (the clientId fix)
  - [ ] Save empty after removing all — triggers confirm dialog
  - [ ] Country edit accepts lowercase, persists as uppercase
  - [ ] Country "Not set" hint disappears once a value is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)