### PR TITLE
feat(linkedin): composer upgrade — AI toolbar, scheduler, policy chip, foundation primitives

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -78,6 +78,7 @@ import {
 } from "@/components/composer";
 import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
 import type { ScheduleSourceType } from "@/lib/scheduler/types";
+import { sourceTextHash } from "@/lib/scheduler/source-hash";
 import { cn } from "@/lib/utils";
 
 const MAX_LEN = 3000;
@@ -346,10 +347,12 @@ export function PostComposer({ identity, seedText }: Props) {
   );
 
   // No-op hashtag search — LinkedIn has no hashtag-history endpoint yet,
-  // so the typeahead surfaces only the inline "Create #tag" affordance
-  // (the primitive's default-valid-tag rule covers LinkedIn's
-  // letters/digits/underscore convention). Swaps to a real source when
-  // a hashtag endpoint ships.
+  // so the typeahead surfaces only the inline "Create #tag" affordance.
+  // We rely on the primitive's generic default validator (letters/
+  // digits/underscore, min 2 chars), which happens to match LinkedIn's
+  // tag rules; mounted with minQueryLength={2} so a single-char "#a"
+  // doesn't flash an empty "No matches" popover before the Create row
+  // qualifies. Swaps to a real source when a hashtag endpoint ships.
   const searchHashtags = useCallback(
     async (): Promise<HashtagCandidate[]> => [],
     [],
@@ -369,7 +372,7 @@ export function PostComposer({ identity, seedText }: Props) {
     () => ({
       sourceType: (draftId ? "draft" : "ad_hoc") as ScheduleSourceType,
       ...(draftId ? { sourceRef: draftId } : {}),
-      sourceTextHash: sourceTextHashFor(text),
+      sourceTextHash: sourceTextHash(text),
     }),
     [draftId, text],
   );
@@ -604,6 +607,7 @@ export function PostComposer({ identity, seedText }: Props) {
         caret={caret}
         onChange={setText}
         onSearch={searchHashtags}
+        minQueryLength={2}
       />
 
       <div className="flex items-center gap-2">
@@ -804,15 +808,6 @@ function aiOpToastMessage(op: RewriteOp): string {
   }
 }
 
-/** Stable, deterministic fingerprint of the composer text for the
- *  scheduler's required sourceTextHash. djb2a — good enough for the
- *  server's plan-dedup; not security-sensitive. */
-function sourceTextHashFor(text: string): string {
-  let h = 5381;
-  for (let i = 0; i < text.length; i++) h = (h * 33) ^ text.charCodeAt(i);
-  return `li:${(h >>> 0).toString(36)}`;
-}
-
 // ── Content-policy advisory pre-check ────────────────────────────────
 
 const POLICY_DEBOUNCE_MS = 800;
@@ -836,12 +831,17 @@ function usePolicyCheck(
 ): ComposerPolicyAdvisory | null | undefined {
   const trimmed = text.trim();
   const longEnough = trimmed.length >= POLICY_MIN_CHARS;
-  // Store only the async result tagged with the text it was computed
-  // for. The null (too-short) and undefined (pending) states are
-  // DERIVED below from the current text — no synchronous setState in
-  // the effect (avoids cascading renders), and the chip flips to
-  // "pending" the instant the text changes past the last checked value.
-  const [res, setRes] = useState<{ forText: string; advisory: ComposerPolicyAdvisory } | null>(null);
+  // Store only the async result, tagged with BOTH the text and the
+  // author type it was computed for. The null (too-short) and undefined
+  // (pending) states are DERIVED below from the current text+author —
+  // no synchronous setState in the effect (avoids cascading renders),
+  // and the chip flips to "pending" the instant either changes. Tagging
+  // by author matters: an org post has a different policy surface than a
+  // personal post, so a person-scoped result must not linger after the
+  // user switches to a company page without editing the text.
+  const [res, setRes] = useState<
+    { forText: string; forAuthor: "person" | "org"; advisory: ComposerPolicyAdvisory } | null
+  >(null);
 
   useEffect(() => {
     if (!longEnough) return;
@@ -850,13 +850,14 @@ function usePolicyCheck(
       linkedInContentApi
         .checkPolicy(trimmed, authorType)
         .then((advisory) => {
-          if (!cancelled) setRes({ forText: trimmed, advisory });
+          if (!cancelled) setRes({ forText: trimmed, forAuthor: authorType, advisory });
         })
         .catch(() => {
           // 429 / network / soft-fail — treat as "couldn't check".
           if (!cancelled) {
             setRes({
               forText: trimmed,
+              forAuthor: authorType,
               advisory: { overall: "ok", summary: "", findings: [], issueCount: 0, checked: false },
             });
           }
@@ -870,7 +871,8 @@ function usePolicyCheck(
   }, [trimmed, longEnough, authorType]);
 
   if (!longEnough) return null;
-  if (!res || res.forText !== trimmed) return undefined; // pending: no fresh result for current text
+  // pending: no fresh result for the current text + author
+  if (!res || res.forText !== trimmed || res.forAuthor !== authorType) return undefined;
   return res.advisory;
 }
 
@@ -887,7 +889,7 @@ function PolicyChip({ state }: { state: ComposerPolicyAdvisory | null | undefine
   if (state === null) return null;
   if (state === undefined) {
     return (
-      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span role="status" aria-live="polite" className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
         <Loader2 className="size-3 animate-spin motion-reduce:animate-none" />
         Checking policy…
       </span>
@@ -897,6 +899,8 @@ function PolicyChip({ state }: { state: ComposerPolicyAdvisory | null | undefine
   if (!state.checked) {
     return (
       <span
+        role="status"
+        aria-live="polite"
         className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
         title="We couldn't run the policy check just now — it doesn't block publishing."
       >
@@ -908,7 +912,7 @@ function PolicyChip({ state }: { state: ComposerPolicyAdvisory | null | undefine
 
   if (state.overall === "ok") {
     return (
-      <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+      <span role="status" aria-live="polite" className="inline-flex items-center gap-1.5 text-xs text-emerald-700 dark:text-emerald-400">
         <ShieldCheck className="size-3.5" />
         Policy: OK
       </span>

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
@@ -20,17 +27,29 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import {
+  ArrowLeft,
+  CalendarClock,
   ChevronDown,
+  Command as CommandIcon,
   Link2,
   Loader2,
   Mic,
   Send,
+  Shield,
+  ShieldAlert,
+  ShieldCheck,
   Sparkles,
   Wand2,
   X,
 } from "lucide-react";
 import {
   linkedInContentApi,
+  type ComposerPolicyAdvisory,
   type HookScore,
   type HookVariant,
   type LinkedInAuthor,
@@ -41,6 +60,25 @@ import {
   type RewriteHookResponse,
 } from "@/lib/api/linkedin-content";
 import { ApiError } from "@/lib/api";
+import { rewriteContent, createDraft, updateDraft, type ComposerDraftRef } from "@/lib/api/content";
+import {
+  AiComposeToolbar,
+  ComposerCommandPalette,
+  DraftSaver,
+  EmojiPickerTrigger,
+  HashtagSuggest,
+  PlatformCharCounter,
+  VoiceCardPreview,
+  useDraftSaver,
+  type AiActionContext,
+  type ComposerCommand,
+  type HashtagCandidate,
+  type RewriteOp,
+  type VoiceCardSummary,
+} from "@/components/composer";
+import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
+import type { ScheduleSourceType } from "@/lib/scheduler/types";
+import { cn } from "@/lib/utils";
 
 const MAX_LEN = 3000;
 
@@ -57,9 +95,27 @@ interface Props {
   seedText?: string;
 }
 
+/** Compose vs. schedule view of the same composer. "schedule" mounts
+ *  <SchedulerComposer/> with the current draft as the payload; "compose"
+ *  is the default editing surface. */
+type ComposerMode = "compose" | "schedule";
+
 export function PostComposer({ identity, seedText }: Props) {
   const queryClient = useQueryClient();
   const [text, setText] = useState("");
+  const [caret, setCaret] = useState(0);
+  const [mode, setMode] = useState<ComposerMode>("compose");
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  // Composer draft id — reactive (feeds the scheduler source) + set by
+  // the auto-saver after the first create. Declared up here so the
+  // seed effect can reset it on a new composition.
+  const [draftId, setDraftId] = useState<string | null>(null);
+  const createInFlightRef = useRef<Promise<ComposerDraftRef> | null>(null);
+
+  // Refs the caret-aware primitives (emoji insert, hashtag typeahead)
+  // read live. composerWrapRef anchors the hashtag popover.
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composerWrapRef = useRef<HTMLDivElement>(null);
 
   // Seed the composer when the parent passes a fresh seedText (e.g.,
   // the user clicked "Use this draft" on the Suggested Drafts panel).
@@ -70,6 +126,10 @@ export function PostComposer({ identity, seedText }: Props) {
     if (seedText && seedText !== lastSeedRef.current) {
       lastSeedRef.current = seedText;
       setText(seedText);
+      // A seeded draft is a NEW composition — drop any prior draft id so
+      // the next auto-save creates a fresh cnt_drafts row rather than
+      // overwriting the one the user just navigated away from.
+      setDraftId(null);
     }
   }, [seedText]);
   const [visibility, setVisibility] = useState<LinkedInVisibility>("PUBLIC");
@@ -121,18 +181,35 @@ export function PostComposer({ identity, seedText }: Props) {
   // org and person flows share the same control state.
   const isOrgAuthor = authorKey.startsWith("org:");
   const effectiveVisibility: LinkedInVisibility = isOrgAuthor ? "PUBLIC" : visibility;
+  const authorType: "person" | "org" = isOrgAuthor ? "org" : "person";
 
-  // Hook DNA score — debounced live scoring as the user types. Pure
-  // server function (no AI, no DB) so it's safe to fire on every
-  // 400ms keystroke pause. Score is the v0 Tier-C floor; the badge
-  // surfaces "rules" so users see when personalised tiers haven't
-  // shipped yet.
+  // Hook DNA score — debounced live scoring as the user types.
   const hookScore = useHookScore(text);
 
+  // Advisory content-policy pre-check — debounced; advisory only (the
+  // hard gate still runs server-side at publish).
+  const policy = usePolicyCheck(text, authorType);
+
+  // Voice card — shared cache key with <VoiceCardPanel/> below (React
+  // Query dedupes the fetch), mapped to the compact preview chip shape.
+  const voiceCardQuery = useQuery({
+    queryKey: ["linkedin-voice-card"],
+    queryFn: () => linkedInContentApi.voiceCard(),
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && (err.status === 404 || err.status === 403)) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+    staleTime: 5 * 60_000,
+  });
+  const voiceSummary = useMemo(
+    () => mapVoiceCardSummary(voiceCardQuery.data),
+    [voiceCardQuery.data],
+  );
+
   // Rewrite-hook variants — explicit user action (NOT debounced)
-  // because each call is an LLM roundtrip with real cost. Variants
-  // panel mounts when present; clears on successful publish or when
-  // the user picks one to apply.
+  // because each call is an LLM roundtrip with real cost.
   const [variants, setVariants] = useState<RewriteHookResponse | null>(null);
   const rewrite = useMutation({
     mutationFn: () => linkedInContentApi.rewriteHook(text.trim(), 4),
@@ -145,24 +222,60 @@ export function PostComposer({ identity, seedText }: Props) {
   });
 
   function applyVariant(v: HookVariant) {
-    // Replace the textarea with the picked variant. Preserves any
-    // body content the user wrote BELOW the hook by appending it
-    // back — splits on the first blank-line boundary as a "hook
-    // ends here" heuristic. Conservative: when no boundary is
-    // found, just replaces wholesale.
+    // Replace the hook with the picked variant, preserving any body
+    // below the first blank-line boundary.
     const [, ...rest] = text.split(/\n\s*\n/);
     setText(rest.length > 0 ? `${v.hook}\n\n${rest.join("\n\n")}` : v.hook);
     setVariants(null);
   }
 
+  // ── Composer draft auto-save ────────────────────────────────────
+  // The create-in-flight ref (declared with draftId near the top)
+  // serialises the FIRST save so two rapid saves can't create two
+  // cnt_drafts rows before the first POST returns.
+  const saveDraft = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) return; // never persist an empty draft
+
+      if (draftId) {
+        await updateDraft(draftId, { text: value });
+        return;
+      }
+      // A create is already running (rapid second save) — wait for it,
+      // then update the row it produced rather than creating another.
+      if (createInFlightRef.current) {
+        const ref = await createInFlightRef.current;
+        await updateDraft(ref.draftId, { text: value });
+        return;
+      }
+      const p = createDraft({ text: value, channel: "linkedin" });
+      createInFlightRef.current = p;
+      try {
+        const ref = await p;
+        setDraftId(ref.draftId);
+      } finally {
+        createInFlightRef.current = null;
+      }
+    },
+    [draftId],
+  );
+
+  const {
+    status: draftStatus,
+    lastSavedAt,
+    lastError: draftError,
+    saveNow,
+  } = useDraftSaver<string>({
+    // Suspend auto-save while empty (null) so we don't create blank rows.
+    value: text.trim().length > 0 ? text : null,
+    save: saveDraft,
+  });
+
   const publish = useMutation({
     mutationFn: (input: PublishLinkedInPostInput) => linkedInContentApi.publish(input),
     onSuccess: () => {
-      setText("");
-      setLinkUrl("");
-      setLinkTitle("");
-      setShowLink(false);
-      setVariants(null);
+      resetComposer();
       setFeedback({ kind: "success", message: "Post published to LinkedIn." });
       queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
     },
@@ -172,14 +285,27 @@ export function PostComposer({ identity, seedText }: Props) {
     },
   });
 
+  /** Clear all composition state after a successful publish/schedule.
+   *  Resets draftId so the next post starts a fresh cnt_drafts row. */
+  function resetComposer() {
+    setText("");
+    setLinkUrl("");
+    setLinkTitle("");
+    setShowLink(false);
+    setVariants(null);
+    setDraftId(null);
+    setMode("compose");
+  }
+
   const remaining = MAX_LEN - text.length;
   const tooLong = remaining < 0;
   const empty = text.trim().length === 0;
   const linkInvalid = showLink && linkUrl.trim().length > 0 && !isProbablyUrl(linkUrl);
-  const disabled = empty || tooLong || publish.isPending || linkInvalid;
+  const publishDisabled = empty || tooLong || publish.isPending || linkInvalid;
+  const scheduleDisabled = empty || tooLong || linkInvalid;
 
   function onSubmit() {
-    if (disabled) return;
+    if (publishDisabled) return;
     setFeedback(null);
 
     const author: LinkedInAuthor = isOrgAuthor
@@ -190,8 +316,6 @@ export function PostComposer({ identity, seedText }: Props) {
       author,
       commentary: text.trim(),
       visibility: effectiveVisibility,
-      // TODO: wire ideaId once the strategist→linkedin bridge ships,
-      // so org-grounded posts feed the source-usage audit pipeline.
     };
 
     if (showLink && linkUrl.trim()) {
@@ -202,6 +326,168 @@ export function PostComposer({ identity, seedText }: Props) {
     }
 
     publish.mutate(body);
+  }
+
+  // ── AI compose toolbar handler ──────────────────────────────────
+  const handleAiAction = useCallback(
+    async (ctx: AiActionContext): Promise<string> => {
+      const { text: newText } = await rewriteContent({
+        op: ctx.op,
+        text: ctx.text,
+        platform: "linkedin",
+        ...(ctx.extras ? { extras: ctx.extras } : {}),
+      });
+      setText(newText);
+      setVariants(null); // stale once the body changed
+      toast.success(aiOpToastMessage(ctx.op));
+      return newText;
+    },
+    [],
+  );
+
+  // No-op hashtag search — LinkedIn has no hashtag-history endpoint yet,
+  // so the typeahead surfaces only the inline "Create #tag" affordance
+  // (the primitive's default-valid-tag rule covers LinkedIn's
+  // letters/digits/underscore convention). Swaps to a real source when
+  // a hashtag endpoint ships.
+  const searchHashtags = useCallback(
+    async (): Promise<HashtagCandidate[]> => [],
+    [],
+  );
+
+  function updateCaret(e: { currentTarget: HTMLTextAreaElement }) {
+    setCaret(e.currentTarget.selectionStart ?? 0);
+  }
+
+  // ── Scheduler props (only consumed in schedule mode) ────────────
+  const scheduleTitle = useMemo(() => {
+    const firstLine = text.trim().split(/\r?\n/).find((l) => l.trim().length > 0);
+    return firstLine ? firstLine.slice(0, 120).trim() : undefined;
+  }, [text]);
+
+  const schedulerSource = useMemo(
+    () => ({
+      sourceType: (draftId ? "draft" : "ad_hoc") as ScheduleSourceType,
+      ...(draftId ? { sourceRef: draftId } : {}),
+      sourceTextHash: sourceTextHashFor(text),
+    }),
+    [draftId, text],
+  );
+
+  const schedulerChannels = useMemo(() => {
+    // channelOptions carries the LinkedIn-specific publish settings the
+    // scheduler's linkedin publisher adapter reads (authorUrn /
+    // visibility / link) so a scheduled post fires with the SAME author
+    // + visibility + link the user picked here.
+    const channelOptions: Record<string, unknown> = {
+      authorUrn: isOrgAuthor
+        ? `urn:li:organization:${authorKey.slice("org:".length)}`
+        : identity.person.urn,
+      visibility: effectiveVisibility,
+    };
+    if (showLink && linkUrl.trim()) {
+      channelOptions.link = {
+        url: linkUrl.trim(),
+        ...(linkTitle.trim() ? { title: linkTitle.trim() } : {}),
+      };
+    }
+    return [
+      {
+        channel: "linkedin",
+        payload: { text: text.trim(), channelOptions },
+      },
+    ];
+  }, [
+    isOrgAuthor,
+    authorKey,
+    identity.person.urn,
+    effectiveVisibility,
+    showLink,
+    linkUrl,
+    linkTitle,
+    text,
+  ]);
+
+  function handleScheduled() {
+    // SchedulerComposer fires its own "Scheduled across N channels."
+    // toast — don't double-toast. Invalidate the calendar query so a
+    // parallel tab refreshes, then reset back to a clean composer.
+    queryClient.invalidateQueries({ queryKey: ["scheduler:items"] });
+    resetComposer();
+  }
+
+  // ── Command palette actions ─────────────────────────────────────
+  const commands = useMemo<ComposerCommand[]>(
+    () => [
+      {
+        id: "ai-compose",
+        label: "Compose with AI",
+        hint: "Generate a fresh draft from your brand voice",
+        group: "AI",
+        icon: Sparkles,
+        run: () => {
+          void handleAiAction({ op: "compose", text, platform: "linkedin" });
+        },
+      },
+      {
+        id: "ai-redraft",
+        label: "Rewrite this draft",
+        group: "AI",
+        icon: Wand2,
+        disabled: empty,
+        run: () => {
+          void handleAiAction({ op: "redraft", text, platform: "linkedin" });
+        },
+      },
+      {
+        id: "schedule",
+        label: "Schedule for later",
+        group: "Publish",
+        icon: CalendarClock,
+        disabled: scheduleDisabled,
+        run: () => setMode("schedule"),
+      },
+      {
+        id: "add-link",
+        label: showLink ? "Link attached" : "Attach a link",
+        group: "Compose",
+        icon: Link2,
+        disabled: showLink,
+        run: () => setShowLink(true),
+      },
+    ],
+    [handleAiAction, text, empty, scheduleDisabled, showLink],
+  );
+
+  // ── Schedule view ───────────────────────────────────────────────
+  // Early return is AFTER all hooks above — safe.
+  if (mode === "schedule") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-3 border-b pb-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <CalendarClock className="size-4 text-primary" />
+            Schedule this post
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setMode("compose")}
+            className="gap-1.5"
+          >
+            <ArrowLeft className="size-3.5" /> Back to editing
+          </Button>
+        </div>
+        <SchedulerComposer
+          key={schedulerSource.sourceTextHash}
+          source={schedulerSource}
+          title={scheduleTitle}
+          channels={schedulerChannels}
+          onScheduled={handleScheduled}
+        />
+      </div>
+    );
   }
 
   return (
@@ -229,19 +515,11 @@ export function PostComposer({ identity, seedText }: Props) {
             </SelectContent>
           </Select>
           {!identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length > 0 && (
-            // Suppressed when pages.length === 0 — a user with no admin
-            // pages has nothing to enable, so the hint would just confuse.
             <p className="text-xs text-muted-foreground">
               Reconnect LinkedIn to enable posting from your company pages.
             </p>
           )}
           {identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length === 0 && (
-            // Scope is granted, but the per-page filter on /me returned an
-            // empty set — the user either has no admin Pages OR has
-            // disabled all of them via the Manage Pages dialog. The
-            // composer can't distinguish, so the hint covers both: it
-            // points at the dialog (which itself shows "No company pages
-            // found" if LinkedIn says there are none).
             <p className="text-xs text-muted-foreground">
               No pages enabled.{" "}
               <a
@@ -281,30 +559,65 @@ export function PostComposer({ identity, seedText }: Props) {
         </div>
       </div>
 
+      {/* Voice chip + command palette trigger */}
+      <div className="flex items-center justify-between gap-2">
+        <VoiceCardPreview voiceCard={voiceSummary} />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setPaletteOpen(true)}
+          className="gap-1.5 text-xs text-muted-foreground"
+        >
+          <CommandIcon className="size-3.5" /> Actions
+        </Button>
+      </div>
+
       <VoiceCardPanel />
 
-      <Textarea
-        value={text}
-        onChange={(e) => {
-          setText(e.target.value);
-          // Stale-variant guard — a typing user has moved on from the
-          // hook the rewrites were generated for. Keeping the panel
-          // visible would let them apply a variant scored against
-          // already-discarded text.
-          if (variants !== null) setVariants(null);
-        }}
-        placeholder="Share an update, story, or question…"
-        rows={6}
-        className="resize-none"
-        aria-label="LinkedIn post content"
+      <AiComposeToolbar text={text} platform="linkedin" onAiAction={handleAiAction} />
+
+      <div ref={composerWrapRef} className="relative">
+        <Textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => {
+            setText(e.target.value);
+            setCaret(e.target.selectionStart ?? e.target.value.length);
+            // Stale-variant guard — a typing user has moved on from the
+            // hook the rewrites were generated for.
+            if (variants !== null) setVariants(null);
+          }}
+          onSelect={updateCaret}
+          onClick={updateCaret}
+          onKeyUp={updateCaret}
+          placeholder="Share an update, story, or question…"
+          rows={6}
+          className="resize-none"
+          aria-label="LinkedIn post content"
+        />
+      </div>
+      <HashtagSuggest
+        containerRef={composerWrapRef}
+        targetRef={textareaRef}
+        text={text}
+        caret={caret}
+        onChange={setText}
+        onSearch={searchHashtags}
       />
+
+      <div className="flex items-center gap-2">
+        <EmojiPickerTrigger targetRef={textareaRef} onChange={setText} />
+        {!showLink && (
+          <Button type="button" variant="ghost" size="sm" onClick={() => setShowLink(true)} className="h-7 gap-1.5 px-2 text-xs">
+            <Link2 className="size-3.5" /> Add link
+          </Button>
+        )}
+      </div>
 
       <HookScoreCard
         score={hookScore}
         onRewrite={() => {
-          // Only fire when there's a real score to improve. Reuse
-          // the same min-chars threshold as the live scorer so the
-          // button never appears on too-short text.
           if (text.trim().length < HOOK_SCORE_MIN_CHARS) return;
           setFeedback(null);
           rewrite.mutate();
@@ -359,28 +672,29 @@ export function PostComposer({ identity, seedText }: Props) {
         </div>
       )}
 
-      <div className="flex items-center justify-between">
-        <div className="flex gap-2">
-          {!showLink && (
-            <Button type="button" variant="ghost" size="sm" onClick={() => setShowLink(true)}>
-              <Link2 className="size-3.5 mr-1" /> Add link
-            </Button>
-          )}
-        </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <span
-            className={
-              tooLong
-                ? "text-sm font-medium text-destructive"
-                : remaining <= 100
-                  ? "text-sm font-medium text-amber-600"
-                  : "text-sm text-muted-foreground"
-            }
-            aria-live="polite"
+          <PlatformCharCounter platform="linkedin" value={text} />
+          <DraftSaver
+            status={draftStatus}
+            lastSavedAt={lastSavedAt}
+            lastError={draftError}
+            onRetry={saveNow}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <PolicyChip state={policy} />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setMode("schedule")}
+            disabled={scheduleDisabled}
+            className="gap-1.5"
           >
-            {remaining}
-          </span>
-          <Button onClick={onSubmit} disabled={disabled} aria-busy={publish.isPending}>
+            <CalendarClock className="size-4" /> Schedule
+          </Button>
+          <Button onClick={onSubmit} disabled={publishDisabled} aria-busy={publish.isPending}>
             <Send className="size-4 mr-1.5" />
             {publish.isPending ? "Publishing…" : "Publish"}
           </Button>
@@ -399,6 +713,13 @@ export function PostComposer({ identity, seedText }: Props) {
           {feedback.message}
         </p>
       )}
+
+      <ComposerCommandPalette
+        paletteId="linkedin-composer"
+        commands={commands}
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+      />
     </div>
   );
 }
@@ -429,9 +750,6 @@ export function useLinkedInIdentity() {
     queryKey: ["linkedin-me"],
     queryFn: () => linkedInContentApi.me(),
     retry: (failureCount, err) => {
-      // Don't keep retrying if LinkedIn isn't connected — the page
-      // will render its EmptyState. Other transient errors get the
-      // default retry behavior.
       if (err instanceof ApiError && (err.code === "NOT_CONNECTED" || err.status === 404)) {
         return false;
       }
@@ -450,6 +768,207 @@ function isProbablyUrl(s: string): boolean {
   }
 }
 
+/** Map the LinkedIn-specific voice card to the shared
+ *  <VoiceCardPreview/> summary shape. Returns null when no card has
+ *  been synthesised yet (the preview renders nothing for null). */
+function mapVoiceCardSummary(card: LinkedInVoiceCard | undefined): VoiceCardSummary | null {
+  if (!card) return null;
+  return {
+    id: `linkedin-post-v${card.version}`,
+    channel: "linkedin",
+    category: "post",
+    toneAdjectives: card.voice.tone ?? [],
+    signaturePhrases: card.voice.signaturePhrases ?? [],
+    avoidPhrases: card.voice.avoidPhrases ?? [],
+    refreshedAt: card.lastGeneratedAt,
+  };
+}
+
+/** Human toast copy per AI op. */
+function aiOpToastMessage(op: RewriteOp): string {
+  switch (op) {
+    case "compose":
+      return "Draft composed.";
+    case "redraft":
+      return "Draft rewritten.";
+    case "shorten":
+      return "Draft shortened.";
+    case "lengthen":
+      return "Draft expanded.";
+    case "tone":
+      return "Tone updated.";
+    case "quote":
+      return "Pull-quote added.";
+    case "disclosure":
+      return "Disclosure added.";
+  }
+}
+
+/** Stable, deterministic fingerprint of the composer text for the
+ *  scheduler's required sourceTextHash. djb2a — good enough for the
+ *  server's plan-dedup; not security-sensitive. */
+function sourceTextHashFor(text: string): string {
+  let h = 5381;
+  for (let i = 0; i < text.length; i++) h = (h * 33) ^ text.charCodeAt(i);
+  return `li:${(h >>> 0).toString(36)}`;
+}
+
+// ── Content-policy advisory pre-check ────────────────────────────────
+
+const POLICY_DEBOUNCE_MS = 800;
+const POLICY_MIN_CHARS = 24;
+
+/**
+ * Debounced advisory content-policy check. Fires
+ * `POST /v1/linkedin/content/check-policy` 800ms after the user stops
+ * typing, once there's enough text to be worth classifying.
+ *
+ * Returns:
+ *   - `null`      while text is too short to check
+ *   - `undefined` while a debounce/request window is open (pending)
+ *   - advisory    otherwise. A 429 (rate-limited) or any error resolves
+ *     to a `checked:false` advisory so the chip renders a neutral
+ *     "couldn't check" — never a scary error or a false "OK".
+ */
+function usePolicyCheck(
+  text: string,
+  authorType: "person" | "org",
+): ComposerPolicyAdvisory | null | undefined {
+  const trimmed = text.trim();
+  const longEnough = trimmed.length >= POLICY_MIN_CHARS;
+  // Store only the async result tagged with the text it was computed
+  // for. The null (too-short) and undefined (pending) states are
+  // DERIVED below from the current text — no synchronous setState in
+  // the effect (avoids cascading renders), and the chip flips to
+  // "pending" the instant the text changes past the last checked value.
+  const [res, setRes] = useState<{ forText: string; advisory: ComposerPolicyAdvisory } | null>(null);
+
+  useEffect(() => {
+    if (!longEnough) return;
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      linkedInContentApi
+        .checkPolicy(trimmed, authorType)
+        .then((advisory) => {
+          if (!cancelled) setRes({ forText: trimmed, advisory });
+        })
+        .catch(() => {
+          // 429 / network / soft-fail — treat as "couldn't check".
+          if (!cancelled) {
+            setRes({
+              forText: trimmed,
+              advisory: { overall: "ok", summary: "", findings: [], issueCount: 0, checked: false },
+            });
+          }
+        });
+    }, POLICY_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [trimmed, longEnough, authorType]);
+
+  if (!longEnough) return null;
+  if (!res || res.forText !== trimmed) return undefined; // pending: no fresh result for current text
+  return res.advisory;
+}
+
+/**
+ * Advisory policy chip rendered near Publish. Non-blocking — the hard
+ * gate still runs server-side at publish. States:
+ *   - hidden while too-short (null)
+ *   - "Checking…" while pending (undefined)
+ *   - "Policy: OK" when clean
+ *   - "Policy: N issue(s)" with a hover popover of findings
+ *   - "Couldn't check" (neutral) when the gate soft-failed / was rate-limited
+ */
+function PolicyChip({ state }: { state: ComposerPolicyAdvisory | null | undefined }) {
+  if (state === null) return null;
+  if (state === undefined) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Loader2 className="size-3 animate-spin motion-reduce:animate-none" />
+        Checking policy…
+      </span>
+    );
+  }
+
+  if (!state.checked) {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+        title="We couldn't run the policy check just now — it doesn't block publishing."
+      >
+        <Shield className="size-3.5" />
+        Policy check unavailable
+      </span>
+    );
+  }
+
+  if (state.overall === "ok") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+        <ShieldCheck className="size-3.5" />
+        Policy: OK
+      </span>
+    );
+  }
+
+  const issues = state.findings.filter((f) => f.verdict !== "ok");
+  const tone =
+    state.overall === "block"
+      ? "text-destructive"
+      : "text-amber-700 dark:text-amber-400";
+  return (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            tone,
+          )}
+          aria-label={`Content policy: ${state.issueCount} issue${state.issueCount === 1 ? "" : "s"}. Hover for details.`}
+        >
+          <ShieldAlert className="size-3.5" />
+          Policy: {state.issueCount} issue{state.issueCount === 1 ? "" : "s"}
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="end" side="top" className="w-80">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <ShieldAlert className={cn("size-4", tone)} />
+          {state.overall === "block" ? "Likely policy violation" : "Possible policy issues"}
+        </div>
+        {state.summary && (
+          <p className="mt-1 text-xs text-muted-foreground">{state.summary}</p>
+        )}
+        <ul className="mt-2 space-y-1.5">
+          {issues.map((f, i) => (
+            <li key={`${f.category}-${i}`} className="text-xs">
+              <span
+                className={cn(
+                  "mr-1.5 rounded-sm px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                  f.verdict === "block"
+                    ? "bg-destructive/10 text-destructive"
+                    : "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+                )}
+              >
+                {f.category.replace(/_/g, " ")}
+              </span>
+              {f.rationale}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-2 border-t pt-2 text-[10px] text-muted-foreground">
+          Advisory only — you can still publish. The same check runs when you post.
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
 // ── Hook DNA scoring ─────────────────────────────────────────────────
 
 const HOOK_SCORE_DEBOUNCE_MS = 400;
@@ -459,48 +978,39 @@ const HOOK_SCORE_MIN_CHARS = 8;
  * Debounced hook scorer. Fires `POST /v1/linkedin/content/score-hook`
  * 400ms after the user stops typing. Pure-server function (no AI),
  * so the cost of getting it wrong is just a request, not a token bill.
- *
- * Returns:
- *   - `null` while text is too short to score meaningfully
- *   - `undefined` while a debounce window is still open
- *   - `HookScore` object otherwise
  */
 function useHookScore(text: string): HookScore | null | undefined {
-  const [score, setScore] = useState<HookScore | null | undefined>(null);
+  const trimmed = text.trim();
+  const longEnough = trimmed.length >= HOOK_SCORE_MIN_CHARS;
+  // Same derived-state pattern as usePolicyCheck: store the async
+  // result tagged with its source text; derive null (too-short) /
+  // undefined (pending) from the current text so we never call
+  // setState synchronously inside the effect. `score: null` is the
+  // error sentinel (HookScoreCard hides on null).
+  const [res, setRes] = useState<{ forText: string; score: HookScore | null } | null>(null);
 
   useEffect(() => {
-    const trimmed = text.trim();
-    if (trimmed.length < HOOK_SCORE_MIN_CHARS) {
-      setScore(null);
-      return;
-    }
-    setScore(undefined); // pending
-
-    // Stale-response guard MUST live at effect-scope so the cleanup
-    // closure can flip it. Hoisting it inside the setTimeout callback
-    // (a previous attempt) was a no-op — setTimeout ignores callback
-    // return values, so the cleanup function returned from there was
-    // discarded. A slow first request would silently clobber a faster
-    // second one. With the flag at effect-scope, the next text-change
-    // tick flips it to true before the in-flight promise can setScore.
+    if (!longEnough) return;
     let cancelled = false;
     const handle = window.setTimeout(() => {
       linkedInContentApi
         .scoreHook(trimmed)
         .then((s) => {
-          if (!cancelled) setScore(s);
+          if (!cancelled) setRes({ forText: trimmed, score: s });
         })
         .catch(() => {
-          if (!cancelled) setScore(null);
+          if (!cancelled) setRes({ forText: trimmed, score: null });
         });
     }, HOOK_SCORE_DEBOUNCE_MS);
     return () => {
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [text]);
+  }, [trimmed, longEnough]);
 
-  return score;
+  if (!longEnough) return null;
+  if (!res || res.forText !== trimmed) return undefined; // pending
+  return res.score;
 }
 
 interface HookScoreBand {
@@ -536,12 +1046,7 @@ function bandForScore(score: number): HookScoreBand {
 
 /**
  * HookScore card — surfaces the v0 score, an honest tier badge, and
- * up to 3 plain-English suggestions. Hidden until the user types
- * enough characters to score (`null`); shows a light pending state
- * while the debounced request is in flight (`undefined`).
- *
- * When `onRewrite` is wired, a Rewrite button appears in the header
- * (LLM-cost action; user clicks explicitly, not on debounce).
+ * up to 3 plain-English suggestions.
  */
 function HookScoreCard({
   score,
@@ -622,10 +1127,7 @@ function HookScoreCard({
 }
 
 /**
- * Friendlier copy for the tier badge. "Rules" / "Industry" / "Personal"
- * reads more meaningful than the raw enum value, with a hover tooltip
- * that explains what produced the score so the badge isn't a mystery
- * abbreviation.
+ * Friendlier copy for the tier badge.
  */
 function tierBadgeMeta(tier: HookScore["tier"]): { label: string; tooltip: string } {
   switch (tier) {
@@ -652,15 +1154,7 @@ function tierBadgeMeta(tier: HookScore["tier"]): { label: string; tooltip: strin
 }
 
 /**
- * Variants panel — renders the rewrite_hook_variants response. Each
- * row shows the variant text, technique label, and its Hook DNA
- * score (same scale as the live scorer; matches by construction
- * since the API uses the same scoreHookV0). Click to apply.
- *
- * Empty `variants` is rendered as a "no rewrites available" state —
- * the AI occasionally returns near-identical variants that all dedup
- * to nothing useful, and a panel that just disappears would be a
- * silent failure.
+ * Variants panel — renders the rewrite_hook_variants response.
  */
 function HookVariantsPanel({
   response,
@@ -742,9 +1236,7 @@ const PERSPECTIVE_LABEL: Record<LinkedInVoiceCard["voice"]["perspective"], strin
 /**
  * Surface the auto-synthesised LinkedIn voice card alongside the
  * composer so the user sees the tone/perspective/signature phrases
- * we learned from their own posts before they type. 404 from the
- * endpoint is the expected "we haven't trained yet" path — render
- * a one-line hint and don't surface it as an error.
+ * we learned from their own posts before they type.
  */
 function VoiceCardPanel() {
   const [open, setOpen] = useState(false);
@@ -752,8 +1244,6 @@ function VoiceCardPanel() {
     queryKey: ["linkedin-voice-card"],
     queryFn: () => linkedInContentApi.voiceCard(),
     retry: (failureCount, err) => {
-      // 404 + FORBIDDEN are expected (no card yet / no business
-      // selected). Other transient errors get the default retry.
       if (err instanceof ApiError && (err.status === 404 || err.status === 403)) {
         return false;
       }
@@ -771,7 +1261,6 @@ function VoiceCardPanel() {
   }
 
   if (isError) {
-    // "Not generated yet" — neutral, not an error.
     if (error instanceof ApiError && error.status === 404) {
       return (
         <div className="rounded-md border border-dashed bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
@@ -780,9 +1269,6 @@ function VoiceCardPanel() {
         </div>
       );
     }
-    // 403 (no business) or transient — render nothing so the composer
-    // stays usable. The Hook DNA panel already conveys the underlying
-    // "pick a business" state via its tier badge.
     return null;
   }
 

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -182,7 +182,7 @@ function LinkedInTabs({
           </CardContent>
         </Card>
         <p className="text-xs text-muted-foreground">
-          Text + link posts only for now — carousels, polls, and scheduling are coming.
+          Compose with AI, schedule for later, or publish now. Carousels and media are coming.
         </p>
       </TabsContent>
 

--- a/src/components/composer/composer-command-palette.tsx
+++ b/src/components/composer/composer-command-palette.tsx
@@ -81,6 +81,17 @@ export interface ComposerCommandPaletteProps {
    *  (e.g. via a `<ComposerCommandPalette ... shortcutHint="⌘⇧K">`
    *  affordance) if it picks a non-default chord. */
   enableGlobalShortcut?: boolean;
+  /** Controlled open state. When provided, the palette is controlled —
+   *  the host owns open/close (e.g. renders its own trigger button) and
+   *  the internal global-shortcut toggle is disabled (the host wires
+   *  its own shortcut if it wants one). Use this on surfaces that
+   *  already have a global Cmd+K (the dashboard shell) so the composer
+   *  palette opens from a button instead of fighting for the chord. */
+  open?: boolean;
+  /** Fires whenever the palette wants to open/close — both on a
+   *  command pick (closes) and on backdrop/Esc dismiss. Required for
+   *  the controlled path; harmless to pass in the uncontrolled path. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const RECENT_PREFIX = "peakhour:composer-palette:recent:";
@@ -114,8 +125,24 @@ export function ComposerCommandPalette({
   commands,
   placeholder = "Search composer actions…",
   enableGlobalShortcut = false,
+  open: controlledOpen,
+  onOpenChange,
 }: ComposerCommandPaletteProps) {
-  const [open, setOpen] = useState(false);
+  // Controlled / uncontrolled: when `controlledOpen` is provided the
+  // host owns open state; otherwise we keep it internally. `setOpen`
+  // updates the internal state only when uncontrolled, and always
+  // notifies the host via onOpenChange so a controlled parent stays in
+  // sync on command-pick / Esc / backdrop close.
+  const isControlled = controlledOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
   // Seed initial recents from localStorage synchronously (lazy init).
   // Subsequent refreshes happen in runCommand after a successful pick,
   // which is the only way recents actually mutate during this
@@ -130,16 +157,19 @@ export function ComposerCommandPalette({
   // Cmd+Shift+K diverging only-this-palette opens when both are
   // enabled in error.
   useEffect(() => {
-    if (!enableGlobalShortcut) return;
+    // Controlled hosts own the trigger (and their own shortcut, if
+    // any), so the internal global listener is disabled for them —
+    // avoids two owners fighting over the chord.
+    if (!enableGlobalShortcut || isControlled) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setOpen((o) => !o);
+        setInternalOpen((o) => !o);
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [enableGlobalShortcut]);
+  }, [enableGlobalShortcut, isControlled]);
 
   const groups = useMemo(() => {
     const map = new Map<string, ComposerCommand[]>();
@@ -175,7 +205,7 @@ export function ComposerCommandPalette({
         // The host owns failure UX (toast). Palette doesn't double-toast.
       }
     },
-    [paletteId],
+    [paletteId, setOpen],
   );
 
   return (

--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -422,12 +422,13 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
           {showingScheduler && schedulerProps && (
             <SchedulerComposer
               // Key on sourceTextHash — unique + deterministic per
-              // source (uses socialPostId or the djb2 fallback from
-              // sourceTextHashFor). Avoids the ad_hoc collision
-              // where two distinct ad_hoc sources share sourceRef
-              // ('undefined') and sourceType ('ad_hoc'); the hash
-              // discriminates them. Remount resets the composer's
-              // internal anchor/timezone/strategy when source flips.
+              // source (the shared 40-hex sourceTextHash fingerprint,
+              // computed over the socialPostId or the sorted adaptation
+              // contents). Avoids the ad_hoc collision where two
+              // distinct ad_hoc sources share sourceRef ('undefined')
+              // and sourceType ('ad_hoc'); the hash discriminates them.
+              // Remount resets the composer's internal anchor/timezone/
+              // strategy when source flips.
               key={schedulerProps.source.sourceTextHash}
               source={schedulerProps.source}
               title={schedulerProps.title}

--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -36,6 +36,7 @@ import {
   type RepurposedAdaptation,
 } from "@/lib/api/repurpose";
 import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
+import { sourceTextHash } from "@/lib/scheduler/source-hash";
 import type {
   CommitPlanRequest,
   ScheduleSourceType,
@@ -123,28 +124,24 @@ function adaptationsToChannels(
 }
 
 /** Stable fingerprint for the scheduler's required `sourceTextHash`.
- *  Prefer the soc_social_posts id when the repurposer persisted at
- *  least one variant — same generation always returns the same id
- *  thanks to the idempotency layer. Fallback: synthesise from source
- *  title + ALL adaptation contents joined in a deterministic
- *  (sorted-by-platform) order — guarantees the same hash across
- *  sessions even if the engine returns adaptations in different
- *  order. Hash doesn't need to be cryptographically strong; the
- *  server uses it for plan dedup, not security. */
+ *  The scheduler commit route validates this against `^[a-f0-9]{40}$`
+ *  (40-char lowercase hex) and stores it verbatim, so it MUST be a
+ *  40-hex string — a raw socialPostId (24 hex) or a `rp:`-prefixed
+ *  base36 value is rejected with a 400. We build a deterministic input
+ *  string (preferring the soc_social_posts id when the repurposer
+ *  persisted a variant — same generation always returns the same id
+ *  thanks to the idempotency layer; else source title + ALL adaptation
+ *  contents joined in a deterministic sorted-by-platform order) and run
+ *  it through the shared 40-hex fingerprinter. */
 function sourceTextHashFor(response: RepurposeResponse): string {
-  if (response.socialPostId) return response.socialPostId;
+  if (response.socialPostId) return sourceTextHash(`sp:${response.socialPostId}`);
   // Sort by platform so a parallel-fanout engine that yields
   // adaptations out of order still produces the same hash.
   const sortedContents = [...response.adaptations]
     .sort((a, b) => a.platform.localeCompare(b.platform))
     .map((a) => `${a.platform}:${a.content}`)
     .join("|");
-  const fallback = (response.sourceTitle ?? "") + "||" + sortedContents;
-  // djb2a (XOR variant) — good enough for plan dedup, avoids a
-  // crypto dependency for this fallback path.
-  let h = 5381;
-  for (let i = 0; i < fallback.length; i++) h = (h * 33) ^ fallback.charCodeAt(i);
-  return `rp:${(h >>> 0).toString(36)}`;
+  return sourceTextHash((response.sourceTitle ?? "") + "||" + sortedContents);
 }
 
 /**

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -1,0 +1,80 @@
+import { api } from "@/lib/api";
+import type { PlatformKey, RewriteOp } from "@/components/composer";
+
+/**
+ * Generic content-composer API client — the endpoints every publish
+ * composer (LinkedIn / X / Beehiiv / Strategist / calendar) shares.
+ * Channel-specific calls (e.g. LinkedIn policy check) live in their
+ * own api modules (linkedin-content.ts).
+ */
+
+// ── AI rewrite (POST /v1/content/rewrite) ──────────────────
+
+/** Per-op extras passed through to the rewrite skill — e.g. the tone
+ *  picker sends `{ targetTone: "warmer" }`. */
+export type RewriteExtras = Record<string, unknown>;
+
+export interface RewriteContentInput {
+  op: RewriteOp;
+  text: string;
+  platform: PlatformKey;
+  extras?: RewriteExtras;
+}
+
+/**
+ * Run an AI rewrite op for the composer's `<AiComposeToolbar/>`.
+ * Returns the NEW full composer text. The toolbar's `onAiAction`
+ * contract resolves to a string, so callers typically do
+ * `const { text } = await rewriteContent(...); setText(text);`.
+ */
+export function rewriteContent(input: RewriteContentInput) {
+  return api.post<{ text: string }>("/v1/content/rewrite", {
+    op: input.op,
+    text: input.text,
+    platform: input.platform,
+    ...(input.extras ? { extras: input.extras } : {}),
+  });
+}
+
+// ── Composer draft auto-save (POST/PUT /v1/content/drafts) ──
+
+export interface ComposerDraftRef {
+  draftId: string;
+  status: string;
+  updatedAt: string;
+}
+
+/** Content categories the composer can author. Subset of the
+ *  cnt_drafts category enum the API accepts. */
+export type ComposerDraftCategory =
+  | "social_post"
+  | "newsletter"
+  | "blog_post"
+  | "email_campaign"
+  | "other";
+
+export interface CreateDraftInput {
+  text: string;
+  /** Which composer authored this — stored in sourceMetadata. */
+  channel?: PlatformKey;
+  contentCategory?: ComposerDraftCategory;
+}
+
+/** Create a composer draft (status:"draft"). Returns the new draftId
+ *  the host should remember and pass to `updateDraft` on later saves. */
+export function createDraft(input: CreateDraftInput) {
+  return api.post<ComposerDraftRef>("/v1/content/drafts", {
+    text: input.text,
+    ...(input.channel ? { channel: input.channel } : {}),
+    ...(input.contentCategory ? { contentCategory: input.contentCategory } : {}),
+  });
+}
+
+/** Update a composer draft. Scoped server-side to status:"draft" rows
+ *  (404 otherwise), so it can never clobber a pipeline draft. */
+export function updateDraft(draftId: string, input: { text: string; title?: string }) {
+  return api.put<ComposerDraftRef>(`/v1/content/drafts/${draftId}`, {
+    text: input.text,
+    ...(input.title ? { title: input.title } : {}),
+  });
+}

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -201,8 +201,46 @@ export interface EngagersResponse {
  *  private folder). */
 export const SUGGESTED_DRAFTS_QUERY_KEY = ["linkedin-suggested-drafts"] as const;
 
+/** One per-category finding from the content-policy classifier. */
+export interface PolicyFinding {
+  category: string;
+  verdict: "ok" | "warn" | "block";
+  /** One-sentence rationale; empty for "ok". */
+  rationale: string;
+}
+
+/**
+ * Advisory result from `POST /v1/linkedin/content/check-policy` — the
+ * proactive, pre-publish content-policy heads-up the composer chip
+ * renders. The hard publish-time block still runs server-side on
+ * publish; this is advisory only.
+ *
+ * `overall` is the RAW AI verdict (not the gate's mode-mapped
+ * decision) so warn-level issues surface even though the default
+ * publish posture would let them through. `checked` is false when the
+ * AI gate soft-failed — the chip should render a neutral "couldn't
+ * check" state, never a false "Policy: OK".
+ */
+export interface ComposerPolicyAdvisory {
+  overall: "ok" | "warn" | "block";
+  summary: string;
+  findings: PolicyFinding[];
+  issueCount: number;
+  checked: boolean;
+}
+
 export const linkedInContentApi = {
   me: () => api.get<LinkedInIdentity>("/v1/linkedin/content/me"),
+
+  /** Advisory content-policy pre-check for the composer chip. The route
+   *  is rate-limited (429 on burst) and fail-soft, so callers should
+   *  treat both a 429 and a thrown error as a transient "couldn't
+   *  check" state — never surface it as a publish failure. */
+  checkPolicy: (text: string, authorType?: "person" | "org") =>
+    api.post<ComposerPolicyAdvisory>("/v1/linkedin/content/check-policy", {
+      text,
+      ...(authorType ? { authorType } : {}),
+    }),
 
   publish: (body: PublishLinkedInPostInput) =>
     api.post<{ postId: string }>("/v1/linkedin/content/publish", body),

--- a/src/lib/scheduler/source-hash.ts
+++ b/src/lib/scheduler/source-hash.ts
@@ -1,0 +1,36 @@
+/**
+ * Deterministic source-text fingerprint for the scheduler's
+ * `source.sourceTextHash`.
+ *
+ * The scheduler commit route (`peakhour-api` /v1/scheduler/plans)
+ * validates this field against `^[a-f0-9]{40}$` — a 40-char lowercase
+ * hex string (SHA-1 shape). The server STORES it verbatim and later
+ * compares a client-provided value against the stored one to detect
+ * payload staleness; it never recomputes a SHA-1 server-side. So we
+ * only need a deterministic 40-char lowercase-hex value derived from
+ * the content — not a cryptographic digest.
+ *
+ * We avoid `crypto.subtle.digest` (async — would force the callers'
+ * synchronous `useMemo` source objects to become async/stateful) and
+ * instead compute five independent FNV-1a-style 32-bit passes (each
+ * seeded from a different offset basis) and concatenate them as
+ * 5 × 8 = 40 lowercase hex chars. Non-cryptographic but well-
+ * distributed enough for dedup/staleness, and synchronous.
+ */
+
+const SEED_BASES = [0x811c9dc5, 0x01000193, 0xdeadbeef, 0x9e3779b1, 0x85ebca77];
+const FNV_PRIME = 0x01000193;
+
+export function sourceTextHash(input: string): string {
+  let out = "";
+  for (const base of SEED_BASES) {
+    let h = base >>> 0;
+    for (let i = 0; i < input.length; i++) {
+      h ^= input.charCodeAt(i);
+      h = Math.imul(h, FNV_PRIME) >>> 0;
+    }
+    out += h.toString(16).padStart(8, "0");
+  }
+  // 5 × 8 = 40 lowercase hex chars — satisfies /^[a-f0-9]{40}$/.
+  return out;
+}


### PR DESCRIPTION
## What

PR #3 of the composer/scheduler buildout — upgrades the **LinkedIn post composer** with the shared foundation kit + scheduling + a proactive content-policy chip. Incremental refactor: keeps the existing voice panel, Hook DNA scoring, rewrite-hook variants, and author/visibility/link flow; mounts the missing pieces.

Depends on (all merged to master): peakhour-api #427 (`/v1/content/rewrite`), #428 (`/v1/content/drafts`), #429 (`/v1/linkedin/content/check-policy`), and peakhour-mongodb `"draft"` status (validator resynced on dev).

## Primitives mounted
- **AiComposeToolbar** → `/v1/content/rewrite` (compose / redraft / shorten / lengthen / tone / quote / disclosure).
- **VoiceCardPreview** chip in the header *alongside* the existing rich voice panel (both, per locked decision) — same query key, deduped.
- **EmojiPickerTrigger** (caret-aware) + **HashtagSuggest** (`#` typeahead; no hashtag-history endpoint yet → inline "Create #tag" affordance, `minQueryLength=2`).
- **PlatformCharCounter** (LinkedIn 3000 ring).
- **DraftSaver** + `useDraftSaver` → `/v1/content/drafts` auto-save (`status:"draft"`). First save serialised via a create-in-flight ref so rapid saves can't duplicate rows; `draftId` reset on publish/schedule/new-seed.
- **ComposerCommandPalette** (controlled-open) behind a header "Actions" button.

## Scheduling
- "Schedule" switches to `<SchedulerComposer/>` (with a Back-to-edit toggle). Author/visibility/link ride along via `channelOptions` (`authorUrn` / `visibility` / `link`) so a scheduled post fires with the **same** settings — the LinkedIn publisher adapter reads these. `sourceType:"draft"` (with the auto-saved draftId) else `ad_hoc`.

## Policy chip
- Debounced advisory check → `/v1/linkedin/content/check-policy`. Renders "Policy: OK" / "Policy: N issues" (hover popover of findings) / neutral "couldn't check" on 429/soft-fail. Advisory only — the hard gate still runs at publish.

## Primitive enhancement
- `ComposerCommandPalette` gains controlled `open`/`onOpenChange` so hosts that already own Cmd+K (the dashboard shell) drive it from a button instead of fighting for the chord.

## Notable fix found during review
- **Scheduler `sourceTextHash` contract**: the commit route requires `^[a-f0-9]{40}$`. Added `src/lib/scheduler/source-hash.ts` (deterministic 40-hex) and wired it into the composer **and the already-shipped RepurposeSheet**, whose Schedule path was emitting a 24-hex socialPostId / `rp:<base36>` and would have 400'd. (Pre-existing bug in #232, fixed here since it's the same contract.)

## Deviations from the plan
- MentionTypeahead (primitive 5) stays excluded — no LinkedIn people-search API yet.
- MediaPicker (primitive 3) not mounted — R2 wiring is next session per the media-manager plan; caption updated accordingly.

## Test
- `npx tsc --noEmit` → 0 errors
- `npx eslint` on all touched files → clean
- `source-hash` verified: 40-char lowercase hex, matches the route regex, deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
