### PR TITLE
fix(cron-toolbar): friendly success toasts + refresh dashboard after sync

### DIFF
--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -212,6 +212,14 @@ function PageShell({ children, loading }: { children?: React.ReactNode; loading?
         onTriggered={() => {
           queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
           queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
+          // The post-sync + retention crons write the very data these
+          // panels render — without invalidating them, a sync completes
+          // but the Boost / Audience tabs keep serving their cached
+          // (often empty) result, so nothing visibly changes. Both panels
+          // also set refetchOnMount:false, so invalidation is the only
+          // thing that refreshes them after a manual trigger.
+          queryClient.invalidateQueries({ queryKey: ["linkedin-boost-candidates"] });
+          queryClient.invalidateQueries({ queryKey: ["linkedin-engagers"] });
         }}
       />
       <div>

--- a/src/app/dashboard/content/x/page.tsx
+++ b/src/app/dashboard/content/x/page.tsx
@@ -224,6 +224,10 @@ function PageShell({ children, loading }: { children?: React.ReactNode; loading?
         onTriggered={() => {
           queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
           queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
+          // x-mentions-sync writes the mentions inbox — invalidate it so
+          // the Mentions tab reflects a manual sync instead of keeping its
+          // cached page. Prefix match covers the [filter, sort] variants.
+          queryClient.invalidateQueries({ queryKey: ["x-mentions"] });
         }}
       />
       <div>

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -18,12 +18,24 @@
  *   - frequency   — human-readable schedule (NOT a cron expression)
  *   - description — one-sentence plain-English explanation of what fires
  *                   when the cron runs. Avoids implementation jargon.
+ *   - summarize   — OPTIONAL. Turns the cron's response payload (the
+ *                   `data` object the handler returns) into a clean,
+ *                   user-facing success sentence — e.g. "12 posts synced
+ *                   successfully." Without it, <CronToolbar/> falls back
+ *                   to a generic "<label> complete" message. NEVER let a
+ *                   summarizer throw on an unexpected shape; return null
+ *                   to defer to the generic fallback instead. The toolbar
+ *                   already wraps the call in a try/catch, but defensive
+ *                   reads keep the intent obvious.
  */
 
 export interface CronMetadata {
   label: string;
   frequency: string;
   description: string;
+  /** Maps the parsed cron `data` payload to a friendly one-line success
+   *  message, or null to fall back to the generic toast. */
+  summarize?: (data: unknown) => string | null;
 }
 
 export const CRON_METADATA: Record<string, CronMetadata> = {
@@ -32,6 +44,10 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     frequency: "Runs every hour",
     description:
       "Pulls your newest Beehiiv newsletter sends into Peakhour so they show up in the library.",
+    // The handler enqueues a background fetch job rather than fetching
+    // inline, so there's no count to report yet — surface that the fetch
+    // is on its way and the library will fill in shortly.
+    summarize: () => "Fetching your latest newsletters — they'll appear in the library shortly.",
   },
   "tag-catchup": {
     label: "AI-tag newsletters",
@@ -50,18 +66,63 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     frequency: "Runs every hour",
     description:
       "Pulls the latest engagement and impression numbers from every connected publishing platform.",
+    summarize: (data) => {
+      const overall = asRecord(asRecord(data)?.overall);
+      if (!overall) return "Performance refreshed.";
+      const total = num(overall.connectionsTotal);
+      if (total === 0) return "Performance refreshed — no connected platforms yet.";
+      if (num(overall.errors) > 0)
+        return "Performance refreshed, but some platforms reported errors.";
+      const run = num(overall.connectionsRun);
+      if (run > 0)
+        return `Performance refreshed across ${run} ${plural(run, "connection")}.`;
+      // total > 0 but nothing ran → every connection was lock-skipped,
+      // i.e. a refresh is already in progress (not "up to date").
+      return "A performance refresh is already running — check back shortly.";
+    },
   },
   "linkedin-post-sync": {
     label: "Sync LinkedIn posts",
     frequency: "Runs at 6 AM and 6 PM UTC",
     description:
       "Refreshes engagement (likes, comments, reshares) on your recent LinkedIn posts.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return null;
+      if (num(d.scanned) === 0) return "No LinkedIn accounts connected yet.";
+      const results = Array.isArray(d.results) ? d.results : [];
+      let upserted = 0;
+      let fetched = 0;
+      for (const r of results) {
+        const rr = asRecord(r);
+        if (!rr) continue;
+        upserted += num(rr.postsUpserted);
+        fetched += num(rr.postsFetched);
+      }
+      if (num(d.synced) === 0 && num(d.failed) > 0)
+        return "LinkedIn sync didn't complete — please reconnect and try again.";
+      if (upserted > 0)
+        return `${upserted} ${plural(upserted, "post")} synced successfully.`;
+      if (fetched > 0) return "LinkedIn synced — your posts are already up to date.";
+      return "LinkedIn synced — no new posts in range yet.";
+    },
   },
   "linkedin-retention-cleanup": {
     label: "Clean LinkedIn data",
     frequency: "Runs every 6 hours",
     description:
       "Removes LinkedIn analytics rows past their retention window (compliance — keeps data scoped to what you actually need).",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return "LinkedIn data cleaned successfully.";
+      const total =
+        num(d.engagersDeleted) +
+        num(d.personPostsDeleted) +
+        num(d.orgPostsDeleted) +
+        num(d.legacyPostsDeleted);
+      if (total === 0) return "LinkedIn data cleaned — nothing to remove.";
+      return `LinkedIn data cleaned — ${total} ${plural(total, "row")} removed.`;
+    },
   },
   "voice-card-refresh": {
     label: "Refresh brand voice",
@@ -163,17 +224,32 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     label: "Sync X metrics",
     frequency: "Runs every 30 minutes",
     description: "Refreshes engagement metrics on your recent X (Twitter) posts.",
+    summarize: (data) => {
+      const synced = num(asRecord(data)?.synced);
+      if (synced === 0) return "X metrics refreshed — no active accounts yet.";
+      return `X metrics refreshed across ${synced} ${plural(synced, "account")}.`;
+    },
   },
   "x-mentions-sync": {
     label: "Sync X mentions",
     frequency: "Runs every 10 minutes",
     description:
       "Pulls new mentions of your account from X so the inbox stays current.",
+    summarize: (data) => {
+      const synced = num(asRecord(data)?.synced);
+      if (synced === 0) return "Mentions refreshed — no active accounts yet.";
+      return "Mentions refreshed.";
+    },
   },
   "x-ads-metrics-sync": {
     label: "Sync X ad metrics",
     frequency: "Runs every hour",
     description: "Refreshes performance numbers on your active X ad campaigns.",
+    summarize: (data) => {
+      const synced = num(asRecord(data)?.synced);
+      if (synced === 0) return "X ad metrics refreshed — no active campaigns yet.";
+      return "X ad metrics refreshed.";
+    },
   },
 };
 
@@ -188,4 +264,51 @@ export function getCronMetadata(cron: string): CronMetadata {
       description: `Triggers the ${cron} cron handler. Add this cron to cron-metadata.ts for a friendly description.`,
     }
   );
+}
+
+// ── Summary plumbing ──────────────────────────────────────────────────
+// Shared by the per-cron `summarize` functions above and by
+// summarizeCronBody() below. Kept defensive — the cron response shape is
+// owned by peakhour-api and can drift, so every read narrows from unknown
+// and tolerates missing/wrong-typed fields rather than throwing.
+
+/** Narrow an unknown value to a plain object, or null. */
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+/** Read a numeric field, coercing absent / non-numeric values to 0. */
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+/** Naive singular/plural — every noun we pluralize here just takes -s. */
+function plural(count: number, noun: string): string {
+  return count === 1 ? noun : `${noun}s`;
+}
+
+/**
+ * Turn a cron handler's raw HTTP response body into a clean, user-facing
+ * success line. <CronToolbar/> calls this on a 2xx run instead of dumping
+ * the raw JSON into the toast.
+ *
+ * The body is the cron's own envelope — `{ ok, data, meta }` — so we
+ * parse it, hand the inner `data` to the cron's `summarize`, and return
+ * whatever friendly string it produces. Returns null (→ caller shows a
+ * generic "<label> complete") whenever there's no summarizer, the body
+ * isn't parseable, or the summarizer opts out. Never throws.
+ */
+export function summarizeCronBody(cron: string, body: string): string | null {
+  const summarize = CRON_METADATA[cron]?.summarize;
+  if (!summarize || !body) return null;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    const data = asRecord(parsed)?.data;
+    return summarize(data);
+  } catch {
+    // Malformed / truncated body — defer to the generic toast.
+    return null;
+  }
 }

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
-import { getCronMetadata } from "./cron-metadata";
+import { getCronMetadata, summarizeCronBody } from "./cron-metadata";
 
 interface DevCronResult {
   cron: string;
@@ -92,23 +92,39 @@ export function CronToolbar({ crons, onTriggered }: Props) {
     try {
       const res = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, {});
       if (res.ok) {
-        toast.success(`${meta.label}: done in ${res.durationMs}ms`, {
-          description: res.body
-            ? `${res.body.slice(0, 200)}${res.truncated ? "…" : ""}`
-            : "(no output)",
-        });
+        // Show a clean, user-facing success line — never the raw cron
+        // JSON. The per-cron summarizer turns the response payload into
+        // something like "12 posts synced successfully."; absent one, we
+        // fall back to a generic "<label> complete". The raw body + timing
+        // still go to the dev console for debugging.
+        const summary = summarizeCronBody(cron, res.body);
+        toast.success(summary ?? `${meta.label} complete`);
+        if (res.body) {
+          console.debug(
+            `[CronToolbar] ${cron} ok in ${res.durationMs}ms:`,
+            res.body,
+          );
+        }
         // Success-only callback — see Props.onTriggered jsdoc. A failed
         // cron run already surfaced via the toast.error branch; the host
         // page doesn't need to invalidate queries for a no-op or error.
         onTriggered?.(res);
       } else {
-        toast.error(`${meta.label} failed: HTTP ${res.status}`, {
-          description: res.body?.slice(0, 200) ?? "no body",
+        // Keep the failure toast friendly too — the HTTP status + body are
+        // dev detail, not something to surface verbatim. Log them instead.
+        console.error(
+          `[CronToolbar] ${cron} failed: HTTP ${res.status}`,
+          res.body,
+        );
+        toast.error(`${meta.label} didn't complete`, {
+          description: "Please try again in a moment.",
         });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error(`${meta.label} request failed`, { description: msg });
+      console.error(`[CronToolbar] ${cron} request failed:`, err);
+      toast.error(`${meta.label} couldn't run`, {
+        description: "Please try again in a moment.",
+      });
     } finally {
       inFlightCrons.delete(cron);
       setRunningCron(null);


### PR DESCRIPTION
## Problem

Under **Content → Library → LinkedIn** (and X, and other pages using the shared dev `CronToolbar`), clicking actions like **Sync LinkedIn posts**, **Refresh performance**, **Clean LinkedIn data** surfaced raw backend JSON in the green success toast:

- `{"ok":true,"data":{...}}`
- `postsFetched:0`

These are technical, not CX-friendly. Separately, after a successful sync **nothing visibly changed** on the dashboard — the Boost-worthy posts panel stayed empty and no data refreshed.

## Root causes

1. **Raw JSON toast** — `CronToolbar` dumped the cron's raw response body (`res.body.slice(0, 200)`) into the toast description.
2. **No refresh** — the LinkedIn page's `onTriggered` only invalidated `content-hub-integrations` + `linkedin-me`, never the Boost (`linkedin-boost-candidates`) or Audience (`linkedin-engagers`) panels. Those panels also set `refetchOnMount: false`, so invalidation is the only thing that refreshes them. X had the same gap for its mentions inbox (`x-mentions`).

> Note: `postsFetched: 0` is the genuine sync result when the connected account has no posts in the scored window (24h–14d, ≥5 weighted engagement) — mapping/rendering is not broken. After this fix the panels refresh; if still empty, it's a true data gap (the empty-state copy already explains it).

## Changes (peakhour-b2c only — no API changes)

- **`cron-metadata.ts`** — add optional `summarize(data)` per cron + a defensive `summarizeCronBody(cron, body)` helper. Summarizers for the reported crons plus X/beehiiv, e.g.:
  - `linkedin-post-sync` → "12 posts synced successfully." / "no new posts in range yet." / "No LinkedIn accounts connected yet."
  - `performance-sync` → "Performance refreshed across N connections."
  - `linkedin-retention-cleanup` → "LinkedIn data cleaned — N rows removed."
- **`cron-toolbar.tsx`** — show the friendly summary (generic `"<label> complete"` fallback); **never** render raw JSON. Raw body + timing go to the console. Failure/error toasts are friendly too.
- **`linkedin/page.tsx`** — `onTriggered` now invalidates `linkedin-boost-candidates` + `linkedin-engagers`.
- **`x/page.tsx`** — `onTriggered` now invalidates `x-mentions`.

`CronToolbar` remains dev/preview-only (hidden in production).

## Verification

- `tsc --noEmit` — clean
- `eslint` on changed files — clean
- Manual review + subagent review (data shapes vs API, query-key alignment, JSON-parse robustness) — no critical/high/medium issues; one low wording nit fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)