### PR TITLE
feat(x-composer): LinkedIn-class parity — AI primitives, scheduler, thread builder

### DIFF
--- a/src/app/dashboard/content/x/_components/tweet-composer.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-composer.tsx
@@ -1,49 +1,376 @@
 "use client";
 
-import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Reply, Quote, X, Send } from "lucide-react";
+import {
+  ArrowLeft,
+  CalendarClock,
+  Command as CommandIcon,
+  Loader2,
+  Plus,
+  Quote,
+  Reply,
+  Send,
+  Sparkles,
+  Trash2,
+  Wand2,
+  X as XIcon,
+} from "lucide-react";
 import { xApi, extractTweetId, type PublishTweetInput } from "@/lib/api/x";
 import { ApiError } from "@/lib/api";
+import {
+  rewriteContent,
+  createDraft,
+  updateDraft,
+  getVoiceCards,
+  type ComposerDraftRef,
+  type VoiceCardDoc,
+} from "@/lib/api/content";
+import {
+  AiComposeToolbar,
+  ComposerCommandPalette,
+  DraftSaver,
+  EmojiPickerTrigger,
+  HashtagSuggest,
+  PlatformCharCounter,
+  VoiceCardPreview,
+  useDraftSaver,
+  type AiActionContext,
+  type ComposerCommand,
+  type HashtagCandidate,
+  type VoiceCardSummary,
+} from "@/components/composer";
+import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
+import type { ScheduleSourceType } from "@/lib/scheduler/types";
+import { sourceTextHash } from "@/lib/scheduler/source-hash";
+import { insertAtCaret } from "@/lib/composer/caret";
+import { cn } from "@/lib/utils";
 
 const MAX_LEN = 280;
 
-type ReplyMode = { kind: "none" } | { kind: "reply"; id: string; raw: string } | { kind: "quote"; id: string; raw: string };
+/** Compose vs. schedule view of the same composer — mirrors the
+ *  LinkedIn composer. "schedule" mounts <SchedulerComposer/> with the
+ *  current tweet/thread as the payload. */
+type ComposerMode = "compose" | "schedule";
+
+/** Reply / quote reference attached to the ROOT tweet (segment 0). */
+type RefMode =
+  | { kind: "none" }
+  | { kind: "reply"; id: string; raw: string }
+  | { kind: "quote"; id: string; raw: string };
+
+function aiOpToast(op: AiActionContext["op"]): string {
+  switch (op) {
+    case "compose":
+      return "Draft generated.";
+    case "redraft":
+      return "Tweet rewritten.";
+    case "shorten":
+      return "Tweet shortened.";
+    case "lengthen":
+      return "Tweet expanded.";
+    case "tone":
+      return "Tone updated.";
+    case "quote":
+      return "Quote inserted.";
+    case "disclosure":
+      return "Disclosure inserted.";
+  }
+}
+
+/** Map the generic voice-cards payload to the chip summary. Best-effort
+ *  — the chip is informational (brand voice is also injected server-side
+ *  by the rewrite skill), so a missing card just renders nothing. */
+function mapXVoiceCard(cards: VoiceCardDoc[] | undefined): VoiceCardSummary | null {
+  if (!cards || cards.length === 0) return null;
+  const card = cards[0];
+  return {
+    id: card._id ?? "x-voice",
+    channel: "x",
+    category: card.category,
+    toneAdjectives: card.voice?.tone ?? [],
+    signaturePhrases: card.voice?.signaturePhrases ?? [],
+    avoidPhrases: card.voice?.avoidPhrases ?? [],
+    refreshedAt: card.lastGeneratedAt ?? card.updatedAt,
+  };
+}
 
 export function TweetComposer() {
   const queryClient = useQueryClient();
-  const [text, setText] = useState("");
+
+  // ── Thread state ────────────────────────────────────────────────
+  // segments[0] is the root tweet; length > 1 = a thread. The composer
+  // edits the ACTIVE segment; the AI toolbar / emoji / hashtag
+  // primitives all operate on it. activeIndex + caret are the single
+  // source of truth for "where an insert lands"; caretRef mirrors caret
+  // for the async AI handler (same pattern as the LinkedIn composer).
+  const [segments, setSegments] = useState<string[]>([""]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [caret, setCaret] = useState(0);
+  const segmentsRef = useRef<string[]>([""]);
+  const activeIndexRef = useRef(0);
+  const caretRef = useRef(0);
+  useEffect(() => {
+    segmentsRef.current = segments;
+  }, [segments]);
+  useEffect(() => {
+    activeIndexRef.current = activeIndex;
+  }, [activeIndex]);
+  useEffect(() => {
+    caretRef.current = caret;
+  }, [caret]);
+
+  // One textarea ref per segment (for focus restore after insert) +
+  // one wrapper per segment (hashtag popover anchor for the active one).
+  const textareaRefs = useRef<(HTMLTextAreaElement | null)[]>([]);
+  const wrapRefs = useRef<(HTMLDivElement | null)[]>([]);
+  // Stable ref object the HashtagSuggest reads for the active segment —
+  // updated to point at the active textarea/wrapper each render.
+  const activeTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const activeWrapRef = useRef<HTMLDivElement | null>(null);
+  activeTextareaRef.current = textareaRefs.current[activeIndex] ?? null;
+  activeWrapRef.current = wrapRefs.current[activeIndex] ?? null;
+
+  // ── Other composer state ────────────────────────────────────────
+  const [mode, setMode] = useState<ComposerMode>("compose");
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [draftId, setDraftId] = useState<string | null>(null);
+  const createInFlightRef = useRef<Promise<ComposerDraftRef> | null>(null);
+
+  const [refMode, setRefMode] = useState<RefMode>({ kind: "none" });
   const [showRefs, setShowRefs] = useState(false);
-  const [refMode, setRefMode] = useState<ReplyMode>({ kind: "none" });
   const [refInput, setRefInput] = useState("");
   const [refError, setRefError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
 
+  const isThread = segments.length > 1;
+  const activeText = segments[activeIndex] ?? "";
+
+  // Combined text — used for the draft body + scheduler source hash.
+  const combinedText = useMemo(
+    () => segments.map((s) => s.trim()).filter(Boolean).join("\n\n"),
+    [segments],
+  );
+  const empty = combinedText.length === 0;
+  const anyTooLong = segments.some((s) => s.length > MAX_LEN);
+
+  // ── Voice card chip (informational) ─────────────────────────────
+  const voiceCardQuery = useQuery({
+    queryKey: ["x-voice-card"],
+    queryFn: () => getVoiceCards({ channel: "x" }),
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && (err.status === 404 || err.status === 403)) return false;
+      return failureCount < 2;
+    },
+    staleTime: 5 * 60_000,
+  });
+  const voiceSummary = useMemo(() => mapXVoiceCard(voiceCardQuery.data), [voiceCardQuery.data]);
+
+  // ── Segment helpers ─────────────────────────────────────────────
+  function updateSegment(index: number, value: string) {
+    setSegments((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      segmentsRef.current = next;
+      return next;
+    });
+  }
+
+  function addSegment() {
+    setSegments((prev) => {
+      const next = [...prev, ""];
+      segmentsRef.current = next;
+      return next;
+    });
+    const newIndex = segments.length;
+    setActiveIndex(newIndex);
+    activeIndexRef.current = newIndex;
+    setCaret(0);
+    caretRef.current = 0;
+    // Focus the new segment once it mounts.
+    requestAnimationFrame(() => textareaRefs.current[newIndex]?.focus());
+  }
+
+  function removeSegment(index: number) {
+    if (segments.length <= 1) return;
+    setSegments((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      segmentsRef.current = next;
+      return next;
+    });
+    const nextActive = Math.max(0, Math.min(activeIndex, segments.length - 2));
+    setActiveIndex(nextActive);
+    activeIndexRef.current = nextActive;
+  }
+
+  function captureCaret(index: number, el: HTMLTextAreaElement) {
+    setActiveIndex(index);
+    activeIndexRef.current = index;
+    const pos = el.selectionStart ?? el.value.length;
+    setCaret(pos);
+    caretRef.current = pos;
+  }
+
+  // ── Caret-aware snippet insertion (emoji + AI insert ops) ───────
+  const insertSnippet = useCallback((snippet: string): string => {
+    const idx = activeIndexRef.current;
+    const current = segmentsRef.current[idx] ?? "";
+    const { text: next, caret: nextCaret } = insertAtCaret(current, caretRef.current, snippet);
+    updateSegment(idx, next);
+    setCaret(nextCaret);
+    caretRef.current = nextCaret;
+    requestAnimationFrame(() => {
+      const el = textareaRefs.current[idx];
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(nextCaret, nextCaret);
+    });
+    return next;
+  }, []);
+
+  // ── AI compose toolbar handler (operates on the active segment) ──
+  const handleAiAction = useCallback(
+    async (ctx: AiActionContext): Promise<string> => {
+      const res = await rewriteContent({
+        op: ctx.op,
+        text: ctx.text,
+        platform: "x",
+        ...(ctx.extras ? { extras: ctx.extras } : {}),
+      });
+      // Insert ops (quote/disclosure) splice at the caret; a missing
+      // `insert` (older API) falls back to a full-segment replace.
+      let newText: string;
+      if (res.insert === true) {
+        newText = insertSnippet(res.text);
+      } else {
+        newText = res.text;
+        updateSegment(activeIndexRef.current, newText);
+      }
+      toast.success(aiOpToast(ctx.op));
+      return newText;
+    },
+    [insertSnippet],
+  );
+
+  // No hashtag-history endpoint for X yet — surface only the inline
+  // "Create #tag" affordance via the primitive's default validator
+  // (letters/digits/underscore), which matches X's tag rules.
+  const searchHashtags = useCallback(async (): Promise<HashtagCandidate[]> => [], []);
+
+  // ── Draft auto-save ─────────────────────────────────────────────
+  const saveDraft = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) return;
+      if (draftId) {
+        await updateDraft(draftId, { text: value });
+        return;
+      }
+      if (createInFlightRef.current) {
+        const ref = await createInFlightRef.current;
+        await updateDraft(ref.draftId, { text: value });
+        return;
+      }
+      const p = createDraft({ text: value, channel: "x" });
+      createInFlightRef.current = p;
+      try {
+        const ref = await p;
+        setDraftId(ref.draftId);
+      } finally {
+        createInFlightRef.current = null;
+      }
+    },
+    [draftId],
+  );
+
+  const {
+    status: draftStatus,
+    lastSavedAt,
+    lastError: draftError,
+    saveNow,
+  } = useDraftSaver<string>({
+    value: combinedText.length > 0 ? combinedText : null,
+    save: saveDraft,
+  });
+
+  // ── Reset after publish/schedule ────────────────────────────────
+  const resetComposer = useCallback(() => {
+    setSegments([""]);
+    segmentsRef.current = [""];
+    setActiveIndex(0);
+    activeIndexRef.current = 0;
+    setCaret(0);
+    caretRef.current = 0;
+    setRefMode({ kind: "none" });
+    setRefInput("");
+    setShowRefs(false);
+    setDraftId(null);
+    setMode("compose");
+  }, []);
+
+  // ── Instant publish (single tweet OR reply-chained thread) ──────
   const publish = useMutation({
-    mutationFn: (input: PublishTweetInput) => xApi.publish(input),
-    onSuccess: () => {
-      setText("");
-      setRefMode({ kind: "none" });
-      setRefInput("");
-      setShowRefs(false);
-      setFeedback({ kind: "success", message: "Tweet published." });
+    mutationFn: async () => {
+      const segs = segments.map((s) => s.trim());
+      // Drop trailing empty segments (an "Add tweet" the user left blank)
+      // but keep interior order intact.
+      while (segs.length > 1 && segs[segs.length - 1] === "") segs.pop();
+
+      let posted = 0;
+      let prevId: string | undefined;
+      for (let i = 0; i < segs.length; i++) {
+        const body: PublishTweetInput = { text: segs[i] };
+        if (i === 0) {
+          if (refMode.kind === "reply") body.replyToTweetId = refMode.id;
+          if (refMode.kind === "quote") body.quoteTweetId = refMode.id;
+        } else {
+          // Chain: each subsequent tweet replies to the previous one's id.
+          body.replyToTweetId = prevId;
+        }
+        try {
+          const res = await xApi.publish(body);
+          prevId = res.id;
+          posted++;
+        } catch (err) {
+          // Partial-thread failure: surface how far we got so the user
+          // isn't left guessing. Re-throw to hit onError.
+          const detail =
+            segs.length > 1 ? ` (${posted}/${segs.length} posted before this failed)` : "";
+          const base = err instanceof ApiError ? err.message : "Failed to publish.";
+          throw new Error(`${base}${detail}`);
+        }
+      }
+      return { posted };
+    },
+    onSuccess: ({ posted }) => {
+      resetComposer();
+      setFeedback({
+        kind: "success",
+        message: posted > 1 ? `Thread published (${posted} tweets).` : "Tweet published.",
+      });
       queryClient.invalidateQueries({ queryKey: ["x-tweets"] });
     },
     onError: (err: unknown) => {
-      const message = err instanceof ApiError ? err.message : "Failed to publish tweet.";
+      const message = err instanceof Error ? err.message : "Failed to publish tweet.";
       setFeedback({ kind: "error", message });
     },
   });
 
-  const remaining = MAX_LEN - text.length;
-  const tooLong = remaining < 0;
-  const empty = text.trim().length === 0;
-  const disabled = empty || tooLong || publish.isPending;
+  const publishDisabled = empty || anyTooLong || publish.isPending;
+  const scheduleDisabled = empty || anyTooLong;
 
+  // ── Reply / quote reference ─────────────────────────────────────
   function attachReference(kind: "reply" | "quote") {
     const id = extractTweetId(refInput);
     if (!id) {
@@ -52,6 +379,7 @@ export function TweetComposer() {
     }
     setRefError(null);
     setRefMode({ kind, id, raw: refInput.trim() });
+    setShowRefs(false);
   }
 
   function clearReference() {
@@ -60,24 +388,143 @@ export function TweetComposer() {
     setRefError(null);
   }
 
-  function onSubmit() {
-    if (disabled) return;
-    setFeedback(null);
-    const body: PublishTweetInput = { text: text.trim() };
-    if (refMode.kind === "reply") body.replyToTweetId = refMode.id;
-    if (refMode.kind === "quote") body.quoteTweetId = refMode.id;
-    publish.mutate(body);
+  // ── Scheduler props (only consumed in schedule mode) ────────────
+  const schedulerSource = useMemo(
+    () => ({
+      sourceType: (draftId ? "draft" : "ad_hoc") as ScheduleSourceType,
+      ...(draftId ? { sourceRef: draftId } : {}),
+      sourceTextHash: sourceTextHash(combinedText),
+    }),
+    [draftId, combinedText],
+  );
+
+  const scheduleTitle = useMemo(() => {
+    const first = segments[0]?.trim().split(/\r?\n/).find((l) => l.trim().length > 0);
+    return first ? first.slice(0, 120).trim() : undefined;
+  }, [segments]);
+
+  const schedulerChannels = useMemo(() => {
+    const trimmed = segments.map((s) => s.trim()).filter(Boolean);
+    const channelOptions: Record<string, unknown> = {};
+    if (refMode.kind === "reply") channelOptions.replyToTweetId = refMode.id;
+    if (refMode.kind === "quote") channelOptions.quoteTweetId = refMode.id;
+    return [
+      {
+        channel: "x",
+        payload: {
+          text: trimmed[0] ?? "",
+          // threadParts drives the scheduler's X publisher (posts each
+          // part sequentially). Only set it for an actual thread so a
+          // single tweet schedules as a plain post.
+          ...(trimmed.length > 1 ? { threadParts: trimmed } : {}),
+          ...(Object.keys(channelOptions).length > 0 ? { channelOptions } : {}),
+        },
+      },
+    ];
+  }, [segments, refMode]);
+
+  function handleScheduled() {
+    queryClient.invalidateQueries({ queryKey: ["scheduler:items"] });
+    resetComposer();
   }
 
+  // ── Command palette ─────────────────────────────────────────────
+  const commands = useMemo<ComposerCommand[]>(
+    () => [
+      {
+        id: "ai-compose",
+        label: "Compose with AI",
+        hint: "Generate a fresh tweet from your brand voice",
+        group: "AI",
+        icon: Sparkles,
+        run: () => void handleAiAction({ op: "compose", text: activeText, platform: "x" }),
+      },
+      {
+        id: "ai-redraft",
+        label: "Rewrite this tweet",
+        group: "AI",
+        icon: Wand2,
+        disabled: activeText.trim().length === 0,
+        run: () => void handleAiAction({ op: "redraft", text: activeText, platform: "x" }),
+      },
+      {
+        id: "add-tweet",
+        label: "Add to thread",
+        hint: "Append another tweet",
+        group: "Compose",
+        icon: Plus,
+        run: addSegment,
+      },
+      {
+        id: "schedule",
+        label: "Schedule for later",
+        group: "Publish",
+        icon: CalendarClock,
+        disabled: scheduleDisabled,
+        run: () => setMode("schedule"),
+      },
+      {
+        id: "reply-quote",
+        label: refMode.kind === "none" ? "Reply to / quote a tweet" : "Reference attached",
+        group: "Compose",
+        icon: Reply,
+        disabled: refMode.kind !== "none",
+        run: () => setShowRefs(true),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [handleAiAction, activeText, scheduleDisabled, refMode.kind, segments.length],
+  );
+
+  // ── Schedule view ───────────────────────────────────────────────
+  if (mode === "schedule") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-3 border-b pb-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <CalendarClock className="size-4 text-primary" />
+            Schedule this {isThread ? "thread" : "tweet"}
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={() => setMode("compose")} className="gap-1.5">
+            <ArrowLeft className="size-3.5" /> Back to editing
+          </Button>
+        </div>
+        <SchedulerComposer
+          key={schedulerSource.sourceTextHash}
+          source={schedulerSource}
+          title={scheduleTitle}
+          channels={schedulerChannels}
+          onScheduled={handleScheduled}
+        />
+      </div>
+    );
+  }
+
+  // ── Compose view ────────────────────────────────────────────────
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
+      {/* Voice chip + actions */}
+      <div className="flex items-center justify-between gap-2">
+        <VoiceCardPreview voiceCard={voiceSummary} />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setPaletteOpen(true)}
+          className="gap-1.5 text-xs text-muted-foreground"
+        >
+          <CommandIcon className="size-3.5" /> Actions
+        </Button>
+      </div>
+
+      {/* Reply/quote reference chip */}
       {refMode.kind !== "none" && (
         <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
           {refMode.kind === "reply" ? <Reply className="size-4" /> : <Quote className="size-4" />}
           <span className="text-muted-foreground">
             {refMode.kind === "reply" ? "Replying to" : "Quoting"}
           </span>
-          <span className="font-mono text-xs truncate">{refMode.raw}</span>
+          <span className="truncate font-mono text-xs">{refMode.raw}</span>
           <Button
             type="button"
             variant="ghost"
@@ -86,20 +533,86 @@ export function TweetComposer() {
             onClick={clearReference}
             aria-label="Remove reference"
           >
-            <X className="size-3" />
+            <XIcon className="size-3" />
           </Button>
         </div>
       )}
 
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder="What's happening?"
-        rows={4}
-        className="resize-none"
-        aria-label="Tweet text"
-      />
+      <AiComposeToolbar text={activeText} platform="x" onAiAction={handleAiAction} />
 
+      {/* Thread segments */}
+      <div className="space-y-3">
+        {segments.map((seg, index) => {
+          const isActive = index === activeIndex;
+          return (
+            <div
+              key={index}
+              ref={(el) => {
+                wrapRefs.current[index] = el;
+              }}
+              className={cn(
+                "relative rounded-md border p-2 transition-colors",
+                isActive ? "border-primary/40 bg-card" : "border-border bg-muted/20",
+              )}
+            >
+              {isThread && (
+                <div className="mb-1 flex items-center justify-between px-1">
+                  <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {index === 0 ? "Tweet 1 (root)" : `Tweet ${index + 1}`}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-1.5 text-muted-foreground hover:text-destructive"
+                    onClick={() => removeSegment(index)}
+                    aria-label={`Remove tweet ${index + 1}`}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              )}
+              <Textarea
+                ref={(el) => {
+                  textareaRefs.current[index] = el;
+                }}
+                value={seg}
+                onChange={(e) => {
+                  updateSegment(index, e.target.value);
+                  captureCaret(index, e.target);
+                }}
+                onSelect={(e) => captureCaret(index, e.currentTarget)}
+                onClick={(e) => captureCaret(index, e.currentTarget)}
+                onKeyUp={(e) => captureCaret(index, e.currentTarget)}
+                onFocus={(e) => captureCaret(index, e.currentTarget)}
+                // Capture caret on blur so an emoji/AI insert (which blurs
+                // the textarea) lands at the right spot.
+                onBlur={(e) => captureCaret(index, e.currentTarget)}
+                placeholder={index === 0 ? "What's happening?" : "Continue the thread…"}
+                rows={index === 0 ? 4 : 3}
+                className="resize-none border-0 bg-transparent p-1 shadow-none focus-visible:ring-0"
+                aria-label={isThread ? `Tweet ${index + 1} text` : "Tweet text"}
+              />
+              <div className="flex items-center justify-end px-1">
+                <PlatformCharCounter value={seg} platform="x" size="sm" showCount />
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Hashtag typeahead anchored to the ACTIVE segment. */}
+        <HashtagSuggest
+          containerRef={activeWrapRef}
+          targetRef={activeTextareaRef}
+          text={activeText}
+          caret={caret}
+          onChange={(next) => updateSegment(activeIndex, next)}
+          onSearch={searchHashtags}
+          minQueryLength={2}
+        />
+      </div>
+
+      {/* Reply/quote input (toggle) */}
       {showRefs && refMode.kind === "none" && (
         <div className="space-y-2 rounded-md border p-3">
           <Label htmlFor="x-ref-input" className="text-xs uppercase tracking-wide text-muted-foreground">
@@ -113,10 +626,10 @@ export function TweetComposer() {
           />
           <div className="flex gap-2">
             <Button type="button" variant="outline" size="sm" onClick={() => attachReference("reply")} disabled={!refInput}>
-              <Reply className="size-3.5 mr-1" /> Reply
+              <Reply className="mr-1 size-3.5" /> Reply
             </Button>
             <Button type="button" variant="outline" size="sm" onClick={() => attachReference("quote")} disabled={!refInput}>
-              <Quote className="size-3.5 mr-1" /> Quote
+              <Quote className="mr-1 size-3.5" /> Quote
             </Button>
             <Button type="button" variant="ghost" size="sm" onClick={() => { setShowRefs(false); setRefInput(""); setRefError(null); }}>
               Cancel
@@ -126,32 +639,42 @@ export function TweetComposer() {
         </div>
       )}
 
-      <div className="flex items-center justify-between">
-        <div className="flex gap-2">
-          {refMode.kind === "none" && !showRefs && (
-            <Button type="button" variant="ghost" size="sm" onClick={() => setShowRefs(true)}>
-              <Reply className="size-3.5 mr-1" /> Reply / quote
-            </Button>
-          )}
-        </div>
-        <div className="flex items-center gap-3">
-          <span
-            className={
-              tooLong
-                ? "text-sm font-medium text-destructive"
-                : remaining <= 20
-                  ? "text-sm font-medium text-amber-600"
-                  : "text-sm text-muted-foreground"
-            }
-            aria-live="polite"
-          >
-            {remaining}
-          </span>
-          <Button onClick={onSubmit} disabled={disabled} aria-busy={publish.isPending}>
-            <Send className="size-4 mr-1.5" />
-            {publish.isPending ? "Publishing…" : "Publish"}
+      {/* Toolbar row: emoji, add-tweet, reply/quote, draft status */}
+      <div className="flex flex-wrap items-center gap-2">
+        <EmojiPickerTrigger onInsert={insertSnippet} />
+        <Button type="button" variant="ghost" size="sm" onClick={addSegment} className="h-7 gap-1.5 px-2 text-xs">
+          <Plus className="size-3.5" /> Add tweet
+        </Button>
+        {refMode.kind === "none" && !showRefs && (
+          <Button type="button" variant="ghost" size="sm" onClick={() => setShowRefs(true)} className="h-7 gap-1.5 px-2 text-xs">
+            <Reply className="size-3.5" /> Reply / quote
           </Button>
-        </div>
+        )}
+        <DraftSaver
+          status={draftStatus}
+          lastSavedAt={lastSavedAt}
+          lastError={draftError}
+          onRetry={saveNow}
+          className="ml-auto"
+        />
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex items-center justify-end gap-2 border-t pt-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setMode("schedule")}
+          disabled={scheduleDisabled}
+          className="gap-1.5"
+        >
+          <CalendarClock className="size-4" /> Schedule
+        </Button>
+        <Button onClick={() => publish.mutate()} disabled={publishDisabled} aria-busy={publish.isPending} className="gap-1.5">
+          {publish.isPending ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+          {publish.isPending ? "Publishing…" : isThread ? "Publish thread" : "Publish"}
+        </Button>
       </div>
 
       {feedback && (
@@ -166,6 +689,14 @@ export function TweetComposer() {
           {feedback.message}
         </p>
       )}
+
+      <ComposerCommandPalette
+        paletteId="x-composer"
+        commands={commands}
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        placeholder="Compose, schedule, add to thread…"
+      />
     </div>
   );
 }

--- a/src/app/dashboard/content/x/_components/tweet-composer.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-composer.tsx
@@ -59,9 +59,24 @@ import { cn } from "@/lib/utils";
 
 const MAX_LEN = 280;
 
-/** Compose vs. schedule view of the same composer — mirrors the
- *  LinkedIn composer. "schedule" mounts <SchedulerComposer/> with the
- *  current tweet/thread as the payload. */
+/** A single tweet in the composer. `id` is STABLE for the life of the
+ *  segment (not the array index) so React keys + the ref maps survive
+ *  removing/reordering a middle tweet — the index-keyed approach made
+ *  the DOM caret/IME state stick to the wrong tweet. */
+interface Segment {
+  id: string;
+  text: string;
+}
+
+// Monotonic id source. Module-level (not Date/random) so ids are stable
+// + collision-free across the session without pulling in a uuid dep.
+let segmentSeq = 0;
+function makeSegment(text = ""): Segment {
+  segmentSeq += 1;
+  return { id: `seg-${segmentSeq}`, text };
+}
+
+/** Compose vs. schedule view — mirrors the LinkedIn composer. */
 type ComposerMode = "compose" | "schedule";
 
 /** Reply / quote reference attached to the ROOT tweet (segment 0). */
@@ -69,6 +84,13 @@ type RefMode =
   | { kind: "none" }
   | { kind: "reply"; id: string; raw: string }
   | { kind: "quote"; id: string; raw: string };
+
+/** X hashtags are ASCII letters/digits/underscore only — pass this to
+ *  HashtagSuggest so users don't pick "Create #🔥" the publish API then
+ *  rejects (the primitive's default validator allows Unicode letters). */
+function isValidXHashtag(query: string): boolean {
+  return /^[A-Za-z0-9_]{2,}$/.test(query);
+}
 
 function aiOpToast(op: AiActionContext["op"]): string {
   switch (op) {
@@ -111,36 +133,37 @@ export function TweetComposer() {
 
   // ── Thread state ────────────────────────────────────────────────
   // segments[0] is the root tweet; length > 1 = a thread. The composer
-  // edits the ACTIVE segment; the AI toolbar / emoji / hashtag
-  // primitives all operate on it. activeIndex + caret are the single
-  // source of truth for "where an insert lands"; caretRef mirrors caret
-  // for the async AI handler (same pattern as the LinkedIn composer).
-  const [segments, setSegments] = useState<string[]>([""]);
-  const [activeIndex, setActiveIndex] = useState(0);
+  // edits the ACTIVE segment (tracked by id, not index); the AI toolbar
+  // / emoji / hashtag primitives all operate on it. activeId + caret
+  // are the source of truth for "where an insert lands"; refs mirror
+  // them for the async AI handler (same pattern as the LinkedIn
+  // composer).
+  const [segments, setSegments] = useState<Segment[]>(() => [makeSegment()]);
+  const [activeId, setActiveId] = useState<string>(() => segments[0]!.id);
   const [caret, setCaret] = useState(0);
-  const segmentsRef = useRef<string[]>([""]);
-  const activeIndexRef = useRef(0);
+  const segmentsRef = useRef<Segment[]>(segments);
+  const activeIdRef = useRef<string>(activeId);
   const caretRef = useRef(0);
   useEffect(() => {
     segmentsRef.current = segments;
   }, [segments]);
   useEffect(() => {
-    activeIndexRef.current = activeIndex;
-  }, [activeIndex]);
+    activeIdRef.current = activeId;
+  }, [activeId]);
   useEffect(() => {
     caretRef.current = caret;
   }, [caret]);
 
-  // One textarea ref per segment (for focus restore after insert) +
-  // one wrapper per segment (hashtag popover anchor for the active one).
-  const textareaRefs = useRef<(HTMLTextAreaElement | null)[]>([]);
-  const wrapRefs = useRef<(HTMLDivElement | null)[]>([]);
-  // Stable ref object the HashtagSuggest reads for the active segment —
-  // updated to point at the active textarea/wrapper each render.
+  // Element maps keyed by STABLE segment id (not index) — survive a
+  // middle-segment removal without mis-associating DOM nodes.
+  const textareaRefs = useRef<Map<string, HTMLTextAreaElement | null>>(new Map());
+  const wrapRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  // Stable ref objects the single HashtagSuggest reads — repointed each
+  // render to the active segment's elements.
   const activeTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const activeWrapRef = useRef<HTMLDivElement | null>(null);
-  activeTextareaRef.current = textareaRefs.current[activeIndex] ?? null;
-  activeWrapRef.current = wrapRefs.current[activeIndex] ?? null;
+  activeTextareaRef.current = textareaRefs.current.get(activeId) ?? null;
+  activeWrapRef.current = wrapRefs.current.get(activeId) ?? null;
 
   // ── Other composer state ────────────────────────────────────────
   const [mode, setMode] = useState<ComposerMode>("compose");
@@ -155,15 +178,14 @@ export function TweetComposer() {
   const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
 
   const isThread = segments.length > 1;
-  const activeText = segments[activeIndex] ?? "";
+  const activeText = segments.find((s) => s.id === activeId)?.text ?? "";
 
-  // Combined text — used for the draft body + scheduler source hash.
   const combinedText = useMemo(
-    () => segments.map((s) => s.trim()).filter(Boolean).join("\n\n"),
+    () => segments.map((s) => s.text.trim()).filter(Boolean).join("\n\n"),
     [segments],
   );
   const empty = combinedText.length === 0;
-  const anyTooLong = segments.some((s) => s.length > MAX_LEN);
+  const anyTooLong = segments.some((s) => s.text.length > MAX_LEN);
 
   // ── Voice card chip (informational) ─────────────────────────────
   const voiceCardQuery = useQuery({
@@ -178,66 +200,72 @@ export function TweetComposer() {
   const voiceSummary = useMemo(() => mapXVoiceCard(voiceCardQuery.data), [voiceCardQuery.data]);
 
   // ── Segment helpers ─────────────────────────────────────────────
-  function updateSegment(index: number, value: string) {
-    setSegments((prev) => {
-      const next = [...prev];
-      next[index] = value;
-      segmentsRef.current = next;
-      return next;
-    });
-  }
+  const updateSegment = useCallback((id: string, value: string) => {
+    setSegments((prev) => prev.map((s) => (s.id === id ? { ...s, text: value } : s)));
+  }, []);
 
-  function addSegment() {
-    setSegments((prev) => {
-      const next = [...prev, ""];
-      segmentsRef.current = next;
-      return next;
-    });
-    const newIndex = segments.length;
-    setActiveIndex(newIndex);
-    activeIndexRef.current = newIndex;
+  const addSegment = useCallback(() => {
+    const seg = makeSegment();
+    setSegments((prev) => [...prev, seg]);
+    setActiveId(seg.id);
+    activeIdRef.current = seg.id;
     setCaret(0);
     caretRef.current = 0;
-    // Focus the new segment once it mounts.
-    requestAnimationFrame(() => textareaRefs.current[newIndex]?.focus());
-  }
+    requestAnimationFrame(() => textareaRefs.current.get(seg.id)?.focus());
+  }, []);
 
-  function removeSegment(index: number) {
-    if (segments.length <= 1) return;
-    setSegments((prev) => {
-      const next = prev.filter((_, i) => i !== index);
-      segmentsRef.current = next;
-      return next;
-    });
-    const nextActive = Math.max(0, Math.min(activeIndex, segments.length - 2));
-    setActiveIndex(nextActive);
-    activeIndexRef.current = nextActive;
-  }
+  const removeSegment = useCallback(
+    (id: string) => {
+      setSegments((prev) => {
+        if (prev.length <= 1) return prev;
+        const idx = prev.findIndex((s) => s.id === id);
+        const next = prev.filter((s) => s.id !== id);
+        // If the active segment is the one being removed, move focus to
+        // the previous tweet (or the new first) — tracked by id, so no
+        // index drift when an earlier segment is removed.
+        if (activeIdRef.current === id) {
+          const newActive = next[Math.max(0, idx - 1)] ?? next[0]!;
+          setActiveId(newActive.id);
+          activeIdRef.current = newActive.id;
+          const len = newActive.text.length;
+          setCaret(len);
+          caretRef.current = len;
+        }
+        return next;
+      });
+      textareaRefs.current.delete(id);
+      wrapRefs.current.delete(id);
+    },
+    [],
+  );
 
-  function captureCaret(index: number, el: HTMLTextAreaElement) {
-    setActiveIndex(index);
-    activeIndexRef.current = index;
+  function captureCaret(id: string, el: HTMLTextAreaElement) {
+    setActiveId(id);
+    activeIdRef.current = id;
     const pos = el.selectionStart ?? el.value.length;
     setCaret(pos);
     caretRef.current = pos;
   }
 
   // ── Caret-aware snippet insertion (emoji + AI insert ops) ───────
-  const insertSnippet = useCallback((snippet: string): string => {
-    const idx = activeIndexRef.current;
-    const current = segmentsRef.current[idx] ?? "";
-    const { text: next, caret: nextCaret } = insertAtCaret(current, caretRef.current, snippet);
-    updateSegment(idx, next);
-    setCaret(nextCaret);
-    caretRef.current = nextCaret;
-    requestAnimationFrame(() => {
-      const el = textareaRefs.current[idx];
-      if (!el) return;
-      el.focus();
-      el.setSelectionRange(nextCaret, nextCaret);
-    });
-    return next;
-  }, []);
+  const insertSnippet = useCallback(
+    (snippet: string): string => {
+      const id = activeIdRef.current;
+      const current = segmentsRef.current.find((s) => s.id === id)?.text ?? "";
+      const { text: next, caret: nextCaret } = insertAtCaret(current, caretRef.current, snippet);
+      updateSegment(id, next);
+      setCaret(nextCaret);
+      caretRef.current = nextCaret;
+      requestAnimationFrame(() => {
+        const el = textareaRefs.current.get(id);
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(nextCaret, nextCaret);
+      });
+      return next;
+    },
+    [updateSegment],
+  );
 
   // ── AI compose toolbar handler (operates on the active segment) ──
   const handleAiAction = useCallback(
@@ -255,17 +283,16 @@ export function TweetComposer() {
         newText = insertSnippet(res.text);
       } else {
         newText = res.text;
-        updateSegment(activeIndexRef.current, newText);
+        updateSegment(activeIdRef.current, newText);
       }
       toast.success(aiOpToast(ctx.op));
       return newText;
     },
-    [insertSnippet],
+    [insertSnippet, updateSegment],
   );
 
   // No hashtag-history endpoint for X yet — surface only the inline
-  // "Create #tag" affordance via the primitive's default validator
-  // (letters/digits/underscore), which matches X's tag rules.
+  // "Create #tag" affordance, gated by the X-ASCII validator.
   const searchHashtags = useCallback(async (): Promise<HashtagCandidate[]> => [], []);
 
   // ── Draft auto-save ─────────────────────────────────────────────
@@ -306,12 +333,14 @@ export function TweetComposer() {
 
   // ── Reset after publish/schedule ────────────────────────────────
   const resetComposer = useCallback(() => {
-    setSegments([""]);
-    segmentsRef.current = [""];
-    setActiveIndex(0);
-    activeIndexRef.current = 0;
+    const fresh = makeSegment();
+    setSegments([fresh]);
+    setActiveId(fresh.id);
+    activeIdRef.current = fresh.id;
     setCaret(0);
     caretRef.current = 0;
+    textareaRefs.current.clear();
+    wrapRefs.current.clear();
     setRefMode({ kind: "none" });
     setRefInput("");
     setShowRefs(false);
@@ -322,29 +351,24 @@ export function TweetComposer() {
   // ── Instant publish (single tweet OR reply-chained thread) ──────
   const publish = useMutation({
     mutationFn: async () => {
-      const segs = segments.map((s) => s.trim());
-      // Drop trailing empty segments (an "Add tweet" the user left blank)
-      // but keep interior order intact.
-      while (segs.length > 1 && segs[segs.length - 1] === "") segs.pop();
-
+      // Filter ALL empties (not just trailing) so an emptied interior
+      // tweet can't post a blank that X rejects mid-chain.
+      const segs = segments.map((s) => s.text.trim()).filter(Boolean);
       let posted = 0;
       let prevId: string | undefined;
       for (let i = 0; i < segs.length; i++) {
-        const body: PublishTweetInput = { text: segs[i] };
+        const body: PublishTweetInput = { text: segs[i]! };
         if (i === 0) {
           if (refMode.kind === "reply") body.replyToTweetId = refMode.id;
           if (refMode.kind === "quote") body.quoteTweetId = refMode.id;
         } else {
-          // Chain: each subsequent tweet replies to the previous one's id.
           body.replyToTweetId = prevId;
         }
         try {
           const res = await xApi.publish(body);
           prevId = res.id;
-          posted++;
+          posted += 1;
         } catch (err) {
-          // Partial-thread failure: surface how far we got so the user
-          // isn't left guessing. Re-throw to hit onError.
           const detail =
             segs.length > 1 ? ` (${posted}/${segs.length} posted before this failed)` : "";
           const base = err instanceof ApiError ? err.message : "Failed to publish.";
@@ -399,12 +423,12 @@ export function TweetComposer() {
   );
 
   const scheduleTitle = useMemo(() => {
-    const first = segments[0]?.trim().split(/\r?\n/).find((l) => l.trim().length > 0);
+    const first = segments[0]?.text.trim().split(/\r?\n/).find((l) => l.trim().length > 0);
     return first ? first.slice(0, 120).trim() : undefined;
   }, [segments]);
 
   const schedulerChannels = useMemo(() => {
-    const trimmed = segments.map((s) => s.trim()).filter(Boolean);
+    const trimmed = segments.map((s) => s.text.trim()).filter(Boolean);
     const channelOptions: Record<string, unknown> = {};
     if (refMode.kind === "reply") channelOptions.replyToTweetId = refMode.id;
     if (refMode.kind === "quote") channelOptions.quoteTweetId = refMode.id;
@@ -414,8 +438,7 @@ export function TweetComposer() {
         payload: {
           text: trimmed[0] ?? "",
           // threadParts drives the scheduler's X publisher (posts each
-          // part sequentially). Only set it for an actual thread so a
-          // single tweet schedules as a plain post.
+          // part sequentially). Only set it for an actual thread.
           ...(trimmed.length > 1 ? { threadParts: trimmed } : {}),
           ...(Object.keys(channelOptions).length > 0 ? { channelOptions } : {}),
         },
@@ -472,8 +495,7 @@ export function TweetComposer() {
         run: () => setShowRefs(true),
       },
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [handleAiAction, activeText, scheduleDisabled, refMode.kind, segments.length],
+    [handleAiAction, activeText, scheduleDisabled, refMode.kind, addSegment],
   );
 
   // ── Schedule view ───────────────────────────────────────────────
@@ -543,12 +565,12 @@ export function TweetComposer() {
       {/* Thread segments */}
       <div className="space-y-3">
         {segments.map((seg, index) => {
-          const isActive = index === activeIndex;
+          const isActive = seg.id === activeId;
           return (
             <div
-              key={index}
+              key={seg.id}
               ref={(el) => {
-                wrapRefs.current[index] = el;
+                wrapRefs.current.set(seg.id, el);
               }}
               className={cn(
                 "relative rounded-md border p-2 transition-colors",
@@ -565,7 +587,7 @@ export function TweetComposer() {
                     variant="ghost"
                     size="sm"
                     className="h-6 px-1.5 text-muted-foreground hover:text-destructive"
-                    onClick={() => removeSegment(index)}
+                    onClick={() => removeSegment(seg.id)}
                     aria-label={`Remove tweet ${index + 1}`}
                   >
                     <Trash2 className="size-3.5" />
@@ -574,27 +596,27 @@ export function TweetComposer() {
               )}
               <Textarea
                 ref={(el) => {
-                  textareaRefs.current[index] = el;
+                  textareaRefs.current.set(seg.id, el);
                 }}
-                value={seg}
+                value={seg.text}
                 onChange={(e) => {
-                  updateSegment(index, e.target.value);
-                  captureCaret(index, e.target);
+                  updateSegment(seg.id, e.target.value);
+                  captureCaret(seg.id, e.target);
                 }}
-                onSelect={(e) => captureCaret(index, e.currentTarget)}
-                onClick={(e) => captureCaret(index, e.currentTarget)}
-                onKeyUp={(e) => captureCaret(index, e.currentTarget)}
-                onFocus={(e) => captureCaret(index, e.currentTarget)}
+                onSelect={(e) => captureCaret(seg.id, e.currentTarget)}
+                onClick={(e) => captureCaret(seg.id, e.currentTarget)}
+                onKeyUp={(e) => captureCaret(seg.id, e.currentTarget)}
+                onFocus={(e) => captureCaret(seg.id, e.currentTarget)}
                 // Capture caret on blur so an emoji/AI insert (which blurs
                 // the textarea) lands at the right spot.
-                onBlur={(e) => captureCaret(index, e.currentTarget)}
+                onBlur={(e) => captureCaret(seg.id, e.currentTarget)}
                 placeholder={index === 0 ? "What's happening?" : "Continue the thread…"}
                 rows={index === 0 ? 4 : 3}
                 className="resize-none border-0 bg-transparent p-1 shadow-none focus-visible:ring-0"
                 aria-label={isThread ? `Tweet ${index + 1} text` : "Tweet text"}
               />
               <div className="flex items-center justify-end px-1">
-                <PlatformCharCounter value={seg} platform="x" size="sm" showCount />
+                <PlatformCharCounter value={seg.text} platform="x" size="sm" showCount />
               </div>
             </div>
           );
@@ -606,8 +628,9 @@ export function TweetComposer() {
           targetRef={activeTextareaRef}
           text={activeText}
           caret={caret}
-          onChange={(next) => updateSegment(activeIndex, next)}
+          onChange={(next) => updateSegment(activeId, next)}
           onSearch={searchHashtags}
+          validateTag={isValidXHashtag}
           minQueryLength={2}
         />
       </div>

--- a/src/app/dashboard/content/x/_components/tweet-composer.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-composer.tsx
@@ -214,30 +214,30 @@ export function TweetComposer() {
     requestAnimationFrame(() => textareaRefs.current.get(seg.id)?.focus());
   }, []);
 
-  const removeSegment = useCallback(
-    (id: string) => {
-      setSegments((prev) => {
-        if (prev.length <= 1) return prev;
-        const idx = prev.findIndex((s) => s.id === id);
-        const next = prev.filter((s) => s.id !== id);
-        // If the active segment is the one being removed, move focus to
-        // the previous tweet (or the new first) — tracked by id, so no
-        // index drift when an earlier segment is removed.
-        if (activeIdRef.current === id) {
-          const newActive = next[Math.max(0, idx - 1)] ?? next[0]!;
-          setActiveId(newActive.id);
-          activeIdRef.current = newActive.id;
-          const len = newActive.text.length;
-          setCaret(len);
-          caretRef.current = len;
-        }
-        return next;
-      });
-      textareaRefs.current.delete(id);
-      wrapRefs.current.delete(id);
-    },
-    [],
-  );
+  const removeSegment = useCallback((id: string) => {
+    // Read current segments from the ref (kept in sync by the effect)
+    // so the setSegments updater stays PURE — computing the next active
+    // segment + caret outside it avoids the StrictMode double-invoke
+    // hazard of calling setState / mutating refs inside an updater.
+    const prev = segmentsRef.current;
+    if (prev.length <= 1) return;
+    const idx = prev.findIndex((s) => s.id === id);
+    const next = prev.filter((s) => s.id !== id);
+    setSegments(next);
+    // If the active segment was the one removed, move focus to the
+    // previous tweet (or the new first) — tracked by id, so removing an
+    // earlier segment never drifts the active target.
+    if (activeIdRef.current === id) {
+      const newActive = next[Math.max(0, idx - 1)] ?? next[0]!;
+      setActiveId(newActive.id);
+      activeIdRef.current = newActive.id;
+      const len = newActive.text.length;
+      setCaret(len);
+      caretRef.current = len;
+    }
+    textareaRefs.current.delete(id);
+    wrapRefs.current.delete(id);
+  }, []);
 
   function captureCaret(id: string, el: HTMLTextAreaElement) {
     setActiveId(id);

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -95,3 +95,33 @@ export function updateDraft(draftId: string, input: { text: string; title?: stri
     ...(input.title ? { title: input.title } : {}),
   });
 }
+
+// ── Voice cards (GET /v1/content/voice-cards) ──────────────
+
+/** A cnt_voice_cards doc as served by GET /v1/content/voice-cards.
+ *  Trimmed to the fields the composer's <VoiceCardPreview/> renders —
+ *  the route returns the full doc, we read defensively. */
+export interface VoiceCardDoc {
+  _id?: string;
+  channel?: string;
+  category?: string;
+  voice?: {
+    tone?: string[];
+    signaturePhrases?: string[];
+    avoidPhrases?: string[];
+  };
+  lastGeneratedAt?: string;
+  updatedAt?: string;
+}
+
+/** Fetch voice cards for a channel (+ optional category). Generic
+ *  across composers — LinkedIn has its own richer endpoint, but X /
+ *  Beehiiv / calendar use this one for the informational voice chip.
+ *  (Brand voice is also injected server-side by the rewrite skill, so
+ *  the chip is purely a "here's the voice we're writing in" cue.) */
+export function getVoiceCards(params: { channel?: string; category?: string } = {}) {
+  const query: Record<string, string> = {};
+  if (params.channel) query.channel = params.channel;
+  if (params.category) query.category = params.category;
+  return api.get<VoiceCardDoc[]>("/v1/content/voice-cards", query);
+}


### PR DESCRIPTION
## What
Rewrites the X composer (171 LOC bare textarea → full kit) to match the LinkedIn composer, the gold-standard reference. Closes the headline gap from the handover: X had zero AI, no scheduler, no drafts, no threads.

## Mounts the shared foundation kit
- **AiComposeToolbar** (`platform="x"`, 7 ops via `/v1/content/rewrite`, X-aware length targets)
- **VoiceCardPreview** (`GET /v1/content/voice-cards?channel=x` — informational; voice is also injected server-side by the rewrite skill)
- **EmojiPickerTrigger** (caret-aware via the shared `insertAtCaret`)
- **HashtagSuggest** (X-ASCII tag validator)
- **PlatformCharCounter** (per-tweet 280 ring)
- **DraftSaver** (auto-save to `cnt_drafts`, `channel:"x"`)
- **ComposerCommandPalette**
- **SchedulerComposer** via a compose/schedule mode toggle (mirrors LinkedIn)

## X-specific
- **Thread builder** — multi-segment with per-tweet 280 counter, add/remove. Segments carry **stable ids** (React key + ref maps keyed by id, not index) so removing a middle tweet doesn't mis-associate DOM/caret state.
- **Instant publish** reply-chains each segment to the prior tweet's id (existing publish endpoint); filters empties; reports partial-thread failures.
- **Scheduled threads** pass `payload.threadParts` → the W8 worker's X publisher posts them sequentially (verified it consumes `threadParts`).
- **Reply / quote** reference preserved on the root tweet (carried into `channelOptions` when scheduling).

## Deferred (tracked follow-up)
**Multi-account picker** — X Master Plan **Phase 7 (plan-gated)**; needs a new accounts endpoint + `connectionId` plumbing. Per scope decision, out of this PR; readers keep picking the first connection.

## Verification
- `tsc --noEmit` clean · `eslint` clean
- `next dev` compiles `/dashboard/content/x` → **200**, no runtime errors
- Reviewed (manual + subagent); round-1 fixes (stable ids/C1, active-by-id/H1, empty-tweet filter/H2, X hashtag validator/M1) in a separate commit
- ⚠️ Interactive publish/schedule needs a connected X account — **manual check pending** (no authenticated browser session headless here)

## Depends on
Caret helper + `{text, insert}` rewrite contract (already merged: b2c #236, api #431).

🤖 Generated with [Claude Code](https://claude.com/claude-code)