### PR TITLE
feat(repurpose): UI — RepurposeSheet + 2 entry points (SuggestedDraftCard + Beehiiv ArticleCard)

### DIFF
--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -35,7 +35,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
-import { FileX, LayoutGrid, List, Library, BrainCircuit } from "lucide-react";
+import { FileX, LayoutGrid, List, Library, BrainCircuit, Share2 } from "lucide-react";
+import { RepurposeSheet } from "@/components/repurpose/repurpose-sheet";
+import type { RepurposeSource } from "@/lib/api/repurpose";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -97,6 +99,9 @@ export default function ContentPage() {
   const prefs = user?.preferences ?? null;
   const contentColumns = useMemo(() => getContentColumns(prefs), [prefs]);
   const [view, setView] = useState<"card" | "table">("table");
+  // Sheet state lives at page level so it survives any row re-render
+  // during the sheet's open lifecycle.
+  const [repurposeSource, setRepurposeSource] = useState<RepurposeSource | null>(null);
 
   const enqueueJob = useEnqueueJob();
   // useJobs("active") is already mounted at the dashboard layout level
@@ -465,6 +470,9 @@ export default function ContentPage() {
                     onClick={() =>
                       router.push(`/dashboard/content/beehiiv/${row.original._id}`)
                     }
+                    onRepurpose={() =>
+                      setRepurposeSource({ type: "draft", draftId: row.original._id })
+                    }
                   />
                 ))}
               </div>
@@ -657,6 +665,13 @@ export default function ContentPage() {
           </TabsContent>
         </Tabs>
       </div>
+      <RepurposeSheet
+        open={repurposeSource !== null}
+        onOpenChange={(o) => {
+          if (!o) setRepurposeSource(null);
+        }}
+        source={repurposeSource}
+      />
     </TooltipProvider>
   );
 }
@@ -710,9 +725,11 @@ function KpiCard({
 function ArticleCard({
   draft,
   onClick,
+  onRepurpose,
 }: {
   draft: Draft;
   onClick: () => void;
+  onRepurpose: () => void;
 }) {
   const t = draft.tags;
   return (
@@ -762,6 +779,26 @@ function ArticleCard({
           <span className="text-xs text-muted-foreground">
             {formatDate(draft.publishedAt, null)}
           </span>
+        </div>
+
+        {/* Repurpose action — stopPropagation so the card's onClick
+            (router.push to the detail page) doesn't fire when the
+            user only wanted to open the platform recommender. */}
+        <div className="flex justify-end pt-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRepurpose();
+            }}
+            title="Score connected platforms and generate variants"
+          >
+            <Share2 className="mr-1 size-3" />
+            Repurpose
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/suggested-drafts-panel.tsx
@@ -10,12 +10,14 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ChevronDown, Sparkles, X } from "lucide-react";
+import { ChevronDown, Share2, Sparkles, X } from "lucide-react";
 import {
   SUGGESTED_DRAFTS_QUERY_KEY,
   type GenerateFromProfileResponse,
   type SuggestedDraft,
 } from "@/lib/api/linkedin-content";
+import { RepurposeSheet } from "@/components/repurpose/repurpose-sheet";
+import type { RepurposeSource } from "@/lib/api/repurpose";
 
 /**
  * Cache lifecycle for the SuggestedDraftsPanel:
@@ -54,6 +56,9 @@ interface Props {
 export function SuggestedDraftsPanel({ onUseDraft }: Props) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(true);
+  // Sheet state lives here (not per-card) so the sheet survives card
+  // dismissal animations without an unmount race.
+  const [repurposeSource, setRepurposeSource] = useState<RepurposeSource | null>(null);
 
   // Pure cache reader — no network call, no queryFn invocation. The
   // launch page populates the cache via setQueryData; this panel only
@@ -130,12 +135,22 @@ export function SuggestedDraftsPanel({ onUseDraft }: Props) {
                   draft={draft}
                   onUse={() => use(draft)}
                   onDismiss={() => dismiss(draft.draftId)}
+                  onRepurpose={() =>
+                    setRepurposeSource({ type: "draft", draftId: draft.draftId })
+                  }
                 />
               ))}
             </ol>
           </CardContent>
         </CollapsibleContent>
       </Card>
+      <RepurposeSheet
+        open={repurposeSource !== null}
+        onOpenChange={(o) => {
+          if (!o) setRepurposeSource(null);
+        }}
+        source={repurposeSource}
+      />
     </Collapsible>
   );
 }
@@ -158,11 +173,13 @@ function SuggestedDraftCard({
   draft,
   onUse,
   onDismiss,
+  onRepurpose,
 }: {
   rank: number;
   draft: SuggestedDraft;
   onUse: () => void;
   onDismiss: () => void;
+  onRepurpose: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   // Fallback to a humanised version of the raw angle key if the server
@@ -212,7 +229,7 @@ function SuggestedDraftCard({
             </span>
           </div>
         </div>
-        <div className="flex shrink-0 flex-col items-end gap-2">
+        <div className="flex shrink-0 flex-col items-end gap-1.5">
           <Button
             type="button"
             size="sm"
@@ -221,6 +238,17 @@ function SuggestedDraftCard({
             className="h-7 text-xs"
           >
             Use this draft
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onRepurpose}
+            className="h-7 text-xs"
+            title="Score connected platforms for this draft and generate variants"
+          >
+            <Share2 className="mr-1 size-3" />
+            Repurpose
           </Button>
           <button
             type="button"

--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Sparkles, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import {
+  recommendPlatforms,
+  repurpose,
+  getChannelDisplay,
+  BAND_STYLES,
+  type RepurposeSource,
+  type PlatformRecommendation,
+  type RepurposeResponse,
+} from "@/lib/api/repurpose";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Caller-provided source. When the sheet opens we fire
+   *  /recommend-platforms with this source; when the user confirms
+   *  the platform picker, /repurpose runs with the same source. */
+  source: RepurposeSource | null;
+}
+
+/**
+ * Shared "Repurpose to platforms" sheet used from every entry point
+ * (SuggestedDraftCard, Beehiiv row action, paste-and-repurpose
+ * composer). Owns the recommend → confirm → generate flow end-to-end:
+ *
+ *   1. Open → fires POST /v1/content/recommend-platforms with the
+ *      source. Renders skeletons while the recommender scores.
+ *   2. Recommendations land → renders one row per scored channel
+ *      with band badge + rationale + checkbox. Green pre-checked,
+ *      amber pre-checked, grey unchecked (the user can override).
+ *      Hard-blocked greys are checkbox-disabled with a tooltip.
+ *   3. User clicks Generate → fires POST /v1/content/repurpose with
+ *      platforms[] + platformFitId. Renders per-channel progress.
+ *   4. Variants land → renders preview cards with "Open in composer"
+ *      CTAs. Stub channels (Coming soon) render as a separate row
+ *      so the user sees the recommender did its job even though
+ *      publishing isn't wired.
+ *
+ * No internal hook — the state is sheet-scoped and unmounts on
+ * close, so co-locating the mutations + selection state here keeps
+ * the surface area small.
+ */
+export function RepurposeSheet({ open, onOpenChange, source }: Props) {
+  const recommendMutation = useMutation({
+    mutationFn: (s: RepurposeSource) => recommendPlatforms(s),
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to score platforms");
+    },
+  });
+
+  const repurposeMutation = useMutation({
+    mutationFn: (args: { source: RepurposeSource; platforms: string[]; platformFitId: string }) =>
+      repurpose(args),
+    onSuccess: (data: RepurposeResponse) => {
+      const real = data.adaptations.length;
+      if (real === 0) {
+        toast.info("No variants generated — every selected channel is either pending or failed.");
+      } else if (data.idempotent) {
+        toast.success(`Showing your previous repurpose (${real} variant${real === 1 ? "" : "s"})`);
+      } else {
+        toast.success(`Generated ${real} variant${real === 1 ? "" : "s"}`);
+      }
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to generate variants");
+    },
+  });
+
+  // User's current platform selection, keyed by channel. Initialised
+  // from the recommendations when they land (green + amber pre-
+  // checked, grey unchecked unless hard-blocked).
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+
+  // Reset everything when the sheet opens with a new source.
+  useEffect(() => {
+    if (!open || !source) return;
+    setSelected({});
+    recommendMutation.reset();
+    repurposeMutation.reset();
+    recommendMutation.mutate(source);
+    // mutations themselves are stable refs; we only want to re-fire
+    // when the open transition happens with a non-null source.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, source]);
+
+  const recommendData = recommendMutation.data;
+  // Memoised so the useEffect dep array sees a stable identity —
+  // without this, the seeding effect would re-fire on every render
+  // (data ref is stable, but `?? []` produces a fresh array each time).
+  const recommendations = useMemo(
+    () => recommendData?.recommendations ?? [],
+    [recommendData],
+  );
+  const platformFitId = recommendData?.platformFitId ?? null;
+
+  // Seed selection state once recommendations are available. Only
+  // runs on the first mount where data is present — subsequent user
+  // toggles take over.
+  useEffect(() => {
+    if (recommendations.length === 0) return;
+    setSelected((prev) => {
+      // Don't overwrite if user already toggled something.
+      if (Object.keys(prev).length > 0) return prev;
+      const seeded: Record<string, boolean> = {};
+      for (const r of recommendations) {
+        const isHardBlocked = (r.hardBlocks?.length ?? 0) > 0;
+        if (isHardBlocked) {
+          seeded[r.channel] = false; // disabled in UI
+        } else {
+          // green + amber pre-checked, grey unchecked (user opt-in)
+          seeded[r.channel] = r.band === "green" || r.band === "amber";
+        }
+      }
+      return seeded;
+    });
+  }, [recommendations]);
+
+  const finalPlatforms = useMemo(
+    () => Object.entries(selected).filter(([, v]) => v).map(([k]) => k),
+    [selected],
+  );
+
+  const stage: "loading" | "recommend" | "generating" | "done" | "empty" =
+    repurposeMutation.isPending
+      ? "generating"
+      : repurposeMutation.isSuccess
+        ? "done"
+        : recommendMutation.isPending
+          ? "loading"
+          : recommendations.length === 0 && recommendMutation.isSuccess
+            ? "empty"
+            : "recommend";
+
+  function handleConfirm() {
+    if (!source || !platformFitId || finalPlatforms.length === 0) return;
+    repurposeMutation.mutate({ source, platforms: finalPlatforms, platformFitId });
+  }
+
+  function handleClose() {
+    onOpenChange(false);
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-lg">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle className="flex items-center gap-2 text-base">
+            <Sparkles className="size-4 text-primary" />
+            Repurpose to platforms
+          </SheetTitle>
+          <SheetDescription className="text-xs">
+            {stage === "done"
+              ? "Your variants are ready — open each in its composer to publish."
+              : "We score each connected channel. Tick the ones you want to generate."}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {stage === "loading" && <LoadingRows />}
+          {stage === "empty" && <EmptyState count={recommendData?.connectedChannelsCount ?? 0} />}
+          {stage === "recommend" && (
+            <RecommendationList
+              recommendations={recommendations}
+              selected={selected}
+              onToggle={(channel, value) =>
+                setSelected((prev) => ({ ...prev, [channel]: value }))
+              }
+            />
+          )}
+          {stage === "generating" && <GeneratingRows platforms={finalPlatforms} />}
+          {stage === "done" && repurposeMutation.data && (
+            <DoneState response={repurposeMutation.data} />
+          )}
+        </div>
+
+        <SheetFooter className="border-t px-6 py-3">
+          {stage === "recommend" && (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={handleConfirm}
+                disabled={finalPlatforms.length === 0 || !platformFitId}
+              >
+                Generate {finalPlatforms.length || ""}{" "}
+                variant{finalPlatforms.length === 1 ? "" : "s"}
+              </Button>
+            </>
+          )}
+          {(stage === "done" || stage === "empty") && (
+            <Button type="button" size="sm" onClick={handleClose}>
+              Close
+            </Button>
+          )}
+          {stage === "generating" && (
+            <Button type="button" size="sm" disabled>
+              <Loader2 className="mr-2 size-3 animate-spin" />
+              Generating
+            </Button>
+          )}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────
+
+function LoadingRows() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 rounded-md border p-3">
+          <Skeleton className="size-4" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ count }: { count: number }) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+      {count === 0 ? (
+        <>
+          <p className="font-medium text-foreground">No channels connected yet.</p>
+          <p className="mt-1 text-xs">
+            Connect at least one channel (LinkedIn, X, etc.) before repurposing.
+            Head to <em>Settings → Integrations</em>.
+          </p>
+        </>
+      ) : (
+        <p>
+          The recommender couldn&apos;t score any of your {count} connected channels for
+          this content. Try a longer source text or add media.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RecommendationList({
+  recommendations,
+  selected,
+  onToggle,
+}: {
+  recommendations: PlatformRecommendation[];
+  selected: Record<string, boolean>;
+  onToggle: (channel: string, value: boolean) => void;
+}) {
+  return (
+    <ol className="space-y-2">
+      {recommendations.map((r) => {
+        const display = getChannelDisplay(r.channel);
+        const isHardBlocked = (r.hardBlocks?.length ?? 0) > 0;
+        const band = BAND_STYLES[r.band];
+        const checked = selected[r.channel] ?? false;
+        return (
+          <li
+            key={r.channel}
+            className="flex items-start gap-3 rounded-md border bg-card p-3 hover:bg-muted/40"
+          >
+            <Checkbox
+              id={`repurpose-${r.channel}`}
+              checked={checked}
+              disabled={isHardBlocked}
+              onCheckedChange={(v) => onToggle(r.channel, v === true)}
+              className="mt-1"
+            />
+            <label
+              htmlFor={`repurpose-${r.channel}`}
+              className={`flex-1 cursor-pointer space-y-1 ${
+                isHardBlocked ? "cursor-not-allowed opacity-60" : ""
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <span className={`size-2 rounded-full ${band.dot}`} aria-hidden />
+                <span className="text-sm font-medium">{display.label}</span>
+                <Badge variant="outline" className={`text-[10px] ${band.chip}`}>
+                  {band.label}
+                </Badge>
+                {!isHardBlocked && (
+                  <span className="text-[10px] text-muted-foreground tabular-nums">
+                    {r.fitScore}/100
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">{r.rationale}</p>
+            </label>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function GeneratingRows({ platforms }: { platforms: string[] }) {
+  return (
+    <div className="space-y-2">
+      {platforms.map((p) => {
+        const display = getChannelDisplay(p);
+        return (
+          <div
+            key={p}
+            className="flex items-center gap-3 rounded-md border bg-card p-3"
+          >
+            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            <span className="text-sm">Writing for {display.label}…</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function DoneState({ response }: { response: RepurposeResponse }) {
+  // Group adaptations by platform for display. X returns two
+  // adaptations (post + thread); the rest return one each.
+  const byPlatform = response.adaptations.reduce<
+    Record<string, RepurposeResponse["adaptations"]>
+  >((acc, a) => {
+    (acc[a.platform] ??= []).push(a);
+    return acc;
+  }, {});
+  return (
+    <div className="space-y-3">
+      {Object.entries(byPlatform).map(([platform, variants]) => {
+        const display = getChannelDisplay(platform);
+        return (
+          <div key={platform} className="rounded-md border bg-card">
+            <div className="flex items-center gap-2 border-b px-3 py-2">
+              <CheckCircle2 className="size-4 text-emerald-500" />
+              <span className="text-sm font-medium">{display.label}</span>
+              <Badge variant="outline" className="text-[10px]">
+                {variants.length} variant{variants.length === 1 ? "" : "s"}
+              </Badge>
+            </div>
+            <div className="space-y-2 px-3 py-2">
+              {variants.map((v, i) => (
+                <div key={i} className="space-y-1">
+                  <div className="flex items-center gap-2 text-[11px] uppercase text-muted-foreground">
+                    {v.contentType}
+                    {v.estimatedEngagement > 0 && (
+                      <span className="tabular-nums">
+                        · {v.estimatedEngagement}/10 engagement
+                      </span>
+                    )}
+                  </div>
+                  <p className="whitespace-pre-line text-sm line-clamp-6">{v.content}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+      {response.failedPlatforms.length > 0 && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3">
+          <div className="mb-1 flex items-center gap-2 text-xs font-medium text-destructive">
+            <AlertCircle className="size-3.5" />
+            Failed
+          </div>
+          <ul className="space-y-0.5 text-xs">
+            {response.failedPlatforms.map((f) => {
+              const display = getChannelDisplay(f.platform);
+              return (
+                <li key={f.platform}>
+                  <span className="font-medium">{display.label}</span>:{" "}
+                  <span className="text-muted-foreground">{f.error}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -103,10 +103,14 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
   const recommendData = recommendMutation.data;
   // Memoised so the useEffect dep array sees a stable identity —
   // without this, the seeding effect would re-fire on every render
-  // (data ref is stable, but `?? []` produces a fresh array each time).
+  // (data ref is stable, but `?? []` produces a fresh array each
+  // time). Depend on the inner `recommendations` array rather than
+  // the whole `recommendData` object so the memo cache hit is tighter
+  // (avoids unnecessary seeding re-fires when other fields on
+  // recommendData would have updated).
   const recommendations = useMemo(
     () => recommendData?.recommendations ?? [],
-    [recommendData],
+    [recommendData?.recommendations],
   );
   const platformFitId = recommendData?.platformFitId ?? null;
 
@@ -142,7 +146,11 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
       ? "generating"
       : repurposeMutation.isSuccess
         ? "done"
-        : recommendMutation.isPending
+        : // `isIdle` (mutation hasn't run yet) AND we have a source =
+          // we're about to call mutate via the reset effect — treat as
+          // loading instead of letting the fallback "recommend" branch
+          // render an empty list for one frame.
+          recommendMutation.isPending || (recommendMutation.isIdle && source !== null)
           ? "loading"
           : recommendations.length === 0 && recommendMutation.isSuccess
             ? "empty"
@@ -314,7 +322,14 @@ function RecommendationList({
                   </span>
                 )}
               </div>
-              <p className="text-xs text-muted-foreground">{r.rationale}</p>
+              <p className="text-xs text-muted-foreground">
+                {r.rationale}
+                {isHardBlocked && r.hardBlocks && r.hardBlocks.length > 0 && (
+                  <span className="ml-1 text-[10px] uppercase tracking-wide opacity-70">
+                    [{r.hardBlocks.join(", ")}]
+                  </span>
+                )}
+              </p>
             </label>
           </li>
         );
@@ -325,7 +340,7 @@ function RecommendationList({
 
 function GeneratingRows({ platforms }: { platforms: string[] }) {
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" role="status" aria-live="polite">
       {platforms.map((p) => {
         const display = getChannelDisplay(p);
         return (
@@ -333,11 +348,45 @@ function GeneratingRows({ platforms }: { platforms: string[] }) {
             key={p}
             className="flex items-center gap-3 rounded-md border bg-card p-3"
           >
-            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            <Loader2
+              className="size-4 animate-spin text-muted-foreground"
+              aria-hidden
+            />
             <span className="text-sm">Writing for {display.label}…</span>
           </div>
         );
       })}
+      <span className="sr-only">Generating variants for {platforms.length} platform{platforms.length === 1 ? "" : "s"}</span>
+    </div>
+  );
+}
+
+function VariantPreview({ variant: v }: { variant: RepurposeResponse["adaptations"][number] }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 text-[11px] uppercase text-muted-foreground">
+        {v.contentType}
+        {v.estimatedEngagement > 0 && (
+          <span className="tabular-nums">
+            · {v.estimatedEngagement}/10 engagement
+          </span>
+        )}
+      </div>
+      <p
+        className={`whitespace-pre-line text-sm ${expanded ? "" : "line-clamp-6"}`}
+      >
+        {v.content}
+      </p>
+      {v.content.length > 280 && (
+        <button
+          type="button"
+          onClick={() => setExpanded((s) => !s)}
+          className="text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
     </div>
   );
 }
@@ -353,6 +402,14 @@ function DoneState({ response }: { response: RepurposeResponse }) {
   }, {});
   return (
     <div className="space-y-3">
+      {response.idempotent && (
+        // Visible cue (in addition to the sonner toast) so a user who
+        // dismisses the toast still sees these are prior variants,
+        // not fresh ones.
+        <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          Showing your previous repurpose for this content (no new variants generated).
+        </div>
+      )}
       {Object.entries(byPlatform).map(([platform, variants]) => {
         const display = getChannelDisplay(platform);
         return (
@@ -365,18 +422,8 @@ function DoneState({ response }: { response: RepurposeResponse }) {
               </Badge>
             </div>
             <div className="space-y-2 px-3 py-2">
-              {variants.map((v, i) => (
-                <div key={i} className="space-y-1">
-                  <div className="flex items-center gap-2 text-[11px] uppercase text-muted-foreground">
-                    {v.contentType}
-                    {v.estimatedEngagement > 0 && (
-                      <span className="tabular-nums">
-                        · {v.estimatedEngagement}/10 engagement
-                      </span>
-                    )}
-                  </div>
-                  <p className="whitespace-pre-line text-sm line-clamp-6">{v.content}</p>
-                </div>
+              {variants.map((v) => (
+                <VariantPreview key={`${platform}-${v.contentType}`} variant={v} />
               ))}
             </div>
           </div>

--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -37,25 +37,32 @@ interface Props {
 
 /**
  * Shared "Repurpose to platforms" sheet used from every entry point
- * (SuggestedDraftCard, Beehiiv row action, paste-and-repurpose
- * composer). Owns the recommend → confirm → generate flow end-to-end:
+ * (SuggestedDraftCard, Beehiiv row action — paste-and-repurpose
+ * composer ships later when /repurpose accepts ad_hoc sources).
+ * Owns the recommend → confirm → generate flow end-to-end:
  *
  *   1. Open → fires POST /v1/content/recommend-platforms with the
  *      source. Renders skeletons while the recommender scores.
  *   2. Recommendations land → renders one row per scored channel
  *      with band badge + rationale + checkbox. Green pre-checked,
  *      amber pre-checked, grey unchecked (the user can override).
- *      Hard-blocked greys are checkbox-disabled with a tooltip.
+ *      Hard-blocked greys are checkbox-disabled with the
+ *      hardBlocks reasons rendered inline next to the rationale.
  *   3. User clicks Generate → fires POST /v1/content/repurpose with
  *      platforms[] + platformFitId. Renders per-channel progress.
- *   4. Variants land → renders preview cards with "Open in composer"
- *      CTAs. Stub channels (Coming soon) render as a separate row
- *      so the user sees the recommender did its job even though
- *      publishing isn't wired.
+ *   4. Variants land → renders preview cards with VariantPreview
+ *      (expand/collapse). Stub channels (Facebook / Instagram /
+ *      Threads) are scored by the recommender but the engine
+ *      filters them out before the soc_social_posts persist — so
+ *      they don't appear in the Done view; users see them only in
+ *      the recommend list with greyed-out / hard-block reasoning.
  *
- * No internal hook — the state is sheet-scoped and unmounts on
- * close, so co-locating the mutations + selection state here keeps
- * the surface area small.
+ * Lifecycle note: the parent mounts <RepurposeSheet/> unconditionally
+ * (open is just a prop), so the component itself persists across
+ * close/open cycles — only radix's <SheetContent/> portal unmounts.
+ * The reset effect on [open, source] calls mutation.reset() before
+ * re-firing the recommend, so no stale data leaks into the next
+ * session.
  */
 export function RepurposeSheet({ open, onOpenChange, source }: Props) {
   const recommendMutation = useMutation({
@@ -71,7 +78,9 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
     onSuccess: (data: RepurposeResponse) => {
       const real = data.adaptations.length;
       if (real === 0) {
-        toast.info("No variants generated — every selected channel is either pending or failed.");
+        toast.info(
+          "No variants generated — every selected channel is either coming soon or failed.",
+        );
       } else if (data.idempotent) {
         toast.success(`Showing your previous repurpose (${real} variant${real === 1 ? "" : "s"})`);
       } else {
@@ -141,20 +150,32 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
     [selected],
   );
 
-  const stage: "loading" | "recommend" | "generating" | "done" | "empty" =
-    repurposeMutation.isPending
-      ? "generating"
-      : repurposeMutation.isSuccess
-        ? "done"
-        : // `isIdle` (mutation hasn't run yet) AND we have a source =
-          // we're about to call mutate via the reset effect — treat as
-          // loading instead of letting the fallback "recommend" branch
-          // render an empty list for one frame.
-          recommendMutation.isPending || (recommendMutation.isIdle && source !== null)
-          ? "loading"
-          : recommendations.length === 0 && recommendMutation.isSuccess
-            ? "empty"
-            : "recommend";
+  const stage:
+    | "loading"
+    | "recommend"
+    | "generating"
+    | "done"
+    | "empty"
+    | "error" =
+    // Defensive: open with no source = a parent bug; render loading
+    // (skeletons) rather than an empty checkbox list while the parent
+    // sorts itself out.
+    source === null
+      ? "loading"
+      : repurposeMutation.isPending
+        ? "generating"
+        : repurposeMutation.isSuccess
+          ? "done"
+          : recommendMutation.isError
+            ? "error"
+            : // `isIdle` = about to call mutate via the reset effect;
+              // treat as loading instead of letting the fallback
+              // "recommend" branch render an empty list for one frame.
+              recommendMutation.isPending || recommendMutation.isIdle
+              ? "loading"
+              : recommendations.length === 0 && recommendMutation.isSuccess
+                ? "empty"
+                : "recommend";
 
   function handleConfirm() {
     if (!source || !platformFitId || finalPlatforms.length === 0) return;
@@ -183,6 +204,16 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
         <div className="flex-1 overflow-y-auto px-6 py-4">
           {stage === "loading" && <LoadingRows />}
           {stage === "empty" && <EmptyState count={recommendData?.connectedChannelsCount ?? 0} />}
+          {stage === "error" && (
+            <ErrorState
+              message={
+                recommendMutation.error instanceof Error
+                  ? recommendMutation.error.message
+                  : "Failed to score platforms"
+              }
+              onRetry={() => source && recommendMutation.mutate(source)}
+            />
+          )}
           {stage === "recommend" && (
             <RecommendationList
               recommendations={recommendations}
@@ -220,7 +251,7 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
               </Button>
             </>
           )}
-          {(stage === "done" || stage === "empty") && (
+          {(stage === "done" || stage === "empty" || stage === "error") && (
             <Button type="button" size="sm" onClick={handleClose}>
               Close
             </Button>
@@ -251,6 +282,21 @@ function LoadingRows() {
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4">
+      <div className="mb-2 flex items-center gap-2 text-sm font-medium text-destructive">
+        <AlertCircle className="size-4" aria-hidden />
+        Failed to score platforms
+      </div>
+      <p className="mb-3 text-xs text-muted-foreground">{message}</p>
+      <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+        Retry
+      </Button>
     </div>
   );
 }

--- a/src/lib/api/repurpose.ts
+++ b/src/lib/api/repurpose.ts
@@ -1,0 +1,182 @@
+import { api } from "@/lib/api";
+
+/**
+ * Typed client for the W4 PlatformRecommender + W6 engine API
+ * surface shipped in peakhour-api PRs #324 (/recommend-platforms) +
+ * #325 (/repurpose). Matches the response shapes returned by those
+ * endpoints; if the API contract changes, update this file and the
+ * consumers (RepurposeSheet, useRepurpose hook).
+ */
+
+// ── Shared types ──────────────────────────────────────────
+
+export type PlatformFitBand = "green" | "amber" | "grey";
+
+export type PlatformFitHardBlock =
+  | "text_too_long_to_compress"
+  | "no_media"
+  | "incompatible_media_type"
+  | "channel_deprecated"
+  | "unknown_channel";
+
+export interface PlatformRecommendation {
+  /** cfg_channels.key — flat lowercase alphanumeric ("linkedin", "x", …) */
+  channel: string;
+  /** 0–100 composite fit score */
+  fitScore: number;
+  band: PlatformFitBand;
+  /** One-line rationale, safe to render verbatim in the UI tooltip */
+  rationale: string;
+  /** Present iff the recommender forced grey regardless of soft signals */
+  hardBlocks?: PlatformFitHardBlock[];
+  /** "linkedin@1.0.0" — useful for ops dashboards, not user-facing */
+  adapterVersion: string;
+  tier: "rules" | "industry" | "personal";
+}
+
+/**
+ * Discriminated source union shared by both endpoints. ad_hoc carries
+ * title + text inline (paste-and-repurpose composer); the other three
+ * are persisted-source references the API loads server-side.
+ */
+export type RepurposeSource =
+  | { type: "draft"; draftId: string }
+  | { type: "idea"; ideaId: string }
+  | { type: "published_post"; socialPostId: string }
+  | {
+      type: "ad_hoc";
+      title: string;
+      text: string;
+      tags?: string[];
+      hasMedia?: boolean;
+    };
+
+// ── POST /v1/content/recommend-platforms ──────────────────
+
+export interface RecommendPlatformsResponse {
+  /** cnt_platform_fit._id — pass back to /repurpose so the user's
+   *  confirmed platforms[] stamps userResponse on the same audit row. */
+  platformFitId: string;
+  recommendations: PlatformRecommendation[];
+  /** Count of channels the business has connected. UI uses this to
+   *  show a "connect a channel" affordance when 0. */
+  connectedChannelsCount: number;
+}
+
+export async function recommendPlatforms(
+  source: RepurposeSource,
+): Promise<RecommendPlatformsResponse> {
+  return api.request<RecommendPlatformsResponse>(
+    "/v1/content/recommend-platforms",
+    {
+      method: "POST",
+      body: JSON.stringify({ source }),
+    },
+  );
+}
+
+// ── POST /v1/content/repurpose ────────────────────────────
+
+/**
+ * One generated variant. The engine returns a single doc per
+ * /repurpose call with `adaptations[]` covering all confirmed
+ * platforms (LinkedIn → 1 entry; X → 2 entries: "post" + "thread";
+ * stub platforms filtered out before persist).
+ */
+export interface RepurposedAdaptation {
+  /** Channel key (matches PlatformRecommendation.channel) */
+  platform: string;
+  /** "post" | "thread" | etc. — content type within the channel */
+  contentType: string;
+  content: string;
+  hashtags?: string[];
+  hook?: string;
+  estimatedEngagement: number;
+  reasoning?: string;
+  /** Extra per-channel metadata (e.g. X thread carries metadata.tweets) */
+  metadata?: Record<string, unknown>;
+}
+
+export interface RepurposeFailure {
+  platform: string;
+  error: string;
+}
+
+export interface RepurposeResponse {
+  /** soc_social_posts._id (string) when at least one variant was
+   *  persisted; null when every requested platform failed or was a
+   *  coming-soon stub (Facebook / Instagram / Threads). */
+  socialPostId: string | null;
+  sourceTitle: string;
+  adaptations: RepurposedAdaptation[];
+  failedPlatforms: RepurposeFailure[];
+  /** True when the route's idempotency short-circuit returned a
+   *  prior post instead of generating fresh variants. UI can show
+   *  "showing your previous repurpose" if it matters for context. */
+  idempotent?: boolean;
+}
+
+export interface RepurposeRequest {
+  source: RepurposeSource;
+  platforms: string[];
+  /** Pass the platformFitId from the prior /recommend-platforms call
+   *  to (a) stamp userResponse on the cnt_platform_fit row for the
+   *  closed-loop training signal, AND (b) opt into the idempotency
+   *  short-circuit (double-POST returns the prior post instead of
+   *  re-generating). */
+  platformFitId?: string;
+}
+
+export async function repurpose(req: RepurposeRequest): Promise<RepurposeResponse> {
+  return api.request<RepurposeResponse>("/v1/content/repurpose", {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+}
+
+// ── Channel display metadata ──────────────────────────────
+// Renders the platform name + icon hint in the picker UI. Stays in
+// lockstep with the cfg_channels keys server-side. Adding a new
+// channel here is purely cosmetic — the recommender/engine work
+// regardless once the cfg_channels seed + adapter ships.
+
+export interface ChannelDisplay {
+  label: string;
+  /** Lucide icon name OR null for channels we don't have a brand-true
+   *  icon for. Renderer falls back to a generic chip. */
+  icon: "linkedin" | "twitter" | "facebook" | "instagram" | "message-circle" | null;
+}
+
+export const CHANNEL_DISPLAY: Record<string, ChannelDisplay> = {
+  linkedin: { label: "LinkedIn", icon: "linkedin" },
+  x: { label: "X (Twitter)", icon: "twitter" },
+  facebook: { label: "Facebook", icon: "facebook" },
+  instagram: { label: "Instagram", icon: "instagram" },
+  threads: { label: "Threads", icon: "message-circle" },
+};
+
+export function getChannelDisplay(channel: string): ChannelDisplay {
+  return CHANNEL_DISPLAY[channel] ?? { label: channel, icon: null };
+}
+
+// ── Band → visual styling (Tailwind classes) ──────────────
+// One place so the chip / row / badge stays consistent across the
+// sheet, suggested-drafts card preview, and any future surface.
+
+export const BAND_STYLES: Record<PlatformFitBand, { dot: string; chip: string; label: string }> = {
+  green: {
+    dot: "bg-emerald-500",
+    chip: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    label: "Recommended",
+  },
+  amber: {
+    dot: "bg-amber-500",
+    chip: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    label: "Optional",
+  },
+  grey: {
+    dot: "bg-slate-400",
+    chip: "border-slate-400/40 bg-slate-400/10 text-slate-600 dark:text-slate-400",
+    label: "Not recommended",
+  },
+};


### PR DESCRIPTION
## Summary

b2c-side UI for the W4 PlatformRecommender + W6 engine shipped in peakhour-api PRs #324 (recommend) + #325 (repurpose) + #326 (skill wiring). The recommend → confirm → generate loop is now user-visible.

## What ships

**Typed API client** — \`src/lib/api/repurpose.ts\`
- Wrappers for POST /v1/content/recommend-platforms + POST /v1/content/repurpose
- Shared \`RepurposeSource\` discriminated union; CHANNEL_DISPLAY + BAND_STYLES for consistent rendering

**Shared component** — \`src/components/repurpose/repurpose-sheet.tsx\`
- 5 stages: loading (skeletons) → recommend (checkbox list) → generating (per-channel spinners) → done (variant preview cards) / empty
- Pre-checks green + amber recommendations; hard-blocked greys are disabled with the hardBlocks reason shown
- Idempotency-aware: when the API short-circuit fires, both a sonner toast AND an inline amber notice surface that variants are cached
- Stub-channel safe: Facebook/Instagram/Threads score and show but are filtered from soc_social_posts persist (engine handles)
- VariantPreview with Show more/less for long content
- a11y: role=\"status\" + aria-live on generating; checkbox + label associated; spinners aria-hidden + sr-only labels

**Entry points (2 of 3)**
1. **SuggestedDraftCard** (suggested-drafts-panel.tsx) — secondary \"Repurpose\" button next to \"Use this draft\"
2. **Beehiiv ArticleCard** (beehiiv/page.tsx) — \"Repurpose\" button at the bottom of each card, stopPropagation-guarded to not trigger the card's router.push to the detail page

**Entry point 3 deferred** — \`/dashboard/content/repurpose\` paste-and-repurpose composer. Reason: the /repurpose API route is v1-restricted to source.type=\"draft\" (per #325 plan — soc_social_posts.draftId is draft-keyed). Shipping the paste composer needs polymorphic source support in the api first.

## Test plan

- [ ] Build + lint clean (verified locally for my files; pre-existing repo-wide lint issues unrelated)
- [ ] Manual on dev: open dashboard with onboarding-generated SuggestedDrafts → click Repurpose → sheet loads → tick LinkedIn + X → click Generate → variants land → close + reopen → \"Showing your previous repurpose\" appears (idempotent short-circuit)
- [ ] Manual: open Beehiiv card view → click Repurpose on an article card → verify the card's onClick (router.push) DOES NOT fire (stopPropagation)
- [ ] Edge case: tick a hard-blocked channel — checkbox should be disabled with reason visible
- [ ] Edge case: business with 0 connected channels — empty state with "connect a channel" CTA
- [ ] a11y: tab through the sheet — focus order is sensible; screen reader announces stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)