### PR TITLE
feat(strategist): newsletter AI toolbar + voice chip + auto-save; fix emoji picker (all composers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "emoji-picker-react": "^4.19.1",
         "isomorphic-dompurify": "^3.15.0",
         "lucide-react": "^1.17.0",
         "next": "^16.2.4",
@@ -7200,6 +7201,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.19.1.tgz",
+      "integrity": "sha512-BmDdqInKFVYJpv7qS9WI6L9656cDAC+FkDvUjJds56nKHbaVTBNeDmLwKBytRnzu37zWHs9Isg7gt5PT43y6xA==",
+      "license": "MIT",
+      "dependencies": {
+        "flairup": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -8669,6 +8685,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -14747,6 +14769,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "emoji-picker-react": "^4.19.1",
     "isomorphic-dompurify": "^3.15.0",
     "lucide-react": "^1.17.0",
     "next": "^16.2.4",

--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import { useParams, useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -15,7 +15,21 @@ import { ChannelIcon } from "@/components/ui/channel-icon";
 import { PipelineStatusBadge } from "../components/status-badge";
 import { PipelineStepper, STAGE_PANEL_MAP } from "../components/pipeline-stepper";
 import { RejectReasonDialog } from "@/components/molecules/reject-reason-dialog";
-import { ComposerShell } from "@/components/composer";
+import {
+  ComposerShell,
+  AiComposeToolbar,
+  EmojiPickerTrigger,
+  DraftSaver,
+  useDraftSaver,
+  type AiActionContext,
+  type VoiceCardSummary,
+} from "@/components/composer";
+import {
+  getVoiceCards,
+  rewriteContent,
+  type VoiceCardDoc,
+} from "@/lib/api/content";
+import { insertAtCaret } from "@/lib/composer/caret";
 import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
 import type { ScheduleSourceType } from "@/lib/scheduler/types";
 import { sourceTextHash } from "@/lib/scheduler/source-hash";
@@ -942,6 +956,38 @@ function FinalizeButton({
   );
 }
 
+/** Map a newsletter voice-card doc to the composer chip summary. */
+function mapNewsletterVoiceCard(cards: VoiceCardDoc[] | undefined): VoiceCardSummary | null {
+  if (!cards || cards.length === 0) return null;
+  const card = cards[0];
+  return {
+    id: card._id ?? "newsletter-voice",
+    // VoiceCardSummary.channel is a PlatformKey; the newsletter platform
+    // key is "beehiiv" (the cnt_voice_cards.channel scope "newsletter" is
+    // the query param, not this display key).
+    channel: "beehiiv",
+    category: card.category,
+    toneAdjectives: card.voice?.tone ?? [],
+    signaturePhrases: card.voice?.signaturePhrases ?? [],
+    avoidPhrases: card.voice?.avoidPhrases ?? [],
+    refreshedAt: card.lastGeneratedAt ?? card.updatedAt,
+  };
+}
+
+/** Success-toast copy per AI op (newsletter-flavoured). */
+function aiOpToast(op: AiActionContext["op"]): string {
+  switch (op) {
+    case "compose": return "Draft generated.";
+    case "redraft": return "Newsletter rewritten.";
+    case "shorten": return "Newsletter shortened.";
+    case "lengthen": return "Newsletter expanded.";
+    case "tone": return "Tone updated.";
+    case "quote": return "Quote inserted.";
+    case "disclosure": return "Disclosure inserted.";
+    default: return "Done.";
+  }
+}
+
 function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: string; onRefresh: () => void }) {
   const [html, setHtml] = useState(idea.content?.html || "");
   const [subject, setSubject] = useState(idea.content?.subject || "");
@@ -961,6 +1007,97 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
   const [generatingPlaceholderIdx, setGeneratingPlaceholderIdx] = useState<number | null>(null);
   // Per-placeholder resolution busy index (paste-URL / library pick).
   const [resolvingPlaceholderIdx, setResolvingPlaceholderIdx] = useState<number | null>(null);
+
+  // ── Shared composer chrome (parity with LinkedIn/X) ─────────────
+  // The HTML body textarea + a caret tracked on every selection change
+  // and on blur — emoji / AI-insert ops splice at this caret (the
+  // popover/toolbar steals focus, so a live selectionStart read would
+  // fall back to 0/end; capturing on blur is the fix the kit uses).
+  const htmlRef = useRef<HTMLTextAreaElement>(null);
+  const [caret, setCaret] = useState(0);
+  const updateCaret = useCallback(() => {
+    const el = htmlRef.current;
+    if (el) setCaret(el.selectionStart ?? el.value.length);
+  }, []);
+
+  // Voice-card chip — newsletter category, matched like the other
+  // composers. Read-only display; the rewrite skill pulls the live
+  // brand voice server-side.
+  const voiceCardQuery = useQuery({
+    queryKey: ["voice-cards", "newsletter", idea.contentFormat ?? "newsletter"],
+    queryFn: () => getVoiceCards({ channel: "newsletter" }),
+    staleTime: 300_000,
+  });
+  const voiceSummary = useMemo(
+    () => mapNewsletterVoiceCard(voiceCardQuery.data),
+    [voiceCardQuery.data],
+  );
+
+  // Insert a snippet (emoji glyph or AI quote/disclosure) at the tracked
+  // caret in the HTML body, then restore focus + selection. Returns the
+  // new body so callers can chain. Mirrors LinkedIn/X insertSnippet.
+  const insertSnippet = useCallback(
+    (snippet: string): string => {
+      const { text: next, caret: nextCaret } = insertAtCaret(html, caret, snippet);
+      setHtml(next);
+      setCaret(nextCaret);
+      requestAnimationFrame(() => {
+        const el = htmlRef.current;
+        if (el) {
+          el.focus();
+          el.setSelectionRange(nextCaret, nextCaret);
+        }
+      });
+      return next;
+    },
+    [html, caret],
+  );
+
+  // AI compose toolbar handler. format:"html" so the rewrite skill
+  // preserves the newsletter body's semantic structure instead of
+  // flattening it to prose. Replace ops swap the whole body; insert
+  // ops (quote/disclosure) splice a plain-text snippet at the caret.
+  const handleAiAction = useCallback(
+    async (ctx: AiActionContext): Promise<string> => {
+      const res = await rewriteContent({
+        op: ctx.op,
+        text: ctx.text,
+        platform: "beehiiv",
+        format: "html",
+        ...(ctx.extras ? { extras: ctx.extras } : {}),
+      });
+      let newText: string;
+      if (res.insert === true) {
+        newText = insertSnippet(res.text);
+      } else {
+        newText = res.text;
+        setHtml(newText);
+      }
+      toast.success(aiOpToast(ctx.op));
+      return newText;
+    },
+    [insertSnippet],
+  );
+
+  // Auto-save the in-progress body to the idea's content. Suspended once
+  // the text is finalized (the finalize stamp locks editing) and while
+  // there's no body yet. Debounced 2s — same cadence as the publish
+  // composers. The manual Save button stays as an explicit affordance.
+  const finalizedForSave = !!(idea.content as { textFinalizedAt?: string } | undefined)?.textFinalizedAt;
+  const autoSaveValue = finalizedForSave ? null : html;
+  const saveBody = useCallback(
+    async (value: string) => {
+      await api.put(`/v1/content/ideas/${ideaId}/content`, { html: value, subject });
+    },
+    [ideaId, subject],
+  );
+  const {
+    status: draftStatus,
+    lastSavedAt,
+    lastError: draftError,
+    saveNow,
+  } = useDraftSaver<string>({ value: autoSaveValue, save: saveBody });
+
   if (idea.content?.html && idea.content.html !== lastSyncedHtml) {
     setLastSyncedHtml(idea.content.html);
     setHtml(idea.content.html);
@@ -1107,12 +1244,26 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
   return (
     <div className={citations?.length ? "grid gap-4 lg:grid-cols-[1fr_320px]" : ""}>
       {/* Routed through the shared <ComposerShell> for cross-surface
-          consistency. The strategist editor has no voice chip / command
-          palette today, so the shell renders chrome-free (no empty row);
-          its mid-column action row + rail stay as children to preserve
-          the exact current order. When WriteTab is later enhanced with
-          the AI toolbar / voice chip, switch those on via shell props. */}
-      <ComposerShell mode="compose">
+          consistency with LinkedIn / X. Voice chip + AI toolbar mounted;
+          the AI toolbar is gated to Edit mode (it operates on the HTML
+          body, which Preview doesn't expose for editing) and suppressed
+          once the text is finalized. format:"html" keeps the rewrite
+          from flattening the newsletter's semantic structure. The
+          mid-column Save/Regenerate/Finalize row + image rail stay as
+          children to preserve the existing order. */}
+      <ComposerShell
+        mode="compose"
+        voiceCard={voiceSummary}
+        toolbarSlot={
+          !preview && !finalized ? (
+            <AiComposeToolbar
+              text={html}
+              platform="beehiiv"
+              onAiAction={handleAiAction}
+            />
+          ) : undefined
+        }
+      >
         {/* Subject line only for newsletter format. Article / PR /
             advertorial outputs don't carry a subject; their headline
             is in the HTML body already (write_article/pr/advertorial
@@ -1155,7 +1306,22 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
               dangerouslySetInnerHTML={{ __html: sanitizeContentHtml(html) }}
             />
           ) : (
-            <textarea value={html} onChange={(e) => setHtml(e.target.value)} rows={20} className="w-full rounded-md border bg-background p-4 font-mono text-sm outline-none focus:ring-1 focus:ring-ring" placeholder="Newsletter content (HTML)..." />
+            <textarea
+              ref={htmlRef}
+              value={html}
+              onChange={(e) => { setHtml(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length); }}
+              onSelect={updateCaret}
+              onClick={updateCaret}
+              onKeyUp={updateCaret}
+              // Capture caret on blur too — the emoji popover / AI insert
+              // buttons steal focus, and selectionStart still holds the
+              // last position at blur time. Without this an insert lands
+              // at 0/end (the kit-wide emoji bug).
+              onBlur={updateCaret}
+              rows={20}
+              className="w-full rounded-md border bg-background p-4 font-mono text-sm outline-none focus:ring-1 focus:ring-ring"
+              placeholder="Newsletter content (HTML)..."
+            />
           )}
         </div>
         <div className="flex flex-wrap gap-2 items-center">
@@ -1166,6 +1332,17 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
             {generating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Sparkles className="mr-1.5 h-4 w-4" />}
             Regenerate
           </Button>
+          {/* Emoji insert — only in Edit mode (operates on the textarea
+              caret) and before finalize. */}
+          {!preview && !finalized && <EmojiPickerTrigger onInsert={insertSnippet} />}
+          {/* Auto-save status pill — sits next to the manual Save so the
+              user sees the debounced save land. */}
+          <DraftSaver
+            status={draftStatus}
+            lastSavedAt={lastSavedAt}
+            lastError={draftError}
+            onRetry={saveNow}
+          />
           <div className="ml-auto">
             <FinalizeButton finalized={finalized} busy={saving} onFinalize={handleFinalize} />
           </div>

--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -1014,17 +1014,22 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
   // popover/toolbar steals focus, so a live selectionStart read would
   // fall back to 0/end; capturing on blur is the fix the kit uses).
   const htmlRef = useRef<HTMLTextAreaElement>(null);
-  const [caret, setCaret] = useState(0);
+  // Caret lives in a ref only (no state): the textarea is controlled by
+  // `value={html}`, not the caret, and insertSnippet reads the freshest
+  // position off the live element (falling back to this ref when the
+  // textarea isn't focused). A state caret would just be an unused
+  // re-render. Captured on select/click/keyup/blur via updateCaret.
+  const caretRef = useRef(0);
   const updateCaret = useCallback(() => {
     const el = htmlRef.current;
-    if (el) setCaret(el.selectionStart ?? el.value.length);
+    if (el) caretRef.current = el.selectionStart ?? el.value.length;
   }, []);
 
   // Voice-card chip — newsletter category, matched like the other
   // composers. Read-only display; the rewrite skill pulls the live
   // brand voice server-side.
   const voiceCardQuery = useQuery({
-    queryKey: ["voice-cards", "newsletter", idea.contentFormat ?? "newsletter"],
+    queryKey: ["voice-cards", "newsletter"],
     queryFn: () => getVoiceCards({ channel: "newsletter" }),
     staleTime: 300_000,
   });
@@ -1035,22 +1040,30 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
 
   // Insert a snippet (emoji glyph or AI quote/disclosure) at the tracked
   // caret in the HTML body, then restore focus + selection. Returns the
-  // new body so callers can chain. Mirrors LinkedIn/X insertSnippet.
+  // new body so callers can chain. Mirrors LinkedIn/X: reads the LIVE
+  // body + caret off the textarea element (not closed-over state) so a
+  // splice during an in-flight AI insert lands on the freshest text and
+  // doesn't drop keystrokes typed mid-call. Stable identity (no deps) →
+  // handleAiAction stays stable too. Falls back to the tracked `caret`
+  // state when the element isn't focused/mounted.
   const insertSnippet = useCallback(
     (snippet: string): string => {
-      const { text: next, caret: nextCaret } = insertAtCaret(html, caret, snippet);
+      const el = htmlRef.current;
+      const baseText = el ? el.value : "";
+      const baseCaret = el ? (el.selectionStart ?? baseText.length) : caretRef.current;
+      const { text: next, caret: nextCaret } = insertAtCaret(baseText, baseCaret, snippet);
       setHtml(next);
-      setCaret(nextCaret);
+      caretRef.current = nextCaret;
       requestAnimationFrame(() => {
-        const el = htmlRef.current;
-        if (el) {
-          el.focus();
-          el.setSelectionRange(nextCaret, nextCaret);
+        const node = htmlRef.current;
+        if (node) {
+          node.focus();
+          node.setSelectionRange(nextCaret, nextCaret);
         }
       });
       return next;
     },
-    [html, caret],
+    [],
   );
 
   // AI compose toolbar handler. format:"html" so the rewrite skill
@@ -1309,7 +1322,7 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
             <textarea
               ref={htmlRef}
               value={html}
-              onChange={(e) => { setHtml(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length); }}
+              onChange={(e) => { setHtml(e.target.value); caretRef.current = e.target.selectionStart ?? e.target.value.length; }}
               onSelect={updateCaret}
               onClick={updateCaret}
               onKeyUp={updateCaret}

--- a/src/components/composer/emoji-picker-trigger.tsx
+++ b/src/components/composer/emoji-picker-trigger.tsx
@@ -33,12 +33,6 @@
 import { Smile } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import EmojiPicker from "@/components/emoji-picker";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export interface EmojiPickerTriggerProps {
@@ -62,23 +56,23 @@ export function EmojiPickerTrigger({
     <EmojiPicker
       onEmojiSelect={onInsert}
       trigger={
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                className={cn("h-7 gap-1.5 px-2 text-xs", className)}
-                aria-label="Insert emoji"
-              >
-                <Smile className="size-3.5" />
-                {compact ? null : <span>Emoji</span>}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Insert emoji</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        // Plain <Button> as the OUTERMOST element so
+        // `<PopoverTrigger asChild>` can Slot its onClick/ref directly
+        // onto a DOM node. The previous TooltipProvider/Tooltip wrapper
+        // swallowed those (a context provider isn't a Slot target), so
+        // clicking the icon opened nothing. Tooltip dropped in favour of
+        // a native `title` to keep the trigger Slot-safe.
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className={cn("h-7 gap-1.5 px-2 text-xs", className)}
+          aria-label="Insert emoji"
+          title="Insert emoji"
+        >
+          <Smile className="size-3.5" />
+          {compact ? null : <span>Emoji</span>}
+        </Button>
       }
     />
   );

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -1,446 +1,84 @@
 "use client";
 
-import {
-  Activity,
-  Clock,
-  Flag,
-  Lightbulb,
-  MapPin,
-  Search,
-  Smile,
-  Users,
-} from "lucide-react";
-import { startTransition, useEffect, useMemo, useRef, useState } from "react";
+/**
+ * <EmojiPicker/> — a Popover-wrapped emoji picker built on the
+ * `emoji-picker-react` library (ealush.com/emoji-picker-react).
+ *
+ * History: this used to be a shadcnblocks demo STUB whose `emojis`
+ * array contained only 3 hardcoded glyphs, AND whose trigger wiring was
+ * broken — the host passed a `<TooltipProvider><Tooltip>…</>` tree as
+ * `trigger`, and `<PopoverTrigger asChild>` tried to Slot the popover's
+ * onClick/ref onto `TooltipProvider` (a context provider, not a DOM
+ * node), which dropped them → clicking the icon opened NOTHING. Both
+ * bugs are fixed here: a real full-Unicode picker, and a Slot-friendly
+ * trigger (a plain `<Button>` — see EmojiPickerTrigger).
+ *
+ * Contract is unchanged for hosts: `onEmojiSelect(glyph)` fires with
+ * the chosen emoji character; the host splices it at its tracked caret
+ * (via `insertAtCaret`). `trigger` is the clickable element (must be a
+ * single Slot-compatible element — a DOM node or a forwardRef
+ * component like our `<Button>`, NOT a context provider).
+ */
 
-import { Badge } from "@/components/ui/badge";
+import { useState } from "react";
+import EmojiPickerReact, {
+  EmojiStyle,
+  Theme,
+  type EmojiClickData,
+} from "emoji-picker-react";
+import { useTheme } from "next-themes";
+import { Smile } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-const emojis = [
-  {
-    code: ["1F600"],
-    emoji: "😀",
-    name: "grinning face",
-    category: "Smileys & Emotion",
-    subcategory: "face-smiling",
-  },
-  {
-    code: ["1F603"],
-    emoji: "😃",
-    name: "grinning face with big eyes",
-    category: "Smileys & Emotion",
-    subcategory: "face-smiling",
-  },
-  {
-    code: ["1F604"],
-    emoji: "😄",
-    name: "grinning face with smiling eyes",
-    category: "Smileys & Emotion",
-    subcategory: "face-smiling",
-  },
-];
 
 interface EmojiPickerProps {
+  /** Fired with the chosen emoji glyph (the character itself). */
   onEmojiSelect: (emoji: string) => void;
+  /** Clickable trigger. MUST be a single Slot-compatible element
+   *  (forwardRef component or DOM node) — `<PopoverTrigger asChild>`
+   *  merges onClick/ref onto it. A context-provider wrapper (e.g.
+   *  TooltipProvider) would swallow those and the popover would never
+   *  open. */
   trigger?: React.ReactNode;
-  maxRecentEmojis?: number;
 }
-
-const categoryIcons = {
-  "Smileys & Emotion": Smile,
-  "People & Body": Users,
-  "Animals & Nature": Activity,
-  "Food & Drink": Activity,
-  "Travel & Places": MapPin,
-  Activities: Activity,
-  Objects: Lightbulb,
-  Symbols: Flag,
-  Flags: Flag,
-};
-
-interface EmojiGridProps {
-  emojis: typeof emojis;
-  showCategory?: boolean;
-  selectedIndex: number;
-  allVisibleEmojis: typeof emojis;
-  onEmojiClick: (emoji: string) => void;
-  setSelectedIndex: (index: number) => void;
-  emojiGridRef: React.RefObject<HTMLDivElement | null>;
-}
-
-const EmojiGrid = ({
-  emojis: emojiList,
-  showCategory = false,
-  selectedIndex,
-  allVisibleEmojis,
-  onEmojiClick,
-  setSelectedIndex,
-  emojiGridRef,
-}: EmojiGridProps) => (
-  <div className="grid grid-cols-8 gap-1 p-2" ref={emojiGridRef}>
-    {emojiList.map((emoji, index) => {
-      const globalIndex = showCategory
-        ? allVisibleEmojis.findIndex((e) => e.emoji === emoji.emoji)
-        : index;
-
-      return (
-        <Button
-          key={`${emoji.emoji}-${index}`}
-          variant="ghost"
-          size="sm"
-          className={`h-10 w-10 p-0 transition-colors hover:bg-accent ${
-            selectedIndex === globalIndex ? "bg-accent ring-2 ring-primary" : ""
-          }`}
-          onClick={() => onEmojiClick(emoji.emoji)}
-          title={emoji.name}
-          onMouseEnter={() => setSelectedIndex(globalIndex)}
-        >
-          <span className="text-lg" role="img" aria-label={emoji.name}>
-            {emoji.emoji}
-          </span>
-        </Button>
-      );
-    })}
-  </div>
-);
 
 export default function EmojiPicker({
   onEmojiSelect,
   trigger,
-  maxRecentEmojis = 24,
 }: EmojiPickerProps) {
-  const [searchTerm, setSearchTerm] = useState("");
-  const [isOpen, setIsOpen] = useState(false);
-  const [recentEmojis, setRecentEmojis] = useState<string[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState(-1);
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const emojiGridRef = useRef<HTMLDivElement>(null);
-
-  // Load recent emojis from localStorage
-  useEffect(() => {
-    const stored = localStorage.getItem("recent-emojis");
-    if (stored) {
-      try {
-        startTransition(() => {
-          setRecentEmojis(JSON.parse(stored));
-        });
-      } catch {
-        // Ignore invalid JSON in localStorage
-      }
-    }
-  }, []);
-
-  // Get unique categories with better ordering
-  const categories = useMemo(() => {
-    const categoryOrder = [
-      "Smileys & Emotion",
-      "People & Body",
-      "Animals & Nature",
-      "Food & Drink",
-      "Travel & Places",
-      "Activities",
-      "Objects",
-      "Symbols",
-      "Flags",
-    ];
-
-    const availableCategories = Array.from(
-      new Set(emojis.map((emoji) => emoji.category)),
-    );
-    return categoryOrder.filter((cat) => availableCategories.includes(cat));
-  }, []);
-
-  // Enhanced search with keywords and fuzzy matching
-  const filteredEmojis = useMemo(() => {
-    if (!searchTerm) return emojis;
-
-    const searchLower = searchTerm.toLowerCase();
-    return emojis.filter((emoji) => {
-      const nameMatch = emoji.name.toLowerCase().includes(searchLower);
-      const categoryMatch = emoji.category.toLowerCase().includes(searchLower);
-
-      // Add keyword matching if emoji has keywords property
-      const emojiKeywords =
-        "keywords" in emoji && Array.isArray(emoji.keywords)
-          ? emoji.keywords
-          : [];
-      const keywordMatch = emojiKeywords.some((keyword: string) =>
-        keyword.toLowerCase().includes(searchLower),
-      );
-
-      return nameMatch || categoryMatch || keywordMatch;
-    });
-  }, [searchTerm]);
-
-  // Group emojis by category
-  const emojisByCategory = useMemo(() => {
-    return categories.reduce(
-      (acc, category) => {
-        acc[category] = filteredEmojis.filter(
-          (emoji) => emoji.category === category,
-        );
-        return acc;
-      },
-      {} as Record<string, typeof emojis>,
-    );
-  }, [categories, filteredEmojis]);
-
-  // Get all visible emojis for keyboard navigation
-  const allVisibleEmojis = useMemo(() => {
-    if (searchTerm) {
-      return filteredEmojis;
-    }
-    return categories.flatMap((category) => emojisByCategory[category] || []);
-  }, [searchTerm, filteredEmojis, categories, emojisByCategory]);
-
-  const handleEmojiClick = (emoji: string) => {
-    onEmojiSelect(emoji);
-
-    // Update recent emojis
-    const newRecent = [emoji, ...recentEmojis.filter((e) => e !== emoji)].slice(
-      0,
-      maxRecentEmojis,
-    );
-
-    setRecentEmojis(newRecent);
-    localStorage.setItem("recent-emojis", JSON.stringify(newRecent));
-
-    setIsOpen(false);
-    setSearchTerm("");
-    setSelectedIndex(-1);
-  };
-
-  // Keyboard navigation
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!isOpen) return;
-
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault();
-        setSelectedIndex((prev) =>
-          prev < allVisibleEmojis.length - 1 ? prev + 1 : prev,
-        );
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
-        break;
-      case "Enter":
-        e.preventDefault();
-        if (selectedIndex >= 0 && allVisibleEmojis[selectedIndex]) {
-          handleEmojiClick(allVisibleEmojis[selectedIndex].emoji);
-        }
-        break;
-      case "Escape":
-        setIsOpen(false);
-        setSearchTerm("");
-        setSelectedIndex(-1);
-        break;
-    }
-  };
-
-  // Focus search input when popover opens
-  useEffect(() => {
-    if (isOpen && searchInputRef.current) {
-      searchInputRef.current.focus();
-    }
-  }, [isOpen]);
-
-  // Reset selection when search changes
-  useEffect(() => {
-    startTransition(() => {
-      setSelectedIndex(-1);
-    });
-  }, [searchTerm]);
+  const [open, setOpen] = useState(false);
+  const { resolvedTheme } = useTheme();
 
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        {trigger || (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 w-8 bg-transparent p-0"
-          >
+        {trigger ?? (
+          <Button variant="outline" size="sm" className="h-8 w-8 bg-transparent p-0">
             <Smile className="h-4 w-4" />
             <span className="sr-only">Open emoji picker</span>
           </Button>
         )}
       </PopoverTrigger>
-      <PopoverContent
-        className="w-80 p-0"
-        align="end"
-        onKeyDown={handleKeyDown}
-      >
-        {/* Search Header */}
-        <div className="space-y-2 border-b p-3">
-          <div className="relative">
-            <Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
-            <Input
-              ref={searchInputRef}
-              placeholder="Search emojis..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-8"
-              aria-label="Search emojis"
-            />
-          </div>
-
-          {/* Search Results Count */}
-          {searchTerm && (
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span>{filteredEmojis.length} results found</span>
-              {filteredEmojis.length > 0 && (
-                <Badge variant="secondary" className="text-xs">
-                  Use ↑↓ to navigate, Enter to select
-                </Badge>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Search Results */}
-        {searchTerm ? (
-          <ScrollArea className="h-64">
-            {filteredEmojis.length > 0 ? (
-              <EmojiGrid
-                emojis={filteredEmojis}
-                showCategory
-                selectedIndex={selectedIndex}
-                allVisibleEmojis={allVisibleEmojis}
-                onEmojiClick={handleEmojiClick}
-                setSelectedIndex={setSelectedIndex}
-                emojiGridRef={emojiGridRef}
-              />
-            ) : (
-              <div className="flex h-32 flex-col items-center justify-center text-muted-foreground">
-                <Search className="mb-2 h-8 w-8" />
-                <p className="text-sm">No emojis found</p>
-                <p className="text-xs">Try a different search term</p>
-              </div>
-            )}
-          </ScrollArea>
-        ) : (
-          /* Category Tabs */
-          <Tabs
-            defaultValue={recentEmojis.length > 0 ? "recent" : categories[0]}
-            className="w-full"
-          >
-            <TabsList
-              className="grid h-auto w-full p-1"
-              style={{
-                gridTemplateColumns: `repeat(${recentEmojis.length > 0 ? Math.min(categories.length + 1, 4) : Math.min(categories.length, 4)}, 1fr)`,
-              }}
-            >
-              {recentEmojis.length > 0 && (
-                <TabsTrigger
-                  value="recent"
-                  className="flex items-center gap-1 px-2 py-1 text-xs"
-                  title="Recently used"
-                >
-                  <Clock className="h-3 w-3" />
-                  <span className="hidden sm:inline">Recent</span>
-                </TabsTrigger>
-              )}
-              {categories
-                .slice(0, recentEmojis.length > 0 ? 3 : 4)
-                .map((category) => {
-                  const IconComponent =
-                    categoryIcons[category as keyof typeof categoryIcons] ||
-                    Smile;
-                  return (
-                    <TabsTrigger
-                      key={category}
-                      value={category}
-                      className="flex items-center gap-1 px-2 py-1 text-xs"
-                      title={category}
-                    >
-                      <IconComponent className="h-3 w-3" />
-                      <span className="hidden sm:inline">
-                        {category.split(" ")[0]}
-                      </span>
-                    </TabsTrigger>
-                  );
-                })}
-            </TabsList>
-
-            {/* Recent Emojis Tab */}
-            {recentEmojis.length > 0 && (
-              <TabsContent value="recent" className="mt-0">
-                <ScrollArea className="h-64">
-                  <div className="p-2">
-                    <div className="mb-2 flex items-center gap-2 px-1">
-                      <Clock className="h-4 w-4 text-muted-foreground" />
-                      <span className="text-sm font-medium">Recently Used</span>
-                    </div>
-                    <div className="grid grid-cols-8 gap-1">
-                      {recentEmojis.map((emoji, index) => (
-                        <Button
-                          key={`recent-${emoji}-${index}`}
-                          variant="ghost"
-                          size="sm"
-                          className="h-10 w-10 p-0 transition-colors hover:bg-accent"
-                          onClick={() => handleEmojiClick(emoji)}
-                          title={`Recently used: ${emoji}`}
-                        >
-                          <span className="text-lg" role="img">
-                            {emoji}
-                          </span>
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                </ScrollArea>
-              </TabsContent>
-            )}
-
-            {/* Category Tabs */}
-            {categories.map((category) => (
-              <TabsContent key={category} value={category} className="mt-0">
-                <ScrollArea className="h-64">
-                  {emojisByCategory[category]?.length > 0 ? (
-                    <div className="p-2">
-                      <div className="mb-2 flex items-center gap-2 px-1">
-                        {(() => {
-                          const IconComponent =
-                            categoryIcons[
-                              category as keyof typeof categoryIcons
-                            ] || Smile;
-                          return (
-                            <IconComponent className="h-4 w-4 text-muted-foreground" />
-                          );
-                        })()}
-                        <span className="text-sm font-medium">{category}</span>
-                        <Badge variant="outline" className="text-xs">
-                          {emojisByCategory[category].length}
-                        </Badge>
-                      </div>
-                      <EmojiGrid
-                        emojis={emojisByCategory[category]}
-                        selectedIndex={selectedIndex}
-                        allVisibleEmojis={allVisibleEmojis}
-                        onEmojiClick={handleEmojiClick}
-                        setSelectedIndex={setSelectedIndex}
-                        emojiGridRef={emojiGridRef}
-                      />
-                    </div>
-                  ) : (
-                    <div className="flex h-32 items-center justify-center text-muted-foreground">
-                      <p className="text-sm">No emojis in this category</p>
-                    </div>
-                  )}
-                </ScrollArea>
-              </TabsContent>
-            ))}
-          </Tabs>
-        )}
+      {/* p-0 + w-auto so the library panel sizes itself. */}
+      <PopoverContent align="end" className="w-auto border-0 p-0 shadow-none">
+        <EmojiPickerReact
+          onEmojiClick={(data: EmojiClickData) => {
+            onEmojiSelect(data.emoji);
+            setOpen(false);
+          }}
+          theme={resolvedTheme === "dark" ? Theme.DARK : Theme.LIGHT}
+          // Native glyphs (no CDN sprite fetch) — fastest + matches how
+          // the inserted character renders in the textarea.
+          emojiStyle={EmojiStyle.NATIVE}
+          lazyLoadEmojis
+          width={320}
+          height={400}
+          previewConfig={{ showPreview: false }}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -18,6 +18,10 @@ export interface RewriteContentInput {
   op: RewriteOp;
   text: string;
   platform: PlatformKey;
+  /** Body format. Omit (default "text") for plain-text/social composers.
+   *  "html" for the strategist newsletter/article editor so the rewrite
+   *  preserves semantic HTML structure instead of flattening to prose. */
+  format?: "text" | "html";
   extras?: RewriteExtras;
 }
 
@@ -49,6 +53,7 @@ export function rewriteContent(input: RewriteContentInput) {
     op: input.op,
     text: input.text,
     platform: input.platform,
+    ...(input.format ? { format: input.format } : {}),
     ...(input.extras ? { extras: input.extras } : {}),
   });
 }


### PR DESCRIPTION
## What

Two things, bundled because the newsletter editor needs a working emoji picker:

### 1. Emoji fix (all composers) — you reported "clicking the emoji icon opens nothing"
Root cause: `EmojiPickerTrigger` wrapped its button in `<TooltipProvider><Tooltip>`, and `<PopoverTrigger asChild>` tried to Slot the popover's `onClick`/`ref` onto `TooltipProvider` (a context provider, not a DOM node) — so the props were dropped and the popover never opened. This hit **X and LinkedIn too** (shared component).

Fix: the trigger is now a plain Slot-safe `<Button>` (tooltip → native `title`), and `emoji-picker.tsx` wraps the real **`emoji-picker-react`** library (full Unicode, search, recents, skin tones, dark-mode via next-themes) — replacing the old shadcnblocks stub that only had 3 hardcoded emojis.

### 2. Strategist WriteTab → LinkedIn-class feel
Mounts the shared composer chrome on the newsletter editor:
- **VoiceCardPreview chip** (via ComposerShell `voiceCard`)
- **AiComposeToolbar** — gated to Edit mode & pre-finalize, calls `/v1/content/rewrite` with **`format:"html"`** so redraft/shorten/lengthen/tone **preserve the body's semantic HTML** instead of flattening to prose
- **Emoji insert** + **caret tracking** on the HTML textarea (select/click/keyup/blur) so emoji + AI insert ops splice at the caret
- **DraftSaver auto-save** (debounced PUT to `/content`, suspended once finalized) alongside the manual Save

`rewriteContent` client gains the `format` passthrough.

## Notes
- All WriteTab hooks declared before its early returns (rules-of-hooks). Caret read from the live textarea / a ref (no stale-closure on AI inserts — parity with X/LinkedIn).
- **Depends on peakhour-api #438** (HTML-aware rewrite `format` param) — merge api first.
- `tsc` + `eslint` clean. Double-reviewed (manual + subagent): emoji fix confirmed to fix X/LinkedIn without breaking their contract; format chain + auto-save + caret all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
