### PR TITLE
feat(dev): wire pipeline-run-janitor on /cms/ai-health + fix metadata

### DIFF
--- a/src/app/cms/ai-health/page.tsx
+++ b/src/app/cms/ai-health/page.tsx
@@ -89,6 +89,7 @@ export default function AiHealthPage() {
         "x-mentions-sync",
         "x-ads-metrics-sync",
         "sync-ai-models",
+        "pipeline-run-janitor",
       ]}
       onTriggered={() => {
         queryClient.invalidateQueries({ queryKey: ["cms-ai-health"] });

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -139,10 +139,10 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       "Aggregates AI spend by business + use-case for the /cms/ai-usage dashboard.",
   },
   "pipeline-run-janitor": {
-    label: "Tidy pipeline runs",
+    label: "Reap orphan pipeline runs",
     frequency: "Runs every hour",
     description:
-      "Trims old pipeline-run observability rows past their retention window.",
+      "Stamps endedAt + outcome=failed on orphan pipeline-run rows (older than 24h with no outcome) so they become eligible for the TTL index to evict.",
   },
   "per-stream-effectiveness-rollup": {
     label: "Roll up stream effectiveness",


### PR DESCRIPTION
## Summary
- Closes the last gap from the 2026-05-29 cron-toolbar audit: `pipeline-run-janitor` was the only active cron without a contextual page (hub-only)
- Wired into `/cms/ai-health` — the page already surfaces retention/observability info, so this is the natural semantic home
- Review #1 fix: corrected the CRON_METADATA description (it reaps orphans for TTL eviction, doesn't trim rows directly)

## Trade-off (documented)
The toolbar's `onTriggered` callback invalidates `cms-ai-health` + `cms-ingest-health`, but neither response surfaces `cnt_pipeline_runs` counts. Triggering the button still gives operators feedback via the success toast (which includes orphansFound/reaped from the cron's response body). When/if a per-collection retention card lands on this page, the invalidation will start producing visible UI changes.

## Review history
- Review #1: 2 subagents (correctness + adversarial) + manual. Found: factually-wrong metadata description (medium) — fixed in commit `b20494b`. Other findings (theme fit, invalidation no-op) deliberately accepted per architectural rule "every cron has a contextual home; hub is safety net not substitute."

## Test plan
- [x] `tsc --noEmit` passes
- [x] Cron name matches all 4 sources (handler, route, whitelist, metadata)
- [ ] Manual: visit /cms/ai-health on preview, click "Reap orphan pipeline runs", verify success toast + JSON body in description

🤖 Generated with [Claude Code](https://claude.com/claude-code)