### PR TITLE
feat(errors): reusable ErrorBoundary + Next.js error boundaries (built on @shadcn/empty)

### DIFF
--- a/src/app/cms/error.tsx
+++ b/src/app/cms/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/molecules/error-fallback";
+
+export default function CmsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[cms/error]", error);
+  }, [error]);
+
+  return (
+    <div className="p-4 md:p-6">
+      <ErrorFallback error={error} reset={reset} />
+    </div>
+  );
+}

--- a/src/app/cms/error.tsx
+++ b/src/app/cms/error.tsx
@@ -14,9 +14,6 @@ export default function CmsError({
     console.error("[cms/error]", error);
   }, [error]);
 
-  return (
-    <div className="p-4 md:p-6">
-      <ErrorFallback error={error} reset={reset} />
-    </div>
-  );
+  // CMS layout already pads `{children}` with p-6 — render directly.
+  return <ErrorFallback error={error} reset={reset} />;
 }

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -20,9 +20,8 @@ export default function DashboardError({
     console.error("[dashboard/error]", error);
   }, [error]);
 
-  return (
-    <div className="p-4 md:p-6">
-      <ErrorFallback error={error} reset={reset} />
-    </div>
-  );
+  // Dashboard layout already wraps {children} in a `p-6` container, so we
+  // render the fallback directly — adding our own padding would double up
+  // and push the card off-grid.
+  return <ErrorFallback error={error} reset={reset} />;
 }

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/molecules/error-fallback";
+
+/**
+ * Dashboard-scoped error boundary. Sits below `app/error.tsx` and catches
+ * render errors inside any `/dashboard/**` segment that doesn't have its
+ * own `error.tsx`. Keeps the dashboard chrome (sidebar/topbar) intact so
+ * the user can still navigate away from a broken page.
+ */
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[dashboard/error]", error);
+  }, [error]);
+
+  return (
+    <div className="p-4 md:p-6">
+      <ErrorFallback error={error} reset={reset} />
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/molecules/error-fallback";
+
+/**
+ * Root error boundary. Catches render errors anywhere below the root
+ * layout — including dashboard, CMS, onboarding etc. — that aren't caught
+ * by a closer per-segment `error.tsx`. Sibling to `global-error.tsx`,
+ * which only fires if the root layout itself crashes.
+ */
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Visible in the browser console + Vercel runtime logs. Sentry/etc.
+    // can hook in here later by reading `error.digest` for correlation.
+    console.error("[app/error]", error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto p-6 md:p-10">
+      <ErrorFallback error={error} reset={reset} />
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/molecules/error-fallback";
+
+/**
+ * Global error boundary — fires ONLY when the root `app/layout.tsx`
+ * itself throws (i.e. before normal `error.tsx` boundaries can render).
+ * Per Next.js, this component must provide its own <html>/<body> because
+ * the root layout never mounted.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[app/global-error]", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="font-sans antialiased">
+        <div className="container mx-auto p-6 md:p-10">
+          <ErrorFallback
+            error={error}
+            reset={reset}
+            title="The app failed to load"
+            description="The root layout crashed before the page could render. This usually clears up with a reload."
+          />
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -19,7 +19,7 @@ import {
 export default function NotFound() {
   return (
     <div className="container mx-auto p-6 md:p-10">
-      <Empty role="alert">
+      <Empty role="status">
         <EmptyHeader>
           <EmptyMedia variant="icon">
             <FileQuestion />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+/**
+ * Root 404 page — fires for any URL that doesn't match a route or for
+ * explicit `notFound()` calls inside server components. Renders the same
+ * `Empty` chrome as ErrorFallback / EmptyState so the look stays consistent
+ * across error, empty, and not-found states.
+ */
+export default function NotFound() {
+  return (
+    <div className="container mx-auto p-6 md:p-10">
+      <Empty role="alert">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <FileQuestion />
+          </EmptyMedia>
+          <EmptyTitle>Page not found</EmptyTitle>
+          <EmptyDescription>
+            The page you&apos;re looking for doesn&apos;t exist or has moved.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Button asChild>
+              <Link href="/dashboard">Go to dashboard</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/">Home</Link>
+            </Button>
+          </div>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
+}

--- a/src/app/onboarding/error.tsx
+++ b/src/app/onboarding/error.tsx
@@ -14,9 +14,7 @@ export default function OnboardingError({
     console.error("[onboarding/error]", error);
   }, [error]);
 
-  return (
-    <div className="container mx-auto p-6 md:p-10">
-      <ErrorFallback error={error} reset={reset} />
-    </div>
-  );
+  // Onboarding layout already wraps in a max-w-2xl padded container —
+  // render directly to avoid double-wrap + container/max-width fight.
+  return <ErrorFallback error={error} reset={reset} />;
 }

--- a/src/app/onboarding/error.tsx
+++ b/src/app/onboarding/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/molecules/error-fallback";
+
+export default function OnboardingError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[onboarding/error]", error);
+  }, [error]);
+
+  return (
+    <div className="container mx-auto p-6 md:p-10">
+      <ErrorFallback error={error} reset={reset} />
+    </div>
+  );
+}

--- a/src/components/molecules/error-boundary.tsx
+++ b/src/components/molecules/error-boundary.tsx
@@ -9,13 +9,27 @@ interface ErrorBoundaryProps {
   fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
   /** Optional side effect on catch — e.g. log to Sentry, post a breadcrumb, fire a metric. */
   onError?: (error: Error, info: ErrorInfo) => void;
-  /** Pass any value (e.g. a queryKey, route segment) that should trigger a reset when it changes —
-   *  useful for "auto-recover when the user navigates away." */
-  resetKey?: unknown;
+  /** Primitive values (string/number) compared by `Object.is` between renders;
+   *  any change resets the boundary. Useful for "auto-recover on navigation."
+   *  Arrays/objects would create a fresh reference every render and reset
+   *  loop forever — primitives only. */
+  resetKeys?: ReadonlyArray<string | number | boolean | null | undefined>;
 }
 
 interface ErrorBoundaryState {
   error: Error | null;
+}
+
+function resetKeysChanged(
+  a: ErrorBoundaryProps["resetKeys"],
+  b: ErrorBoundaryProps["resetKeys"],
+): boolean {
+  if (a === b) return false;
+  if (!a || !b || a.length !== b.length) return true;
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return true;
+  }
+  return false;
 }
 
 /**
@@ -44,7 +58,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps): void {
-    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+    if (this.state.error && resetKeysChanged(prevProps.resetKeys, this.props.resetKeys)) {
       this.setState({ error: null });
     }
   }

--- a/src/components/molecules/error-boundary.tsx
+++ b/src/components/molecules/error-boundary.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { ErrorFallback } from "./error-fallback";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Custom fallback. Receives the error and a reset callback; rendered in place of children on catch. */
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
+  /** Optional side effect on catch — e.g. log to Sentry, post a breadcrumb, fire a metric. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+  /** Pass any value (e.g. a queryKey, route segment) that should trigger a reset when it changes —
+   *  useful for "auto-recover when the user navigates away." */
+  resetKey?: unknown;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Class-based React error boundary for client subtrees that need isolation
+ * INSIDE a page (e.g. a chart widget, an embedded iframe wrapper) — Next.js's
+ * `error.tsx` files already wrap whole route segments, so use those for
+ * page-level catches and reach for this only when you want one widget's
+ * failure not to take down the rest of the screen.
+ *
+ * NOTE: only render-time and lifecycle errors are caught. Event handlers and
+ * promise rejections still escape — handle those at the call site (try/catch
+ * around async work, useMutation onError, etc.).
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.props.onError?.(error, info);
+    // Surface to the browser console too — without this, a custom fallback
+    // would silently swallow the stack and make production triage harder.
+    console.error("[ErrorBoundary]", error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  reset = (): void => this.setState({ error: null });
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback({ error, reset: this.reset });
+    return <ErrorFallback error={error} reset={this.reset} />;
+  }
+}

--- a/src/components/molecules/error-fallback.tsx
+++ b/src/components/molecules/error-fallback.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { AlertTriangle, RotateCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ErrorFallbackProps {
+  /** The error that was caught. `digest` is Next.js-only; absent for class-boundary catches. */
+  error?: (Error & { digest?: string }) | null;
+  /** Reset handler. For Next.js error.tsx pass the framework's `reset`; for class boundaries, pass your retry callback. */
+  reset?: () => void;
+  /** Override the default heading. */
+  title?: string;
+  /** Override the default body copy. */
+  description?: string;
+  /** Reset button label. Defaults to "Try again". */
+  resetLabel?: string;
+  /** Tailwind classes for the outer container. */
+  className?: string;
+}
+
+export function ErrorFallback({
+  error,
+  reset,
+  title = "Something went wrong",
+  description = "We hit an unexpected error rendering this view. Try again, or reload the page.",
+  resetLabel = "Try again",
+  className,
+}: ErrorFallbackProps) {
+  const detail = error?.message?.trim();
+  const digest = error?.digest;
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex min-h-100 flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center",
+        className,
+      )}
+    >
+      <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-destructive/10">
+        <AlertTriangle aria-hidden="true" className="size-6 text-destructive" />
+      </div>
+      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">{description}</p>
+
+      {detail && (
+        <p className="mt-3 max-w-md font-mono text-xs text-muted-foreground/80 break-words">
+          {detail}
+        </p>
+      )}
+
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+        {reset && (
+          <Button onClick={reset}>
+            <RotateCw className="mr-1.5 size-4" />
+            {resetLabel}
+          </Button>
+        )}
+        <Button variant="outline" onClick={() => window.location.reload()}>
+          Reload page
+        </Button>
+      </div>
+
+      {/* `digest` lets ops correlate this exact error with the server log entry.
+          Hidden visually but selectable for support — kept small to avoid scaring users. */}
+      {digest && (
+        <p className="mt-4 text-[10px] text-muted-foreground/60 tabular-nums select-all">
+          ref: {digest}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/molecules/error-fallback.tsx
+++ b/src/components/molecules/error-fallback.tsx
@@ -2,6 +2,14 @@
 
 import { AlertTriangle, RotateCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
 
 interface ErrorFallbackProps {
@@ -19,6 +27,11 @@ interface ErrorFallbackProps {
   className?: string;
 }
 
+/**
+ * Error variant of the shadcn `Empty` primitive — same visual chrome as
+ * EmptyState so error/empty/no-results screens read from one vocabulary.
+ * Used by every `error.tsx` boundary and the class `ErrorBoundary`.
+ */
 export function ErrorFallback({
   error,
   reset,
@@ -31,44 +44,48 @@ export function ErrorFallback({
   const digest = error?.digest;
 
   return (
-    <div
+    <Empty
       role="alert"
-      className={cn(
-        "flex min-h-100 flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center",
-        className,
-      )}
+      className={cn("border border-destructive/30 bg-destructive/5", className)}
     >
-      <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-destructive/10">
-        <AlertTriangle aria-hidden="true" className="size-6 text-destructive" />
-      </div>
-      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
-      <p className="mt-2 max-w-md text-sm text-muted-foreground">{description}</p>
+      <EmptyHeader>
+        <EmptyMedia
+          variant="icon"
+          className="bg-destructive/10 text-destructive [&_svg:not([class*='size-'])]:size-6"
+        >
+          <AlertTriangle />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
 
-      {detail && (
-        <p className="mt-3 max-w-md font-mono text-xs text-muted-foreground/80 break-words">
-          {detail}
-        </p>
-      )}
-
-      <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
-        {reset && (
-          <Button onClick={reset}>
-            <RotateCw className="mr-1.5 size-4" />
-            {resetLabel}
-          </Button>
+      <EmptyContent>
+        {detail && (
+          <p className="font-mono text-xs text-muted-foreground/80 wrap-break-word">
+            {detail}
+          </p>
         )}
-        <Button variant="outline" onClick={() => window.location.reload()}>
-          Reload page
-        </Button>
-      </div>
 
-      {/* `digest` lets ops correlate this exact error with the server log entry.
-          Hidden visually but selectable for support — kept small to avoid scaring users. */}
-      {digest && (
-        <p className="mt-4 text-[10px] text-muted-foreground/60 tabular-nums select-all">
-          ref: {digest}
-        </p>
-      )}
-    </div>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {reset && (
+            <Button onClick={reset}>
+              <RotateCw className="mr-1.5 size-4" />
+              {resetLabel}
+            </Button>
+          )}
+          <Button variant="outline" onClick={() => window.location.reload()}>
+            Reload page
+          </Button>
+        </div>
+
+        {/* `digest` lets ops correlate this exact error with the server log
+            entry. Hidden visually but selectable for support. */}
+        {digest && (
+          <p className="text-[10px] text-muted-foreground/60 tabular-nums select-all">
+            ref: {digest}
+          </p>
+        )}
+      </EmptyContent>
+    </Empty>
   );
 }

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -3,6 +3,8 @@ export type { FacetedFilterOption, UseDataTableOptions } from "./data-table";
 export { CommandMenu } from "./command-menu";
 export { KpiCard } from "./kpi-card";
 export { EmptyState } from "./empty-state";
+export { ErrorFallback } from "./error-fallback";
+export { ErrorBoundary } from "./error-boundary";
 export { StatusBadge } from "./status-badge";
 export { ConfirmDialog } from "./confirm-dialog";
 export { ElapsedTimer } from "./elapsed-timer";

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}


### PR DESCRIPTION
## Summary

- **ErrorFallback molecule** built on the official `@shadcn/empty` primitive so error / empty / no-results screens share one vocabulary. Includes icon, title, description, optional error detail, Try-again + Reload actions, and a `digest` ref for log correlation.
- **ErrorBoundary class** for inline subtree isolation when one widget's crash shouldn't take down the page. Custom fallback render-prop + primitives-only `resetKeys` array (compared with Object.is) for navigation-driven recovery without infinite-reset traps.
- **Next.js error boundaries at every top-level segment** — `app/global-error.tsx`, `app/error.tsx`, `app/dashboard/error.tsx`, `app/onboarding/error.tsx`, `app/cms/error.tsx`. Per-segment files override their ancestors, so the user keeps the closest chrome (sidebar/topbar) when a single route crashes.
- **`app/not-found.tsx`** using the same Empty chrome — closes the last \"Chrome/Vercel generic screen\" gap.

## Driver

Quests.travel hit Chrome's generic \"page couldn't load\" screen on `/dashboard/content/x` with zero diagnostic info today. With this in place, future client render-time crashes surface as a styled panel with the actual error message + a digest ref that ops can grep in Vercel logs.

## Files

- `src/components/ui/empty.tsx` — installed via shadcn CLI from `@shadcn/empty`
- `src/components/molecules/error-fallback.tsx` — shared error UI
- `src/components/molecules/error-boundary.tsx` — class boundary
- `src/components/molecules/index.ts` — re-exports
- `src/app/global-error.tsx`, `src/app/error.tsx`, `src/app/dashboard/error.tsx`, `src/app/onboarding/error.tsx`, `src/app/cms/error.tsx`
- `src/app/not-found.tsx`

## Test plan

- [ ] Navigate to a non-existent route → see the new 404 Empty chrome
- [ ] Temporarily throw an error inside a dashboard route → confirm sidebar/topbar stay, ErrorFallback renders with message + Try again
- [ ] Verify Quests' \`/dashboard/content/x\` now shows a useful error (if there is one) instead of Chrome's generic screen
- [ ] Visual check: ErrorFallback matches EmptyState visually (both built on Empty primitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)