### PR TITLE
feat(calendar): "+ Compose new" entry point (buildout #6)

### DIFF
--- a/src/app/dashboard/calendar/_components/compose-new-sheet.tsx
+++ b/src/app/dashboard/calendar/_components/compose-new-sheet.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import { ArrowLeft } from "lucide-react";
+import {
+  PostComposer,
+  PostComposerSkeleton,
+  useLinkedInIdentity,
+} from "@/app/dashboard/content/linkedin/_components/post-composer";
+import { TweetComposer } from "@/app/dashboard/content/x/_components/tweet-composer";
+
+/**
+ * <ComposeNewSheet/> — the "create from scratch" entry point that
+ * existed nowhere before: a calendar-header CTA that opens a Sheet to
+ * pick a platform and compose a brand-new post (publish now OR schedule)
+ * without first having a draft/idea/repurpose source.
+ *
+ * It delegates entirely to the per-platform composers shipped earlier
+ * (LinkedIn PostComposer, X TweetComposer) — each already bundles the
+ * AI toolbar, emoji/hashtag primitives, AND a compose/schedule toggle
+ * (<SchedulerComposer/>), so "schedule" is always available here with
+ * no extra wiring. When the Beehiiv composer lands (buildout #5) it
+ * slots into the picker the same way.
+ *
+ * On schedule, each composer invalidates the ["scheduler:items"] query
+ * the calendar subscribes to, so the grid behind the sheet refreshes
+ * live. The composer resets itself after publish/schedule; the user
+ * closes the sheet when done (auto-close-on-success is a follow-up —
+ * it needs the composers to expose a completion callback).
+ */
+
+type Platform = "linkedin" | "x";
+
+const PLATFORMS: { value: Platform; label: string; blurb: string }[] = [
+  { value: "linkedin", label: "LinkedIn", blurb: "Personal feed or a company page" },
+  { value: "x", label: "X (Twitter)", blurb: "A single tweet or a thread" },
+];
+
+export interface ComposeNewSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ComposeNewSheet({ open, onOpenChange }: ComposeNewSheetProps) {
+  const [platform, setPlatform] = useState<Platform | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    // Reset the platform choice whenever the sheet closes so the next
+    // open starts at the picker.
+    if (!next) setPlatform(null);
+    onOpenChange(next);
+  }
+
+  const activeLabel = PLATFORMS.find((p) => p.value === platform)?.label;
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto p-0 sm:max-w-2xl">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle className="text-base">
+            {platform ? `Compose for ${activeLabel}` : "Compose new"}
+          </SheetTitle>
+          <SheetDescription className="text-xs">
+            {platform
+              ? "Write your post, then publish now or schedule it for later."
+              : "Pick a channel to start a brand-new post."}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 px-6 py-4">
+          {!platform ? (
+            <ul className="space-y-2">
+              {PLATFORMS.map((p) => (
+                <li key={p.value}>
+                  <button
+                    type="button"
+                    onClick={() => setPlatform(p.value)}
+                    className="flex w-full items-center gap-3 rounded-md border bg-card p-3 text-left transition-colors hover:bg-muted/40"
+                  >
+                    <ChannelIconCompact channel={p.value} size={18} />
+                    <span className="flex flex-col">
+                      <span className="text-sm font-medium">{p.label}</span>
+                      <span className="text-xs text-muted-foreground">{p.blurb}</span>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="space-y-3">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setPlatform(null)}
+                className="gap-1.5"
+              >
+                <ArrowLeft className="size-3.5" /> Change channel
+              </Button>
+              {platform === "linkedin" ? <LinkedInCompose /> : <TweetComposer />}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/** LinkedIn branch — fetches the identity the PostComposer needs and
+ *  renders the appropriate gate (loading / not-connected / composer). */
+function LinkedInCompose() {
+  const identity = useLinkedInIdentity();
+
+  if (identity.isLoading) {
+    return <PostComposerSkeleton />;
+  }
+  if (!identity.data) {
+    return (
+      <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+        Connect LinkedIn to compose here.{" "}
+        <a
+          href="/dashboard/integrations"
+          className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+        >
+          Manage integrations
+        </a>
+        .
+      </div>
+    );
+  }
+  return <PostComposer identity={identity.data} />;
+}

--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -35,6 +35,7 @@ import {
   CalendarDays,
   CalendarRange,
   RefreshCw,
+  Plus,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -54,6 +55,7 @@ import type {
   ScheduledItemStatus,
 } from "@/lib/scheduler/types";
 import { CalendarItemDrawer } from "./_components/calendar-item-drawer";
+import { ComposeNewSheet } from "./_components/compose-new-sheet";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 
 type Mode = "week" | "month";
@@ -146,6 +148,7 @@ export default function CalendarPage() {
   // two queries.
   const [tz, setTz] = useState("UTC");
   const [anchor, setAnchor] = useState<Date | null>(null);
+  const [composeOpen, setComposeOpen] = useState(false);
   useEffect(() => {
     setTz(detectTimezone());
     setAnchor(new Date());
@@ -461,8 +464,17 @@ export default function CalendarPage() {
               className={cn("h-3.5 w-3.5", isFetching && "animate-spin")}
             />
           </Button>
+          <Button
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => setComposeOpen(true)}
+          >
+            <Plus className="h-3.5 w-3.5" /> Compose
+          </Button>
         </div>
       </div>
+
+      <ComposeNewSheet open={composeOpen} onOpenChange={setComposeOpen} />
 
       {/* Date navigation */}
       <div className="flex flex-wrap items-center justify-between gap-2">


### PR DESCRIPTION
## What
Adds the **create-from-scratch** path that existed nowhere: a calendar-header **"Compose"** CTA → Sheet → pick a channel → compose a brand-new post (**publish now or schedule**) without first needing a draft/idea/repurpose source.

## How
Delegates entirely to the per-platform composers shipped earlier (LinkedIn `PostComposer`, X `TweetComposer`). Each already bundles the AI toolbar + emoji/hashtag primitives + a compose/schedule toggle (`<SchedulerComposer/>`), so scheduling works here with **zero extra wiring**. On schedule, the composers invalidate `["scheduler:items"]` — the query the calendar subscribes to — so the grid refreshes live behind the sheet. Beehiiv slots into the picker the same way once buildout #5 lands.

- `compose-new-sheet.tsx`: platform picker → per-platform composer; LinkedIn branch fetches identity (`useLinkedInIdentity`) and gates on loading / not-connected / ready. The identity query is **lazy** (fires only when the LinkedIn branch mounts).
- `calendar/page.tsx`: `composeOpen` state + header CTA + sheet mount.

## Notes
- Composers are **route-portable** (no `useParams`/route-scoped provider deps; rely only on the shared dashboard layout + global QueryClient) — verified no circular import.
- Auto-close-on-success deferred (needs composers to expose a completion callback); composer resets after publish/schedule, user closes the sheet.

## Verification
- `tsc --noEmit` clean · `eslint` clean
- `next dev` compiles `/dashboard/calendar` → **200**, no runtime/circular-import errors
- Reviewed (manual + subagent): clean, no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)