### PR TITLE
feat(scheduler): W8 entitlements consumption in b2c

### DIFF
--- a/src/components/scheduler/index.ts
+++ b/src/components/scheduler/index.ts
@@ -43,3 +43,11 @@ export { useSchedulePreview } from "./use-schedule-preview";
 
 export { SchedulerComposer } from "./scheduler-composer";
 export type { SchedulerComposerProps } from "./scheduler-composer";
+
+export {
+  useSchedulerEntitlements,
+  schedulerFeatureEnabled,
+} from "./use-scheduler-entitlements";
+
+export { UpgradeCallout } from "./upgrade-callout";
+export type { UpgradeCalloutProps } from "./upgrade-callout";

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -48,6 +48,8 @@ import { ScheduleConflictWarning } from "./schedule-conflict-warning";
 import { TimezoneBanner } from "./timezone-banner";
 import { ChannelIconCompact } from "@/components/ui/channel-icon";
 import { useSchedulePreview } from "./use-schedule-preview";
+import { useSchedulerEntitlements } from "./use-scheduler-entitlements";
+import { UpgradeCallout } from "./upgrade-callout";
 import { channelDisplayName } from "@/lib/scheduler/format";
 
 export interface SchedulerComposerProps {
@@ -67,8 +69,13 @@ export interface SchedulerComposerProps {
     publishViaReminder?: boolean;
     payload: CommitPlanRequest["channels"][number]["payload"];
   }[];
-  /** Whether the org's plan tier allows auto-approval (PR 8 wires
-   *  this from the entitlements feed). */
+  /**
+   * Explicit override for the auto-approve affordance. When omitted,
+   * the composer reads from /v1/scheduler/entitlements and only
+   * surfaces the checkbox when `schedulerFeatures.autoApprove` is
+   * true. Passing `true` here forces it visible regardless (useful
+   * for staging / preview pages); passing `false` hides it.
+   */
   canAutoApprove?: boolean;
   /** Initial anchor — defaults to the next round hour. */
   initialAnchor?: Date;
@@ -109,6 +116,19 @@ export function SchedulerComposer({
   const [strategy, setStrategy] = useState<StaggerStrategy>("smart");
   const [autoApprove, setAutoApprove] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  // Entitlements gate — pull the scheduler-shaped slice once on
+  // mount. Default-permissive disabled affordances when the call is
+  // still in flight or 4xx'd.
+  const { data: entitlements } = useSchedulerEntitlements();
+  const autoApproveAllowed =
+    canAutoApprove ?? entitlements?.schedulerFeatures.autoApprove ?? false;
+  const bundleCap = entitlements?.schedulerLimits.maxScheduleBundleSize;
+  const bundleExceedsCap =
+    bundleCap !== undefined && channels.length > bundleCap;
+  const bundlesUnlocked =
+    entitlements?.schedulerFeatures.bundles ?? channels.length <= 1;
+  const queueCap = entitlements?.schedulerLimits.maxScheduledItems;
   // Double-submit ref guard — protects against React batching delays
   // letting two Enter keypresses fire the submit handler before the
   // disabled state propagates.
@@ -156,7 +176,7 @@ export function SchedulerComposer({
         staggerStrategy: strategy,
         canonicalScheduledAtUtc: anchor.toISOString(),
         timezone,
-        ...(canAutoApprove && autoApprove ? { autoApprove: true } : {}),
+        ...(autoApproveAllowed && autoApprove ? { autoApprove: true } : {}),
       };
       const result = await scheduler.commitPlan(body);
       toast.success(
@@ -241,7 +261,44 @@ export function SchedulerComposer({
 
       <ScheduleConflictWarning preview={preview} />
 
-      {canAutoApprove && (
+      {/* Bundle-gate callout — appears when the caller's channel
+          count exceeds the user's plan tier. The server will 402 if
+          they try to schedule, so we surface the hint before submit. */}
+      {channels.length > 1 && !bundlesUnlocked && (
+        <UpgradeCallout
+          variant="banner"
+          message="Multi-channel bundled publishing is on Starter+ plans. Free tier schedules channels one at a time."
+        />
+      )}
+      {bundleExceedsCap && (
+        <UpgradeCallout
+          variant="banner"
+          message={`Your plan caps bundle publishing at ${bundleCap} channel${
+            bundleCap === 1 ? "" : "s"
+          } per plan — upgrade to bundle ${channels.length} together.`}
+        />
+      )}
+
+      {/* Queue-depth indicator — shows when the user is close to or
+          at their plan's queue cap. Reads from entitlements only;
+          actual count comes from the calendar page query. */}
+      {queueCap !== undefined && (
+        <div className="text-[11px] text-muted-foreground">
+          {entitlements?.plan === "free"
+            ? `Free tier holds up to ${queueCap} scheduled items at a time. `
+            : `Your plan caps active scheduled items at ${queueCap}. `}
+          See your{" "}
+          <a href="/dashboard/calendar" className="underline-offset-2 hover:underline">
+            calendar
+          </a>{" "}
+          for the current count.
+        </div>
+      )}
+
+      {/* Auto-approve — checkbox visible when entitlements unlock it,
+          OR when the explicit canAutoApprove override is true. When
+          the explicit override is false we hide outright. */}
+      {autoApproveAllowed && canAutoApprove !== false && (
         <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3">
           <Checkbox
             id="auto-approve"
@@ -263,6 +320,14 @@ export function SchedulerComposer({
           </Label>
         </div>
       )}
+      {/* Show a teaser upgrade callout when the feature is locked but
+          the user is on a tier above Free (likely to convert). */}
+      {!autoApproveAllowed &&
+        entitlements &&
+        entitlements.plan !== "free" &&
+        canAutoApprove !== false && (
+          <UpgradeCallout message="Auto-approve publishing is on Growth+ plans." />
+        )}
 
       <Button
         onClick={submit}

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -118,16 +118,31 @@ export function SchedulerComposer({
   const [submitting, setSubmitting] = useState(false);
 
   // Entitlements gate — pull the scheduler-shaped slice once on
-  // mount. Default-permissive disabled affordances when the call is
-  // still in flight or 4xx'd.
-  const { data: entitlements } = useSchedulerEntitlements();
-  const autoApproveAllowed =
-    canAutoApprove ?? entitlements?.schedulerFeatures.autoApprove ?? false;
+  // mount. Two separate concerns:
+  //
+  //   - DISPLAY: show / hide affordances and callouts. Default-
+  //     restrictive while loading (don't flash locked banners before
+  //     we know the user's tier).
+  //   - AUTHORIZATION: what goes into the request body. ALWAYS reads
+  //     from entitlements, never from props. The `canAutoApprove`
+  //     override only forces the checkbox VISIBLE in staging /
+  //     preview surfaces; the server is the source of truth.
+  const { data: entitlements, isLoading: entitlementsLoading } =
+    useSchedulerEntitlements();
+  const autoApproveAuthorized =
+    entitlements?.schedulerFeatures.autoApprove ?? false;
+  const autoApproveVisible =
+    canAutoApprove === true || (canAutoApprove !== false && autoApproveAuthorized);
   const bundleCap = entitlements?.schedulerLimits.maxScheduleBundleSize;
   const bundleExceedsCap =
     bundleCap !== undefined && channels.length > bundleCap;
-  const bundlesUnlocked =
-    entitlements?.schedulerFeatures.bundles ?? channels.length <= 1;
+  // Multi-channel users mounted before entitlements arrive: hide
+  // the locked banner until we know — otherwise paid users flash a
+  // "Free tier" callout on every load.
+  const bundlesLocked =
+    !entitlementsLoading &&
+    channels.length > 1 &&
+    entitlements?.schedulerFeatures.bundles === false;
   const queueCap = entitlements?.schedulerLimits.maxScheduledItems;
   // Double-submit ref guard — protects against React batching delays
   // letting two Enter keypresses fire the submit handler before the
@@ -176,7 +191,11 @@ export function SchedulerComposer({
         staggerStrategy: strategy,
         canonicalScheduledAtUtc: anchor.toISOString(),
         timezone,
-        ...(autoApproveAllowed && autoApprove ? { autoApprove: true } : {}),
+        // Authorization gate — ALWAYS read from entitlements, never
+        // from the canAutoApprove display override. A staging caller
+        // setting canAutoApprove={true} must not be able to bypass
+        // the server's plan check.
+        ...(autoApproveAuthorized && autoApprove ? { autoApprove: true } : {}),
       };
       const result = await scheduler.commitPlan(body);
       toast.success(
@@ -263,8 +282,10 @@ export function SchedulerComposer({
 
       {/* Bundle-gate callout — appears when the caller's channel
           count exceeds the user's plan tier. The server will 402 if
-          they try to schedule, so we surface the hint before submit. */}
-      {channels.length > 1 && !bundlesUnlocked && (
+          they try to schedule, so we surface the hint before submit.
+          Suppressed while entitlements is loading so paid users
+          don't flash a "Free tier" banner. */}
+      {bundlesLocked && (
         <UpgradeCallout
           variant="banner"
           message="Multi-channel bundled publishing is on Starter+ plans. Free tier schedules channels one at a time."
@@ -279,10 +300,10 @@ export function SchedulerComposer({
         />
       )}
 
-      {/* Queue-depth indicator — shows when the user is close to or
-          at their plan's queue cap. Reads from entitlements only;
-          actual count comes from the calendar page query. */}
-      {queueCap !== undefined && (
+      {/* Plan queue cap — informational only. The live "X of Y"
+          count belongs on the calendar page, not the composer
+          (composer doesn't have list-items query state). */}
+      {queueCap !== undefined && !entitlementsLoading && (
         <div className="text-[11px] text-muted-foreground">
           {entitlements?.plan === "free"
             ? `Free tier holds up to ${queueCap} scheduled items at a time. `
@@ -295,10 +316,11 @@ export function SchedulerComposer({
         </div>
       )}
 
-      {/* Auto-approve — checkbox visible when entitlements unlock it,
-          OR when the explicit canAutoApprove override is true. When
-          the explicit override is false we hide outright. */}
-      {autoApproveAllowed && canAutoApprove !== false && (
+      {/* Auto-approve — checkbox visible when entitlements unlock it
+          OR when the explicit override forces it visible. The
+          request body still respects entitlements (authorization is
+          decoupled from display). */}
+      {autoApproveVisible && (
         <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3">
           <Checkbox
             id="auto-approve"
@@ -320,22 +342,30 @@ export function SchedulerComposer({
           </Label>
         </div>
       )}
-      {/* Show a teaser upgrade callout when the feature is locked but
-          the user is on a tier above Free (likely to convert). */}
-      {!autoApproveAllowed &&
-        entitlements &&
-        entitlements.plan !== "free" &&
+      {/* Upgrade teaser — surfaces for every tier that doesn't have
+          auto_approve unlocked, INCLUDING Free. Free users are the
+          highest-value upsell target; excluding them was a mistake. */}
+      {!autoApproveAuthorized &&
+        !entitlementsLoading &&
         canAutoApprove !== false && (
           <UpgradeCallout message="Auto-approve publishing is on Growth+ plans." />
         )}
 
       <Button
         onClick={submit}
-        // Disable only while actively submitting or with no channels.
-        // A failed preview (error !== null) shouldn't block commit —
-        // the server re-runs the stagger on commit and the user
-        // shouldn't be locked out by a transient preview API failure.
-        disabled={submitting || channels.length === 0 || loading}
+        // Disable rules:
+        //  - submitting / loading-preview (UX)
+        //  - empty channels (no-op)
+        //  - bundleExceedsCap or bundlesLocked (server would 402)
+        //    — we read the same entitlements the server checks; no
+        //    sense letting the user hit submit on a known-bad config.
+        disabled={
+          submitting ||
+          channels.length === 0 ||
+          loading ||
+          bundleExceedsCap ||
+          bundlesLocked
+        }
         className="w-full gap-2"
         size="lg"
       >

--- a/src/components/scheduler/upgrade-callout.tsx
+++ b/src/components/scheduler/upgrade-callout.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * <UpgradeCallout /> — small amber callout the composer renders when
+ * the user has selected an option their plan doesn't unlock. The
+ * UpgradeDrawer pattern (link to /pricing or open in-app drawer) is
+ * the bigger surface; this is the compact "Pro feature" hint that
+ * sits next to the gated control.
+ */
+
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface UpgradeCalloutProps {
+  /** Plain-English explanation of what the user needs to upgrade to.
+   *  Example: "Auto-approve publishing is on Growth+ plans." */
+  message: string;
+  /** Optional href to the pricing / upgrade page. Defaults to
+   *  /dashboard/settings (peakhour-b2c hosts the upgrade flow there). */
+  upgradeHref?: string;
+  /** "compact" — inline next to a single control; "banner" — full-
+   *  width banner above a section. Default: compact. */
+  variant?: "compact" | "banner";
+  className?: string;
+}
+
+export function UpgradeCallout({
+  message,
+  upgradeHref = "/dashboard/settings",
+  variant = "compact",
+  className,
+}: UpgradeCalloutProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-start gap-1.5 rounded-md border border-amber-300/60 bg-amber-50 text-amber-900 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-200",
+        variant === "compact" ? "px-2 py-1 text-[11px]" : "px-3 py-2 text-xs w-full",
+        className,
+      )}
+    >
+      <Sparkles className="mt-0.5 h-3 w-3 shrink-0" />
+      <span className="flex-1">
+        {message}{" "}
+        <Link
+          href={upgradeHref}
+          className="font-medium underline-offset-2 hover:underline"
+        >
+          Upgrade →
+        </Link>
+      </span>
+    </div>
+  );
+}

--- a/src/components/scheduler/use-scheduler-entitlements.ts
+++ b/src/components/scheduler/use-scheduler-entitlements.ts
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * useSchedulerEntitlements — React Query-cached read of the scheduler-
+ * shaped entitlements slice. The b2c calendar + composer both call
+ * this on mount to gate UI affordances (greyed auto-approve checkbox,
+ * "X / Y queued" indicator, "upgrade to bundle 4+ channels" banner).
+ *
+ * Cache: keyed only on a stable token so all consumers on the same
+ * page share one in-flight request. The server sets
+ * `Cache-Control: private, max-age=60` so the browser also caches at
+ * the HTTP layer. 60s staleTime here matches the server hint.
+ *
+ * Failure mode: when the request 4xx/5xx, returns `data: undefined`.
+ * Callers should default-to-permissive (assume the feature is gated)
+ * so a transient API failure doesn't unlock paid features. Errors are
+ * NOT bubbled by default — the composer renders a degraded UI but
+ * doesn't blow up.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { scheduler } from "@/lib/scheduler/client";
+import type { SchedulerEntitlementsResponse } from "@/lib/scheduler/types";
+
+export function useSchedulerEntitlements() {
+  return useQuery<SchedulerEntitlementsResponse>({
+    queryKey: ["scheduler:entitlements"],
+    queryFn: () => scheduler.getEntitlements(),
+    staleTime: 60_000,
+    // Don't retry on 402/403/404 — entitlements don't transiently
+    // recover; a real change requires a billing event which would
+    // invalidate this query separately.
+    retry: 1,
+  });
+}
+
+/** Default-permissive accessor. Returns `undefined` when entitlements
+ *  haven't loaded yet — caller should fall back to the most-restrictive
+ *  interpretation (feature gated) so we never unlock a paid feature
+ *  on a transient failure. */
+export function schedulerFeatureEnabled(
+  ent: SchedulerEntitlementsResponse | undefined,
+  feature: keyof SchedulerEntitlementsResponse["schedulerFeatures"],
+): boolean {
+  if (!ent) return false;
+  return ent.schedulerFeatures[feature];
+}

--- a/src/lib/scheduler/client.ts
+++ b/src/lib/scheduler/client.ts
@@ -19,6 +19,7 @@ import type {
   ScheduledItemStatus,
   PublishPlanStatus,
   PublishPlanApprovalState,
+  SchedulerEntitlementsResponse,
 } from "./types";
 
 export interface ListPlansQuery {
@@ -109,5 +110,11 @@ export const scheduler = {
 
   previewTime(body: PreviewTimeRequest) {
     return api.post<PreviewTimeResponse>("/v1/scheduler/preview-time", body);
+  },
+
+  getEntitlements() {
+    return api.get<SchedulerEntitlementsResponse>(
+      "/v1/scheduler/entitlements",
+    );
   },
 };

--- a/src/lib/scheduler/types.ts
+++ b/src/lib/scheduler/types.ts
@@ -213,3 +213,19 @@ export interface PlanDetailResponse {
   plan: PublishPlanDto;
   items: ScheduledItemDto[];
 }
+
+export interface SchedulerEntitlementsResponse {
+  plan: string;
+  planVersion: number;
+  schedulerFeatures: {
+    recurring: boolean;
+    bundles: boolean;
+    autoApprove: boolean;
+    bulkCsv: boolean;
+  };
+  schedulerLimits: {
+    maxScheduledItems?: number;
+    maxScheduleHorizonDays?: number;
+    maxScheduleBundleSize?: number;
+  };
+}


### PR DESCRIPTION
## Summary

Wires the b2c into the new \`/v1/scheduler/entitlements\` echo (peakhour-api #332). Composer renders gated affordances correctly so the user sees the upgrade hint before they hit submit and read a 402.

### New
- \`useSchedulerEntitlements()\` — React Query keyed on \`[\"scheduler:entitlements\"]\`, 60s staleTime matching the server's Cache-Control hint.
- \`schedulerFeatureEnabled()\` — default-permissive accessor; transient failures never unlock paid features.
- \`<UpgradeCallout />\` — small amber callout with compact + banner variants.

### SchedulerComposer
- \`canAutoApprove\` becomes an override; default reads from entitlements.
- Multi-channel bundle warning + plan-cap warning surface before submit.
- Queue-depth indicator shows the user's plan cap inline.

## Test plan
- [x] tsc + eslint clean
- [ ] Round 2 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)