### PR TITLE
feat(library): tooltip on Ad Score when API marks draft unprocessable

### DIFF
--- a/src/app/dashboard/content/beehiiv/columns.tsx
+++ b/src/app/dashboard/content/beehiiv/columns.tsx
@@ -305,7 +305,18 @@ export function getContentColumns(prefs: UserPreferences | null): ColumnDef<Draf
           return (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                {/* stopPropagation on click + pointerdown — the row is
+                    wired to navigate on click in the parent table, and
+                    Radix opens its tooltip on pointerdown. Without
+                    both, tapping the Info icon routes away and the
+                    tooltip the user was trying to read closes
+                    immediately. Mirrors the Repurpose button pattern
+                    elsewhere on this page. */}
+                <span
+                  className="flex items-center gap-1 text-xs text-muted-foreground"
+                  onClick={(e) => e.stopPropagation()}
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
                   Can&apos;t score
                   <Info className="size-3 text-amber-500" aria-label="Why not scored?" />
                 </span>

--- a/src/app/dashboard/content/beehiiv/columns.tsx
+++ b/src/app/dashboard/content/beehiiv/columns.tsx
@@ -301,19 +301,27 @@ export function getContentColumns(prefs: UserPreferences | null): ColumnDef<Draf
         // fired, etc.), surface the reason as a tooltip so the user
         // doesn't sit waiting for a score that will never come. The
         // reason `message` is pre-rendered by the API — display as-is.
-        if (unprocessable) {
+        // Defence-in-depth: if the API ever ships an empty message,
+        // fall through to plain "Not scored" rather than render an
+        // empty hover bubble. The API contract requires a non-empty
+        // string (schema maxLength 512, no minLength but the writer
+        // always populates it) — this guard is for forward-compat.
+        if (unprocessable && unprocessable.message) {
           return (
             <Tooltip>
               <TooltipTrigger asChild>
-                {/* stopPropagation on click + pointerdown — the row is
-                    wired to navigate on click in the parent table, and
-                    Radix opens its tooltip on pointerdown. Without
-                    both, tapping the Info icon routes away and the
-                    tooltip the user was trying to read closes
-                    immediately. Mirrors the Repurpose button pattern
-                    elsewhere on this page. */}
+                {/* tabIndex makes the span focusable so keyboard
+                    users can reach the tooltip — Radix auto-opens on
+                    focus once the trigger is focusable. stopPropagation
+                    on click + pointerdown — the row is wired to
+                    navigate on click, and Radix opens its tooltip on
+                    pointerdown; without both, tapping the Info icon
+                    routes away and the tooltip closes immediately.
+                    Mirrors the Repurpose button pattern elsewhere on
+                    this page. */}
                 <span
-                  className="flex items-center gap-1 text-xs text-muted-foreground"
+                  className="flex items-center gap-1 rounded-sm text-xs text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  tabIndex={0}
                   onClick={(e) => e.stopPropagation()}
                   onPointerDown={(e) => e.stopPropagation()}
                 >

--- a/src/app/dashboard/content/beehiiv/columns.tsx
+++ b/src/app/dashboard/content/beehiiv/columns.tsx
@@ -25,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Info } from "lucide-react";
 
 const FORMAT_LABELS: Record<string, string> = {
   article: "Article",
@@ -45,6 +46,28 @@ export interface Draft {
   webUrl?: string;
   thumbnailUrl?: string;
   readingTimeMin?: number;
+  /**
+   * Set by the API when an automated pipeline (today: AI tagger hits
+   * retry cap; future: deterministic preflight gates) determines no
+   * further automated processing will help. Surfaced as an info icon
+   * + tooltip next to "Not scored" in the Ad Score column so users
+   * understand WHY a score will never appear rather than waiting
+   * indefinitely. `code` is stable across businesses for analytics;
+   * `message` is the human-readable, possibly business-contextual
+   * tooltip text.
+   */
+  unprocessable?: {
+    code:
+      | "ai_persistent_failure"
+      | "content_too_short"
+      | "image_only"
+      | "unsupported_language"
+      | "duplicate_content"
+      | "boilerplate_only"
+      | "ai_no_extractable_tags";
+    message: string;
+    detectedAt: string;
+  };
   tags: {
     sectors: { name: string; weight: number; rationale?: string }[];
     companies: { name: string; role: string; sentiment?: string }[];
@@ -272,8 +295,29 @@ export function getContentColumns(prefs: UserPreferences | null): ColumnDef<Draf
     ),
     cell: ({ row }) => {
       const score = row.original.tags?.adPotentialScore;
-      if (score == null)
+      const unprocessable = row.original.unprocessable;
+      if (score == null) {
+        // When the API marked this draft unprocessable (cap hit, gate
+        // fired, etc.), surface the reason as a tooltip so the user
+        // doesn't sit waiting for a score that will never come. The
+        // reason `message` is pre-rendered by the API — display as-is.
+        if (unprocessable) {
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  Can&apos;t score
+                  <Info className="size-3 text-amber-500" aria-label="Why not scored?" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>{unprocessable.message}</p>
+              </TooltipContent>
+            </Tooltip>
+          );
+        }
         return <span className="text-xs text-muted-foreground">Not scored</span>;
+      }
       const color =
         score >= 8
           ? "bg-green-500"

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -35,7 +35,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
-import { FileX, LayoutGrid, List, Library, BrainCircuit, Share2 } from "lucide-react";
+import { FileX, LayoutGrid, List, Library, BrainCircuit, Share2, Info } from "lucide-react";
 import { RepurposeSheet } from "@/components/repurpose/repurpose-sheet";
 import type { RepurposeSource } from "@/lib/api/repurpose";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -775,7 +775,7 @@ function ArticleCard({
 
         {/* Ad score bar */}
         <div className="flex items-center justify-between">
-          <AdScoreBar score={t?.adPotentialScore} />
+          <AdScoreBar score={t?.adPotentialScore} unprocessable={draft.unprocessable} />
           <span className="text-xs text-muted-foreground">
             {formatDate(draft.publishedAt, null)}
           </span>
@@ -805,11 +805,36 @@ function ArticleCard({
   );
 }
 
-function AdScoreBar({ score }: { score?: number }) {
-  if (score == null)
+function AdScoreBar({
+  score,
+  unprocessable,
+}: {
+  score?: number;
+  unprocessable?: { message: string };
+}) {
+  if (score == null) {
+    if (unprocessable) {
+      // Reason set by the API (AI cap hit, preflight gate, etc.) —
+      // show why instead of an indefinite "Not scored". `message` is
+      // pre-rendered server-side; display as-is.
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              Can&apos;t score
+              <Info className="size-3 text-amber-500" aria-label="Why not scored?" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            <p>{unprocessable.message}</p>
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
     return (
       <span className="text-xs text-muted-foreground">Not scored</span>
     );
+  }
 
   const color =
     score >= 8

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -820,7 +820,15 @@ function AdScoreBar({
       return (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+            {/* stopPropagation on click + pointerdown — card is wired
+                to navigate on click; without both, tapping the Info
+                routes away and closes the tooltip the user was trying
+                to read. Mirrors the Repurpose button pattern below. */}
+            <span
+              className="flex items-center gap-1 text-xs text-muted-foreground"
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
               Can&apos;t score
               <Info className="size-3 text-amber-500" aria-label="Why not scored?" />
             </span>

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -813,19 +813,25 @@ function AdScoreBar({
   unprocessable?: { message: string };
 }) {
   if (score == null) {
-    if (unprocessable) {
-      // Reason set by the API (AI cap hit, preflight gate, etc.) —
-      // show why instead of an indefinite "Not scored". `message` is
-      // pre-rendered server-side; display as-is.
+    // Reason set by the API (AI cap hit, preflight gate, etc.) —
+    // show why instead of an indefinite "Not scored". `message` is
+    // pre-rendered server-side; display as-is. Guard against an
+    // empty message so we don't render an empty hover bubble if the
+    // API ever ships partial data.
+    if (unprocessable && unprocessable.message) {
       return (
         <Tooltip>
           <TooltipTrigger asChild>
-            {/* stopPropagation on click + pointerdown — card is wired
-                to navigate on click; without both, tapping the Info
-                routes away and closes the tooltip the user was trying
-                to read. Mirrors the Repurpose button pattern below. */}
+            {/* tabIndex makes the span focusable so keyboard users
+                can reach the tooltip — Radix auto-opens on focus
+                once the trigger is focusable. stopPropagation on
+                click + pointerdown — card is wired to navigate on
+                click; without both, tapping the Info routes away and
+                closes the tooltip the user was trying to read.
+                Mirrors the Repurpose button pattern below. */}
             <span
-              className="flex items-center gap-1 text-xs text-muted-foreground"
+              className="flex items-center gap-1 rounded-sm text-xs text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              tabIndex={0}
               onClick={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
             >


### PR DESCRIPTION
## Summary
Companion to peakhour-api **#feat/unprocessable-reason**. When the API stamps \`cnt_drafts.unprocessable\` (today: AI tagger retry cap; future: preflight gates), the Library table and card view now show "Can't score" + an Info icon (amber) instead of indefinitely showing "Not scored". Hovering surfaces the API-provided reason message as a tooltip so the user understands WHY the score will never appear.

## What changed
- **Draft interface**: optional \`unprocessable: { code, message, detectedAt }\` field. \`code\` enum mirrors the schema for future-compat with codes that ship with preflight gates.
- **columns.tsx (table)**: adScore cell branches when \`score == null\` — renders Info + tooltip when \`unprocessable\` is set; falls back to plain "Not scored" otherwise.
- **page.tsx (card view)**: \`AdScoreBar\` takes an optional \`unprocessable\` prop; same branching.
- **stopPropagation guards** on the tooltip trigger (\`onClick\` + \`onPointerDown\`) — without them, tapping the Info icon would route to the draft detail page and dismiss the tooltip the user was trying to read.

## Test plan
- [x] Typecheck clean (\`tsc --noEmit\`)
- [x] Lint clean
- [ ] **Post-merge**: with peakhour-api PR live, trigger an Analyse on Quests.travel; once a draft hits the cap, verify the Library row shows "Can't score" + Info icon, and hovering shows the reason message.
- [ ] **Post-merge**: verify clicking the Info icon does NOT navigate to the draft detail page (stopPropagation working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)