### PR TITLE
fix(dev): recurring-spawn frequency string (lockstep with api PR #425)

### DIFF
--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -119,10 +119,7 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
   },
   "recurring-spawn": {
     label: "Spawn recurring posts",
-    // recurring-spawn is registered as a manual /v1/cron route in peakhour-api
-    // but is NOT in vercel.json's schedules. Operators trigger it via this
-    // toolbar (or the cron-trigger CLI) until the schedule lands.
-    frequency: "Manual trigger only (no production schedule yet)",
+    frequency: "Runs every 15 minutes",
     description:
       "Generates new posts from any recurring schedule rules you've set up.",
   },


### PR DESCRIPTION
## Summary
- peakhour-api PR #425 added \`recurring-spawn\` to vercel.json crons[] at \`7-59/15 * * * *\` (xx:07/22/37/52)
- The CRON_METADATA frequency string + the no-longer-true \"Manual trigger only\" comment become stale the moment that PR merges
- Updated string to \"Runs every 15 minutes\"; dropped the comment

This is a pure copy fix — no logic, no behaviour change. 1-line code diff + comment removal.

## Test plan
- [x] \`tsc --noEmit\` passes
- [ ] Manual: visit any page with CronToolbar mounted (e.g. /cms/crons or /dashboard/calendar), hover the recurring-spawn button, verify tooltip says \"Runs every 15 minutes\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)