### PR TITLE
feat(dev): <DevCronButton> + /cms/crons hub (non-prod manual cron triggers)

### DIFF
--- a/src/app/cms/crons/page.tsx
+++ b/src/app/cms/crons/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/**
+ * /cms/crons — Dev cron hub. Lists every cron handler that can be
+ * manually triggered (the same whitelist the api enforces) with a
+ * one-click "Run now" button per row.
+ *
+ * Vercel Cron only runs on production deployments, so previews + local
+ * dev had no UI way to exercise cron paths. This page is the central
+ * spot; contextual <DevCronButton> components on dashboard pages cover
+ * the per-page case.
+ *
+ * Server-side: /v1/dev/cron and /v1/dev/cron/:name return 403 on
+ * production, so this page degrades to "no crons available" there. The
+ * client-side NEXT_PUBLIC_VERCEL_ENV check is a UX-only gate; the
+ * server is the real protection.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DevCronButton } from "@/components/dev/dev-cron-button";
+import { AlertTriangle, Zap } from "lucide-react";
+
+interface DevCronList {
+  env: string;
+  crons: string[];
+}
+
+/** Vercel cron schedules sourced from vercel.json — kept here for display
+ *  only, NOT for runtime decisions (the server enforces the real whitelist). */
+const SCHEDULE_HINTS: Record<string, string> = {
+  "performance-sync": "hourly (0 * * * *)",
+  "tag-catchup": "daily 02:00 UTC (0 2 * * *)",
+  "beehiiv-sync": "hourly (0 * * * *)",
+  "voice-card-refresh": "weekly Sun 05:00 UTC (0 5 * * 0)",
+  "sync-ai-models": "daily 03:00 UTC (0 3 * * *)",
+  "archetype-centroids": "hourly (0 * * * *)",
+  "tier-a-builder": "daily 02:30 UTC (30 2 * * *)",
+  "linkedin-post-sync": "twice daily 06/18 UTC (0 6,18 * * *)",
+  "linkedin-retention-cleanup": "daily",
+  "trial-expiry-sweep": "daily",
+  "pipeline-cost-rollup": "daily",
+  "per-stream-effectiveness-rollup": "daily",
+  "outcome-backfill": "daily",
+  "pipeline-run-janitor": "daily",
+  "discovery-runner": "every minute (* * * * *)",
+  "refresh-recommendations": "weekly Mon 05:00 UTC (0 5 * * 1)",
+  "x-metrics-sync": "every 30 min (*/30 * * * *)",
+  "x-mentions-sync": "every 10 min (*/10 * * * *)",
+  "x-ads-metrics-sync": "hourly (0 * * * *)",
+  "jobs-runner": "every minute (* * * * *)",
+  "source-fetch-scheduler": "every 15 min (*/15 * * * *)",
+  "publish-scheduled": "frequent",
+  "publish-retry": "frequent",
+  "recurring-spawn": "daily",
+};
+
+export default function CmsCronsPage() {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["dev-crons"],
+    queryFn: () => api.get<DevCronList>("/v1/dev/cron"),
+    // No retry on 403 (production deployment will always reject) — let
+    // the error surface so the user sees the gating message immediately.
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+          <Zap className="size-6" />
+          Dev Cron Hub
+        </h2>
+        <p className="text-muted-foreground">
+          Manually trigger any cron handler. Vercel Cron only fires on production
+          deployments — this hub covers preview + local dev.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-start gap-2 text-sm">
+              <AlertTriangle className="size-4 text-amber-500 mt-0.5 shrink-0" />
+              <div>
+                <p className="font-medium">Cron hub unavailable</p>
+                <p className="text-muted-foreground mt-1">
+                  This usually means you&apos;re on a production deployment (the
+                  /v1/dev namespace is server-side-blocked on prod). Dev cron
+                  triggers are only available on preview + local dev.
+                </p>
+                {error instanceof Error && (
+                  <p className="text-xs text-muted-foreground mt-2 font-mono">{error.message}</p>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {data && (
+        <>
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">Environment:</span>
+            <Badge variant="outline">{data.env}</Badge>
+            <span className="text-muted-foreground">·</span>
+            <span className="text-muted-foreground">{data.crons.length} crons</span>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="grid gap-2">
+                {data.crons.map((name) => (
+                  <div
+                    key={name}
+                    className="flex items-center justify-between border-b pb-2 last:border-b-0 last:pb-0"
+                  >
+                    <div className="flex flex-col">
+                      <span className="font-mono text-sm">{name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {SCHEDULE_HINTS[name] ?? "(schedule unknown)"}
+                      </span>
+                    </div>
+                    <DevCronButton cron={name} label="Run now" />
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -38,6 +38,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { FileX, LayoutGrid, List, Library, BrainCircuit, Share2, Info } from "lucide-react";
 import { RepurposeSheet } from "@/components/repurpose/repurpose-sheet";
 import type { RepurposeSource } from "@/lib/api/repurpose";
+import { DevCronButton } from "@/components/dev/dev-cron-button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -294,7 +295,37 @@ export default function ContentPage() {
               Your newsletters, AI-tagged and scored for ad potential
             </p>
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center flex-wrap">
+            {/* Dev-only cron triggers — visible only on preview + local
+                dev (server returns 403 on production). These cover the
+                crons whose effects this page reflects: beehiiv-sync
+                pulls new newsletters, tag-catchup tags them, jobs-runner
+                drains content_analyse children. On prod they're scheduled;
+                here you click. Refetches the page's queries after each
+                trigger so KPIs update without a manual reload. */}
+            <DevCronButton
+              cron="beehiiv-sync"
+              label="Cron: beehiiv-sync"
+              onTriggered={() => {
+                queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
+                queryClient.invalidateQueries({ queryKey: ["content-stats"] });
+              }}
+            />
+            <DevCronButton
+              cron="jobs-runner"
+              label="Cron: jobs-runner"
+              onTriggered={() => {
+                queryClient.invalidateQueries({ queryKey: ["content-stats"] });
+              }}
+            />
+            <DevCronButton
+              cron="tag-catchup"
+              label="Cron: tag-catchup"
+              onTriggered={() => {
+                queryClient.invalidateQueries({ queryKey: ["content-library-all"] });
+                queryClient.invalidateQueries({ queryKey: ["content-stats"] });
+              }}
+            />
             <Button
               variant="outline"
               onClick={() => syncBeehiiv()}

--- a/src/components/dev/dev-cron-button.tsx
+++ b/src/components/dev/dev-cron-button.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * <DevCronButton> — dev-only button that manually fires a cron handler.
+ *
+ * Vercel Cron only runs on production deployments, so previews + local
+ * dev have no way to exercise the cron paths. The button drops on
+ * dashboard pages whose data depends on a cron (beehiiv tag-catchup,
+ * jobs-runner, etc.) so the operator can trigger it inline.
+ *
+ * Visibility:
+ *   - Renders nothing when NEXT_PUBLIC_VERCEL_ENV === "production".
+ *     This is a UX-only gate — the api endpoint server-side-blocks
+ *     production regardless, so even with the env var spoofed nothing
+ *     fires.
+ *   - On preview + local dev, renders a small ghost button with a
+ *     Zap icon. Clicking calls POST /v1/dev/cron/:name and toasts the
+ *     result (status + duration + first 200 chars of body).
+ *
+ * Usage:
+ *   <DevCronButton cron="tag-catchup" label="Run tag-catchup now" />
+ *
+ * Pair with the page state the cron mutates — e.g. on the beehiiv
+ * content page, the buttons for tag-catchup + beehiiv-sync + jobs-runner
+ * sit in the header so the operator can re-fetch + re-tag without
+ * leaving the page.
+ */
+import { useState } from "react";
+import { Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+interface DevCronResult {
+  cron: string;
+  status: number;
+  ok: boolean;
+  durationMs: number;
+  body: string;
+  truncated: boolean;
+}
+
+interface Props {
+  /** Cron name from /v1/dev/cron list (e.g. "tag-catchup"). */
+  cron: string;
+  /** Button label. Defaults to "Run {cron} now". */
+  label?: string;
+  /** Optional callback invoked AFTER a successful trigger. Pages use
+   *  this to refetch queries whose data the cron just mutated. */
+  onTriggered?: (result: DevCronResult) => void;
+  /** Hide entirely (in addition to the env gate). Useful if a page wants
+   *  to suppress the button under a flag that's not env-based. */
+  hidden?: boolean;
+}
+
+/** True on production deployments. Read via NEXT_PUBLIC_* so it inlines
+ *  at build time. The api endpoint enforces the real gate server-side. */
+function isProductionEnv(): boolean {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+}
+
+export function DevCronButton({ cron, label, onTriggered, hidden }: Props) {
+  const [running, setRunning] = useState(false);
+
+  if (isProductionEnv() || hidden) return null;
+
+  async function trigger() {
+    if (running) return;
+    setRunning(true);
+    try {
+      const res = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, {});
+      if (res.ok) {
+        toast.success(`Cron ${cron}: ${res.status} in ${res.durationMs}ms`, {
+          description: res.body
+            ? `${res.body.slice(0, 200)}${res.truncated ? "…" : ""}`
+            : "(empty response)",
+        });
+      } else {
+        toast.error(`Cron ${cron} failed: HTTP ${res.status}`, {
+          description: res.body?.slice(0, 200) ?? "no body",
+        });
+      }
+      onTriggered?.(res);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Cron ${cron} request failed`, { description: msg });
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className="h-7 text-xs text-muted-foreground"
+      onClick={(e) => {
+        e.stopPropagation();
+        trigger();
+      }}
+      disabled={running}
+      title={`Dev-only — manually fire the ${cron} cron handler. Not available on production.`}
+    >
+      <Zap className="mr-1 size-3" />
+      {running ? "Running…" : (label ?? `Run ${cron} now`)}
+    </Button>
+  );
+}


### PR DESCRIPTION
Reusable button (renders only when NEXT_PUBLIC_VERCEL_ENV !== "production") + a central /cms/crons hub listing all 24 cron handlers with Run-now buttons + three contextual buttons on the beehiiv page (beehiiv-sync, jobs-runner, tag-catchup) that refetch the page's queries after each fire.

Pairs with api#393 (/v1/dev/cron endpoint that server-side-gates production). Pattern is reusable: drop <DevCronButton cron="..."/> on any page whose data depends on a cron.

🤖 Generated with Claude Code