### PR TITLE
feat(media): PR6 — /dashboard/media Media Manager UI

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -95,6 +95,7 @@ const NAV_GROUPS: NavGroup[] = [
           { href: "/dashboard/content/sources", label: "Sources" },
           { href: "/dashboard/strategist", label: "Strategist" },
           { href: "/dashboard/calendar", label: "Calendar" },
+          { href: "/dashboard/media", label: "Media" },
           { href: "/dashboard/content/seasonal-events", label: "Seasonal Events" },
         ],
       },

--- a/src/app/dashboard/media/page.tsx
+++ b/src/app/dashboard/media/page.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useMemo, useRef, useState, useCallback } from "react";
+import {
+  useInfiniteQuery,
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Upload,
+  Search,
+  Image as ImageIcon,
+  Trash2,
+  Loader2,
+  Sparkles,
+  AlertTriangle,
+} from "lucide-react";
+import {
+  listMedia,
+  getStorageUsage,
+  uploadMedia,
+  deleteMedia,
+  formatBytes,
+  type MediaItem,
+  type MediaSource,
+} from "@/lib/api/media";
+import { ApiError } from "@/lib/api";
+import { StorageMeter } from "./storage-meter";
+import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { formatDate } from "@/lib/locale";
+
+const MEDIA_CRONS = [
+  "media-usage-scan",
+  "media-cleanup-suggestions",
+  "media-hard-delete",
+  "media-storage-reconcile",
+] as const;
+
+const SOURCE_LABELS: Record<MediaSource, string> = {
+  ai_generated: "AI generated",
+  uploaded: "Uploaded",
+  unsplash: "Unsplash",
+  imported_beehiiv: "Beehiiv",
+  imported_data_url: "Imported",
+};
+
+const SUGGESTION_LABELS: Record<string, string> = {
+  unused_90d: "Unused 90d+",
+  large_5mb_plus: "Large file",
+  duplicate_content_hash: "Duplicate",
+  orphan_generated: "Never used",
+};
+
+// Client-side upload guards (server re-validates). SVG excluded to match the
+// api upload allowlist (stored-XSS decision).
+const ACCEPTED_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+const MAX_UPLOAD_BYTES = 15 * 1024 * 1024;
+
+export default function MediaManagerPage() {
+  const queryClient = useQueryClient();
+  const [source, setSource] = useState<MediaSource | undefined>(undefined);
+  const [status, setStatus] = useState<"active" | "deleted">("active");
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<MediaItem | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const usageQuery = useQuery({
+    queryKey: ["storage-usage"],
+    queryFn: getStorageUsage,
+  });
+
+  const mediaQuery = useInfiniteQuery({
+    queryKey: ["media", source ?? "all", status],
+    queryFn: ({ pageParam }) =>
+      listMedia({ source, status, page: pageParam, limit: 40 }),
+    initialPageParam: 1,
+    getNextPageParam: (last) =>
+      last.meta.hasMore ? last.meta.page + 1 : undefined,
+  });
+
+  const items = useMemo(
+    () => mediaQuery.data?.pages.flatMap((p) => p.items) ?? [],
+    [mediaQuery.data],
+  );
+
+  // Client-side search over the loaded pages (AI prompt + source label).
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (m) =>
+        m.aiOrigin?.prompt?.toLowerCase().includes(q) ||
+        SOURCE_LABELS[m.source].toLowerCase().includes(q) ||
+        m.mimeType.toLowerCase().includes(q),
+    );
+  }, [items, search]);
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ["media"] });
+    void queryClient.invalidateQueries({ queryKey: ["storage-usage"] });
+  }, [queryClient]);
+
+  const uploadMutation = useMutation({
+    mutationFn: uploadMedia,
+    onSuccess: (res) => {
+      toast.success(res.deduped ? "Image already in your library" : "Image uploaded");
+      invalidate();
+    },
+    onError: (err) => {
+      const msg =
+        err instanceof ApiError && err.code === "STORAGE_QUOTA_EXCEEDED"
+          ? "Storage limit reached — clean up or upgrade to upload more."
+          : err instanceof ApiError
+            ? err.message
+            : "Upload failed";
+      toast.error(msg);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteMedia,
+    onSuccess: (res) => {
+      toast.success(`Moved to trash — ${formatBytes(res.freedBytes)} freed (recoverable for 30 days)`);
+      setSelected(null);
+      invalidate();
+    },
+    onError: () => toast.error("Couldn't delete that item"),
+  });
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files?.length) return;
+      for (const file of Array.from(files)) {
+        if (!ACCEPTED_TYPES.includes(file.type)) {
+          toast.error(`${file.name}: unsupported type (PNG/JPEG/WebP/GIF only)`);
+          continue;
+        }
+        if (file.size > MAX_UPLOAD_BYTES) {
+          toast.error(`${file.name}: too large (max 15 MB)`);
+          continue;
+        }
+        uploadMutation.mutate(file);
+      }
+    },
+    [uploadMutation],
+  );
+
+  return (
+    <div className="space-y-4">
+      <CronToolbar crons={MEDIA_CRONS} onTriggered={invalidate} />
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Media</h1>
+          <p className="text-sm text-muted-foreground">
+            Images generated and uploaded across your content.
+          </p>
+        </div>
+        <Button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploadMutation.isPending}
+        >
+          {uploadMutation.isPending ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Upload className="size-4" />
+          )}
+          Upload
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES.join(",")}
+          multiple
+          hidden
+          onChange={(e) => {
+            handleFiles(e.target.files);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      {usageQuery.data && (
+        <div className="rounded-lg border p-4">
+          <StorageMeter usage={usageQuery.data} />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search prompt or type…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-56 pl-8"
+          />
+        </div>
+        <Select
+          value={source ?? "all"}
+          onValueChange={(v) => setSource(v === "all" ? undefined : (v as MediaSource))}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Source" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            {Object.entries(SOURCE_LABELS).map(([k, v]) => (
+              <SelectItem key={k} value={k}>
+                {v}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <ToggleGroup
+          type="single"
+          value={status}
+          onValueChange={(v) => v && setStatus(v as "active" | "deleted")}
+          variant="outline"
+          size="sm"
+        >
+          <ToggleGroupItem value="active">Active</ToggleGroupItem>
+          <ToggleGroupItem value="deleted">Trash</ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+
+      {/* Drop zone + grid */}
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          handleFiles(e.dataTransfer.files);
+        }}
+        className={`rounded-lg border-2 border-dashed p-4 transition-colors ${
+          dragOver ? "border-primary bg-primary/5" : "border-transparent"
+        }`}
+      >
+        {mediaQuery.isLoading ? (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square rounded-md" />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            icon={ImageIcon}
+            title={search ? "No matches" : status === "deleted" ? "Trash is empty" : "No media yet"}
+            description={
+              search
+                ? "Try a different search."
+                : status === "deleted"
+                  ? "Deleted media appears here for 30 days before it's permanently removed."
+                  : "Generate images on a finalized idea, or drag files here to upload."
+            }
+          />
+        ) : (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+            {filtered.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setSelected(m)}
+                className="group relative overflow-hidden rounded-md border bg-muted text-left transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <div className="aspect-square overflow-hidden">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={m.publicUrl}
+                    alt={m.aiOrigin?.prompt ?? "media asset"}
+                    loading="lazy"
+                    className="size-full object-cover transition-transform group-hover:scale-105"
+                  />
+                </div>
+                <div className="flex items-center justify-between gap-1 p-1.5 text-[11px]">
+                  <Badge variant="secondary" className="gap-1 px-1 py-0">
+                    {m.source === "ai_generated" && <Sparkles className="size-3" />}
+                    {SOURCE_LABELS[m.source]}
+                  </Badge>
+                  <span className="text-muted-foreground">{formatBytes(m.sizeBytes)}</span>
+                </div>
+                {m.suggestedAction && (
+                  <span className="absolute right-1 top-1 rounded bg-amber-500/90 px-1 py-0.5 text-[10px] font-medium text-white">
+                    {SUGGESTION_LABELS[m.suggestedAction.kind] ?? "Cleanup"}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {mediaQuery.hasNextPage && (
+          <div className="mt-4 flex justify-center">
+            <Button
+              variant="outline"
+              onClick={() => void mediaQuery.fetchNextPage()}
+              disabled={mediaQuery.isFetchingNextPage}
+            >
+              {mediaQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Detail sheet */}
+      <Sheet open={!!selected} onOpenChange={(o) => !o && setSelected(null)}>
+        <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+          {selected && (
+            <>
+              <SheetHeader>
+                <SheetTitle>Media detail</SheetTitle>
+                <SheetDescription>
+                  {SOURCE_LABELS[selected.source]} · {formatBytes(selected.sizeBytes)}
+                  {selected.width && selected.height ? ` · ${selected.width}×${selected.height}` : ""}
+                </SheetDescription>
+              </SheetHeader>
+              <div className="space-y-4 px-4 pb-4">
+                <div className="overflow-hidden rounded-md border bg-muted">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={selected.publicUrl} alt="" className="max-h-80 w-full object-contain" />
+                </div>
+                <dl className="space-y-1.5 text-sm">
+                  <Row label="Type" value={selected.mimeType} />
+                  <Row label="Created" value={formatDate(selected.createdAt, null)} />
+                  <Row label="Used in" value={`${selected.usedInCount} idea${selected.usedInCount === 1 ? "" : "s"}`} />
+                  {selected.uploadedBy?.userName && (
+                    <Row label="Uploaded by" value={selected.uploadedBy.userName} />
+                  )}
+                  {selected.aiOrigin?.modelId && (
+                    <Row label="Model" value={selected.aiOrigin.modelId} />
+                  )}
+                  {selected.suggestedAction && (
+                    <Row
+                      label="Suggestion"
+                      value={`${SUGGESTION_LABELS[selected.suggestedAction.kind]} · ${formatBytes(selected.suggestedAction.reclaimableBytes)} reclaimable`}
+                    />
+                  )}
+                  {selected.deletedAt && selected.hardDeleteAfter && (
+                    <Row
+                      label="Auto-purge"
+                      value={formatDate(selected.hardDeleteAfter, null)}
+                    />
+                  )}
+                </dl>
+                {selected.aiOrigin?.prompt && (
+                  <div>
+                    <p className="text-xs font-medium text-muted-foreground">AI prompt</p>
+                    <p className="mt-1 rounded bg-muted p-2 text-xs">{selected.aiOrigin.prompt}</p>
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <Button asChild variant="outline" className="flex-1">
+                    <a href={selected.publicUrl} target="_blank" rel="noreferrer">
+                      Open original
+                    </a>
+                  </Button>
+                  {!selected.deletedAt && (
+                    <ConfirmDialog
+                      trigger={
+                        <Button variant="destructive" disabled={deleteMutation.isPending}>
+                          <Trash2 className="size-4" />
+                          Delete
+                        </Button>
+                      }
+                      title="Delete this image?"
+                      description="It moves to the trash and is recoverable for 30 days, then permanently removed. Your storage is freed immediately."
+                      confirmLabel="Delete"
+                      variant="destructive"
+                      onConfirm={() => deleteMutation.mutate(selected.id)}
+                    />
+                  )}
+                </div>
+                {selected.usedInCount > 0 && !selected.deletedAt && (
+                  <p className="flex items-center gap-1 text-xs text-amber-600">
+                    <AlertTriangle className="size-3" />
+                    Used in {selected.usedInCount} idea{selected.usedInCount === 1 ? "" : "s"} — deleting may break them.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="text-right font-medium">{value}</dd>
+    </div>
+  );
+}

--- a/src/app/dashboard/media/page.tsx
+++ b/src/app/dashboard/media/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import {
   listMedia,
+  getMedia,
   getStorageUsage,
   uploadMedia,
   deleteMedia,
@@ -114,7 +115,7 @@ export default function MediaManagerPage() {
     return items.filter(
       (m) =>
         m.aiOrigin?.prompt?.toLowerCase().includes(q) ||
-        SOURCE_LABELS[m.source].toLowerCase().includes(q) ||
+        (SOURCE_LABELS[m.source] ?? m.source).toLowerCase().includes(q) ||
         m.mimeType.toLowerCase().includes(q),
     );
   }, [items, search]);
@@ -271,6 +272,13 @@ export default function MediaManagerPage() {
               <Skeleton key={i} className="aspect-square rounded-md" />
             ))}
           </div>
+        ) : mediaQuery.isError ? (
+          <EmptyState
+            icon={AlertTriangle}
+            title="Couldn't load your media"
+            description="Something went wrong fetching the library. Please try again."
+            action={{ label: "Retry", onClick: () => void mediaQuery.refetch() }}
+          />
         ) : filtered.length === 0 ? (
           <EmptyState
             icon={ImageIcon}
@@ -289,7 +297,12 @@ export default function MediaManagerPage() {
               <button
                 key={m.id}
                 type="button"
-                onClick={() => setSelected(m)}
+                onClick={() => {
+                  setSelected(m);
+                  // Fire-and-forget: bumps lastAccessedAt server-side
+                  // (feeds unused-90d detection). UI keeps the list row.
+                  void getMedia(m.id).catch(() => {});
+                }}
                 className="group relative overflow-hidden rounded-md border bg-muted text-left transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring"
               >
                 <div className="aspect-square overflow-hidden">
@@ -304,7 +317,7 @@ export default function MediaManagerPage() {
                 <div className="flex items-center justify-between gap-1 p-1.5 text-[11px]">
                   <Badge variant="secondary" className="gap-1 px-1 py-0">
                     {m.source === "ai_generated" && <Sparkles className="size-3" />}
-                    {SOURCE_LABELS[m.source]}
+                    {SOURCE_LABELS[m.source] ?? m.source}
                   </Badge>
                   <span className="text-muted-foreground">{formatBytes(m.sizeBytes)}</span>
                 </div>

--- a/src/app/dashboard/media/storage-meter.tsx
+++ b/src/app/dashboard/media/storage-meter.tsx
@@ -18,8 +18,11 @@ export function StorageMeter({
   compact?: boolean;
   className?: string;
 }) {
-  const pct = usage.percentUsed ?? 0;
   const unbounded = usage.limitBytes === null;
+  // A 0 GB quota (or any limit with no positive denominator) reports
+  // percentUsed=null from the api but is fully blocked, not unbounded.
+  const blockedZeroQuota = !unbounded && usage.limitBytes === 0;
+  const pct = blockedZeroQuota ? 100 : (usage.percentUsed ?? 0);
   const tone = pct >= 90 ? "red" : pct >= 75 ? "amber" : "normal";
 
   const barColor =
@@ -35,7 +38,7 @@ export function StorageMeter({
           ) : (
             <>
               {usage.gbUsed.toFixed(usage.gbUsed < 1 ? 2 : 1)} /{" "}
-              {usage.gbIncluded} GB
+              {usage.gbIncluded?.toFixed(usage.gbIncluded < 1 ? 2 : 0)} GB
               {usage.isOverage ? " · overage" : ""}
             </>
           )}

--- a/src/app/dashboard/media/storage-meter.tsx
+++ b/src/app/dashboard/media/storage-meter.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+import { type StorageUsage, formatBytes } from "@/lib/api/media";
+
+/**
+ * Storage usage meter (Media Manager / R2 plan §7 L13). Shows GB used vs the
+ * plan quota with amber@75% / red@90% states. Reused on the Media Manager
+ * page (full) and the dashboard sidebar (compact, PR7).
+ */
+export function StorageMeter({
+  usage,
+  compact = false,
+  className,
+}: {
+  usage: StorageUsage;
+  compact?: boolean;
+  className?: string;
+}) {
+  const pct = usage.percentUsed ?? 0;
+  const unbounded = usage.limitBytes === null;
+  const tone = pct >= 90 ? "red" : pct >= 75 ? "amber" : "normal";
+
+  const barColor =
+    tone === "red" ? "bg-red-500" : tone === "amber" ? "bg-amber-500" : "bg-primary";
+
+  return (
+    <div className={cn("w-full", className)}>
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">Storage</span>
+        <span className="text-muted-foreground">
+          {unbounded ? (
+            `${formatBytes(usage.totalBytes)} used`
+          ) : (
+            <>
+              {usage.gbUsed.toFixed(usage.gbUsed < 1 ? 2 : 1)} /{" "}
+              {usage.gbIncluded} GB
+              {usage.isOverage ? " · overage" : ""}
+            </>
+          )}
+        </span>
+      </div>
+      {!unbounded && (
+        <Progress
+          value={Math.min(100, pct)}
+          className="mt-1.5 h-2"
+          indicatorClassName={barColor}
+          aria-label={`Storage ${pct.toFixed(0)}% used`}
+        />
+      )}
+      {!compact && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          {unbounded
+            ? "No storage limit configured for your plan."
+            : tone === "red"
+              ? "Storage almost full — clean up or upgrade to keep adding media."
+              : tone === "amber"
+                ? "Approaching your storage limit."
+                : `${usage.plan.charAt(0).toUpperCase() + usage.plan.slice(1)} plan`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -39,6 +39,48 @@ export interface CronMetadata {
 }
 
 export const CRON_METADATA: Record<string, CronMetadata> = {
+  "media-cleanup-suggestions": {
+    label: "Find cleanup suggestions",
+    frequency: "Runs weekly (Sun 4:00 AM UTC)",
+    description:
+      "Scans your media library for unused, duplicate, oversized, or never-used AI images and flags them for the Smart Delete review (advisory only — nothing is deleted automatically).",
+    summarize: (data) => {
+      const d = data as { totalTagged?: number } | null;
+      return typeof d?.totalTagged === "number"
+        ? `${d.totalTagged} cleanup suggestion${d.totalTagged === 1 ? "" : "s"} found.`
+        : null;
+    },
+  },
+  "media-hard-delete": {
+    label: "Purge expired deletions",
+    frequency: "Runs nightly (3:00 AM UTC)",
+    description:
+      "Permanently removes media that has been in the trash past its 30-day recovery window, freeing the storage for good.",
+    summarize: (data) => {
+      const d = data as { purged?: number } | null;
+      return typeof d?.purged === "number" ? `${d.purged} expired item${d.purged === 1 ? "" : "s"} purged.` : null;
+    },
+  },
+  "media-storage-reconcile": {
+    label: "Reconcile storage usage",
+    frequency: "Runs weekly (Sun 5:00 AM UTC)",
+    description:
+      "Recomputes each organisation's storage meter from the media library so the usage numbers stay exact.",
+    summarize: (data) => {
+      const d = data as { orgsReconciled?: number } | null;
+      return typeof d?.orgsReconciled === "number" ? `${d.orgsReconciled} org meter(s) reconciled.` : null;
+    },
+  },
+  "media-usage-scan": {
+    label: "Scan media usage",
+    frequency: "Runs daily (1:00 AM UTC)",
+    description:
+      "Refreshes which ideas each image is used in, so the cleanup suggestions know what's safe to remove.",
+    summarize: (data) => {
+      const d = data as { mediaUpdated?: number } | null;
+      return typeof d?.mediaUpdated === "number" ? `Usage refreshed for ${d.mediaUpdated} asset(s).` : null;
+    },
+  },
   "beehiiv-sync": {
     label: "Fetch newsletters",
     frequency: "Runs every hour",

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,9 +7,12 @@ import { cn } from "@/lib/utils"
 
 function Progress({
   className,
+  indicatorClassName,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string
+}) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -21,7 +24,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="h-full w-full flex-1 bg-primary transition-all"
+        className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -192,6 +192,41 @@ class ApiClient {
     return this.request<T>(path, { method: "GET", params });
   }
 
+  /**
+   * GET that also returns the response envelope's `meta` (pagination etc.).
+   * Mirrors request()'s 401-refresh + error handling and throws ApiError,
+   * unlike a raw fetch — so list views keep auto-refresh + typed errors.
+   */
+  async getWithMeta<T>(
+    path: string,
+    params?: Record<string, string>,
+  ): Promise<{ data: T; meta: Record<string, unknown> }> {
+    if (!this.baseUrl) {
+      throw new ApiError("CONFIG_ERROR", "NEXT_PUBLIC_API_URL is not configured", 0);
+    }
+    let url = `${this.baseUrl}${path}`;
+    if (params) url += `?${new URLSearchParams(params).toString()}`;
+    const doFetch = () => fetch(url, { credentials: "include" });
+
+    let res = await doFetch();
+    if (res.status === 401 && !path.includes("/auth/refresh")) {
+      const refreshed = await this.tryRefresh();
+      if (refreshed) res = await doFetch();
+    }
+
+    let json: Record<string, unknown>;
+    try {
+      json = (await res.json()) as Record<string, unknown>;
+    } catch {
+      throw new ApiError("PARSE_ERROR", `Server returned non-JSON response (${res.status})`, res.status);
+    }
+    if (!res.ok || !json.ok) {
+      const error = (json.error as { code?: string; message?: string }) || { message: "Request failed" };
+      throw new ApiError(error.code || "UNKNOWN", error.message || "Request failed", res.status);
+    }
+    return { data: json.data as T, meta: (json.meta as Record<string, unknown>) ?? {} };
+  }
+
   post<T>(path: string, body?: unknown) {
     return this.request<T>(path, {
       method: "POST",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -218,6 +218,46 @@ class ApiClient {
   }
 
   /**
+   * POST multipart/form-data (file uploads). Unlike post(), this does NOT
+   * set Content-Type — the browser sets the multipart boundary itself.
+   * Handles CSRF + a single 401-refresh retry like request().
+   */
+  async postForm<T>(path: string, form: FormData): Promise<T> {
+    if (!this.baseUrl) {
+      throw new ApiError("CONFIG_ERROR", "NEXT_PUBLIC_API_URL is not configured", 0);
+    }
+    const headers: Record<string, string> = {};
+    const token = await this.getCsrfToken();
+    if (token) headers["X-CSRF-Token"] = token;
+
+    const doFetch = () =>
+      fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        credentials: "include",
+        headers,
+        body: form,
+      });
+
+    let res = await doFetch();
+    if (res.status === 401 && !path.includes("/auth/refresh")) {
+      const refreshed = await this.tryRefresh();
+      if (refreshed) res = await doFetch();
+    }
+
+    let json: Record<string, unknown>;
+    try {
+      json = (await res.json()) as Record<string, unknown>;
+    } catch {
+      throw new ApiError("PARSE_ERROR", `Server returned non-JSON response (${res.status})`, res.status);
+    }
+    if (!res.ok || !json.ok) {
+      const error = (json.error as { code?: string; message?: string }) || { message: "Upload failed" };
+      throw new ApiError(error.code || "UNKNOWN", error.message || "Upload failed", res.status);
+    }
+    return json.data as T;
+  }
+
+  /**
    * POST that returns a raw Response for SSE streaming.
    * Handles CSRF + credentials like other methods, but
    * does NOT parse JSON — caller reads the stream.

--- a/src/lib/api/media.ts
+++ b/src/lib/api/media.ts
@@ -1,0 +1,149 @@
+import { api } from "@/lib/api";
+
+/**
+ * Media Manager API client (Media Manager / Cloudflare R2). Wraps the
+ * /v1/media + /v1/storage endpoints (peakhour-api PR4).
+ */
+
+export type MediaSource =
+  | "ai_generated"
+  | "uploaded"
+  | "unsplash"
+  | "imported_beehiiv"
+  | "imported_data_url";
+
+export type SuggestedActionKind =
+  | "unused_90d"
+  | "large_5mb_plus"
+  | "duplicate_content_hash"
+  | "orphan_generated";
+
+export interface MediaItem {
+  id: string;
+  publicUrl: string;
+  mimeType: string;
+  sizeBytes: number;
+  width?: number;
+  height?: number;
+  source: MediaSource;
+  aiOrigin?: {
+    ideaId?: string;
+    placeholderIndex?: number;
+    prompt?: string;
+    modelId?: string;
+  };
+  uploadedBy?: { userName?: string };
+  suggestedAction?: {
+    kind: SuggestedActionKind;
+    reclaimableBytes: number;
+    detectedAt: string;
+    relatedMediaId?: string;
+  };
+  usedInCount: number;
+  lastAccessedAt?: string;
+  deletedAt?: string;
+  hardDeleteAfter?: string;
+  createdAt: string;
+}
+
+export interface MediaListMeta {
+  page: number;
+  limit: number;
+  total: number;
+  hasMore: boolean;
+}
+
+export interface StorageUsage {
+  totalBytes: number;
+  softDeletedBytes: number;
+  fileCount: number;
+  limitBytes: number | null;
+  gbIncluded: number | null;
+  gbUsed: number;
+  percentUsed: number | null;
+  overageBytes: number;
+  isOverage: boolean;
+  plan: string;
+}
+
+export interface ListMediaParams {
+  source?: MediaSource;
+  suggestedAction?: SuggestedActionKind;
+  status?: "active" | "deleted";
+  page?: number;
+  limit?: number;
+}
+
+/** The api client unwraps `data`; list responses carry pagination in `meta`,
+ *  so we re-request the raw envelope here to read it. */
+export async function listMedia(
+  params: ListMediaParams = {},
+): Promise<{ items: MediaItem[]; meta: MediaListMeta }> {
+  const qs: Record<string, string> = {};
+  if (params.source) qs.source = params.source;
+  if (params.suggestedAction) qs.suggestedAction = params.suggestedAction;
+  if (params.status) qs.status = params.status;
+  if (params.page) qs.page = String(params.page);
+  if (params.limit) qs.limit = String(params.limit);
+
+  // api.get returns `data` only; pagination lives in `meta`. Fetch the
+  // envelope directly so we keep total/hasMore.
+  const search = new URLSearchParams(qs).toString();
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? ""}/v1/media${search ? `?${search}` : ""}`,
+    { credentials: "include" },
+  );
+  const json = (await res.json()) as {
+    ok: boolean;
+    data?: MediaItem[];
+    meta?: MediaListMeta;
+    error?: { message?: string };
+  };
+  if (!res.ok || !json.ok) {
+    throw new Error(json.error?.message ?? "Failed to load media");
+  }
+  return {
+    items: json.data ?? [],
+    meta: json.meta ?? { page: 1, limit: 40, total: json.data?.length ?? 0, hasMore: false },
+  };
+}
+
+export function getMedia(id: string): Promise<MediaItem> {
+  return api.get<MediaItem>(`/v1/media/${id}`);
+}
+
+export function getStorageUsage(): Promise<StorageUsage> {
+  return api.get<StorageUsage>(`/v1/storage/usage`);
+}
+
+export function uploadMedia(
+  file: File,
+): Promise<{ mediaId: string; publicUrl: string; sizeBytes: number; deduped: boolean }> {
+  const form = new FormData();
+  form.append("file", file);
+  return api.postForm(`/v1/media/upload`, form);
+}
+
+export function deleteMedia(id: string): Promise<{ deletedCount: number; freedBytes: number }> {
+  return api.delete(`/v1/media/${id}`);
+}
+
+export function bulkDeleteMedia(
+  mediaIds: string[],
+): Promise<{ deletedCount: number; freedBytes: number }> {
+  return api.post(`/v1/media/bulk-delete`, { mediaIds });
+}
+
+export function restoreMedia(id: string): Promise<{ restored: boolean; mediaId: string }> {
+  return api.post(`/v1/media/${id}/restore`, {});
+}
+
+/** Human-readable byte size. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(0)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(2)} GB`;
+}

--- a/src/lib/api/media.ts
+++ b/src/lib/api/media.ts
@@ -86,25 +86,18 @@ export async function listMedia(
   if (params.page) qs.page = String(params.page);
   if (params.limit) qs.limit = String(params.limit);
 
-  // api.get returns `data` only; pagination lives in `meta`. Fetch the
-  // envelope directly so we keep total/hasMore.
-  const search = new URLSearchParams(qs).toString();
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL ?? ""}/v1/media${search ? `?${search}` : ""}`,
-    { credentials: "include" },
-  );
-  const json = (await res.json()) as {
-    ok: boolean;
-    data?: MediaItem[];
-    meta?: MediaListMeta;
-    error?: { message?: string };
-  };
-  if (!res.ok || !json.ok) {
-    throw new Error(json.error?.message ?? "Failed to load media");
-  }
+  // getWithMeta keeps the shared client's 401-refresh + typed ApiError and
+  // returns the envelope's `meta` (pagination lives there, not in `data`).
+  const { data, meta } = await api.getWithMeta<MediaItem[]>("/v1/media", qs);
+  const m = meta as Partial<MediaListMeta>;
   return {
-    items: json.data ?? [],
-    meta: json.meta ?? { page: 1, limit: 40, total: json.data?.length ?? 0, hasMore: false },
+    items: data ?? [],
+    meta: {
+      page: m.page ?? 1,
+      limit: m.limit ?? 40,
+      total: m.total ?? data?.length ?? 0,
+      hasMore: m.hasMore ?? false,
+    },
   };
 }
 


### PR DESCRIPTION
## PR6 — Media Manager UI (Media Manager / R2 plan §7)

`/dashboard/media` page + nav entry (Content → Media). Additive; shows empty states until R2-backed media exists.

- Asset grid (thumbnail, source badge, size, cleanup flag) → detail Sheet (preview, metadata, AI prompt, open-original, delete w/ 30-day-recovery confirm). Opening detail bumps `lastAccessedAt`.
- Filters: source select + active/trash toggle; client-side search (prompt/type).
- Upload: button + drag-drop dropzone (PNG/JPEG/WebP/GIF, 15MB; server re-validates; SVG excluded to match api allowlist). 402 → friendly quota message.
- Storage meter (amber@75/red@90; 0 GB = blocked). CronToolbar → 4 media crons (dev-only).
- `useInfiniteQuery` load-more; error+Retry state.

Supporting: `lib/api/media.ts` (typed client), `api.ts` `postForm` (multipart) + `getWithMeta` (paginated GET w/ refresh), `progress.tsx` optional `indicatorClassName`.

### Reviews
Review #1 (subagent) confirmed the api contract matches `serializeMedia` field-by-field. Fixes: error state, list 401-refresh, meter 0 GB edge, label guards. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
