### PR TITLE
fix(overview): hide SetupBanner when all visible steps are complete

### DIFF
--- a/src/app/dashboard/overview/page.tsx
+++ b/src/app/dashboard/overview/page.tsx
@@ -354,6 +354,18 @@ function SetupBanner({ stats }: { stats: DashboardStats }) {
   const nextStep = steps.find((s) => !s.done);
   const completedCount = steps.filter((s) => s.done).length;
 
+  // Self-hide when every visible step is done. The outer parent already
+  // hides on `stats.onboarding.completed`, but that persisted flag can
+  // be stale for businesses that completed the steps before the flag
+  // existed (or whose flag never got set due to an onboarding-cron
+  // hiccup). Without this guard, the banner would render as "3 of 3
+  // steps complete" with no CTA — pure clutter for a user who has
+  // already finished setup. Matches the existing "Engine active"
+  // sub-banner pattern in the AI Engine card.
+  if (completedCount === steps.length) {
+    return null;
+  }
+
   return (
     <Card className="overflow-hidden border-0 bg-linear-to-r from-primary/8 via-primary/4 to-transparent">
       <CardContent className="flex items-center justify-between py-5">


### PR DESCRIPTION
## Summary

Quests.Travel reported the "Set up your AI engine — 3 of 3 steps complete" banner persists on their dashboard despite all three steps being checked. Root cause: the **parent conditional** hides the banner on `stats.onboarding.completed`, but the banner's own visible counter (hasTaxonomy + a beehiiv/linkedin connection + hasBudget) is computed independently. For a business whose `onboarding.completed` flag never got set (onboarded before the flag existed, or whose onboarding-completion writer hiccuped), the banner persists indefinitely with no CTA — the next-step button only renders when at least one step is unchecked.

## Fix

`SetupBanner` now self-returns `null` when `completedCount === steps.length`. The outer parent guard still hides on the persisted flag, so a future regression (e.g., an integration disconnect that flips one step back to incomplete) re-shows the banner correctly.

```diff
   const nextStep = steps.find((s) => !s.done);
   const completedCount = steps.filter((s) => s.done).length;

+  if (completedCount === steps.length) {
+    return null;
+  }
+
   return (
     <Card ...>
```

Same dual-signal pattern as the "Engine active" sub-banner in the AI Engine card (which also keys off computed state).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] Live on Quests.Travel's dashboard: confirm the banner disappears once this deploys
- [ ] Live on a new-onboarding account: confirm the banner still shows the unchecked steps + CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)