### PR TITLE
feat(content/x): Suggest Reply drawer on mention cards (Phase 1 M-2)

### DIFF
--- a/src/app/dashboard/content/x/_components/mentions-list.tsx
+++ b/src/app/dashboard/content/x/_components/mentions-list.tsx
@@ -246,7 +246,7 @@ function MentionCard({
           </div>
           <div className="flex flex-col items-end gap-1.5 shrink-0">
             <Button
-              variant="default"
+              variant="outline"
               size="sm"
               className="h-7 px-2 gap-1 text-xs"
               onClick={onReply}

--- a/src/app/dashboard/content/x/_components/mentions-list.tsx
+++ b/src/app/dashboard/content/x/_components/mentions-list.tsx
@@ -16,6 +16,7 @@ import {
   ExternalLink,
   Check,
   Inbox,
+  Sparkles,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,7 @@ import { EmptyState } from "@/components/molecules/empty-state";
 import { formatDate } from "@/lib/locale";
 import { xApi, type XMention, type MentionsFilter } from "@/lib/api/x";
 import { ApiError } from "@/lib/api";
+import { ReplyDrawer } from "./reply-drawer";
 
 const PAGE_SIZE = 20;
 
@@ -44,6 +46,7 @@ const PAGE_SIZE = 20;
  */
 export function MentionsList() {
   const [filter, setFilter] = useState<MentionsFilter>("all");
+  const [replyTarget, setReplyTarget] = useState<XMention | null>(null);
   const queryClient = useQueryClient();
 
   const query = useInfiniteQuery({
@@ -170,6 +173,7 @@ export function MentionsList() {
               mention={m}
               onMarkRead={() => markRead.mutate(m.id)}
               markPending={markRead.isPending && markRead.variables === m.id}
+              onReply={() => setReplyTarget(m)}
             />
           ))}
           {query.hasNextPage && (
@@ -186,6 +190,14 @@ export function MentionsList() {
           )}
         </div>
       )}
+
+      <ReplyDrawer
+        mention={replyTarget}
+        open={replyTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setReplyTarget(null);
+        }}
+      />
     </div>
   );
 }
@@ -194,10 +206,12 @@ function MentionCard({
   mention,
   onMarkRead,
   markPending,
+  onReply,
 }: {
   mention: XMention;
   onMarkRead: () => void;
   markPending: boolean;
+  onReply: () => void;
 }) {
   const m = mention.metrics;
   const isUnread = !mention.readAt;
@@ -231,6 +245,15 @@ function MentionCard({
             </p>
           </div>
           <div className="flex flex-col items-end gap-1.5 shrink-0">
+            <Button
+              variant="default"
+              size="sm"
+              className="h-7 px-2 gap-1 text-xs"
+              onClick={onReply}
+            >
+              <Sparkles className="size-3.5" />
+              Suggest reply
+            </Button>
             {mention.url && (
               <Button
                 variant="ghost"

--- a/src/app/dashboard/content/x/_components/reply-drawer.tsx
+++ b/src/app/dashboard/content/x/_components/reply-drawer.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Sparkles, Send, Reply, RefreshCw, AlertCircle } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { xApi, type XMention } from "@/lib/api/x";
+import { ApiError } from "@/lib/api";
+
+const MAX_LEN = 280;
+
+/**
+ * Reply drawer for X mentions (Phase 1 M-2). Opens from a mention card's
+ * "Suggest reply" button; calls /v1/x/content/mentions/:id/suggest-reply
+ * to draft a reply, then publishes via POST /v1/x/content/publish with
+ * the mention's externalId as replyToTweetId.
+ *
+ * Resets fully on close — the next open re-rolls the draft. This is
+ * intentional: each session is fresh; partial reply state shouldn't
+ * leak between mentions.
+ */
+export function ReplyDrawer({
+  mention,
+  open,
+  onOpenChange,
+}: {
+  mention: XMention | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [text, setText] = useState("");
+  const [reasoning, setReasoning] = useState<string | null>(null);
+  // Track which mention's draft is loaded so changing the mention prop
+  // while the drawer is open (rare but possible) re-rolls instead of
+  // showing the wrong draft.
+  const loadedFor = useRef<string | null>(null);
+
+  const suggest = useMutation({
+    mutationFn: (id: string) => xApi.suggestReplyForMention(id),
+    onSuccess: (data, id) => {
+      loadedFor.current = id;
+      setText(data.text);
+      setReasoning(data.reasoning);
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof ApiError ? err.message : "Couldn't draft a reply.";
+      toast.error(message);
+    },
+  });
+
+  const publish = useMutation({
+    mutationFn: (input: { text: string; replyToTweetId: string }) =>
+      xApi.publish(input),
+    onSuccess: () => {
+      toast.success("Reply published.");
+      // The reply itself is a new tweet from the business's account, so
+      // refresh the Recent tab too. The mentions list invalidate makes
+      // the original mention's metrics tick up on next refresh.
+      queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
+      queryClient.invalidateQueries({ queryKey: ["x-mentions"] });
+      onOpenChange(false);
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof ApiError ? err.message : "Couldn't publish the reply.";
+      toast.error(message);
+    },
+  });
+
+  // Auto-fire the suggestion when the drawer opens for a new mention.
+  // Skip if we already have a draft for this mention loaded (re-opens
+  // shouldn't burn a fresh AI call).
+  useEffect(() => {
+    if (!open || !mention) return;
+    if (loadedFor.current === mention.id) return;
+    setText("");
+    setReasoning(null);
+    suggest.mutate(mention.id);
+    // suggest is a stable react-query mutation handle; the effect only
+    // needs to fire on open/mention transitions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, mention?.id]);
+
+  // Reset on close so a re-open of a different mention starts clean.
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      loadedFor.current = null;
+      setText("");
+      setReasoning(null);
+    }
+    onOpenChange(next);
+  }
+
+  const remaining = MAX_LEN - text.length;
+  const tooLong = remaining < 0;
+  const empty = text.trim().length === 0;
+  const publishDisabled =
+    empty || tooLong || publish.isPending || suggest.isPending || !mention;
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent className="sm:max-w-lg flex flex-col gap-4 p-6">
+        <SheetHeader className="p-0">
+          <SheetTitle className="flex items-center gap-2">
+            <Reply className="size-4" />
+            Reply to mention
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            AI-drafted reply you can edit before publishing.
+          </SheetDescription>
+        </SheetHeader>
+
+        {mention && (
+          <div className="rounded-md border bg-muted/30 p-3 text-sm">
+            <p className="text-xs text-muted-foreground mb-1">
+              {mention.author.name ?? mention.author.handle ?? mention.author.id}
+              {mention.author.handle && (
+                <span className="ml-1">@{mention.author.handle}</span>
+              )}
+            </p>
+            <p className="whitespace-pre-wrap line-clamp-4 leading-relaxed">
+              {mention.text || (
+                <span className="italic text-muted-foreground">
+                  (media-only mention)
+                </span>
+              )}
+            </p>
+          </div>
+        )}
+
+        {suggest.isPending ? (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+              <Sparkles className="size-3.5 animate-pulse" />
+              Drafting a reply…
+            </p>
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : suggest.isError ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive flex items-start gap-2">
+            <AlertCircle className="size-4 mt-0.5 shrink-0" />
+            <div>
+              <p>{suggest.error instanceof ApiError ? suggest.error.message : "Draft failed."}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => mention && suggest.mutate(mention.id)}
+              >
+                <RefreshCw className="size-3.5 mr-1" /> Try again
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <Textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Your reply…"
+              rows={6}
+              className="resize-none"
+              aria-label="Reply text"
+            />
+            {reasoning && (
+              <p className="text-xs text-muted-foreground border-l-2 border-primary/40 pl-2">
+                <span className="font-medium">Why this reply: </span>
+                {reasoning}
+              </p>
+            )}
+          </>
+        )}
+
+        <div className="flex items-center justify-between gap-2 mt-auto">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => mention && suggest.mutate(mention.id)}
+            disabled={!mention || suggest.isPending}
+            className="gap-1.5"
+          >
+            <Sparkles className="size-3.5" />
+            Re-draft
+          </Button>
+          <div className="flex items-center gap-3">
+            <span
+              className={
+                tooLong
+                  ? "text-sm font-medium text-destructive"
+                  : remaining <= 20
+                    ? "text-sm font-medium text-amber-600"
+                    : "text-sm text-muted-foreground"
+              }
+              aria-live="polite"
+            >
+              {remaining}
+            </span>
+            <Button
+              onClick={() =>
+                mention &&
+                publish.mutate({
+                  text: text.trim(),
+                  replyToTweetId: mention.externalId,
+                })
+              }
+              disabled={publishDisabled}
+              aria-busy={publish.isPending}
+            >
+              <Send className="size-4 mr-1.5" />
+              {publish.isPending ? "Publishing…" : "Publish reply"}
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/lib/api/x.ts
+++ b/src/lib/api/x.ts
@@ -82,6 +82,14 @@ export const xApi = {
 
   markMentionRead: (id: string) =>
     api.post<{ id: string; readAt: string }>(`/v1/x/content/mentions/${id}/read`),
+
+  suggestReplyForMention: (id: string) =>
+    api.post<{
+      mentionId: string;
+      replyToTweetId: string;
+      text: string;
+      reasoning: string | null;
+    }>(`/v1/x/content/mentions/${id}/suggest-reply`),
 };
 
 /**


### PR DESCRIPTION
## Summary
Wires the api companion PR (peakhour-api #388) into the Mentions inbox. Each mention card gets a **Suggest reply** CTA that opens a Sheet drawer with the AI-drafted reply, editable, plus reasoning. Publish → \`POST /v1/x/content/publish\` with \`replyToTweetId = mention.externalId\`.

## UX
- Original mention preview (author + body, line-clamped) at the top
- Editable textarea with the draft
- Reasoning sidecar ("Why this reply: …") in a subtle left-border strip — not inlined into the tweet
- Re-draft button (re-rolls)
- Live 280-char counter (amber under 20, red over)

## Behavior
- Auto-fires suggest on open; \`loadedFor\` ref skips redundant calls if the user re-opens the same mention without closing.
- Close = full reset (text, reasoning, loadedFor). User-edited text discarded. Trade-off documented; each session is a fresh draft, no leaked state between mentions.
- Publish success → invalidates both \`x-tweets\` (Recent tab) and \`x-mentions\` (mention's reply count tick).
- Suggest failure → inline error + "Try again". Publish failure → toast.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Manual: click Suggest on a mention → drawer opens, draft loads in <2s, edit + publish → reply lands on x.com

## What this completes
M-2 (Suggest Reply) is end-to-end shipped: api endpoint + skill function + b2c drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)