### PR TITLE
feat(beehiiv): repurpose-fit colour + filter chip + sticky-right action

### DIFF
--- a/src/app/dashboard/content/beehiiv/columns.tsx
+++ b/src/app/dashboard/content/beehiiv/columns.tsx
@@ -453,8 +453,13 @@ export function getContentColumns(
     meta: {
       thClassName:
         "sticky right-0 bg-background z-10 shadow-[-4px_0_4px_-2px_rgba(0,0,0,0.05)]",
+      // `group-hover:bg-muted/50` mirrors the TableRow's hover background
+      // so the sticky cell doesn't form a visible seam — without this,
+      // hover paints muted/50 on every non-sticky cell and bg-background
+      // on the sticky one. The TableRow needs `group` set on it (see
+      // page.tsx) for this group-hover variant to fire.
       tdClassName:
-        "sticky right-0 bg-background z-10 shadow-[-4px_0_4px_-2px_rgba(0,0,0,0.05)]",
+        "sticky right-0 bg-background group-hover:bg-muted/50 z-10 shadow-[-4px_0_4px_-2px_rgba(0,0,0,0.05)]",
     },
     filterFn: (row, _id, value) => {
       // "Repurposable" filter chip → keep rows whose top platform-fit

--- a/src/app/dashboard/content/beehiiv/columns.tsx
+++ b/src/app/dashboard/content/beehiiv/columns.tsx
@@ -87,6 +87,27 @@ export interface Draft {
     topKeywords: string[];
     audienceRelevance: { segment: string; relevance: number }[];
   } | null;
+  /**
+   * Per-row platform-fit summary from the rules-based recommender
+   * (peakhour-api PR-F.1: GET /library?includeRepurposeFit=true). Drives:
+   *   - the Repurpose row-action button's colour (green/amber/grey)
+   *   - the "Repurposable" filter chip (greenBand=true)
+   *   - the platform-suitability rationale shown in the hover tooltip
+   *
+   * Absent when:
+   *   - the api wasn't passed includeRepurposeFit (old callsites)
+   *   - the business has zero connected channels
+   *   - the draft has no `plainText` hydrated (conservative — don't
+   *     score raw HTML; the persisting recommender re-scores when the
+   *     user opens the sheet)
+   */
+  repurposeFit?: {
+    topBand: "green" | "amber" | "grey";
+    topChannel: string;
+    topFitScore: number;
+    topRationale: string;
+    breakdown: { channel: string; band: "green" | "amber" | "grey"; fitScore: number }[];
+  };
 }
 
 /** Inline format Select — primary classification axis, user-controlled. */
@@ -412,29 +433,119 @@ export function getContentColumns(
     // row's onClick (router.push to the detail page) doesn't fire when
     // the user only wanted to open the platform recommender. Mirrors
     // the card-view Repurpose pattern at page.tsx:800.
+    //
+    // Colour band comes from the api's rules-based platform-fit preview
+    // (peakhour-api PR-F.1). When the band is absent (legacy callers,
+    // no plainText hydrated, no connected channels) the button keeps
+    // its neutral ghost styling — the user can still click and the
+    // persisting recommender will score on open.
     id: "actions",
     enableSorting: false,
     enableHiding: false,
     header: "",
-    cell: ({ row }) => (
-      <div className="flex justify-end">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="h-7 text-xs"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRepurpose(row.original._id);
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          title="Score connected platforms and generate variants"
-        >
-          <Share2 className="mr-1 size-3" />
-          Repurpose
-        </Button>
-      </div>
-    ),
+    // STICKY-RIGHT — the Repurpose action stays visible regardless of
+    // viewport width or horizontal overflow on the rest of the table.
+    // The wrapping `overflow-hidden` on the table container was clipping
+    // the actions column on narrow viewports (user-reported "Repurpose
+    // button hidden on the right"). With sticky, the cell pins to the
+    // right edge and the rest of the table content scrolls / shrinks
+    // behind it. Background + shadow provide a visual edge.
+    meta: {
+      thClassName:
+        "sticky right-0 bg-background z-10 shadow-[-4px_0_4px_-2px_rgba(0,0,0,0.05)]",
+      tdClassName:
+        "sticky right-0 bg-background z-10 shadow-[-4px_0_4px_-2px_rgba(0,0,0,0.05)]",
+    },
+    filterFn: (row, _id, value) => {
+      // "Repurposable" filter chip → keep rows whose top platform-fit
+      // band is in the selected set (typically [green], sometimes
+      // [green, amber]). Rows without a fit summary fall through ONLY
+      // when the filter is unset; an active filter excludes them.
+      if (!Array.isArray(value) || value.length === 0) return true;
+      const band = row.original.repurposeFit?.topBand;
+      if (!band) return false;
+      return value.includes(band);
+    },
+    accessorFn: (row) => row.repurposeFit?.topBand ?? "",
+    cell: ({ row }) => <RepurposeActionCell draft={row.original} onRepurpose={onRepurpose} />,
   },
   ];
+}
+
+/**
+ * Repurpose row-action cell. The button's variant + colour reflects the
+ * top platform-fit band:
+ *   green  → strong fit at least one channel  → emphasised default-ish
+ *   amber  → workable but not strongest        → muted amber
+ *   grey   → no fit (or only hard-blocks)      → ghost (unchanged)
+ *   absent → unknown (no preview)              → plain ghost
+ *
+ * Hover tooltip surfaces the recommender's rationale (the
+ * platform-suitability reason the user asked to see) + a per-channel
+ * breakdown.
+ */
+function RepurposeActionCell({
+  draft,
+  onRepurpose,
+}: {
+  draft: Draft;
+  onRepurpose: (draftId: string) => void;
+}) {
+  const fit = draft.repurposeFit;
+  // Band-specific class — only differentiate on the visually meaningful
+  // bands (green, amber). Grey + absent both use the neutral ghost so
+  // a draft with no preview doesn't look "worse" than a draft with a
+  // grey fit (they're functionally the same: nothing recommended).
+  const bandClass =
+    fit?.topBand === "green"
+      ? "text-green-700 hover:text-green-700 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-950/40"
+      : fit?.topBand === "amber"
+        ? "text-amber-700 hover:text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950/40"
+        : "";
+
+  const trigger = (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={`h-7 text-xs ${bandClass}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onRepurpose(draft._id);
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <Share2 className="mr-1 size-3" />
+      Repurpose
+    </Button>
+  );
+
+  // No preview available → keep the neutral button without a tooltip.
+  // The button itself still works; the user just doesn't get a peek
+  // until the recommender persists on click.
+  if (!fit) return <div className="flex justify-end">{trigger}</div>;
+
+  return (
+    <div className="flex justify-end">
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        <TooltipContent className="max-w-sm">
+          <p className="font-medium text-xs">
+            Top fit: {fit.topChannel} ({fit.topBand})
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">{fit.topRationale}</p>
+          {fit.breakdown.length > 1 && (
+            <div className="mt-2 border-t pt-1 text-[10px] text-muted-foreground">
+              <p className="font-medium mb-0.5">All channels:</p>
+              {fit.breakdown.map((b) => (
+                <p key={b.channel} className="font-mono">
+                  {b.channel}: {b.band} ({b.fitScore})
+                </p>
+              ))}
+            </div>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
 }

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -155,11 +155,19 @@ export default function ContentPage() {
   );
   const taxonomyContentTypes = useMemo(() => orgData?.taxonomy?.contentTypes || [], [orgData]);
 
-  // Client-side: fetch last 500 content pieces in one call
+  // Client-side: fetch last 500 content pieces in one call. Pass
+  // includeRepurposeFit=true so the api decorates each row with a
+  // rules-based platform-fit band (green/amber/grey) for the per-row
+  // Repurpose action color + the "Repurposable" filter chip + the
+  // platform-suitability rationale tooltip. No AI cost (rules-only).
   const { data: libraryRes, isLoading: libraryLoading } = useQuery({
     queryKey: ["content-library-all"],
     queryFn: () =>
-      api.get<Draft[]>("/v1/content/library", { limit: String(CONTENT_FETCH_LIMIT), sort: "publishedAt_desc" }),
+      api.get<Draft[]>("/v1/content/library", {
+        limit: String(CONTENT_FETCH_LIMIT),
+        sort: "publishedAt_desc",
+        includeRepurposeFit: "true",
+      }),
   });
 
   // Build faceted filter options from taxonomy
@@ -467,6 +475,22 @@ export default function ContentPage() {
                 options={shelfLifeFilterOptions}
                 align="start"
               />
+              {/* "Repurposable" filter — keys on the actions column's
+                  accessor (repurposeFit.topBand). Default selection is
+                  the most useful single filter ("green" = strong fit on
+                  ≥1 connected channel); we leave it as a multi-select
+                  so an operator can also include amber ("workable
+                  with caveats") if they want a broader pool. */}
+              <FacetedFilter
+                column={table.getColumn("actions")}
+                title="Repurposable"
+                options={[
+                  { value: "green", label: "Strong fit (green)" },
+                  { value: "amber", label: "Workable (amber)" },
+                  { value: "grey", label: "Not a fit (grey)" },
+                ]}
+                align="start"
+              />
               {hasActiveFilters && (
                 <Button variant="ghost" size="sm" onClick={clearFilters} className="h-8">
                   Clear all
@@ -534,13 +558,22 @@ export default function ContentPage() {
                   <TableHeader>
                     {table.getHeaderGroups().map((headerGroup) => (
                       <TableRow key={headerGroup.id}>
-                        {headerGroup.headers.map((header) => (
-                          <TableHead key={header.id}>
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(header.column.columnDef.header, header.getContext())}
-                          </TableHead>
-                        ))}
+                        {headerGroup.headers.map((header) => {
+                          // Pull optional per-column header className from
+                          // the column def's `meta` (used by the sticky-
+                          // right actions column to pin Repurpose to the
+                          // viewport edge regardless of overflow).
+                          const meta = header.column.columnDef.meta as
+                            | { thClassName?: string }
+                            | undefined;
+                          return (
+                            <TableHead key={header.id} className={meta?.thClassName}>
+                              {header.isPlaceholder
+                                ? null
+                                : flexRender(header.column.columnDef.header, header.getContext())}
+                            </TableHead>
+                          );
+                        })}
                       </TableRow>
                     ))}
                   </TableHeader>
@@ -552,11 +585,19 @@ export default function ContentPage() {
                           className="cursor-pointer hover:bg-muted/50"
                           onClick={() => router.push(`/dashboard/content/beehiiv/${row.original._id}`)}
                         >
-                          {row.getVisibleCells().map((cell) => (
-                            <TableCell key={cell.id}>
-                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                            </TableCell>
-                          ))}
+                          {row.getVisibleCells().map((cell) => {
+                            // Same per-column class hook for body cells.
+                            // The actions column reads meta.tdClassName to
+                            // stay sticky-right; other columns ignore it.
+                            const meta = cell.column.columnDef.meta as
+                              | { tdClassName?: string }
+                              | undefined;
+                            return (
+                              <TableCell key={cell.id} className={meta?.tdClassName}>
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              </TableCell>
+                            );
+                          })}
                         </TableRow>
                       ))
                     ) : (

--- a/src/app/dashboard/content/beehiiv/page.tsx
+++ b/src/app/dashboard/content/beehiiv/page.tsx
@@ -553,7 +553,12 @@ export default function ContentPage() {
                 ))}
               </div>
             ) : (
-              <div className="overflow-hidden rounded-md border">
+              // `overflow-x-auto` (not overflow-hidden) — the sticky-right
+              // actions column needs a scroll container to pin against;
+              // overflow-hidden would clip wide columns silently and the
+              // sticky positioning would resolve against the document
+              // viewport instead of the table's box.
+              <div className="overflow-x-auto rounded-md border">
                 <Table>
                   <TableHeader>
                     {table.getHeaderGroups().map((headerGroup) => (
@@ -582,7 +587,12 @@ export default function ContentPage() {
                       table.getRowModel().rows.map((row) => (
                         <TableRow
                           key={row.id}
-                          className="cursor-pointer hover:bg-muted/50"
+                          // `group` exposes a hover variant to descendants
+                          // — the sticky-right actions cell uses
+                          // `group-hover:bg-muted/50` to match the row's
+                          // hover background and avoid the sticky-seam
+                          // visual artifact.
+                          className="group cursor-pointer hover:bg-muted/50"
                           onClick={() => router.push(`/dashboard/content/beehiiv/${row.original._id}`)}
                         >
                           {row.getVisibleCells().map((cell) => {
@@ -874,20 +884,34 @@ function ArticleCard({
           </span>
         </div>
 
-        {/* Repurpose action — stopPropagation so the card's onClick
-            (router.push to the detail page) doesn't fire when the
-            user only wanted to open the platform recommender. */}
+        {/* Repurpose action — coloured by the row's repurposeFit band,
+            same as the table-view RepurposeActionCell. The card view and
+            the table view sit in front of the same Draft data; keeping
+            their treatments consistent avoids "the table says green but
+            the card says nothing" confusion when the user toggles
+            between views. stopPropagation prevents the card's onClick
+            (router.push) firing on a Repurpose click. */}
         <div className="flex justify-end pt-1">
           <Button
             type="button"
             size="sm"
             variant="ghost"
-            className="h-7 text-xs"
+            className={`h-7 text-xs ${
+              draft.repurposeFit?.topBand === "green"
+                ? "text-green-700 hover:text-green-700 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-950/40"
+                : draft.repurposeFit?.topBand === "amber"
+                  ? "text-amber-700 hover:text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950/40"
+                  : ""
+            }`}
             onClick={(e) => {
               e.stopPropagation();
               onRepurpose();
             }}
-            title="Score connected platforms and generate variants"
+            title={
+              draft.repurposeFit
+                ? `Top fit: ${draft.repurposeFit.topChannel} (${draft.repurposeFit.topBand}) — ${draft.repurposeFit.topRationale}`
+                : "Score connected platforms and generate variants"
+            }
           >
             <Share2 className="mr-1 size-3" />
             Repurpose


### PR DESCRIPTION
Three user-reported issues fixed.

Repurpose button always visible (sticky-right). Coloured by recommender band with rationale tooltip + per-channel breakdown. New "Repurposable" filter chip. Card view consistent with table view.

Two commits: 2c41b67 initial + round-1 fixes (sticky hover seam, overflow-x-auto, card parity). Pairs with api#394. Full 11-step workflow.

🤖 Generated with Claude Code