### PR TITLE
feat(x-feed): Repurpose-this-tweet row action on the Recent tab

### DIFF
--- a/src/app/dashboard/content/x/_components/tweet-card.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-card.tsx
@@ -18,12 +18,26 @@ import {
   Quote,
   BarChart3,
   MoreHorizontal,
+  Sparkles,
+  Loader2,
 } from "lucide-react";
 import { formatDate } from "@/lib/locale";
 import { xApi, type XTweet } from "@/lib/api/x";
 import { ApiError } from "@/lib/api";
 
-export function TweetCard({ tweet }: { tweet: XTweet }) {
+export interface TweetCardProps {
+  tweet: XTweet;
+  /** Repurpose this tweet to other platforms. The host (X page) creates
+   *  a draft from the tweet text and opens the RepurposeSheet; the card
+   *  just signals intent + reflects the in-flight state. Omitted = the
+   *  Repurpose action is hidden (e.g. a surface without the sheet). */
+  onRepurpose?: (tweet: XTweet) => void;
+  /** True while the host is preparing this tweet's repurpose (draft
+   *  create in flight) — disables the menu item + shows a spinner. */
+  repurposing?: boolean;
+}
+
+export function TweetCard({ tweet, onRepurpose, repurposing }: TweetCardProps) {
   const queryClient = useQueryClient();
   const del = useMutation({
     mutationFn: () => xApi.deleteTweet(tweet.id),
@@ -51,6 +65,20 @@ export function TweetCard({ tweet }: { tweet: XTweet }) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              {onRepurpose && (
+                <DropdownMenuItem
+                  onSelect={() => onRepurpose(tweet)}
+                  disabled={repurposing}
+                  className="gap-2"
+                >
+                  {repurposing ? (
+                    <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+                  ) : (
+                    <Sparkles className="size-3.5" />
+                  )}
+                  Repurpose to other platforms
+                </DropdownMenuItem>
+              )}
               <ConfirmDialog
                 trigger={
                   <DropdownMenuItem

--- a/src/app/dashboard/content/x/page.tsx
+++ b/src/app/dashboard/content/x/page.tsx
@@ -232,7 +232,12 @@ function XContentDashboardInner() {
                 <TweetCard
                   key={t.id}
                   tweet={t}
-                  onRepurpose={(tweet) => prepareRepurpose.mutate(tweet)}
+                  onRepurpose={(tweet) => {
+                    // Ignore a second click while a prepare is already in
+                    // flight — avoids creating an orphan draft from a
+                    // rapid click on another card before the first lands.
+                    if (!prepareRepurpose.isPending) prepareRepurpose.mutate(tweet);
+                  }}
                   repurposing={repurposingId === t.id}
                 />
               ))}

--- a/src/app/dashboard/content/x/page.tsx
+++ b/src/app/dashboard/content/x/page.tsx
@@ -2,8 +2,9 @@
 
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -11,6 +12,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { MessageCircle, Send, Inbox, MessageSquare, RefreshCw } from "lucide-react";
 import { xApi, type XTweet } from "@/lib/api/x";
+import { createDraft } from "@/lib/api/content";
+import { RepurposeSheet } from "@/components/repurpose/repurpose-sheet";
+import type { RepurposeSource } from "@/lib/api/repurpose";
 import { TweetComposer } from "./_components/tweet-composer";
 import { TweetCard } from "./_components/tweet-card";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
@@ -80,6 +84,30 @@ function XContentDashboardInner() {
     queryKey: ["x-tweets", RECENT_TWEET_COUNT],
     queryFn: () => xApi.listTweets(RECENT_TWEET_COUNT),
     enabled: isConnected,
+  });
+
+  // ── Repurpose-this-tweet ────────────────────────────────────────
+  // The repurpose engine is draft-keyed, so we persist the tweet text
+  // as a cnt_drafts row first, then open the shared RepurposeSheet with
+  // a {type:"draft"} source — reusing the proven path with no engine
+  // change. `repurposeSource` drives the sheet's open state; the
+  // in-flight tweet id disables that card's menu item while the draft
+  // is created.
+  const [repurposeSource, setRepurposeSource] = useState<RepurposeSource | null>(null);
+  const [repurposingId, setRepurposingId] = useState<string | null>(null);
+  const prepareRepurpose = useMutation({
+    mutationFn: (tweet: XTweet) =>
+      createDraft({ text: tweet.text, channel: "x" }),
+    onMutate: (tweet: XTweet) => setRepurposingId(tweet.id),
+    onSuccess: (ref) => {
+      setRepurposeSource({ type: "draft", draftId: ref.draftId });
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof ApiError ? err.message : "Couldn't prepare this tweet for repurposing.";
+      toast.error(message);
+    },
+    onSettled: () => setRepurposingId(null),
   });
 
   const stats = useMemo(() => {
@@ -201,7 +229,12 @@ function XContentDashboardInner() {
           ) : (
             <div className="space-y-3">
               {(tweets.data ?? []).map((t: XTweet) => (
-                <TweetCard key={t.id} tweet={t} />
+                <TweetCard
+                  key={t.id}
+                  tweet={t}
+                  onRepurpose={(tweet) => prepareRepurpose.mutate(tweet)}
+                  repurposing={repurposingId === t.id}
+                />
               ))}
             </div>
           )}
@@ -211,6 +244,14 @@ function XContentDashboardInner() {
           <MentionsList />
         </TabsContent>
       </Tabs>
+
+      <RepurposeSheet
+        open={repurposeSource !== null}
+        onOpenChange={(o) => {
+          if (!o) setRepurposeSource(null);
+        }}
+        source={repurposeSource}
+      />
     </PageShell>
   );
 }


### PR DESCRIPTION
## What
The X **Recent** tab was delete-only. Adds a **"Repurpose to other platforms"** action to each tweet card → opens the shared `RepurposeSheet`, closing the repurpose-from-X loop the X Master Plan calls for.

## How (no engine/API change)
Reuses the proven **draft-keyed** repurpose path: the tweet text is persisted as a `cnt_drafts` row (`channel:"x"`), then the sheet opens with a `{type:"draft"}` source. Verified end-to-end against the API — `loadContentSource` reads `plainText` (exactly what `createDraft` writes), with no status filter, so a just-created draft is immediately repurposable.

- `tweet-card.tsx`: optional `onRepurpose(tweet)` + `repurposing` props; menu item hidden when no handler (card stays reusable). In-flight tweet shows a spinner + is disabled.
- `page.tsx`: lifts `repurposeSource` state, `createDraft` mutation (onMutate/onSettled track the in-flight id), mounts `RepurposeSheet` (referentially-stable source while open). A second click while a prepare is in flight is ignored (no orphan draft). Failures → friendly toast (no provider strings; this path has no AI call).

## Scope note (deliberate)
This is the **highest-value slice** of "X feed depth." **Reply** already exists (reply-drawer). **Live-timeline pagination + filters** are deferred to a tracked follow-up — they need an infinite-query refactor of the stats/refresh-metrics path + a breaking `/tweets` response-shape change, which is lower value than the repurpose loop.

## Verification
- `tsc --noEmit` clean · `eslint` clean
- `next dev` compiles `/dashboard/content/x` → **200**, no errors
- Reviewed (manual + subagent): ship-ready, no bugs; review hardening (double-prepare guard) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)