### PR TITLE
feat(composer): extract <ComposerShell> + migrate X, LinkedIn, strategist

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -32,10 +32,8 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import {
-  ArrowLeft,
   CalendarClock,
   ChevronDown,
-  Command as CommandIcon,
   Link2,
   Loader2,
   Mic,
@@ -64,12 +62,12 @@ import { rewriteContent, createDraft, updateDraft, type ComposerDraftRef } from 
 import { insertAtCaret } from "@/lib/composer/caret";
 import {
   AiComposeToolbar,
+  ComposerShell,
   ComposerCommandPalette,
   DraftSaver,
   EmojiPickerTrigger,
   HashtagSuggest,
   PlatformCharCounter,
-  VoiceCardPreview,
   useDraftSaver,
   type AiActionContext,
   type ComposerCommand,
@@ -529,120 +527,153 @@ export function PostComposer({ identity, seedText }: Props) {
   // Early return is AFTER all hooks above — safe.
   if (mode === "schedule") {
     return (
-      <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3 border-b pb-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <CalendarClock className="size-4 text-primary" />
-            Schedule this post
-          </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => setMode("compose")}
-            className="gap-1.5"
-          >
-            <ArrowLeft className="size-3.5" /> Back to editing
-          </Button>
-        </div>
-        <SchedulerComposer
-          key={schedulerSource.sourceTextHash}
-          source={schedulerSource}
-          title={scheduleTitle}
-          channels={schedulerChannels}
-          onScheduled={handleScheduled}
-        />
-      </div>
+      <ComposerShell
+        mode="schedule"
+        scheduleView={{
+          noun: "post",
+          onBack: () => setMode("compose"),
+          scheduler: (
+            <SchedulerComposer
+              key={schedulerSource.sourceTextHash}
+              source={schedulerSource}
+              title={scheduleTitle}
+              channels={schedulerChannels}
+              onScheduled={handleScheduled}
+            />
+          ),
+        }}
+      />
     );
   }
 
   return (
-    <div className="space-y-4">
-      <div className="grid gap-3 sm:grid-cols-2">
-        <div className="space-y-1.5">
-          <Label htmlFor="li-author" className="text-xs uppercase tracking-wide text-muted-foreground">
-            Post as
-          </Label>
-          <Select value={authorKey} onValueChange={setAuthorKey}>
-            <SelectTrigger id="li-author">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {authorOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  <span className="flex flex-col">
-                    <span>{opt.label}</span>
-                    {opt.sublabel && (
-                      <span className="text-xs text-muted-foreground">{opt.sublabel}</span>
-                    )}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {!identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length > 0 && (
-            <p className="text-xs text-muted-foreground">
-              Reconnect LinkedIn to enable posting from your company pages.
-            </p>
-          )}
-          {identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length === 0 && (
-            <p className="text-xs text-muted-foreground">
-              No pages enabled.{" "}
-              <a
-                href="/dashboard/integrations"
-                className="font-medium text-primary underline underline-offset-2 hover:no-underline"
-              >
-                Manage pages
-              </a>
-              .
-            </p>
-          )}
-        </div>
+    <ComposerShell
+      mode="compose"
+      voiceCard={voiceSummary}
+      onOpenPalette={() => setPaletteOpen(true)}
+      headerSlot={
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="li-author" className="text-xs uppercase tracking-wide text-muted-foreground">
+              Post as
+            </Label>
+            <Select value={authorKey} onValueChange={setAuthorKey}>
+              <SelectTrigger id="li-author">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {authorOptions.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    <span className="flex flex-col">
+                      <span>{opt.label}</span>
+                      {opt.sublabel && (
+                        <span className="text-xs text-muted-foreground">{opt.sublabel}</span>
+                      )}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {!identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                Reconnect LinkedIn to enable posting from your company pages.
+              </p>
+            )}
+            {identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                No pages enabled.{" "}
+                <a
+                  href="/dashboard/integrations"
+                  className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                >
+                  Manage pages
+                </a>
+                .
+              </p>
+            )}
+          </div>
 
-        <div className="space-y-1.5">
-          <Label htmlFor="li-visibility" className="text-xs uppercase tracking-wide text-muted-foreground">
-            Visibility
-          </Label>
-          <Select
-            value={effectiveVisibility}
-            onValueChange={(v) => setVisibility(v as LinkedInVisibility)}
-            disabled={isOrgAuthor}
+          <div className="space-y-1.5">
+            <Label htmlFor="li-visibility" className="text-xs uppercase tracking-wide text-muted-foreground">
+              Visibility
+            </Label>
+            <Select
+              value={effectiveVisibility}
+              onValueChange={(v) => setVisibility(v as LinkedInVisibility)}
+              disabled={isOrgAuthor}
+            >
+              <SelectTrigger id="li-visibility">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="PUBLIC">Public — anyone on LinkedIn</SelectItem>
+                <SelectItem value="CONNECTIONS">Connections only</SelectItem>
+                <SelectItem value="LOGGED_IN">Signed-in members</SelectItem>
+              </SelectContent>
+            </Select>
+            {isOrgAuthor && (
+              <p className="text-xs text-muted-foreground">
+                Company page posts are always public.
+              </p>
+            )}
+          </div>
+        </div>
+      }
+      subHeaderSlot={<VoiceCardPanel />}
+      toolbarSlot={<AiComposeToolbar text={text} platform="linkedin" onAiAction={handleAiAction} />}
+      statusSlot={
+        <>
+          <PlatformCharCounter platform="linkedin" value={text} />
+          <DraftSaver
+            status={draftStatus}
+            lastSavedAt={lastSavedAt}
+            lastError={draftError}
+            onRetry={saveNow}
+          />
+        </>
+      }
+      actionsSlot={
+        <>
+          <PolicyChip state={policy} />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setMode("schedule")}
+            disabled={scheduleDisabled}
+            className="gap-1.5"
           >
-            <SelectTrigger id="li-visibility">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="PUBLIC">Public — anyone on LinkedIn</SelectItem>
-              <SelectItem value="CONNECTIONS">Connections only</SelectItem>
-              <SelectItem value="LOGGED_IN">Signed-in members</SelectItem>
-            </SelectContent>
-          </Select>
-          {isOrgAuthor && (
-            <p className="text-xs text-muted-foreground">
-              Company page posts are always public.
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* Voice chip + command palette trigger */}
-      <div className="flex items-center justify-between gap-2">
-        <VoiceCardPreview voiceCard={voiceSummary} />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => setPaletteOpen(true)}
-          className="gap-1.5 text-xs text-muted-foreground"
-        >
-          <CommandIcon className="size-3.5" /> Actions
-        </Button>
-      </div>
-
-      <VoiceCardPanel />
-
-      <AiComposeToolbar text={text} platform="linkedin" onAiAction={handleAiAction} />
-
+            <CalendarClock className="size-4" /> Schedule
+          </Button>
+          <Button onClick={onSubmit} disabled={publishDisabled} aria-busy={publish.isPending}>
+            <Send className="size-4 mr-1.5" />
+            {publish.isPending ? "Publishing…" : "Publish"}
+          </Button>
+        </>
+      }
+      footerSlot={
+        feedback ? (
+          <p
+            role="status"
+            className={
+              feedback.kind === "error"
+                ? "rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+                : "rounded-md border border-green-200 bg-green-50/60 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
+            }
+          >
+            {feedback.message}
+          </p>
+        ) : undefined
+      }
+      paletteSlot={
+        <ComposerCommandPalette
+          paletteId="linkedin-composer"
+          commands={commands}
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
+        />
+      }
+    >
       <div ref={composerWrapRef} className="relative">
         <Textarea
           ref={textareaRef}
@@ -744,55 +775,7 @@ export function PostComposer({ identity, seedText }: Props) {
         </div>
       )}
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <PlatformCharCounter platform="linkedin" value={text} />
-          <DraftSaver
-            status={draftStatus}
-            lastSavedAt={lastSavedAt}
-            lastError={draftError}
-            onRetry={saveNow}
-          />
-        </div>
-        <div className="flex items-center gap-2">
-          <PolicyChip state={policy} />
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setMode("schedule")}
-            disabled={scheduleDisabled}
-            className="gap-1.5"
-          >
-            <CalendarClock className="size-4" /> Schedule
-          </Button>
-          <Button onClick={onSubmit} disabled={publishDisabled} aria-busy={publish.isPending}>
-            <Send className="size-4 mr-1.5" />
-            {publish.isPending ? "Publishing…" : "Publish"}
-          </Button>
-        </div>
-      </div>
-
-      {feedback && (
-        <p
-          role="status"
-          className={
-            feedback.kind === "error"
-              ? "rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
-              : "rounded-md border border-green-200 bg-green-50/60 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
-          }
-        >
-          {feedback.message}
-        </p>
-      )}
-
-      <ComposerCommandPalette
-        paletteId="linkedin-composer"
-        commands={commands}
-        open={paletteOpen}
-        onOpenChange={setPaletteOpen}
-      />
-    </div>
+    </ComposerShell>
   );
 }
 

--- a/src/app/dashboard/content/x/_components/tweet-composer.tsx
+++ b/src/app/dashboard/content/x/_components/tweet-composer.tsx
@@ -14,9 +14,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  ArrowLeft,
   CalendarClock,
-  Command as CommandIcon,
   Loader2,
   Plus,
   Quote,
@@ -39,12 +37,12 @@ import {
 } from "@/lib/api/content";
 import {
   AiComposeToolbar,
+  ComposerShell,
   ComposerCommandPalette,
   DraftSaver,
   EmojiPickerTrigger,
   HashtagSuggest,
   PlatformCharCounter,
-  VoiceCardPreview,
   useDraftSaver,
   type AiActionContext,
   type ComposerCommand,
@@ -501,67 +499,96 @@ export function TweetComposer() {
   // ── Schedule view ───────────────────────────────────────────────
   if (mode === "schedule") {
     return (
-      <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3 border-b pb-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <CalendarClock className="size-4 text-primary" />
-            Schedule this {isThread ? "thread" : "tweet"}
-          </div>
-          <Button type="button" variant="ghost" size="sm" onClick={() => setMode("compose")} className="gap-1.5">
-            <ArrowLeft className="size-3.5" /> Back to editing
-          </Button>
-        </div>
-        <SchedulerComposer
-          key={schedulerSource.sourceTextHash}
-          source={schedulerSource}
-          title={scheduleTitle}
-          channels={schedulerChannels}
-          onScheduled={handleScheduled}
-        />
-      </div>
+      <ComposerShell
+        mode="schedule"
+        scheduleView={{
+          noun: isThread ? "thread" : "tweet",
+          onBack: () => setMode("compose"),
+          scheduler: (
+            <SchedulerComposer
+              key={schedulerSource.sourceTextHash}
+              source={schedulerSource}
+              title={scheduleTitle}
+              channels={schedulerChannels}
+              onScheduled={handleScheduled}
+            />
+          ),
+        }}
+      />
     );
   }
 
   // ── Compose view ────────────────────────────────────────────────
   return (
-    <div className="space-y-4">
-      {/* Voice chip + actions */}
-      <div className="flex items-center justify-between gap-2">
-        <VoiceCardPreview voiceCard={voiceSummary} />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => setPaletteOpen(true)}
-          className="gap-1.5 text-xs text-muted-foreground"
-        >
-          <CommandIcon className="size-3.5" /> Actions
-        </Button>
-      </div>
-
-      {/* Reply/quote reference chip */}
-      {refMode.kind !== "none" && (
-        <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
-          {refMode.kind === "reply" ? <Reply className="size-4" /> : <Quote className="size-4" />}
-          <span className="text-muted-foreground">
-            {refMode.kind === "reply" ? "Replying to" : "Quoting"}
-          </span>
-          <span className="truncate font-mono text-xs">{refMode.raw}</span>
+    <ComposerShell
+      mode="compose"
+      voiceCard={voiceSummary}
+      onOpenPalette={() => setPaletteOpen(true)}
+      subHeaderSlot={
+        refMode.kind !== "none" ? (
+          <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+            {refMode.kind === "reply" ? <Reply className="size-4" /> : <Quote className="size-4" />}
+            <span className="text-muted-foreground">
+              {refMode.kind === "reply" ? "Replying to" : "Quoting"}
+            </span>
+            <span className="truncate font-mono text-xs">{refMode.raw}</span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="ml-auto h-6 px-2"
+              onClick={clearReference}
+              aria-label="Remove reference"
+            >
+              <XIcon className="size-3" />
+            </Button>
+          </div>
+        ) : undefined
+      }
+      toolbarSlot={<AiComposeToolbar text={activeText} platform="x" onAiAction={handleAiAction} />}
+      actionsBordered
+      actionsSlot={
+        <>
           <Button
             type="button"
-            variant="ghost"
+            variant="outline"
             size="sm"
-            className="ml-auto h-6 px-2"
-            onClick={clearReference}
-            aria-label="Remove reference"
+            onClick={() => setMode("schedule")}
+            disabled={scheduleDisabled}
+            className="gap-1.5"
           >
-            <XIcon className="size-3" />
+            <CalendarClock className="size-4" /> Schedule
           </Button>
-        </div>
-      )}
-
-      <AiComposeToolbar text={activeText} platform="x" onAiAction={handleAiAction} />
-
+          <Button onClick={() => publish.mutate()} disabled={publishDisabled} aria-busy={publish.isPending} className="gap-1.5">
+            {publish.isPending ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+            {publish.isPending ? "Publishing…" : isThread ? "Publish thread" : "Publish"}
+          </Button>
+        </>
+      }
+      footerSlot={
+        feedback ? (
+          <p
+            role="status"
+            className={
+              feedback.kind === "error"
+                ? "rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+                : "rounded-md border border-green-200 bg-green-50/60 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
+            }
+          >
+            {feedback.message}
+          </p>
+        ) : undefined
+      }
+      paletteSlot={
+        <ComposerCommandPalette
+          paletteId="x-composer"
+          commands={commands}
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
+          placeholder="Compose, schedule, add to thread…"
+        />
+      }
+    >
       {/* Thread segments */}
       <div className="space-y-3">
         {segments.map((seg, index) => {
@@ -681,45 +708,6 @@ export function TweetComposer() {
           className="ml-auto"
         />
       </div>
-
-      {/* Footer actions */}
-      <div className="flex items-center justify-end gap-2 border-t pt-3">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setMode("schedule")}
-          disabled={scheduleDisabled}
-          className="gap-1.5"
-        >
-          <CalendarClock className="size-4" /> Schedule
-        </Button>
-        <Button onClick={() => publish.mutate()} disabled={publishDisabled} aria-busy={publish.isPending} className="gap-1.5">
-          {publish.isPending ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
-          {publish.isPending ? "Publishing…" : isThread ? "Publish thread" : "Publish"}
-        </Button>
-      </div>
-
-      {feedback && (
-        <p
-          role="status"
-          className={
-            feedback.kind === "error"
-              ? "rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
-              : "rounded-md border border-green-200 bg-green-50/60 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
-          }
-        >
-          {feedback.message}
-        </p>
-      )}
-
-      <ComposerCommandPalette
-        paletteId="x-composer"
-        commands={commands}
-        open={paletteOpen}
-        onOpenChange={setPaletteOpen}
-        placeholder="Compose, schedule, add to thread…"
-      />
-    </div>
+    </ComposerShell>
   );
 }

--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -15,6 +15,7 @@ import { ChannelIcon } from "@/components/ui/channel-icon";
 import { PipelineStatusBadge } from "../components/status-badge";
 import { PipelineStepper, STAGE_PANEL_MAP } from "../components/pipeline-stepper";
 import { RejectReasonDialog } from "@/components/molecules/reject-reason-dialog";
+import { ComposerShell } from "@/components/composer";
 import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
 import type { ScheduleSourceType } from "@/lib/scheduler/types";
 import { sourceTextHash } from "@/lib/scheduler/source-hash";
@@ -1105,7 +1106,13 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
 
   return (
     <div className={citations?.length ? "grid gap-4 lg:grid-cols-[1fr_320px]" : ""}>
-      <div className="space-y-4">
+      {/* Routed through the shared <ComposerShell> for cross-surface
+          consistency. The strategist editor has no voice chip / command
+          palette today, so the shell renders chrome-free (no empty row);
+          its mid-column action row + rail stay as children to preserve
+          the exact current order. When WriteTab is later enhanced with
+          the AI toolbar / voice chip, switch those on via shell props. */}
+      <ComposerShell mode="compose">
         {/* Subject line only for newsletter format. Article / PR /
             advertorial outputs don't carry a subject; their headline
             is in the HTML body already (write_article/pr/advertorial
@@ -1173,7 +1180,7 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
           generatingIndex={generatingPlaceholderIdx}
           resolvingIndex={resolvingPlaceholderIdx}
         />
-      </div>
+      </ComposerShell>
       {citations?.length ? <DataCitationsPanel citations={citations} /> : null}
     </div>
   );

--- a/src/components/composer/composer-shell.tsx
+++ b/src/components/composer/composer-shell.tsx
@@ -174,7 +174,10 @@ export function ComposerShell({
             actionsBordered && "border-t pt-3",
           )}
         >
-          <div className="flex items-center gap-3">{statusSlot}</div>
+          {/* Only render the left cell when there's status content, so a
+              status-less bar (X) collapses to a clean right-aligned row
+              rather than an empty flex child. */}
+          {statusSlot ? <div className="flex items-center gap-3">{statusSlot}</div> : null}
           <div className="flex items-center gap-2">{actionsSlot}</div>
         </div>
       )}

--- a/src/components/composer/composer-shell.tsx
+++ b/src/components/composer/composer-shell.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * <ComposerShell/> — the shared presentational frame every publish/edit
+ * composer mounts so the platform looks uniform (X, LinkedIn, and the
+ * strategist WriteTab today; Beehiiv/calendar later).
+ *
+ * It is a LAYOUT FRAME, not a controller: it owns NO state, no hooks,
+ * no network, no scheduler wiring. Each host keeps its own state and
+ * passes its platform-specific UI in as slots. This is deliberate — it
+ * means adopting the shell cannot change a composer's behavior, only
+ * its surrounding chrome + spacing.
+ *
+ * What the shell renders itself (the only thing it owns):
+ *   - the `space-y-4` outer column,
+ *   - the schedule-mode wrapper (the "Schedule this {noun}" header +
+ *     "Back to editing" button, then the host's <SchedulerComposer/>),
+ *   - the TOP CHROME row (voice-card chip + "Actions" command-palette
+ *     trigger) — OPTIONAL: omitted entirely when a surface passes
+ *     neither `voiceCard` nor `onOpenPalette` (e.g. the strategist
+ *     editor, which has no voice chip / palette — so no empty row is
+ *     ever rendered),
+ *   - the bottom action-bar wrapper (statusSlot left, actionsSlot
+ *     right) — border-less so a host can bring its own divider.
+ *
+ * Everything platform-specific (textareas, thread builder, author
+ * pickers, policy chip, image rail, the actual action <Button>s,
+ * DraftSaver, char counter, emoji trigger, command palette node) is a
+ * slot — rendered by the host so its wiring is untouched.
+ */
+
+import type { ReactNode } from "react";
+import { ArrowLeft, CalendarClock, Command as CommandIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { VoiceCardPreview } from "./voice-card-preview";
+import type { VoiceCardSummary } from "./types";
+
+/** Schedule-mode config. When `mode === "schedule"` the shell renders
+ *  the shared header + the host-provided scheduler node and ignores
+ *  every other slot. The host still owns <SchedulerComposer/> (its
+ *  props, its `key` remount, its onScheduled) and passes it in. */
+export interface ComposerScheduleView {
+  /** Noun for the header copy: "post" | "tweet" | "thread" | … */
+  noun: string;
+  /** Host-rendered <SchedulerComposer/> (keyed + wired by the host). */
+  scheduler: ReactNode;
+  /** Return to compose mode. */
+  onBack: () => void;
+}
+
+export interface ComposerShellProps {
+  /** "compose" renders chrome + body; "schedule" renders scheduleView. */
+  mode: "compose" | "schedule";
+  /** Required when mode === "schedule". */
+  scheduleView?: ComposerScheduleView;
+
+  // ── TOP CHROME (optional; shell renders the row when present) ──────
+  /** Voice-card chip summary. When BOTH this and `onOpenPalette` are
+   *  omitted, the shell renders NO chrome row at all. */
+  voiceCard?: VoiceCardSummary | null;
+  /** Opens the command palette (shell renders the "Actions" button).
+   *  Omit (with voiceCard) to drop the chrome row entirely. */
+  onOpenPalette?: () => void;
+  /** Controls rendered ABOVE the chrome row (e.g. LinkedIn's author +
+   *  visibility grid). Pure passthrough. */
+  headerSlot?: ReactNode;
+  /** Rendered BETWEEN the chrome row and the toolbar (e.g. X's
+   *  reply/quote reference chip; LinkedIn's VoiceCardPanel) so slot
+   *  order matches the pre-shell layout exactly. */
+  subHeaderSlot?: ReactNode;
+  /** The AI compose toolbar (host-owned — it holds the text + handler).
+   *  Shell slots it directly under the chrome so spacing is uniform. */
+  toolbarSlot?: ReactNode;
+
+  // ── BODY (host-owned editable surface) ────────────────────────────
+  /** The editable body. Optional because schedule mode renders only
+   *  the scheduler, not the body. */
+  children?: ReactNode;
+
+  // ── BOTTOM CHROME ─────────────────────────────────────────────────
+  /** Left of the action bar: char counter + draft-saver (host renders;
+   *  shell only positions). Omit when a host has none. */
+  statusSlot?: ReactNode;
+  /** Right of the action bar: the primary action buttons (Schedule/
+   *  Publish, or Save/Regenerate/Finalize). Host renders the real
+   *  <Button>s so every handler / disabled / aria-busy is unchanged. */
+  actionsSlot?: ReactNode;
+  /** Inline feedback banner under the action bar (host renders). */
+  footerSlot?: ReactNode;
+  /** Command-palette node (host renders; shell places it last). */
+  paletteSlot?: ReactNode;
+  /** Draw a top divider above the action bar (X's `border-t pt-3`
+   *  footer-actions look). Off by default (LinkedIn groups its
+   *  counter+saver into statusSlot with no divider). */
+  actionsBordered?: boolean;
+
+  className?: string;
+}
+
+export function ComposerShell({
+  mode,
+  scheduleView,
+  voiceCard,
+  onOpenPalette,
+  headerSlot,
+  subHeaderSlot,
+  toolbarSlot,
+  children,
+  statusSlot,
+  actionsSlot,
+  footerSlot,
+  paletteSlot,
+  actionsBordered,
+  className,
+}: ComposerShellProps) {
+  // ── Schedule view ───────────────────────────────────────────────
+  if (mode === "schedule" && scheduleView) {
+    return (
+      <div className={cn("space-y-4", className)}>
+        <div className="flex items-center justify-between gap-3 border-b pb-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <CalendarClock className="size-4 text-primary" />
+            Schedule this {scheduleView.noun}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={scheduleView.onBack}
+            className="gap-1.5"
+          >
+            <ArrowLeft className="size-3.5" /> Back to editing
+          </Button>
+        </div>
+        {scheduleView.scheduler}
+      </div>
+    );
+  }
+
+  // ── Compose view ────────────────────────────────────────────────
+  const showChrome = voiceCard !== undefined || !!onOpenPalette;
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      {headerSlot}
+
+      {showChrome && (
+        <div className="flex items-center justify-between gap-2">
+          <VoiceCardPreview voiceCard={voiceCard} />
+          {onOpenPalette && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onOpenPalette}
+              className="gap-1.5 text-xs text-muted-foreground"
+            >
+              <CommandIcon className="size-3.5" /> Actions
+            </Button>
+          )}
+        </div>
+      )}
+
+      {subHeaderSlot}
+      {toolbarSlot}
+
+      {children}
+
+      {(statusSlot || actionsSlot) && (
+        <div
+          className={cn(
+            "flex flex-wrap items-center justify-between gap-3",
+            actionsBordered && "border-t pt-3",
+          )}
+        >
+          <div className="flex items-center gap-3">{statusSlot}</div>
+          <div className="flex items-center gap-2">{actionsSlot}</div>
+        </div>
+      )}
+
+      {footerSlot}
+      {paletteSlot}
+    </div>
+  );
+}

--- a/src/components/composer/index.ts
+++ b/src/components/composer/index.ts
@@ -17,6 +17,9 @@
 export { AiComposeToolbar } from "./ai-compose-toolbar";
 export type { AiComposeToolbarProps } from "./ai-compose-toolbar";
 
+export { ComposerShell } from "./composer-shell";
+export type { ComposerShellProps, ComposerScheduleView } from "./composer-shell";
+
 export { ComposerCommandPalette } from "./composer-command-palette";
 export type {
   ComposerCommandPaletteProps,


### PR DESCRIPTION
## What

Extracts a reusable **`<ComposerShell>`** so every publish/edit composer shares uniform chrome (Prashant's consistency thesis), and migrates all three surfaces onto it: **X**, **LinkedIn**, and the **strategist WriteTab**.

## The shell (`src/components/composer/composer-shell.tsx`)

A **presentational frame** — owns NO state, hooks, network, or scheduler wiring. It renders only:
- the `space-y-4` outer column,
- the **schedule-mode wrapper** ("Schedule this {noun}" header + "Back to editing" + the host's `<SchedulerComposer/>`),
- an **OPTIONAL top chrome row** (`VoiceCardPreview` chip + "Actions" palette trigger) — omitted entirely when a surface passes neither `voiceCard` nor `onOpenPalette` (so the strategist gets **no empty row**),
- the **bottom action-bar positioning** (`statusSlot` left, `actionsSlot` right; optional `actionsBordered` for X's `border-t`).

Everything platform-specific (textareas, thread builder, author/visibility, policy chip, image rail, action buttons, DraftSaver, char counter, emoji, command palette) is a host-rendered **slot** → behavior is provably unchanged.

## Migrations (zero behavior change)

- **X** + **LinkedIn**: schedule/compose returns moved onto the shell, each region mapped to the matching slot (`headerSlot`, `subHeaderSlot` preserving ref-chip / VoiceCardPanel order, `toolbarSlot`, `statusSlot`, `actionsSlot`, `footerSlot`, `paletteSlot`). HashtagSuggest + its `containerRef`, X's segment refs + caret/insertSnippet, and the `SchedulerComposer key={…sourceTextHash}` remount all stay inside children/slots untouched. Pruned now-unused imports.
- **Strategist WriteTab**: routed through `<ComposerShell mode="compose">` **chrome-free** — its mid-column Save/Regenerate/Finalize row + ImagePlaceholderRail stay as children to preserve exact order, so it's **DOM-identical** to before; it just shares the frame so a future AI-toolbar/voice-chip enhancement flips on via props.

## Risk + test

- Both X (#237) and LinkedIn (#233) shipped this week — this is a refactor of just-shipped code, so regression was the review focus.
- `tsc --noEmit` + `eslint` clean.
- **Review #1** (manual + subagent): diffed each composer against master; verdict "1:1 faithful extraction, zero behavior change" — no issues at any severity. Review #2 to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
