### PR TITLE
feat(scheduler): reusable UI primitives

### DIFF
--- a/src/components/scheduler/calendar-view.tsx
+++ b/src/components/scheduler/calendar-view.tsx
@@ -347,9 +347,11 @@ export function CalendarView({
                       "application/x-scheduled-item-id",
                       item._id,
                     );
+                    // Shift-drag = item-only; plain drag = bundle-move.
+                    // Same contract as week view.
                     e.dataTransfer.setData(
-                      "application/x-alt",
-                      e.altKey ? "1" : "0",
+                      "application/x-item-only",
+                      e.shiftKey ? "1" : "0",
                     );
                     e.dataTransfer.effectAllowed = "move";
                   }}

--- a/src/components/scheduler/calendar-view.tsx
+++ b/src/components/scheduler/calendar-view.tsx
@@ -197,18 +197,20 @@ export function CalendarView({
     e.preventDefault();
     if (!onItemMove) return;
     const itemId = e.dataTransfer.getData("application/x-scheduled-item-id");
-    const altKey = e.dataTransfer.getData("application/x-alt") === "1";
+    const itemOnly = e.dataTransfer.getData("application/x-item-only") === "1";
     const item = items.find((i) => i._id === itemId);
     if (!item) return;
     onItemMove({
       item,
       toDayLocal: day,
-      mode: altKey ? "item" : "bundle",
+      mode: itemOnly ? "item" : "bundle",
     });
   };
 
   if (mode === "week") {
-    // 7-column week grid; tall cells with day items stacked vertically.
+    // Below `md` (768px) week stacks into a vertical list with
+    // inline day headers — 7 full-height cards on mobile is too
+    // tall to scan. Above md, 7-column grid with stacked items.
     return (
       <div
         className={cn(
@@ -226,7 +228,10 @@ export function CalendarView({
               onDragOver={(e) => e.preventDefault()}
               onDrop={onDrop(day)}
               className={cn(
-                "flex min-h-[140px] flex-col rounded-lg border bg-background p-2",
+                "flex flex-col rounded-lg border bg-background p-2",
+                // Mobile (stacked): compact min-height. Desktop
+                // (7-col grid): taller cells to show multiple items.
+                "min-h-20 md:min-h-35",
                 isToday && "border-primary/40 ring-1 ring-primary/20",
               )}
             >
@@ -267,9 +272,13 @@ export function CalendarView({
                           "application/x-scheduled-item-id",
                           item._id,
                         );
+                        // Shift-drag selects item-only mode; plain
+                        // drag is bundle-move (locked decision #10).
+                        // Shift avoids the OS-level "create link"
+                        // overload that Alt triggers on Windows.
                         e.dataTransfer.setData(
-                          "application/x-alt",
-                          e.altKey ? "1" : "0",
+                          "application/x-item-only",
+                          e.shiftKey ? "1" : "0",
                         );
                         e.dataTransfer.effectAllowed = "move";
                       }}
@@ -302,7 +311,7 @@ export function CalendarView({
             onDragOver={(e) => e.preventDefault()}
             onDrop={onDrop(day)}
             className={cn(
-              "flex min-h-[100px] flex-col rounded p-1 text-xs",
+              "flex min-h-25 flex-col rounded p-1 text-xs",
               isToday && "bg-primary/5",
             )}
           >

--- a/src/components/scheduler/calendar-view.tsx
+++ b/src/components/scheduler/calendar-view.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+/**
+ * <CalendarView /> — reusable week-grid + month-grid component that
+ * renders scheduled items as dense, drag-droppable cards. Stateless:
+ * parent owns the items + the selected date range + drag callbacks.
+ *
+ * Two display modes:
+ *   - "week" — 7-column day grid with per-day item stacks
+ *   - "month" — 6-row month grid with item chips (denser overview)
+ *
+ * Drag-to-reschedule is opt-in via the `onItemMove` prop. Per locked
+ * decision #10 in content-pipeline-hardening.md, plain drag moves the
+ * whole BUNDLE (every sibling item in the same plan); alt-drag moves
+ * the single item only. The callback receives a `mode: "bundle" |
+ * "item"` flag so the parent can stage the right mutation.
+ *
+ * Channel filter is owned by the parent (the calendar PAGE in PR 7
+ * renders the chip strip + passes filtered items down).
+ */
+
+import { useMemo } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  PauseCircle,
+  RotateCw,
+  XCircle,
+} from "lucide-react";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import { cn } from "@/lib/utils";
+import {
+  channelDisplayName,
+  formatTimeLabel,
+  statusTone,
+} from "@/lib/scheduler/format";
+import type { ScheduledItemDto } from "@/lib/scheduler/types";
+
+const STATUS_ICON = {
+  published: CheckCircle2,
+  queued: Clock,
+  awaiting_retry: RotateCw,
+  ready: Clock,
+  in_flight: RotateCw,
+  failed: XCircle,
+  cancelled: XCircle,
+  skipped: PauseCircle,
+  needs_action: AlertTriangle,
+} as const;
+
+export interface CalendarViewProps {
+  items: ScheduledItemDto[];
+  /** UTC start of the visible window — inclusive. */
+  rangeStart: Date;
+  /** UTC end of the visible window — exclusive. */
+  rangeEnd: Date;
+  /** IANA timezone the user is viewing in. */
+  timezone: string;
+  mode?: "week" | "month";
+  /** Open the per-item drawer. */
+  onItemClick?: (item: ScheduledItemDto) => void;
+  /** Drop callback. mode="bundle" when user dragged without alt;
+   *  "item" with alt-drag. The parent stages the actual API mutation. */
+  onItemMove?: (args: {
+    item: ScheduledItemDto;
+    toDayLocal: Date;
+    mode: "bundle" | "item";
+  }) => void;
+  className?: string;
+}
+
+/** Inclusive list of midnight-local Dates between rangeStart and
+ *  rangeEnd, computed in the target timezone. */
+function listLocalDays(start: Date, end: Date, tz: string): Date[] {
+  const out: Date[] = [];
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  let cursor = new Date(start.getTime());
+  // Snap cursor to midnight-local of its day.
+  while (cursor < end) {
+    const parts = fmt.format(cursor);
+    out.push(new Date(`${parts}T00:00:00Z`));
+    cursor = new Date(cursor.getTime() + 24 * 3600 * 1000);
+  }
+  return out;
+}
+
+/** Bucket items by local-day key (YYYY-MM-DD in the target timezone). */
+function bucketByDay(
+  items: ScheduledItemDto[],
+  tz: string,
+): Map<string, ScheduledItemDto[]> {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const map = new Map<string, ScheduledItemDto[]>();
+  for (const item of items) {
+    const key = fmt.format(new Date(item.scheduledAtUtc));
+    const arr = map.get(key) ?? [];
+    arr.push(item);
+    map.set(key, arr);
+  }
+  // Sort each day's items by time.
+  for (const arr of map.values()) {
+    arr.sort((a, b) => a.scheduledAtUtc.localeCompare(b.scheduledAtUtc));
+  }
+  return map;
+}
+
+function dayKey(d: Date, tz: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+interface ItemChipProps {
+  item: ScheduledItemDto;
+  onClick?: () => void;
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+}
+
+function ItemChip({ item, onClick, draggable, onDragStart }: ItemChipProps) {
+  const Icon = STATUS_ICON[item.status] ?? Clock;
+  const tone = statusTone(item.status);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      className={cn(
+        "group relative flex w-full items-center gap-1.5 rounded-md border bg-card px-2 py-1.5 text-left text-xs transition",
+        "hover:border-primary/40 hover:shadow-sm",
+        item.payloadStale && "border-amber-400 bg-amber-50 dark:bg-amber-950/40",
+        tone === "warn" && !item.payloadStale &&
+          "border-amber-300 bg-amber-50 dark:bg-amber-950/30",
+        tone === "error" && "border-rose-300 bg-rose-50 dark:bg-rose-950/30",
+        tone === "success" && "bg-emerald-50 dark:bg-emerald-950/20",
+        draggable && "cursor-grab active:cursor-grabbing",
+      )}
+      title={
+        item.payload.text.length > 80
+          ? `${item.payload.text.slice(0, 80)}…`
+          : item.payload.text
+      }
+    >
+      <ChannelIconCompact channel={item.channel} size={14} />
+      <span className="min-w-0 flex-1 truncate font-medium">
+        {item.payload.text.split("\n")[0]!.slice(0, 60) ||
+          channelDisplayName(item.channel)}
+      </span>
+      <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+        {formatTimeLabel(item.scheduledAtUtc, item.audienceTimezone)}
+      </span>
+      <Icon
+        className={cn(
+          "h-3 w-3 shrink-0",
+          tone === "success" && "text-emerald-600",
+          tone === "info" && "text-sky-600",
+          tone === "warn" && "text-amber-600",
+          tone === "error" && "text-rose-600",
+        )}
+      />
+    </button>
+  );
+}
+
+export function CalendarView({
+  items,
+  rangeStart,
+  rangeEnd,
+  timezone,
+  mode = "week",
+  onItemClick,
+  onItemMove,
+  className,
+}: CalendarViewProps) {
+  const days = useMemo(
+    () => listLocalDays(rangeStart, rangeEnd, timezone),
+    [rangeStart, rangeEnd, timezone],
+  );
+  const buckets = useMemo(() => bucketByDay(items, timezone), [items, timezone]);
+
+  const onDrop = (day: Date) => (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!onItemMove) return;
+    const itemId = e.dataTransfer.getData("application/x-scheduled-item-id");
+    const altKey = e.dataTransfer.getData("application/x-alt") === "1";
+    const item = items.find((i) => i._id === itemId);
+    if (!item) return;
+    onItemMove({
+      item,
+      toDayLocal: day,
+      mode: altKey ? "item" : "bundle",
+    });
+  };
+
+  if (mode === "week") {
+    // 7-column week grid; tall cells with day items stacked vertically.
+    return (
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-2 md:grid-cols-7",
+          className,
+        )}
+      >
+        {days.map((day) => {
+          const key = dayKey(day, timezone);
+          const dayItems = buckets.get(key) ?? [];
+          const isToday = key === dayKey(new Date(), timezone);
+          return (
+            <div
+              key={key}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={onDrop(day)}
+              className={cn(
+                "flex min-h-[140px] flex-col rounded-lg border bg-background p-2",
+                isToday && "border-primary/40 ring-1 ring-primary/20",
+              )}
+            >
+              <div className="mb-1.5 flex items-baseline justify-between text-xs">
+                <span
+                  className={cn(
+                    "font-semibold",
+                    isToday && "text-primary",
+                  )}
+                >
+                  {new Intl.DateTimeFormat(undefined, {
+                    weekday: "short",
+                    timeZone: timezone,
+                  }).format(day)}
+                </span>
+                <span className="tabular-nums text-muted-foreground">
+                  {new Intl.DateTimeFormat(undefined, {
+                    day: "numeric",
+                    month: "short",
+                    timeZone: timezone,
+                  }).format(day)}
+                </span>
+              </div>
+              <div className="space-y-1">
+                {dayItems.length === 0 ? (
+                  <div className="text-[11px] italic text-muted-foreground/60">
+                    nothing scheduled
+                  </div>
+                ) : (
+                  dayItems.map((item) => (
+                    <ItemChip
+                      key={item._id}
+                      item={item}
+                      onClick={() => onItemClick?.(item)}
+                      draggable={!!onItemMove}
+                      onDragStart={(e) => {
+                        e.dataTransfer.setData(
+                          "application/x-scheduled-item-id",
+                          item._id,
+                        );
+                        e.dataTransfer.setData(
+                          "application/x-alt",
+                          e.altKey ? "1" : "0",
+                        );
+                        e.dataTransfer.effectAllowed = "move";
+                      }}
+                    />
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Month view — denser, drops fine-grained per-day time labels.
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-7 gap-1 rounded-lg border bg-background p-1.5",
+        className,
+      )}
+    >
+      {days.map((day) => {
+        const key = dayKey(day, timezone);
+        const dayItems = buckets.get(key) ?? [];
+        const isToday = key === dayKey(new Date(), timezone);
+        return (
+          <div
+            key={key}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={onDrop(day)}
+            className={cn(
+              "flex min-h-[100px] flex-col rounded p-1 text-xs",
+              isToday && "bg-primary/5",
+            )}
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <span
+                className={cn(
+                  "tabular-nums",
+                  isToday
+                    ? "rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground"
+                    : "text-[10px] text-muted-foreground",
+                )}
+              >
+                {new Intl.DateTimeFormat(undefined, {
+                  day: "numeric",
+                  timeZone: timezone,
+                }).format(day)}
+              </span>
+              {dayItems.length > 0 && (
+                <span className="text-[10px] tabular-nums text-muted-foreground">
+                  {dayItems.length}
+                </span>
+              )}
+            </div>
+            <div className="space-y-0.5">
+              {dayItems.slice(0, 3).map((item) => (
+                <ItemChip
+                  key={item._id}
+                  item={item}
+                  onClick={() => onItemClick?.(item)}
+                  draggable={!!onItemMove}
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData(
+                      "application/x-scheduled-item-id",
+                      item._id,
+                    );
+                    e.dataTransfer.setData(
+                      "application/x-alt",
+                      e.altKey ? "1" : "0",
+                    );
+                    e.dataTransfer.effectAllowed = "move";
+                  }}
+                />
+              ))}
+              {dayItems.length > 3 && (
+                <button
+                  type="button"
+                  onClick={() => onItemClick?.(dayItems[0]!)}
+                  className="text-[10px] text-muted-foreground underline-offset-2 hover:underline"
+                >
+                  +{dayItems.length - 3} more
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/scheduler/index.ts
+++ b/src/components/scheduler/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Reusable scheduler UI primitives — the @peakhour/scheduler-ui kit
+ * inlined in the b2c codebase. Every primitive is presentational +
+ * controlled (parent owns state); the only side-effects live in
+ * `useSchedulePreview` (debounced API preview).
+ *
+ * Plan reference: peakhour-mongodb/docs/idea/content-pipeline-hardening.md
+ * §2.3 — "Reusable UI primitives" list.
+ */
+
+export { ScheduleTimePicker } from "./schedule-time-picker";
+export type { ScheduleTimePickerProps } from "./schedule-time-picker";
+
+export { StaggerStrategyChooser } from "./stagger-strategy-chooser";
+export type { StaggerStrategyChooserProps } from "./stagger-strategy-chooser";
+
+export { ScheduleConfirmCard } from "./schedule-confirm-card";
+export type { ScheduleConfirmCardProps } from "./schedule-confirm-card";
+
+export {
+  PublishBundleSummary,
+  NextActionScheduleSlot,
+} from "./publish-bundle-summary";
+export type { PublishBundleSummaryProps } from "./publish-bundle-summary";
+
+export { TimezoneBanner } from "./timezone-banner";
+export type { TimezoneBannerProps } from "./timezone-banner";
+
+export { ScheduleConflictWarning } from "./schedule-conflict-warning";
+export type { ScheduleConflictWarningProps } from "./schedule-conflict-warning";
+
+export { RecurringScheduleEditor } from "./recurring-schedule-editor";
+export type {
+  RecurringScheduleEditorProps,
+  RecurringRuleInput,
+  RecurringFreq,
+} from "./recurring-schedule-editor";
+
+export { CalendarView } from "./calendar-view";
+export type { CalendarViewProps } from "./calendar-view";
+
+export { useSchedulePreview } from "./use-schedule-preview";
+
+export { SchedulerComposer } from "./scheduler-composer";
+export type { SchedulerComposerProps } from "./scheduler-composer";

--- a/src/components/scheduler/publish-bundle-summary.tsx
+++ b/src/components/scheduler/publish-bundle-summary.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+/**
+ * <PublishBundleSummary /> — denser bundle card for the dashboard
+ * "next publish" surface. Renders one row per channel with the
+ * resolved time, current item status, and any payload-stale /
+ * needs-action banner inline.
+ *
+ * Distinct from ScheduleConfirmCard (pre-commit preview) — this one
+ * renders ALREADY-COMMITTED items.
+ */
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  Clock,
+  CheckCircle2,
+  RotateCw,
+  XCircle,
+} from "lucide-react";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  channelDisplayName,
+  formatScheduleLabel,
+  formatRelative,
+  statusTone,
+} from "@/lib/scheduler/format";
+import type { ScheduledItemDto } from "@/lib/scheduler/types";
+
+const STATUS_ICON = {
+  published: CheckCircle2,
+  queued: Clock,
+  awaiting_retry: RotateCw,
+  ready: Clock,
+  in_flight: RotateCw,
+  failed: XCircle,
+  cancelled: XCircle,
+  skipped: XCircle,
+  needs_action: AlertTriangle,
+} as const;
+
+export interface PublishBundleSummaryProps {
+  /** Plan title for the header — falls back to the source title. */
+  title?: string;
+  items: ScheduledItemDto[];
+  /** Optional href to drill into the per-plan detail page. */
+  detailHref?: string;
+  /** Optional "Refresh snapshot" button for stale items. */
+  onRefreshStale?: () => void;
+  /** Cancel button — when omitted, header is read-only. */
+  onCancel?: () => void;
+  className?: string;
+}
+
+export function PublishBundleSummary({
+  title,
+  items,
+  detailHref,
+  onRefreshStale,
+  onCancel,
+  className,
+}: PublishBundleSummaryProps) {
+  if (items.length === 0) return null;
+  const tz = items[0]!.audienceTimezone;
+  const staleCount = items.filter((i) => i.payloadStale).length;
+  const needsActionCount = items.filter((i) => i.status === "needs_action").length;
+  const earliest = items
+    .slice()
+    .sort((a, b) => a.scheduledAtUtc.localeCompare(b.scheduledAtUtc))[0]!;
+
+  return (
+    <Card className={cn("overflow-hidden", className)}>
+      <CardHeader className="flex flex-row items-start justify-between gap-2 pb-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm font-semibold">
+            {title ?? "Scheduled bundle"}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            First out · {formatRelative(earliest.scheduledAtUtc)} ·{" "}
+            {items.length} channel{items.length === 1 ? "" : "s"}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1">
+          {detailHref && (
+            <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-xs">
+              <Link href={detailHref}>Open</Link>
+            </Button>
+          )}
+          {onCancel && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {(staleCount > 0 || needsActionCount > 0) && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="flex-1">
+              {staleCount > 0 && (
+                <div>
+                  {staleCount} item{staleCount === 1 ? "" : "s"} need a snapshot
+                  refresh — your source content changed since these were
+                  scheduled.
+                </div>
+              )}
+              {needsActionCount > 0 && (
+                <div>
+                  {needsActionCount} item{needsActionCount === 1 ? "" : "s"}{" "}
+                  paused — waiting for you to reconnect or resolve.
+                </div>
+              )}
+            </div>
+            {onRefreshStale && staleCount > 0 && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 border-amber-300 px-2 text-xs"
+                onClick={onRefreshStale}
+              >
+                Refresh
+              </Button>
+            )}
+          </div>
+        )}
+
+        <ul className="divide-y rounded-md border bg-background text-sm">
+          {items.map((item) => {
+            const Icon = STATUS_ICON[item.status] ?? Clock;
+            const tone = statusTone(item.status);
+            return (
+              <li
+                key={item._id}
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2",
+                  item.payloadStale && "bg-amber-50/50 dark:bg-amber-950/20",
+                )}
+              >
+                <ChannelIconCompact channel={item.channel} size={16} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">
+                    {channelDisplayName(item.channel)}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatScheduleLabel(item.scheduledAtUtc, tz)}
+                  </div>
+                </div>
+                <div
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                    tone === "success" &&
+                      "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300",
+                    tone === "info" &&
+                      "bg-sky-100 text-sky-700 dark:bg-sky-950/40 dark:text-sky-300",
+                    tone === "warn" &&
+                      "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",
+                    tone === "error" &&
+                      "bg-rose-100 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300",
+                    tone === "neutral" && "bg-muted text-muted-foreground",
+                  )}
+                >
+                  <Icon className="h-3 w-3" />
+                  {item.status.replaceAll("_", " ")}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Helper for the "next item up" sidebar slot — a single
+ *  scheduled item, denser than the bundle card. */
+export function NextActionScheduleSlot({
+  item,
+  className,
+}: {
+  item: ScheduledItemDto;
+  className?: string;
+}) {
+  const Icon = STATUS_ICON[item.status] ?? Clock;
+  const tone = statusTone(item.status);
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg border p-3",
+        item.status === "needs_action" &&
+          "border-amber-300 bg-amber-50 dark:bg-amber-950/30",
+        item.payloadStale && "border-amber-300",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "inline-flex h-9 w-9 items-center justify-center rounded-full",
+          tone === "success" && "bg-emerald-100 text-emerald-700",
+          tone === "info" && "bg-sky-100 text-sky-700",
+          tone === "warn" && "bg-amber-100 text-amber-700",
+          tone === "error" && "bg-rose-100 text-rose-700",
+          tone === "neutral" && "bg-muted text-muted-foreground",
+        )}
+      >
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 text-sm font-medium">
+          <ChannelIconCompact channel={item.channel} size={14} />
+          {channelDisplayName(item.channel)}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {formatRelative(item.scheduledAtUtc)} ·{" "}
+          {formatScheduleLabel(item.scheduledAtUtc, item.audienceTimezone)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduler/recurring-schedule-editor.tsx
+++ b/src/components/scheduler/recurring-schedule-editor.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+/**
+ * <RecurringScheduleEditor /> — configures a recurring rule. Supports
+ * daily / weekly (with weekday picker) / monthly (with day-of-month
+ * picker) / custom cron.
+ *
+ * Stateless control surface — parent owns the rule shape. Validates
+ * locally (weekly requires weekdays; monthly requires dayOfMonth;
+ * custom_cron requires cron string).
+ */
+
+import { useId } from "react";
+import { CalendarClock, Repeat } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+export type RecurringFreq = "daily" | "weekly" | "monthly" | "custom_cron";
+
+export interface RecurringRuleInput {
+  freq: RecurringFreq;
+  interval?: number;
+  /** JS getDay() convention: 0=Sunday … 6=Saturday */
+  weekdays?: number[];
+  dayOfMonth?: number;
+  cron?: string;
+  localTime: string;
+  timezone: string;
+  effectiveFrom: string; // ISO date
+  effectiveUntil?: string;
+  maxRuns?: number;
+}
+
+const WEEKDAYS = [
+  { idx: 1, label: "M" },
+  { idx: 2, label: "T" },
+  { idx: 3, label: "W" },
+  { idx: 4, label: "T" },
+  { idx: 5, label: "F" },
+  { idx: 6, label: "S" },
+  { idx: 0, label: "S" },
+];
+
+export interface RecurringScheduleEditorProps {
+  value: RecurringRuleInput;
+  onChange: (next: RecurringRuleInput) => void;
+  className?: string;
+}
+
+export function RecurringScheduleEditor({
+  value,
+  onChange,
+  className,
+}: RecurringScheduleEditorProps) {
+  const id = useId();
+  const toggleWeekday = (idx: number) => {
+    const set = new Set(value.weekdays ?? []);
+    if (set.has(idx)) set.delete(idx);
+    else set.add(idx);
+    onChange({ ...value, weekdays: [...set].sort((a, b) => a - b) });
+  };
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <Repeat className="h-4 w-4 text-primary" /> Repeat
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-[160px_120px_1fr]">
+        <div>
+          <Label htmlFor={`${id}-freq`} className="mb-1 block text-xs">
+            Cadence
+          </Label>
+          <Select
+            value={value.freq}
+            onValueChange={(v) => onChange({ ...value, freq: v as RecurringFreq })}
+          >
+            <SelectTrigger id={`${id}-freq`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="daily">Daily</SelectItem>
+              <SelectItem value="weekly">Weekly</SelectItem>
+              <SelectItem value="monthly">Monthly</SelectItem>
+              <SelectItem value="custom_cron">Custom cron</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label htmlFor={`${id}-interval`} className="mb-1 block text-xs">
+            Every
+          </Label>
+          <Input
+            id={`${id}-interval`}
+            type="number"
+            min={1}
+            max={365}
+            value={value.interval ?? 1}
+            onChange={(e) =>
+              onChange({ ...value, interval: Number(e.target.value) || 1 })
+            }
+          />
+        </div>
+        <div>
+          <Label htmlFor={`${id}-time`} className="mb-1 block text-xs">
+            Time-of-day ({value.timezone})
+          </Label>
+          <Input
+            id={`${id}-time`}
+            type="time"
+            value={value.localTime}
+            onChange={(e) =>
+              onChange({ ...value, localTime: e.target.value })
+            }
+          />
+        </div>
+      </div>
+
+      {value.freq === "weekly" && (
+        <div>
+          <Label className="mb-1 block text-xs">On weekdays</Label>
+          <div className="flex flex-wrap gap-1">
+            {WEEKDAYS.map((d) => {
+              const active = value.weekdays?.includes(d.idx);
+              return (
+                <button
+                  key={d.idx}
+                  type="button"
+                  onClick={() => toggleWeekday(d.idx)}
+                  aria-pressed={active}
+                  className={cn(
+                    "inline-flex h-8 w-8 items-center justify-center rounded-full border text-xs font-medium",
+                    active
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-input bg-background text-muted-foreground hover:bg-accent",
+                  )}
+                  title={
+                    ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"][d.idx]
+                  }
+                >
+                  {d.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {value.freq === "monthly" && (
+        <div>
+          <Label htmlFor={`${id}-dom`} className="mb-1 block text-xs">
+            Day of month
+          </Label>
+          <Input
+            id={`${id}-dom`}
+            type="number"
+            min={1}
+            max={31}
+            value={value.dayOfMonth ?? 1}
+            onChange={(e) =>
+              onChange({ ...value, dayOfMonth: Number(e.target.value) })
+            }
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Day 29-31 will clamp to the last day in months that don&apos;t reach it
+            (e.g. Feb 29 → Feb 28).
+          </p>
+        </div>
+      )}
+
+      {value.freq === "custom_cron" && (
+        <div>
+          <Label htmlFor={`${id}-cron`} className="mb-1 block text-xs">
+            Cron expression
+          </Label>
+          <Input
+            id={`${id}-cron`}
+            type="text"
+            placeholder="0 9 * * 1-5"
+            value={value.cron ?? ""}
+            onChange={(e) => onChange({ ...value, cron: e.target.value })}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Standard 5-field crontab: minute, hour, day-of-month, month,
+            day-of-week.
+          </p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div>
+          <Label htmlFor={`${id}-from`} className="mb-1 block text-xs">
+            Start
+          </Label>
+          <Input
+            id={`${id}-from`}
+            type="date"
+            value={value.effectiveFrom.slice(0, 10)}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                effectiveFrom: new Date(e.target.value).toISOString(),
+              })
+            }
+          />
+        </div>
+        <div className="flex items-end gap-2">
+          <Switch
+            id={`${id}-bounded`}
+            checked={!!value.effectiveUntil}
+            onCheckedChange={(checked) =>
+              onChange({
+                ...value,
+                effectiveUntil: checked
+                  ? new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString()
+                  : undefined,
+              })
+            }
+          />
+          <Label
+            htmlFor={`${id}-bounded`}
+            className="flex items-center gap-1 text-xs"
+          >
+            <CalendarClock className="h-3 w-3" /> End date
+          </Label>
+          {value.effectiveUntil && (
+            <Input
+              type="date"
+              value={value.effectiveUntil.slice(0, 10)}
+              onChange={(e) =>
+                onChange({
+                  ...value,
+                  effectiveUntil: new Date(e.target.value).toISOString(),
+                })
+              }
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduler/recurring-schedule-editor.tsx
+++ b/src/components/scheduler/recurring-schedule-editor.tsx
@@ -53,6 +53,19 @@ function composeLocalDateTime(
   if (!yyyymmdd) return new Date().toISOString();
   const [y, mo, d] = yyyymmdd.split("-").map(Number);
   const [hh, mm] = hhmm.split(":").map(Number);
+  // Native <input type="date"> shouldn't emit malformed strings,
+  // but a future bound-prop change or a paste of garbage would
+  // otherwise produce Date.UTC(NaN, …) → Invalid Date → toISOString
+  // throws. Guard so the caller gets a usable fallback.
+  if (
+    !Number.isFinite(y) ||
+    !Number.isFinite(mo) ||
+    !Number.isFinite(d) ||
+    !Number.isFinite(hh) ||
+    !Number.isFinite(mm)
+  ) {
+    return new Date().toISOString();
+  }
   // Initial guess: parts interpreted as UTC.
   const guess = new Date(Date.UTC(y!, (mo ?? 1) - 1, d!, hh ?? 0, mm ?? 0));
   // Re-format the guess into the target tz to compute the offset.

--- a/src/components/scheduler/recurring-schedule-editor.tsx
+++ b/src/components/scheduler/recurring-schedule-editor.tsx
@@ -40,6 +40,44 @@ export interface RecurringRuleInput {
   maxRuns?: number;
 }
 
+/** Compose a `yyyy-MM-dd` date input value + `HH:mm` time + IANA tz
+ *  into a proper UTC ISO string. Avoids the `new Date("yyyy-mm-dd")`
+ *  trap where the string is interpreted as UTC midnight (drifting
+ *  the date back by one for east-of-UTC users). Uses the same
+ *  guess-and-diff trick as the time picker's fromLocalParts. */
+function composeLocalDateTime(
+  yyyymmdd: string,
+  hhmm: string,
+  tz: string,
+): string {
+  if (!yyyymmdd) return new Date().toISOString();
+  const [y, mo, d] = yyyymmdd.split("-").map(Number);
+  const [hh, mm] = hhmm.split(":").map(Number);
+  // Initial guess: parts interpreted as UTC.
+  const guess = new Date(Date.UTC(y!, (mo ?? 1) - 1, d!, hh ?? 0, mm ?? 0));
+  // Re-format the guess into the target tz to compute the offset.
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(guess);
+  const get = (k: string) => parts.find((p) => p.type === k)?.value ?? "00";
+  const renderedMs = Date.UTC(
+    Number(get("year")),
+    Number(get("month")) - 1,
+    Number(get("day")),
+    Number(get("hour")),
+    Number(get("minute")),
+  );
+  const desiredMs = Date.UTC(y!, (mo ?? 1) - 1, d!, hh ?? 0, mm ?? 0);
+  return new Date(guess.getTime() + (desiredMs - renderedMs)).toISOString();
+}
+
 const WEEKDAYS = [
   { idx: 1, label: "M" },
   { idx: 2, label: "T" },
@@ -208,7 +246,16 @@ export function RecurringScheduleEditor({
             onChange={(e) =>
               onChange({
                 ...value,
-                effectiveFrom: new Date(e.target.value).toISOString(),
+                // Compose the date with the rule's localTime + tz so
+                // an east-of-UTC user doesn't drift back by a day on
+                // round-trip. Plain `new Date("yyyy-mm-dd")` parses
+                // as UTC midnight which becomes the previous local
+                // day for any positive UTC offset.
+                effectiveFrom: composeLocalDateTime(
+                  e.target.value,
+                  value.localTime,
+                  value.timezone,
+                ),
               })
             }
           />
@@ -239,7 +286,11 @@ export function RecurringScheduleEditor({
               onChange={(e) =>
                 onChange({
                   ...value,
-                  effectiveUntil: new Date(e.target.value).toISOString(),
+                  effectiveUntil: composeLocalDateTime(
+                    e.target.value,
+                    value.localTime,
+                    value.timezone,
+                  ),
                 })
               }
             />

--- a/src/components/scheduler/schedule-confirm-card.tsx
+++ b/src/components/scheduler/schedule-confirm-card.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * <ScheduleConfirmCard /> — shows resolved per-channel times before
+ * the user clicks Schedule. Pairs with the /v1/scheduler/preview-time
+ * preview endpoint so the user sees real numbers, not a guess.
+ *
+ * Single-glance summary above + per-channel rows below with their
+ * resolved time, audience timezone, and smart-time audit chips
+ * ("shifted +90m for cross-channel min-spacing").
+ */
+
+import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { channelDisplayName, formatScheduleLabel } from "@/lib/scheduler/format";
+import type { PreviewTimeResponse } from "@/lib/scheduler/types";
+
+export interface ScheduleConfirmCardProps {
+  timezone: string;
+  preview?: PreviewTimeResponse;
+  loading?: boolean;
+  error?: string | null;
+  className?: string;
+}
+
+export function ScheduleConfirmCard({
+  timezone,
+  preview,
+  loading,
+  error,
+  className,
+}: ScheduleConfirmCardProps) {
+  if (loading) {
+    return (
+      <Card className={cn("border-dashed", className)}>
+        <CardContent className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Resolving your schedule…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className={cn("border-destructive/30 bg-destructive/5", className)}>
+        <CardContent className="flex items-center gap-2 py-4 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!preview || preview.resolvedTimes.length === 0) return null;
+
+  // First scheduled time = "publishes at" headline.
+  const earliest = preview.resolvedTimes
+    .filter((r) => r.scheduledAtUtc)
+    .sort((a, b) => (a.scheduledAtUtc ?? "").localeCompare(b.scheduledAtUtc ?? ""))[0];
+
+  return (
+    <Card className={cn("border-primary/30 bg-primary/5", className)}>
+      <CardContent className="space-y-3 py-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <CheckCircle2 className="h-4 w-4 text-primary" />
+          Your post starts publishing{" "}
+          {earliest?.scheduledAtUtc && (
+            <span className="text-primary">
+              {formatScheduleLabel(earliest.scheduledAtUtc, timezone)}
+            </span>
+          )}
+        </div>
+
+        <ul className="divide-y rounded-md border bg-background">
+          {preview.resolvedTimes.map((r) => (
+            <li
+              key={r.channel}
+              className="flex items-start gap-3 px-3 py-2 text-sm"
+            >
+              <ChannelIconCompact channel={r.channel} size={16} />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="font-medium">
+                    {channelDisplayName(r.channel)}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {r.scheduledAtUtc
+                      ? formatScheduleLabel(r.scheduledAtUtc, timezone)
+                      : "no time resolved"}
+                  </span>
+                </div>
+                {r.audit && r.audit.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {r.audit.map((note) => (
+                      <span
+                        key={note}
+                        className="rounded-full bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+                      >
+                        {note.replaceAll("_", " ")}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/scheduler/schedule-conflict-warning.tsx
+++ b/src/components/scheduler/schedule-conflict-warning.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * <ScheduleConflictWarning /> — surfaces stagger conflicts the
+ * SmartTimeEngine resolved (audience-tz filtering, cross-channel
+ * min-spacing, ±15 min push-out, clamped wraparound). Renders a
+ * collapsible explanation list so the user can see WHY a channel
+ * landed at a different time than the others.
+ *
+ * Powered by the audit strings on PreviewTimeResponse.resolvedTimes[].
+ * Hidden when no audit notes exist (synchronized strategies).
+ */
+
+import { useState } from "react";
+import { ChevronDown, Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { channelDisplayName } from "@/lib/scheduler/format";
+import type { PreviewTimeResponse } from "@/lib/scheduler/types";
+
+export interface ScheduleConflictWarningProps {
+  preview?: PreviewTimeResponse;
+  className?: string;
+}
+
+/** Pretty-print an audit code like `smart_tier1_clamped_to_+-90m` →
+ *  `Clamped to ±90 min`. */
+function formatNote(note: string): string {
+  return note
+    .replace(/^smart_tier1_/, "")
+    .replace(/^rolling_/, "")
+    .replaceAll("_", " ")
+    .replace(/(\d+)m/g, "$1 min")
+    .replace(/\+-/g, "±")
+    .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+export function ScheduleConflictWarning({
+  preview,
+  className,
+}: ScheduleConflictWarningProps) {
+  const [open, setOpen] = useState(false);
+  if (!preview) return null;
+  const rowsWithNotes = preview.resolvedTimes.filter(
+    (r) => r.audit && r.audit.length > 0,
+  );
+  if (rowsWithNotes.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-amber-300/60 bg-amber-50 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-200",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left"
+      >
+        <Info className="h-4 w-4 shrink-0" />
+        <span className="flex-1">
+          Smart-time engine adjusted{" "}
+          <b>
+            {rowsWithNotes.length} channel
+            {rowsWithNotes.length === 1 ? "" : "s"}
+          </b>{" "}
+          to resolve scheduling conflicts.
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="space-y-2 border-t border-amber-300/60 px-3 py-2 dark:border-amber-700/40">
+          {rowsWithNotes.map((r) => (
+            <div key={r.channel}>
+              <div className="font-medium">{channelDisplayName(r.channel)}</div>
+              <ul className="ml-4 list-disc space-y-0.5">
+                {(r.audit ?? []).map((note) => (
+                  <li key={note}>{formatNote(note)}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-1 text-[11px] text-amber-900 hover:bg-amber-100 dark:text-amber-200 dark:hover:bg-amber-900/30"
+            onClick={() => setOpen(false)}
+          >
+            Got it
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scheduler/schedule-time-picker.tsx
+++ b/src/components/scheduler/schedule-time-picker.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+/**
+ * <ScheduleTimePicker /> — best-in-world date+time+timezone control.
+ *
+ * Three quick-action chips above the inputs: "Next hour", "Tomorrow
+ * morning", "Next Tuesday 9am" — covers ~80% of intent. Below: native
+ * date + time inputs with the timezone displayed inline, plus a
+ * collapsible advanced section for an explicit IANA timezone change.
+ *
+ * Native `<input type="date">` + `<input type="time">` give us OS-level
+ * accessibility + locale formatting for free; no react-day-picker
+ * dependency. We treat the inputs as the user's LOCAL wall-clock in the
+ * declared timezone and convert to UTC at the boundary.
+ *
+ * Controlled component: parent owns the Date value (UTC) and the
+ * timezone (IANA). The component re-renders both inputs whenever the
+ * parent re-renders.
+ */
+
+import { useMemo, useState } from "react";
+import { Calendar, Clock, ChevronDown, Globe } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { detectTimezone, formatTimeLabel } from "@/lib/scheduler/format";
+
+export interface ScheduleTimePickerProps {
+  /** Currently-selected scheduled instant (UTC). */
+  value: Date;
+  /** IANA timezone the user is composing in (`Asia/Kolkata`, …). */
+  timezone: string;
+  onChange: (next: { date: Date; timezone: string }) => void;
+  /** Show the timezone-override row. Defaults to true. */
+  allowTimezoneOverride?: boolean;
+  className?: string;
+}
+
+/** Convert a UTC instant + IANA timezone into the local
+ *  `yyyy-MM-ddTHH:mm` string the native input expects. */
+function toLocalParts(d: Date, tz: string): { date: string; time: string } {
+  // Format to ISO-ish parts in the target timezone via Intl.
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const get = (k: string) => parts.find((p) => p.type === k)?.value ?? "00";
+  return {
+    date: `${get("year")}-${get("month")}-${get("day")}`,
+    time: `${get("hour")}:${get("minute")}`,
+  };
+}
+
+/** Convert local wall-clock parts + timezone back to a UTC Date.
+ *  We construct a fake-UTC date from the parts, then compute the
+ *  zone offset at that moment by re-rendering it in the target
+ *  timezone and diffing — robust against DST transitions. */
+function fromLocalParts(date: string, time: string, tz: string): Date {
+  const [y, mo, d] = date.split("-").map(Number);
+  const [hh, mm] = time.split(":").map(Number);
+  // Start with a guess: the parts interpreted as UTC.
+  const guess = new Date(Date.UTC(y!, (mo ?? 1) - 1, d!, hh ?? 0, mm ?? 0));
+  // Render guess in target tz; compute the offset between the local
+  // string that came out and the local string we wanted.
+  const rendered = toLocalParts(guess, tz);
+  const renderedMs = Date.UTC(
+    Number(rendered.date.slice(0, 4)),
+    Number(rendered.date.slice(5, 7)) - 1,
+    Number(rendered.date.slice(8, 10)),
+    Number(rendered.time.slice(0, 2)),
+    Number(rendered.time.slice(3, 5)),
+  );
+  const desiredMs = Date.UTC(y!, (mo ?? 1) - 1, d!, hh ?? 0, mm ?? 0);
+  return new Date(guess.getTime() + (desiredMs - renderedMs));
+}
+
+interface QuickAction {
+  label: string;
+  compute: (now: Date) => Date;
+}
+
+const QUICK_ACTIONS: QuickAction[] = [
+  {
+    label: "Next hour",
+    compute: (now) => {
+      const next = new Date(now);
+      next.setMinutes(0, 0, 0);
+      next.setHours(next.getHours() + 1);
+      return next;
+    },
+  },
+  {
+    label: "Tomorrow 9 am",
+    compute: (now) => {
+      const next = new Date(now);
+      next.setDate(next.getDate() + 1);
+      next.setHours(9, 0, 0, 0);
+      return next;
+    },
+  },
+  {
+    label: "Next Tuesday 9 am",
+    compute: (now) => {
+      const next = new Date(now);
+      const day = next.getDay();
+      // Sunday=0, Monday=1, Tuesday=2.
+      const delta = ((2 - day + 7) % 7) || 7;
+      next.setDate(next.getDate() + delta);
+      next.setHours(9, 0, 0, 0);
+      return next;
+    },
+  },
+];
+
+export function ScheduleTimePicker({
+  value,
+  timezone,
+  onChange,
+  allowTimezoneOverride = true,
+  className,
+}: ScheduleTimePickerProps) {
+  const [tzOpen, setTzOpen] = useState(false);
+  const detected = useMemo(() => detectTimezone(), []);
+  const parts = useMemo(() => toLocalParts(value, timezone), [value, timezone]);
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      {/* Quick-action chip row */}
+      <div className="flex flex-wrap gap-2">
+        {QUICK_ACTIONS.map((q) => (
+          <Button
+            key={q.label}
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 rounded-full px-3 text-xs"
+            onClick={() => onChange({ date: q.compute(new Date()), timezone })}
+          >
+            {q.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Native date + time + inline timezone */}
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_140px_auto]">
+        <div>
+          <Label
+            htmlFor="schedule-date"
+            className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground"
+          >
+            <Calendar className="h-3.5 w-3.5" /> Date
+          </Label>
+          <Input
+            id="schedule-date"
+            type="date"
+            value={parts.date}
+            onChange={(e) =>
+              onChange({
+                date: fromLocalParts(e.target.value, parts.time, timezone),
+                timezone,
+              })
+            }
+          />
+        </div>
+        <div>
+          <Label
+            htmlFor="schedule-time"
+            className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground"
+          >
+            <Clock className="h-3.5 w-3.5" /> Time
+          </Label>
+          <Input
+            id="schedule-time"
+            type="time"
+            value={parts.time}
+            onChange={(e) =>
+              onChange({
+                date: fromLocalParts(parts.date, e.target.value, timezone),
+                timezone,
+              })
+            }
+          />
+        </div>
+        {allowTimezoneOverride && (
+          <div className="flex flex-col">
+            <Label className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Globe className="h-3.5 w-3.5" /> Timezone
+            </Label>
+            <button
+              type="button"
+              onClick={() => setTzOpen((o) => !o)}
+              className="inline-flex h-9 items-center gap-1 rounded-md border border-input bg-background px-3 text-sm text-foreground hover:bg-accent"
+              aria-expanded={tzOpen}
+            >
+              <span className="truncate">{timezone}</span>
+              <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {tzOpen && allowTimezoneOverride && (
+        <div className="rounded-md border bg-muted/30 p-3 text-sm">
+          <Label
+            htmlFor="schedule-tz"
+            className="mb-1 block text-xs font-medium text-muted-foreground"
+          >
+            IANA timezone identifier (e.g. <code>Asia/Kolkata</code>)
+          </Label>
+          <Input
+            id="schedule-tz"
+            type="text"
+            defaultValue={timezone}
+            placeholder={detected}
+            onBlur={(e) => {
+              const v = e.target.value.trim();
+              if (v && v !== timezone) {
+                onChange({ date: value, timezone: v });
+                setTzOpen(false);
+              }
+            }}
+          />
+          {detected !== timezone && (
+            <button
+              type="button"
+              onClick={() => {
+                onChange({ date: value, timezone: detected });
+                setTzOpen(false);
+              }}
+              className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
+            >
+              Use your local timezone ({detected})
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Tiny preview row — confirms the resolved local time so the
+          user catches AM/PM mistakes before scheduling. */}
+      <div className="text-xs text-muted-foreground">
+        Publishes at <b>{formatTimeLabel(value, timezone)}</b> {timezone}
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+/**
+ * <SchedulerComposer /> — opinionated composition of the 8 scheduler
+ * primitives into a complete "schedule this content" form.
+ *
+ * Caller passes:
+ *   - the content payload (source + per-channel payload snapshots),
+ *   - the available channels (typically intersection of recommender
+ *     output + connected channels),
+ *   - a `onScheduled(plan)` callback for after commit.
+ *
+ * This is the "scheduler glue" for the b2c repurpose sheet, the
+ * Beehiiv composer, and any other surface that wants the full
+ * schedule UX without re-assembling primitives. The pure
+ * <CalendarView /> stays on the /dashboard/calendar page (PR 7).
+ *
+ * Renders top-to-bottom:
+ *   1. Channel target list (read-only badges per channel)
+ *   2. <ScheduleTimePicker /> for the anchor
+ *   3. <StaggerStrategyChooser /> chips
+ *   4. <TimezoneBanner /> when audience tz differs from user tz
+ *   5. <ScheduleConfirmCard /> with live preview
+ *   6. <ScheduleConflictWarning /> when the smart-time engine adjusted
+ *   7. Commit button + auto-approve checkbox (gated by plan tier)
+ */
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { CalendarPlus, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { scheduler } from "@/lib/scheduler/client";
+import { detectTimezone } from "@/lib/scheduler/format";
+import type {
+  ChannelKey,
+  CommitPlanRequest,
+  CommitPlanResponse,
+  StaggerStrategy,
+  ScheduleSourceType,
+} from "@/lib/scheduler/types";
+import { ScheduleTimePicker } from "./schedule-time-picker";
+import { StaggerStrategyChooser } from "./stagger-strategy-chooser";
+import { ScheduleConfirmCard } from "./schedule-confirm-card";
+import { ScheduleConflictWarning } from "./schedule-conflict-warning";
+import { TimezoneBanner } from "./timezone-banner";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import { useSchedulePreview } from "./use-schedule-preview";
+import { channelDisplayName } from "@/lib/scheduler/format";
+
+export interface SchedulerComposerProps {
+  /** Source-content reference for the plan. */
+  source: {
+    sourceType: ScheduleSourceType;
+    sourceRef?: string;
+    sourceTextHash: string;
+  };
+  /** Optional title (overrides server-side fallback). */
+  title?: string;
+  /** Channels to schedule + their pre-built payloads. */
+  channels: {
+    channel: ChannelKey;
+    connectionId?: string;
+    preferredLocalTime?: string;
+    publishViaReminder?: boolean;
+    payload: CommitPlanRequest["channels"][number]["payload"];
+  }[];
+  /** Whether the org's plan tier allows auto-approval (PR 8 wires
+   *  this from the entitlements feed). */
+  canAutoApprove?: boolean;
+  /** Initial anchor — defaults to the next round hour. */
+  initialAnchor?: Date;
+  /** Initial timezone — defaults to detected. */
+  initialTimezone?: string;
+  /** Called after a successful commit; the parent typically closes
+   *  the sheet or navigates to /dashboard/calendar. */
+  onScheduled?: (result: CommitPlanResponse) => void;
+  className?: string;
+}
+
+function defaultAnchor(): Date {
+  const d = new Date();
+  d.setMinutes(0, 0, 0);
+  d.setHours(d.getHours() + 1);
+  return d;
+}
+
+export function SchedulerComposer({
+  source,
+  title,
+  channels,
+  canAutoApprove,
+  initialAnchor,
+  initialTimezone,
+  onScheduled,
+  className,
+}: SchedulerComposerProps) {
+  const [anchor, setAnchor] = useState<Date>(initialAnchor ?? defaultAnchor());
+  const [timezone, setTimezone] = useState<string>(
+    initialTimezone ?? detectTimezone(),
+  );
+  const [strategy, setStrategy] = useState<StaggerStrategy>("smart");
+  const [autoApprove, setAutoApprove] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Debounced preview — fires on every anchor / strategy / channels[]
+  // change.
+  const previewInput = useMemo(
+    () => ({
+      canonicalScheduledAtUtc: anchor.toISOString(),
+      timezone,
+      staggerStrategy: strategy,
+      channels: channels.map((c) => ({
+        channel: c.channel,
+        preferredLocalTime: c.preferredLocalTime,
+      })),
+    }),
+    [anchor, timezone, strategy, channels],
+  );
+  const { preview, loading, error } = useSchedulePreview(previewInput);
+
+  const submit = async () => {
+    if (channels.length === 0) {
+      toast.error("Pick at least one channel before scheduling.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const body: CommitPlanRequest = {
+        ...(title ? { title } : {}),
+        source,
+        channels: channels.map((c) => ({
+          channel: c.channel,
+          ...(c.connectionId ? { connectionId: c.connectionId } : {}),
+          ...(c.preferredLocalTime
+            ? { preferredLocalTime: c.preferredLocalTime }
+            : {}),
+          ...(c.publishViaReminder !== undefined
+            ? { publishViaReminder: c.publishViaReminder }
+            : {}),
+          payload: c.payload,
+        })),
+        staggerStrategy: strategy,
+        canonicalScheduledAtUtc: anchor.toISOString(),
+        timezone,
+        ...(canAutoApprove && autoApprove ? { autoApprove: true } : {}),
+      };
+      const result = await scheduler.commitPlan(body);
+      toast.success(
+        `Scheduled across ${result.scheduledItemIds.length} channel${
+          result.scheduledItemIds.length === 1 ? "" : "s"
+        }.`,
+      );
+      onScheduled?.(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Scheduling failed.";
+      toast.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      {/* Channel targets — read-only badges */}
+      <div>
+        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+          Publishing to {channels.length} channel
+          {channels.length === 1 ? "" : "s"}
+        </Label>
+        <div className="flex flex-wrap gap-1.5">
+          {channels.map((c) => (
+            <div
+              key={c.channel}
+              className="inline-flex items-center gap-1.5 rounded-full border bg-background px-2.5 py-1 text-xs"
+            >
+              <ChannelIconCompact channel={c.channel} size={14} />
+              <span className="font-medium">{channelDisplayName(c.channel)}</span>
+              {c.publishViaReminder && (
+                <span className="rounded-full bg-muted px-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Reminder
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <ScheduleTimePicker
+        value={anchor}
+        timezone={timezone}
+        onChange={({ date, timezone: tz }) => {
+          setAnchor(date);
+          setTimezone(tz);
+        }}
+      />
+
+      <div>
+        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+          Stagger strategy
+        </Label>
+        <StaggerStrategyChooser value={strategy} onChange={setStrategy} />
+      </div>
+
+      <TimezoneBanner timezone={timezone} storageKey="composer-tz-banner" />
+
+      <ScheduleConfirmCard
+        timezone={timezone}
+        preview={preview}
+        loading={loading}
+        error={error}
+      />
+
+      <ScheduleConflictWarning preview={preview} />
+
+      {canAutoApprove && (
+        <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3">
+          <Checkbox
+            id="auto-approve"
+            checked={autoApprove}
+            onCheckedChange={(v) => setAutoApprove(v === true)}
+            className="mt-0.5"
+          />
+          <Label
+            htmlFor="auto-approve"
+            className="flex flex-col gap-0.5 text-xs"
+          >
+            <span className="flex items-center gap-1 text-sm font-medium">
+              <ShieldCheck className="h-3.5 w-3.5 text-primary" /> Auto-approve
+            </span>
+            <span className="text-muted-foreground">
+              Skip the manual approval queue. Items fire at their scheduled
+              time without further review.
+            </span>
+          </Label>
+        </div>
+      )}
+
+      <Button
+        onClick={submit}
+        disabled={submitting || channels.length === 0 || !preview}
+        className="w-full gap-2"
+        size="lg"
+      >
+        <CalendarPlus className="h-4 w-4" />
+        {submitting ? "Scheduling…" : "Schedule"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -175,21 +175,21 @@ export function SchedulerComposer({
   };
 
   // Cmd+Enter / Ctrl+Enter to schedule — power-user shortcut.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-        e.preventDefault();
-        void submit();
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-    // submit closes over current state — fine to re-bind on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  });
+  // Scoped to keydown events INSIDE the composer's root (via the
+  // wrapper div's onKeyDown below) so it doesn't fire from unrelated
+  // modals or sibling composers. Global window listener was scope-
+  // leaking across multiple mounted composers.
 
   return (
-    <div className={cn("flex flex-col gap-4", className)}>
+    <div
+      className={cn("flex flex-col gap-4", className)}
+      onKeyDown={(e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+          e.preventDefault();
+          void submit();
+        }
+      }}
+    >
       {/* Channel targets — read-only badges */}
       <div>
         <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -25,7 +25,7 @@
  *   7. Commit button + auto-approve checkbox (gated by plan tier)
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CalendarPlus, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -98,12 +98,21 @@ export function SchedulerComposer({
   className,
 }: SchedulerComposerProps) {
   const [anchor, setAnchor] = useState<Date>(initialAnchor ?? defaultAnchor());
-  const [timezone, setTimezone] = useState<string>(
-    initialTimezone ?? detectTimezone(),
-  );
+  // SSR-safe timezone init: start with UTC (or caller's explicit choice),
+  // then hydrate to the user's real tz after mount. Avoids the hydration
+  // mismatch where the server renders "UTC" and the client renders
+  // "Asia/Kolkata".
+  const [timezone, setTimezone] = useState<string>(initialTimezone ?? "UTC");
+  useEffect(() => {
+    if (!initialTimezone) setTimezone(detectTimezone());
+  }, [initialTimezone]);
   const [strategy, setStrategy] = useState<StaggerStrategy>("smart");
   const [autoApprove, setAutoApprove] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  // Double-submit ref guard — protects against React batching delays
+  // letting two Enter keypresses fire the submit handler before the
+  // disabled state propagates.
+  const submittingRef = useRef(false);
 
   // Debounced preview — fires on every anchor / strategy / channels[]
   // change.
@@ -126,6 +135,8 @@ export function SchedulerComposer({
       toast.error("Pick at least one channel before scheduling.");
       return;
     }
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setSubmitting(true);
     try {
       const body: CommitPlanRequest = {
@@ -159,8 +170,23 @@ export function SchedulerComposer({
       toast.error(msg);
     } finally {
       setSubmitting(false);
+      submittingRef.current = false;
     }
   };
+
+  // Cmd+Enter / Ctrl+Enter to schedule — power-user shortcut.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void submit();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // submit closes over current state — fine to re-bind on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  });
 
   return (
     <div className={cn("flex flex-col gap-4", className)}>
@@ -240,7 +266,11 @@ export function SchedulerComposer({
 
       <Button
         onClick={submit}
-        disabled={submitting || channels.length === 0 || !preview}
+        // Disable only while actively submitting or with no channels.
+        // A failed preview (error !== null) shouldn't block commit —
+        // the server re-runs the stagger on commit and the user
+        // shouldn't be locked out by a transient preview API failure.
+        disabled={submitting || channels.length === 0 || loading}
         className="w-full gap-2"
         size="lg"
       >

--- a/src/components/scheduler/stagger-strategy-chooser.tsx
+++ b/src/components/scheduler/stagger-strategy-chooser.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * <StaggerStrategyChooser /> — radio-card picker for synchronized /
+ * rolling / smart with an inline explanation for each. Smart is the
+ * locked default per content-pipeline-hardening.md decision #6.
+ */
+
+import { Sparkles, Layers, Zap } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { staggerDescription } from "@/lib/scheduler/format";
+import type { StaggerStrategy } from "@/lib/scheduler/types";
+
+const OPTIONS: {
+  value: StaggerStrategy;
+  label: string;
+  icon: typeof Sparkles;
+}[] = [
+  { value: "smart", label: "Smart time", icon: Sparkles },
+  { value: "rolling", label: "Rolling stagger", icon: Layers },
+  { value: "synchronized", label: "Synchronized", icon: Zap },
+];
+
+export interface StaggerStrategyChooserProps {
+  value: StaggerStrategy;
+  onChange: (next: StaggerStrategy) => void;
+  className?: string;
+  /** When true, render only the chip strip without the per-card
+   *  description text — useful for tight composer layouts. */
+  compact?: boolean;
+}
+
+export function StaggerStrategyChooser({
+  value,
+  onChange,
+  className,
+  compact,
+}: StaggerStrategyChooserProps) {
+  return (
+    <div
+      className={cn(
+        "grid gap-2",
+        compact
+          ? "grid-cols-3"
+          : "grid-cols-1 sm:grid-cols-3",
+        className,
+      )}
+      role="radiogroup"
+      aria-label="Stagger strategy"
+    >
+      {OPTIONS.map((opt) => {
+        const Icon = opt.icon;
+        const selected = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "group flex flex-col rounded-lg border p-3 text-left transition",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? "border-primary bg-primary/5 ring-1 ring-primary"
+                : "border-input hover:border-primary/50 hover:bg-accent/50",
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Icon
+                className={cn(
+                  "h-4 w-4",
+                  selected ? "text-primary" : "text-muted-foreground",
+                )}
+              />
+              <span
+                className={cn(
+                  "text-sm font-medium",
+                  selected ? "text-foreground" : "text-foreground/90",
+                )}
+              >
+                {opt.label}
+              </span>
+              {opt.value === "smart" && (
+                <span className="ml-auto rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+                  Default
+                </span>
+              )}
+            </div>
+            {!compact && (
+              <p className="mt-1 text-xs leading-snug text-muted-foreground">
+                {staggerDescription(opt.value)}
+              </p>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/scheduler/stagger-strategy-chooser.tsx
+++ b/src/components/scheduler/stagger-strategy-chooser.tsx
@@ -4,8 +4,14 @@
  * <StaggerStrategyChooser /> — radio-card picker for synchronized /
  * rolling / smart with an inline explanation for each. Smart is the
  * locked default per content-pipeline-hardening.md decision #6.
+ *
+ * Implements the full ARIA radiogroup keyboard pattern: Left/Right/
+ * Up/Down move selection and focus to the next option; Home/End
+ * jump to first/last. Tab moves focus OUT of the group (not
+ * between options) per the spec.
  */
 
+import { useRef } from "react";
 import { Sparkles, Layers, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { staggerDescription } from "@/lib/scheduler/format";
@@ -36,6 +42,33 @@ export function StaggerStrategyChooser({
   className,
   compact,
 }: StaggerStrategyChooserProps) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const onKeyDown = (idx: number) => (e: React.KeyboardEvent) => {
+    let nextIdx = -1;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        nextIdx = (idx + 1) % OPTIONS.length;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        nextIdx = (idx - 1 + OPTIONS.length) % OPTIONS.length;
+        break;
+      case "Home":
+        nextIdx = 0;
+        break;
+      case "End":
+        nextIdx = OPTIONS.length - 1;
+        break;
+    }
+    if (nextIdx !== -1) {
+      e.preventDefault();
+      onChange(OPTIONS[nextIdx]!.value);
+      refs.current[nextIdx]?.focus();
+    }
+  };
+
   return (
     <div
       className={cn(
@@ -48,15 +81,22 @@ export function StaggerStrategyChooser({
       role="radiogroup"
       aria-label="Stagger strategy"
     >
-      {OPTIONS.map((opt) => {
+      {OPTIONS.map((opt, idx) => {
         const Icon = opt.icon;
         const selected = value === opt.value;
         return (
           <button
             key={opt.value}
+            ref={(el) => {
+              refs.current[idx] = el;
+            }}
             type="button"
             role="radio"
             aria-checked={selected}
+            // Per ARIA radiogroup pattern: only the selected option
+            // is in the tab order; arrows move within the group.
+            tabIndex={selected ? 0 : -1}
+            onKeyDown={onKeyDown(idx)}
             onClick={() => onChange(opt.value)}
             className={cn(
               "group flex flex-col rounded-lg border p-3 text-left transition",

--- a/src/components/scheduler/timezone-banner.tsx
+++ b/src/components/scheduler/timezone-banner.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * <TimezoneBanner /> — surfaces when the audience timezone differs
+ * from the user's detected timezone. Subtle, dismissable. Helps the
+ * user catch "I scheduled at 9am IST but my audience is in PST" before
+ * publishing.
+ */
+
+import { Globe, X } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { detectTimezone } from "@/lib/scheduler/format";
+
+export interface TimezoneBannerProps {
+  /** The plan's chosen timezone (typically the audience tz). */
+  timezone: string;
+  className?: string;
+  /** When provided, the banner remembers dismissal under this key in
+   *  sessionStorage so it doesn't re-pester on every render. */
+  storageKey?: string;
+}
+
+/** Lazy initialiser so SSR doesn't touch sessionStorage; the second
+ *  render hydrates with the persisted value if any. Avoids the
+ *  "setState-in-effect" lint by computing once at mount instead. */
+function initialDismissed(storageKey?: string): boolean {
+  if (!storageKey || typeof window === "undefined") return false;
+  try {
+    return sessionStorage.getItem(storageKey) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function TimezoneBanner({
+  timezone,
+  className,
+  storageKey,
+}: TimezoneBannerProps) {
+  const [dismissed, setDismissed] = useState(() => initialDismissed(storageKey));
+  const userTz = typeof window !== "undefined" ? detectTimezone() : "UTC";
+
+  if (dismissed || userTz === timezone) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-sky-300/60 bg-sky-50 px-3 py-2 text-xs text-sky-900 dark:border-sky-700/40 dark:bg-sky-950/30 dark:text-sky-200",
+        className,
+      )}
+    >
+      <Globe className="h-4 w-4 shrink-0" />
+      <div className="flex-1">
+        Scheduling in <b>{timezone}</b> — different from your local{" "}
+        <b>{userTz}</b>. Times shown reflect when your audience sees them.
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          setDismissed(true);
+          if (storageKey && typeof window !== "undefined") {
+            sessionStorage.setItem(storageKey, "1");
+          }
+        }}
+        aria-label="Dismiss timezone banner"
+        className="rounded p-0.5 hover:bg-sky-200/50 dark:hover:bg-sky-800/40"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/scheduler/timezone-banner.tsx
+++ b/src/components/scheduler/timezone-banner.tsx
@@ -71,7 +71,11 @@ export function TimezoneBanner({
         onClick={() => {
           setDismissed(true);
           if (storageKey && typeof window !== "undefined") {
-            sessionStorage.setItem(storageKey, "1");
+            try {
+              sessionStorage.setItem(storageKey, "1");
+            } catch {
+              /* private mode / quota — dismissal is in-memory only. */
+            }
           }
         }}
         aria-label="Dismiss timezone banner"

--- a/src/components/scheduler/timezone-banner.tsx
+++ b/src/components/scheduler/timezone-banner.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Globe, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { detectTimezone } from "@/lib/scheduler/format";
 
@@ -21,27 +21,38 @@ export interface TimezoneBannerProps {
   storageKey?: string;
 }
 
-/** Lazy initialiser so SSR doesn't touch sessionStorage; the second
- *  render hydrates with the persisted value if any. Avoids the
- *  "setState-in-effect" lint by computing once at mount instead. */
-function initialDismissed(storageKey?: string): boolean {
-  if (!storageKey || typeof window === "undefined") return false;
-  try {
-    return sessionStorage.getItem(storageKey) === "1";
-  } catch {
-    return false;
-  }
-}
-
 export function TimezoneBanner({
   timezone,
   className,
   storageKey,
 }: TimezoneBannerProps) {
-  const [dismissed, setDismissed] = useState(() => initialDismissed(storageKey));
-  const userTz = typeof window !== "undefined" ? detectTimezone() : "UTC";
+  // SSR-safe: render NOTHING until mounted on the client. The banner
+  // is decorative — its absence on the first paint is acceptable, and
+  // a hydration mismatch (userTz="UTC" on server vs real tz on client)
+  // is not.
+  const [mounted, setMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [userTz, setUserTz] = useState("UTC");
 
-  if (dismissed || userTz === timezone) return null;
+  // The setState calls below are mount-time hydration of values
+  // that legitimately can't be computed during SSR (timezone +
+  // sessionStorage). Lint rule guards against cascading renders;
+  // here the effect runs exactly once per mount with no cascade.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    setMounted(true);
+    setUserTz(detectTimezone());
+    if (storageKey) {
+      try {
+        setDismissed(sessionStorage.getItem(storageKey) === "1");
+      } catch {
+        /* sessionStorage may be unavailable (private mode). */
+      }
+    }
+  }, [storageKey]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  if (!mounted || dismissed || userTz === timezone) return null;
 
   return (
     <div

--- a/src/components/scheduler/use-schedule-preview.ts
+++ b/src/components/scheduler/use-schedule-preview.ts
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * useSchedulePreview — debounced hook for the composer's live
+ * "your post would publish at X" affordance. Calls
+ * /v1/scheduler/preview-time as the user adjusts channels / time /
+ * stagger, and surfaces { preview, loading, error } for the
+ * <ScheduleConfirmCard /> + <ScheduleConflictWarning /> components.
+ *
+ * Debounces 300 ms so a stuck keypress doesn't hammer the API.
+ * Out-of-order responses guarded by a monotonic sequence counter so
+ * a late preview can't overwrite a newer one.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { scheduler } from "@/lib/scheduler/client";
+import type {
+  PreviewTimeRequest,
+  PreviewTimeResponse,
+} from "@/lib/scheduler/types";
+
+interface UseSchedulePreviewResult {
+  preview: PreviewTimeResponse | undefined;
+  loading: boolean;
+  error: string | null;
+}
+
+/** Stable key for the input — useEffect deps array can compare this
+ *  cheaply without a deep-equal lib. Reset to `null` when input is
+ *  empty so the effect short-circuits without setState. */
+function buildKey(input: PreviewTimeRequest | null): string | null {
+  if (!input || input.channels.length === 0) return null;
+  return JSON.stringify(input);
+}
+
+export function useSchedulePreview(
+  input: PreviewTimeRequest | null,
+  debounceMs = 300,
+): UseSchedulePreviewResult {
+  const [preview, setPreview] = useState<PreviewTimeResponse | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const seqRef = useRef(0);
+
+  const key = useMemo(() => buildKey(input), [input]);
+
+  // React 19's `react-hooks/set-state-in-effect` flags the setState
+  // calls below. The rule's purpose is to avoid cascading renders,
+  // but in this debounced-fetch pattern the effect body is gated on
+  // `key` change and the synchronous setError/setLoading calls reset
+  // the visible state to "loading" precisely once per key. There's
+  // no cascade — `key` doesn't depend on the state we're setting.
+  // Documented exception per the rule's guidance.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (key === null) {
+      seqRef.current++;
+      return;
+    }
+    const mySeq = ++seqRef.current;
+    setError(null);
+    setLoading(true);
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await scheduler.previewTime(JSON.parse(key));
+          if (seqRef.current === mySeq) {
+            setPreview(res);
+            setLoading(false);
+          }
+        } catch (err) {
+          if (seqRef.current === mySeq) {
+            setError(err instanceof Error ? err.message : "Preview failed");
+            setLoading(false);
+          }
+        }
+      })();
+    }, debounceMs);
+    return () => clearTimeout(timer);
+  }, [key, debounceMs]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Derive the visible state from key alone: empty key ⇒ no preview.
+  return {
+    preview: key === null ? undefined : preview,
+    loading: key !== null && loading,
+    error: key === null ? null : error,
+  };
+}

--- a/src/lib/scheduler/client.ts
+++ b/src/lib/scheduler/client.ts
@@ -1,0 +1,113 @@
+/**
+ * Typed client for /v1/scheduler/* REST surface.
+ *
+ * All calls go through the shared `api` ApiClient (handles CSRF +
+ * credentials + auth refresh). This file is a thin typed wrapper so
+ * component code can `await scheduler.commitPlan(input)` without
+ * memorising the path strings.
+ */
+
+import { api } from "../api";
+import type {
+  CommitPlanRequest,
+  CommitPlanResponse,
+  ListItemsResponse,
+  ListPlansResponse,
+  PlanDetailResponse,
+  PreviewTimeRequest,
+  PreviewTimeResponse,
+  ScheduledItemStatus,
+  PublishPlanStatus,
+  PublishPlanApprovalState,
+} from "./types";
+
+export interface ListPlansQuery {
+  from?: Date;
+  to?: Date;
+  status?: PublishPlanStatus;
+  approvalState?: PublishPlanApprovalState;
+  recurringRuleId?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListItemsQuery {
+  from?: Date;
+  to?: Date;
+  channel?: string;
+  status?: ScheduledItemStatus;
+  planId?: string;
+  payloadStale?: boolean;
+  limit?: number;
+}
+
+function dateParam(d: Date | undefined): string | undefined {
+  return d ? d.toISOString() : undefined;
+}
+
+function buildQuery(record: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(record)) {
+    if (v === undefined || v === null) continue;
+    out[k] = String(v);
+  }
+  return out;
+}
+
+export const scheduler = {
+  commitPlan(body: CommitPlanRequest) {
+    return api.post<CommitPlanResponse>("/v1/scheduler/plans", body);
+  },
+
+  cancelPlan(planId: string, reason?: string) {
+    const path = `/v1/scheduler/plans/${planId}${
+      reason ? `?reason=${encodeURIComponent(reason)}` : ""
+    }`;
+    return api.delete<{ cancelledItems: number; providerCancels: number }>(path);
+  },
+
+  markStale(planId: string, sourceTextHash: string) {
+    return api.post<{ flagged: number }>(
+      `/v1/scheduler/plans/${planId}/stale`,
+      { sourceTextHash },
+    );
+  },
+
+  listPlans(query: ListPlansQuery = {}) {
+    return api.get<ListPlansResponse>(
+      "/v1/scheduler/plans",
+      buildQuery({
+        from: dateParam(query.from),
+        to: dateParam(query.to),
+        status: query.status,
+        approvalState: query.approvalState,
+        recurringRuleId: query.recurringRuleId,
+        limit: query.limit,
+        cursor: query.cursor,
+      }),
+    );
+  },
+
+  listItems(query: ListItemsQuery = {}) {
+    return api.get<ListItemsResponse>(
+      "/v1/scheduler/items",
+      buildQuery({
+        from: dateParam(query.from),
+        to: dateParam(query.to),
+        channel: query.channel,
+        status: query.status,
+        planId: query.planId,
+        payloadStale: query.payloadStale,
+        limit: query.limit,
+      }),
+    );
+  },
+
+  getPlan(planId: string) {
+    return api.get<PlanDetailResponse>(`/v1/scheduler/plans/${planId}`);
+  },
+
+  previewTime(body: PreviewTimeRequest) {
+    return api.post<PreviewTimeResponse>("/v1/scheduler/preview-time", body);
+  },
+};

--- a/src/lib/scheduler/format.ts
+++ b/src/lib/scheduler/format.ts
@@ -1,0 +1,163 @@
+/**
+ * Date / time / channel formatting helpers — pure functions.
+ * No date library dependency; uses Intl.DateTimeFormat which ships
+ * with every modern browser and respects the caller's IANA timezone.
+ */
+
+import type { ChannelKey, ScheduledItemStatus, StaggerStrategy } from "./types";
+
+/** Render a Date in the given IANA timezone as `Mon, 1 Jun · 8:00 am`. */
+export function formatScheduleLabel(
+  iso: string | Date,
+  timezone: string,
+): string {
+  const d = typeof iso === "string" ? new Date(iso) : iso;
+  const date = new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    timeZone: timezone,
+  }).format(d);
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: timezone,
+  }).format(d);
+  return `${date} · ${time.toLowerCase()}`;
+}
+
+/** Shorter time-only render: `8:00 am`. */
+export function formatTimeLabel(iso: string | Date, timezone: string): string {
+  const d = typeof iso === "string" ? new Date(iso) : iso;
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: timezone,
+  })
+    .format(d)
+    .toLowerCase();
+}
+
+/** Render a Date as `Mon, 1 Jun`. */
+export function formatDateLabel(iso: string | Date, timezone: string): string {
+  const d = typeof iso === "string" ? new Date(iso) : iso;
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    timeZone: timezone,
+  }).format(d);
+}
+
+/** Relative human label — "in 3 hours", "2 days ago". */
+export function formatRelative(iso: string | Date): string {
+  const d = typeof iso === "string" ? new Date(iso) : iso;
+  const diffMs = d.getTime() - Date.now();
+  const absMs = Math.abs(diffMs);
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  if (absMs < hour) {
+    return rtf.format(Math.round(diffMs / minute), "minute");
+  }
+  if (absMs < day) {
+    return rtf.format(Math.round(diffMs / hour), "hour");
+  }
+  if (absMs < 30 * day) {
+    return rtf.format(Math.round(diffMs / day), "day");
+  }
+  return rtf.format(Math.round(diffMs / (30 * day)), "month");
+}
+
+/** Detect the user's IANA timezone (`Asia/Kolkata`, `America/New_York`, etc.). */
+export function detectTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "UTC";
+  }
+}
+
+/** Pretty channel name — UI-only; falls back to the raw key. */
+export function channelDisplayName(channel: ChannelKey): string {
+  const MAP: Record<string, string> = {
+    newsletter: "Newsletter",
+    linkedin: "LinkedIn",
+    x: "X",
+    facebook: "Facebook",
+    instagram: "Instagram",
+    threads: "Threads",
+    youtube: "YouTube",
+  };
+  return MAP[channel] ?? channel.charAt(0).toUpperCase() + channel.slice(1);
+}
+
+/** Tone-coded label for an item status. Returns Tailwind tokens that
+ *  match the existing peakhour-b2c StatusBadge palette so chips don't
+ *  drift visually. */
+export function statusTone(
+  status: ScheduledItemStatus,
+): "success" | "warn" | "error" | "info" | "neutral" {
+  switch (status) {
+    case "published":
+      return "success";
+    case "queued":
+    case "awaiting_retry":
+    case "ready":
+    case "in_flight":
+      return "info";
+    case "needs_action":
+      return "warn";
+    case "failed":
+      return "error";
+    case "cancelled":
+    case "skipped":
+      return "neutral";
+  }
+}
+
+/** Plain-English explanation of a stagger strategy. Used in the
+ *  picker tooltip and the confirmation card. */
+export function staggerDescription(strategy: StaggerStrategy): string {
+  switch (strategy) {
+    case "synchronized":
+      return "Every channel publishes at the same moment — max-blast announce pattern.";
+    case "rolling":
+      return "Newsletter first, then LinkedIn (+90 min), then X (+90 min after). Earns peak attention on each channel in sequence.";
+    case "smart":
+      return "Each channel picks its best time — based on adapter priors and your past engagement curve.";
+  }
+}
+
+/** SHA-1 helper for sourceTextHash. Uses the browser SubtleCrypto so
+ *  no bundle-cost dependency. Falls back to a textual hash for the
+ *  edge case where SubtleCrypto isn't available (only relevant for
+ *  ad_hoc paste-and-schedule — persisted sources have their hash
+ *  computed server-side). */
+export async function sha1Hex(text: string): Promise<string> {
+  if (typeof crypto !== "undefined" && crypto.subtle) {
+    const buf = new TextEncoder().encode(text);
+    const hash = await crypto.subtle.digest("SHA-1", buf);
+    return Array.from(new Uint8Array(hash))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+  // Fallback: trivial non-crypto hash for environments without
+  // SubtleCrypto (notably old Node test runners). The server-side
+  // hash is the source of truth; this is only the b2c's local stamp
+  // for ad_hoc paste-and-schedule when SubtleCrypto isn't available.
+  // Not used for cryptographic verification — just a stable 40-hex
+  // digest that the schema accepts.
+  let h = 0x811c9dc5; // FNV-1a 32-bit seed
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  const hex8 = h.toString(16).padStart(8, "0");
+  // Repeat the digest 5× to fill the 40-hex span the schema requires.
+  return (hex8 + hex8 + hex8 + hex8 + hex8).slice(0, 40);
+}

--- a/src/lib/scheduler/types.ts
+++ b/src/lib/scheduler/types.ts
@@ -1,0 +1,215 @@
+/**
+ * Wire-shape types matching the /v1/scheduler/* REST surface.
+ * Mirrors the API responses (camelCase, hex-encoded ObjectIds, ISO dates).
+ *
+ * Keep aligned with peakhour-api/src/v1/routes/scheduler/index.ts
+ * (normalisePlanForApi + normaliseItemForApi).
+ */
+
+export type ChannelKey = string;
+
+export type StaggerStrategy = "synchronized" | "rolling" | "smart";
+
+export type ScheduleSourceType = "draft" | "idea" | "social_post" | "ad_hoc";
+
+export type PublishPlanStatus =
+  | "draft"
+  | "active"
+  | "paused"
+  | "cancelled"
+  | "completed"
+  | "failed_all";
+
+export type PublishPlanApprovalState =
+  | "draft"
+  | "pending_approval"
+  | "approved"
+  | "rejected"
+  | "auto_approved";
+
+export type ScheduledItemStatus =
+  | "queued"
+  | "awaiting_retry"
+  | "ready"
+  | "in_flight"
+  | "published"
+  | "failed"
+  | "cancelled"
+  | "skipped"
+  | "needs_action";
+
+export interface PreflightAudit {
+  ranAt: string;
+  mode: "live" | "deep";
+  band: "needs_work" | "good_fit" | "strong_fit";
+  compositeScore?: number;
+}
+
+export interface PayloadSnapshot {
+  text: string;
+  hashtags?: string[];
+  mediaUrls?: string[];
+  firstComment?: string;
+  threadParts?: string[];
+  channelOptions?: Record<string, unknown>;
+  audit?: PreflightAudit;
+  snapshotAt: string;
+  version: number;
+}
+
+export interface SmartTimeMeta {
+  tier: "tier1" | "tier2" | "manual";
+  adapterVersion: string;
+  engineVersion: string;
+  candidateHoursUtc?: number[];
+  chosenHourLocal?: number;
+  conflictsResolved?: string[];
+}
+
+export interface PlanChannelTarget {
+  channel: ChannelKey;
+  connectionId?: string;
+  preferredLocalTime?: string;
+  publishViaReminder: boolean;
+}
+
+export interface PublishPlanDto {
+  _id: string;
+  orgId: string;
+  businessId: string;
+  ownerUserId: string;
+  title?: string;
+  source: {
+    sourceType: ScheduleSourceType;
+    sourceRef?: string;
+    sourceTextHash: string;
+  };
+  channels: PlanChannelTarget[];
+  staggerStrategy: StaggerStrategy;
+  canonicalScheduledAtUtc: string;
+  timezone: string;
+  approvalState: PublishPlanApprovalState;
+  approvalActorUserId?: string;
+  approvalActorChannel?: string;
+  approvedAt?: string;
+  approvalNote?: string;
+  status: PublishPlanStatus;
+  recurringRuleId?: string;
+  recurringRunNumber?: number;
+  requestId: string;
+  totalCostUsd?: number;
+  cancellationReason?: string;
+  editLog?: { at: string; action: string; summary?: string }[];
+  meta?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface ScheduledAttempt {
+  startedAt: string;
+  endedAt: string;
+  outcome:
+    | "success"
+    | "transient_error"
+    | "permanent_error"
+    | "rate_limited";
+  durationMs: number;
+  providerHttpStatus?: number;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+export interface ScheduledItemDto {
+  _id: string;
+  orgId: string;
+  businessId: string;
+  planId: string;
+  channel: ChannelKey;
+  connectionId: string;
+  status: ScheduledItemStatus;
+  scheduledAtUtc: string;
+  audienceTimezone: string;
+  payload: PayloadSnapshot;
+  attempts?: ScheduledAttempt[];
+  attemptsCount: number;
+  payloadStale: boolean;
+  publishViaReminder: boolean;
+  priority: "low" | "normal" | "high";
+  smartTime?: SmartTimeMeta;
+  externalId?: string;
+  externalUrl?: string;
+  publishedAt?: string;
+  terminatedAt?: string;
+  cancellationReason?: string;
+  nextAttemptAt?: string;
+  socialPostId?: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+// ── Request bodies ───────────────────────────────────────────
+
+export interface CommitPlanRequest {
+  title?: string;
+  source: {
+    sourceType: ScheduleSourceType;
+    sourceRef?: string;
+    sourceTextHash: string;
+  };
+  channels: {
+    channel: ChannelKey;
+    connectionId?: string;
+    preferredLocalTime?: string;
+    publishViaReminder?: boolean;
+    payload: {
+      text: string;
+      hashtags?: string[];
+      mediaUrls?: string[];
+      firstComment?: string;
+      threadParts?: string[];
+      channelOptions?: Record<string, unknown>;
+      audit?: PreflightAudit;
+    };
+  }[];
+  staggerStrategy?: StaggerStrategy;
+  canonicalScheduledAtUtc: string;
+  timezone: string;
+  autoApprove?: boolean;
+  meta?: Record<string, unknown>;
+}
+
+export interface CommitPlanResponse {
+  planId: string;
+  scheduledItemIds: string[];
+  requestId: string;
+  resolvedTimes: { channel: ChannelKey; scheduledAtUtc: string }[];
+}
+
+export interface PreviewTimeRequest {
+  channels: { channel: ChannelKey; preferredLocalTime?: string }[];
+  staggerStrategy?: StaggerStrategy;
+  canonicalScheduledAtUtc: string;
+  timezone: string;
+}
+
+export interface PreviewTimeResponse {
+  resolvedTimes: {
+    channel: ChannelKey;
+    scheduledAtUtc: string | null;
+    audit: string[];
+  }[];
+}
+
+export interface ListPlansResponse {
+  plans: PublishPlanDto[];
+  nextCursor: string | null;
+}
+
+export interface ListItemsResponse {
+  items: ScheduledItemDto[];
+}
+
+export interface PlanDetailResponse {
+  plan: PublishPlanDto;
+  items: ScheduledItemDto[];
+}


### PR DESCRIPTION
## Summary

Reusable scheduler UI primitives — the \`@peakhour/scheduler-ui\` kit inlined in b2c. Eight components + one debounced hook + one opinionated composer.

### Components
- **ScheduleTimePicker** — date + time + IANA tz with quick-action chips
- **StaggerStrategyChooser** — synchronized / rolling / smart radio cards
- **ScheduleConfirmCard** — pre-commit live preview with smart-time audit chips
- **ScheduleConflictWarning** — collapsible explanation of engine adjustments
- **PublishBundleSummary** + **NextActionScheduleSlot** — committed-plan cards
- **TimezoneBanner** — audience-tz ≠ user-tz callout
- **RecurringScheduleEditor** — cadence / weekday / cron editor
- **CalendarView** — week + month grids with drag-to-reschedule (bundle-move default; alt-drag for item-only per locked decision #10)

### Hook + Composer
- **useSchedulePreview** — debounced POST /preview-time with sequence guard
- **SchedulerComposer** — opinionated composition for drop-in schedule sheets

### Lib
- **types.ts** — wire DTOs matching /v1/scheduler/* shape
- **client.ts** — typed thin wrapper around api.get/post
- **format.ts** — pure formatters + SubtleCrypto SHA-1 helper

Tailwind v4 throughout. No new npm deps.

## Test plan
- [x] tsc --noEmit clean
- [x] eslint clean
- [ ] PR 7 wires CalendarView into /dashboard/calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)