### PR TITLE
feat(media): PR7 — Smart Delete wizard, sidebar meter, reusable MediaUploader

### DIFF
--- a/components.json
+++ b/components.json
@@ -25,6 +25,7 @@
       "headers": {
         "Authorization": "Bearer ${SHADCNBLOCKS_API_KEY}"
       }
-    }
+    },
+    "@diceui": "https://diceui.com/r/{name}.json"
   }
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -38,6 +38,7 @@ import { PlanBadge } from "@/components/dashboard/plan-badge";
 import { AttentionBell } from "@/components/dashboard/attention-bell";
 import { TrialExpiryBanner } from "@/components/dashboard/trial-expiry-banner";
 import { CommandMenu } from "@/components/molecules/command-menu";
+import { SidebarStorageMeter } from "@/components/dashboard/sidebar-storage-meter";
 import { FeedbackWidget } from "@/components/molecules/feedback-widget";
 import { ChatPanel } from "@/components/molecules/chat-panel";
 import {
@@ -315,8 +316,9 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
           ))}
         </SidebarContent>
 
-        {/* ── Footer: User ──────────────────────────────────── */}
+        {/* ── Footer: Storage meter + User ──────────────────── */}
         <SidebarFooter>
+          <SidebarStorageMeter />
           <SidebarMenu>
             <SidebarMenuItem>
               <DropdownMenu>

--- a/src/app/dashboard/media/page.tsx
+++ b/src/app/dashboard/media/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, useCallback } from "react";
+import { useMemo, useState, useCallback } from "react";
 import {
   useInfiniteQuery,
   useQuery,
@@ -9,11 +9,9 @@ import {
 } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
-  Upload,
   Search,
   Image as ImageIcon,
   Trash2,
-  Loader2,
   Sparkles,
   AlertTriangle,
 } from "lucide-react";
@@ -21,14 +19,14 @@ import {
   listMedia,
   getMedia,
   getStorageUsage,
-  uploadMedia,
   deleteMedia,
   formatBytes,
   type MediaItem,
   type MediaSource,
 } from "@/lib/api/media";
-import { ApiError } from "@/lib/api";
+import { MediaUploader } from "@/components/media/media-uploader";
 import { StorageMeter } from "./storage-meter";
+import { SmartDelete } from "./smart-delete";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -75,19 +73,12 @@ const SUGGESTION_LABELS: Record<string, string> = {
   orphan_generated: "Never used",
 };
 
-// Client-side upload guards (server re-validates). SVG excluded to match the
-// api upload allowlist (stored-XSS decision).
-const ACCEPTED_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
-const MAX_UPLOAD_BYTES = 15 * 1024 * 1024;
-
 export default function MediaManagerPage() {
   const queryClient = useQueryClient();
   const [source, setSource] = useState<MediaSource | undefined>(undefined);
   const [status, setStatus] = useState<"active" | "deleted">("active");
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState<MediaItem | null>(null);
-  const [dragOver, setDragOver] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const usageQuery = useQuery({
     queryKey: ["storage-usage"],
@@ -125,23 +116,6 @@ export default function MediaManagerPage() {
     void queryClient.invalidateQueries({ queryKey: ["storage-usage"] });
   }, [queryClient]);
 
-  const uploadMutation = useMutation({
-    mutationFn: uploadMedia,
-    onSuccess: (res) => {
-      toast.success(res.deduped ? "Image already in your library" : "Image uploaded");
-      invalidate();
-    },
-    onError: (err) => {
-      const msg =
-        err instanceof ApiError && err.code === "STORAGE_QUOTA_EXCEEDED"
-          ? "Storage limit reached — clean up or upgrade to upload more."
-          : err instanceof ApiError
-            ? err.message
-            : "Upload failed";
-      toast.error(msg);
-    },
-  });
-
   const deleteMutation = useMutation({
     mutationFn: deleteMedia,
     onSuccess: (res) => {
@@ -152,57 +126,15 @@ export default function MediaManagerPage() {
     onError: () => toast.error("Couldn't delete that item"),
   });
 
-  const handleFiles = useCallback(
-    (files: FileList | null) => {
-      if (!files?.length) return;
-      for (const file of Array.from(files)) {
-        if (!ACCEPTED_TYPES.includes(file.type)) {
-          toast.error(`${file.name}: unsupported type (PNG/JPEG/WebP/GIF only)`);
-          continue;
-        }
-        if (file.size > MAX_UPLOAD_BYTES) {
-          toast.error(`${file.name}: too large (max 15 MB)`);
-          continue;
-        }
-        uploadMutation.mutate(file);
-      }
-    },
-    [uploadMutation],
-  );
-
   return (
     <div className="space-y-4">
       <CronToolbar crons={MEDIA_CRONS} onTriggered={invalidate} />
 
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Media</h1>
-          <p className="text-sm text-muted-foreground">
-            Images generated and uploaded across your content.
-          </p>
-        </div>
-        <Button
-          onClick={() => fileInputRef.current?.click()}
-          disabled={uploadMutation.isPending}
-        >
-          {uploadMutation.isPending ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <Upload className="size-4" />
-          )}
-          Upload
-        </Button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={ACCEPTED_TYPES.join(",")}
-          multiple
-          hidden
-          onChange={(e) => {
-            handleFiles(e.target.files);
-            e.target.value = "";
-          }}
-        />
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Media</h1>
+        <p className="text-sm text-muted-foreground">
+          Images generated and uploaded across your content.
+        </p>
       </div>
 
       {usageQuery.data && (
@@ -210,6 +142,10 @@ export default function MediaManagerPage() {
           <StorageMeter usage={usageQuery.data} />
         </div>
       )}
+
+      <SmartDelete />
+
+      <MediaUploader onUploaded={() => invalidate()} multiple />
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-2">
@@ -250,22 +186,8 @@ export default function MediaManagerPage() {
         </ToggleGroup>
       </div>
 
-      {/* Drop zone + grid */}
-      <div
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDragOver(true);
-        }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => {
-          e.preventDefault();
-          setDragOver(false);
-          handleFiles(e.dataTransfer.files);
-        }}
-        className={`rounded-lg border-2 border-dashed p-4 transition-colors ${
-          dragOver ? "border-primary bg-primary/5" : "border-transparent"
-        }`}
-      >
+      {/* Grid (drag-to-upload lives in the MediaUploader dropzone above) */}
+      <div>
         {mediaQuery.isLoading ? (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
             {Array.from({ length: 12 }).map((_, i) => (

--- a/src/app/dashboard/media/smart-delete.tsx
+++ b/src/app/dashboard/media/smart-delete.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Trash2, Sparkles } from "lucide-react";
+import {
+  listMedia,
+  bulkDeleteMedia,
+  formatBytes,
+  type MediaItem,
+  type SuggestedActionKind,
+} from "@/lib/api/media";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Smart Delete banner + wizard (Media Manager / R2 plan §7, L11/L12).
+ * Surfaces the 4 advisory cleanup categories tagged by the weekly cron;
+ * the user reviews + multi-selects, then bulk soft-deletes. Advisory only —
+ * nothing is auto-deleted.
+ */
+
+const CATEGORIES: { kind: SuggestedActionKind; label: string; hint: string }[] = [
+  { kind: "duplicate_content_hash", label: "Duplicates", hint: "Identical to a newer image" },
+  { kind: "orphan_generated", label: "AI images, never used", hint: "Generated but not embedded anywhere" },
+  { kind: "unused_90d", label: "Unused for 90+ days", hint: "No references, created over 90 days ago" },
+  { kind: "large_5mb_plus", label: "Large files (5 MB+)", hint: "Consider re-encoding before deleting" },
+];
+
+interface CategoryGroup {
+  kind: SuggestedActionKind;
+  items: MediaItem[];
+}
+
+export function SmartDelete() {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const { data: groups = [] } = useQuery({
+    queryKey: ["smart-delete"],
+    queryFn: async (): Promise<CategoryGroup[]> => {
+      const results = await Promise.all(
+        CATEGORIES.map((c) =>
+          listMedia({ suggestedAction: c.kind, status: "active", limit: 100 }),
+        ),
+      );
+      return CATEGORIES.map((c, i) => ({ kind: c.kind, items: results[i]!.items }));
+    },
+    staleTime: 60_000,
+  });
+
+  const totalSuggested = useMemo(
+    () => groups.reduce((sum, g) => sum + g.items.length, 0),
+    [groups],
+  );
+
+  const allItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
+
+  const reclaimable = useMemo(
+    () =>
+      allItems
+        .filter((m) => selected.has(m.id))
+        .reduce((sum, m) => sum + (m.suggestedAction?.reclaimableBytes ?? m.sizeBytes), 0),
+    [allItems, selected],
+  );
+
+  const bulkDelete = useMutation({
+    mutationFn: () => bulkDeleteMedia([...selected]),
+    onSuccess: (res) => {
+      toast.success(`${res.deletedCount} item(s) moved to trash — ${formatBytes(res.freedBytes)} freed`);
+      setSelected(new Set());
+      setOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ["media"] });
+      void queryClient.invalidateQueries({ queryKey: ["storage-usage"] });
+      void queryClient.invalidateQueries({ queryKey: ["smart-delete"] });
+    },
+    onError: () => toast.error("Couldn't delete the selected items"),
+  });
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleCategory(kind: SuggestedActionKind, on: boolean) {
+    const ids = groups.find((g) => g.kind === kind)?.items.map((m) => m.id) ?? [];
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (on) next.add(id);
+        else next.delete(id);
+      }
+      return next;
+    });
+  }
+
+  if (totalSuggested === 0) return null;
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm dark:border-amber-900/40 dark:bg-amber-950/20">
+        <span className="flex items-center gap-2 text-amber-800 dark:text-amber-300">
+          <Sparkles className="size-4" />
+          Smart Delete found {totalSuggested} item{totalSuggested === 1 ? "" : "s"} you may not need.
+        </span>
+        <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+          Review suggestions
+        </Button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Suggested cleanup</DialogTitle>
+            <DialogDescription>
+              Review and select what to remove. Deleted media stays recoverable for 30 days; your storage is freed immediately. Nothing is deleted without your confirmation.
+            </DialogDescription>
+          </DialogHeader>
+
+          <ScrollArea className="max-h-[55vh] pr-3">
+            <div className="space-y-5">
+              {CATEGORIES.map((cat) => {
+                const group = groups.find((g) => g.kind === cat.kind);
+                if (!group || group.items.length === 0) return null;
+                const groupBytes = group.items.reduce(
+                  (s, m) => s + (m.suggestedAction?.reclaimableBytes ?? m.sizeBytes),
+                  0,
+                );
+                const allOn = group.items.every((m) => selected.has(m.id));
+                return (
+                  <div key={cat.kind}>
+                    <label className="flex items-center gap-2 font-medium">
+                      <Checkbox
+                        checked={allOn}
+                        onCheckedChange={(v) => toggleCategory(cat.kind, v === true)}
+                      />
+                      {cat.label}
+                      <span className="text-xs font-normal text-muted-foreground">
+                        ({group.items.length} · {formatBytes(groupBytes)})
+                      </span>
+                    </label>
+                    <p className="ml-6 text-xs text-muted-foreground">{cat.hint}</p>
+                    <div className="ml-6 mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                      {group.items.map((m) => (
+                        <label
+                          key={m.id}
+                          className="flex cursor-pointer items-center gap-2 rounded border p-1.5 text-xs"
+                        >
+                          <Checkbox
+                            checked={selected.has(m.id)}
+                            onCheckedChange={() => toggle(m.id)}
+                          />
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={m.publicUrl}
+                            alt=""
+                            loading="lazy"
+                            className="size-8 shrink-0 rounded object-cover"
+                          />
+                          <span className="truncate text-muted-foreground">{formatBytes(m.sizeBytes)}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+
+          <DialogFooter className="items-center gap-2 sm:justify-between">
+            <span className="text-sm text-muted-foreground">
+              {selected.size} selected · {formatBytes(reclaimable)} reclaimable
+            </span>
+            <Button
+              variant="destructive"
+              disabled={selected.size === 0 || bulkDelete.isPending}
+              onClick={() => bulkDelete.mutate()}
+            >
+              <Trash2 className="size-4" />
+              {bulkDelete.isPending ? "Deleting…" : `Delete ${selected.size} selected`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/dashboard/media/smart-delete.tsx
+++ b/src/app/dashboard/media/smart-delete.tsx
@@ -40,7 +40,14 @@ const CATEGORIES: { kind: SuggestedActionKind; label: string; hint: string }[] =
 interface CategoryGroup {
   kind: SuggestedActionKind;
   items: MediaItem[];
+  /** True category size (may exceed the 100 loaded for selection). */
+  total: number;
 }
+
+/** API caps bulk-delete at 200 ids/call; chunk larger selections. */
+const BULK_DELETE_CHUNK = 200;
+/** Per-category fetch cap (API list limit max). */
+const CATEGORY_FETCH_LIMIT = 100;
 
 export function SmartDelete() {
   const queryClient = useQueryClient();
@@ -52,31 +59,55 @@ export function SmartDelete() {
     queryFn: async (): Promise<CategoryGroup[]> => {
       const results = await Promise.all(
         CATEGORIES.map((c) =>
-          listMedia({ suggestedAction: c.kind, status: "active", limit: 100 }),
+          listMedia({ suggestedAction: c.kind, status: "active", limit: CATEGORY_FETCH_LIMIT }),
         ),
       );
-      return CATEGORIES.map((c, i) => ({ kind: c.kind, items: results[i]!.items }));
+      return CATEGORIES.map((c, i) => ({
+        kind: c.kind,
+        items: results[i]!.items,
+        total: results[i]!.meta.total,
+      }));
     },
     staleTime: 60_000,
   });
 
+  // True suggestion count (uses meta.total, not just the loaded page).
   const totalSuggested = useMemo(
-    () => groups.reduce((sum, g) => sum + g.items.length, 0),
+    () => groups.reduce((sum, g) => sum + g.total, 0),
+    [groups],
+  );
+  // Whether any category has more than the loaded cap — informs a "re-run" hint.
+  const hasMoreThanLoaded = useMemo(
+    () => groups.some((g) => g.total > g.items.length),
     [groups],
   );
 
   const allItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
 
+  // Estimate trusts reclaimableBytes (duplicates can be 0 — they share bytes
+  // with the surviving copy); never falls back to sizeBytes, which would
+  // overstate what delete actually frees.
   const reclaimable = useMemo(
     () =>
       allItems
         .filter((m) => selected.has(m.id))
-        .reduce((sum, m) => sum + (m.suggestedAction?.reclaimableBytes ?? m.sizeBytes), 0),
+        .reduce((sum, m) => sum + (m.suggestedAction?.reclaimableBytes ?? 0), 0),
     [allItems, selected],
   );
 
   const bulkDelete = useMutation({
-    mutationFn: () => bulkDeleteMedia([...selected]),
+    mutationFn: async () => {
+      const ids = [...selected];
+      let deletedCount = 0;
+      let freedBytes = 0;
+      // Chunk to the API's 200-id cap so a large selection doesn't 400.
+      for (let i = 0; i < ids.length; i += BULK_DELETE_CHUNK) {
+        const res = await bulkDeleteMedia(ids.slice(i, i + BULK_DELETE_CHUNK));
+        deletedCount += res.deletedCount;
+        freedBytes += res.freedBytes;
+      }
+      return { deletedCount, freedBytes };
+    },
     onSuccess: (res) => {
       toast.success(`${res.deletedCount} item(s) moved to trash — ${formatBytes(res.freedBytes)} freed`);
       setSelected(new Set());
@@ -138,7 +169,7 @@ export function SmartDelete() {
                 const group = groups.find((g) => g.kind === cat.kind);
                 if (!group || group.items.length === 0) return null;
                 const groupBytes = group.items.reduce(
-                  (s, m) => s + (m.suggestedAction?.reclaimableBytes ?? m.sizeBytes),
+                  (s, m) => s + (m.suggestedAction?.reclaimableBytes ?? 0),
                   0,
                 );
                 const allOn = group.items.every((m) => selected.has(m.id));
@@ -151,7 +182,10 @@ export function SmartDelete() {
                       />
                       {cat.label}
                       <span className="text-xs font-normal text-muted-foreground">
-                        ({group.items.length} · {formatBytes(groupBytes)})
+                        ({group.total > group.items.length
+                          ? `${group.items.length} of ${group.total}`
+                          : group.items.length}{" "}
+                        · {formatBytes(groupBytes)})
                       </span>
                     </label>
                     <p className="ml-6 text-xs text-muted-foreground">{cat.hint}</p>
@@ -181,6 +215,12 @@ export function SmartDelete() {
               })}
             </div>
           </ScrollArea>
+
+          {hasMoreThanLoaded && (
+            <p className="text-xs text-muted-foreground">
+              Showing the first {CATEGORY_FETCH_LIMIT} per category. Delete these and re-run to review the rest.
+            </p>
+          )}
 
           <DialogFooter className="items-center gap-2 sm:justify-between">
             <span className="text-sm text-muted-foreground">

--- a/src/components/dashboard/sidebar-storage-meter.tsx
+++ b/src/components/dashboard/sidebar-storage-meter.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { getStorageUsage } from "@/lib/api/media";
+import { StorageMeter } from "@/app/dashboard/media/storage-meter";
+
+/**
+ * Always-visible storage meter in the dashboard sidebar footer (Media
+ * Manager / R2 plan §7 L13). Compact; links to the Media Manager. Hidden
+ * when the sidebar is collapsed to icons, and renders nothing until usage
+ * loads (or if it errors — the meter is secondary, never blocks the UI).
+ */
+export function SidebarStorageMeter() {
+  const { data } = useQuery({
+    queryKey: ["storage-usage"],
+    queryFn: getStorageUsage,
+    staleTime: 60_000,
+  });
+
+  if (!data) return null;
+
+  return (
+    <Link
+      href="/dashboard/media"
+      className="block rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent group-data-[collapsible=icon]:hidden"
+      aria-label="Storage usage — open Media Manager"
+    >
+      <StorageMeter usage={data} compact />
+    </Link>
+  );
+}

--- a/src/components/media/media-uploader.tsx
+++ b/src/components/media/media-uploader.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { Upload, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  FileUpload,
+  FileUploadDropzone,
+  FileUploadItem,
+  FileUploadItemDelete,
+  FileUploadItemMetadata,
+  FileUploadItemPreview,
+  FileUploadItemProgress,
+  FileUploadList,
+  FileUploadTrigger,
+} from "@/components/ui/file-upload";
+import { cn } from "@/lib/utils";
+import { ApiError } from "@/lib/api";
+import { uploadMedia, type MediaUploadResult } from "@/lib/api/media";
+
+/**
+ * <MediaUploader> — reusable image upload affordance (Media Manager / R2).
+ * Wraps the shadcnblocks-PRO file-upload dropzone (diceui FileUpload
+ * primitive) + the R2 upload endpoint, so any surface can offer uploads:
+ * the Media Manager grid, the per-placeholder picker (PR8), composers, etc.
+ *
+ * Decoupled from data fetching: it reports each stored asset via
+ * `onUploaded` and lets the host decide what to do (invalidate a query,
+ * set a placeholder's resolvedImageUrl + mediaId, append to a picker, …).
+ * SVG is excluded by default to match the api upload allowlist (stored-XSS
+ * decision); the server re-validates type + size + quota regardless.
+ */
+
+export interface MediaUploadedResult extends MediaUploadResult {
+  /** The originating File (name/type), for host-side labelling. */
+  file: File;
+}
+
+export interface MediaUploaderProps {
+  /** Fired once per successfully-stored file (includes content-hash dedupes). */
+  onUploaded?: (result: MediaUploadedResult) => void;
+  accept?: string;
+  maxSizeBytes?: number;
+  multiple?: boolean;
+  /** "compact" shrinks the dropzone for use inside a modal/picker. */
+  variant?: "full" | "compact";
+  disabled?: boolean;
+  className?: string;
+}
+
+const DEFAULT_ACCEPT = "image/png,image/jpeg,image/webp,image/gif";
+const DEFAULT_MAX_BYTES = 15 * 1024 * 1024;
+
+export function MediaUploader({
+  onUploaded,
+  accept = DEFAULT_ACCEPT,
+  maxSizeBytes = DEFAULT_MAX_BYTES,
+  multiple = true,
+  variant = "full",
+  disabled = false,
+  className,
+}: MediaUploaderProps) {
+  // Controlled transient list so the dropzone renders per-file preview +
+  // progress while uploading; cleared once the batch settles (the host's
+  // own view becomes the source of truth after onUploaded fires).
+  const [files, setFiles] = useState<File[]>([]);
+
+  const onUpload = useCallback(
+    async (
+      batch: File[],
+      {
+        onSuccess,
+        onError,
+      }: {
+        onProgress: (file: File, progress: number) => void;
+        onSuccess: (file: File) => void;
+        onError: (file: File, error: Error) => void;
+      },
+    ) => {
+      await Promise.all(
+        batch.map(async (file) => {
+          try {
+            const res = await uploadMedia(file);
+            onSuccess(file);
+            onUploaded?.({ ...res, file });
+            toast.success(res.deduped ? `${file.name} already in your library` : `${file.name} uploaded`);
+          } catch (err) {
+            const msg =
+              err instanceof ApiError && err.code === "STORAGE_QUOTA_EXCEEDED"
+                ? "Storage limit reached — clean up or upgrade to upload more."
+                : err instanceof ApiError
+                  ? err.message
+                  : "Upload failed";
+            onError(file, err instanceof Error ? err : new Error(msg));
+            toast.error(`${file.name}: ${msg}`);
+          }
+        }),
+      );
+      // Reset the transient list; the host view now reflects the uploads.
+      setFiles([]);
+    },
+    [onUploaded],
+  );
+
+  const compact = variant === "compact";
+
+  return (
+    <FileUpload
+      value={files}
+      onValueChange={setFiles}
+      accept={accept}
+      maxSize={maxSizeBytes}
+      multiple={multiple}
+      disabled={disabled}
+      onUpload={onUpload}
+      onFileReject={(file, message) => toast.error(`${file.name}: ${message}`)}
+      className={className}
+    >
+      <FileUploadDropzone
+        className={cn(
+          "border-primary/20 bg-primary/5 hover:bg-primary/10 data-dragging:bg-primary/10",
+          compact && "p-4",
+        )}
+      >
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className={cn("rounded-lg bg-primary/10", compact ? "p-2" : "p-3")}>
+            <Upload className={cn("text-primary", compact ? "size-5" : "size-6")} />
+          </div>
+          <div>
+            <p className="text-sm font-medium">
+              {compact ? "Drop or select an image" : "Drag images here to upload"}
+            </p>
+            {!compact && (
+              <p className="text-xs text-muted-foreground">
+                PNG, JPEG, WebP, GIF · up to {Math.round(maxSizeBytes / 1024 / 1024)} MB
+              </p>
+            )}
+          </div>
+        </div>
+        <FileUploadTrigger asChild>
+          <Button size="sm" variant="outline" className="mt-2">
+            <Upload className="size-4" />
+            {compact ? "Select" : "Select images"}
+          </Button>
+        </FileUploadTrigger>
+      </FileUploadDropzone>
+      <FileUploadList>
+        {files.map((file, i) => (
+          <FileUploadItem key={`${file.name}-${i}`} value={file}>
+            <FileUploadItemPreview />
+            <FileUploadItemMetadata />
+            <FileUploadItemProgress />
+            <FileUploadItemDelete asChild>
+              <Button variant="ghost" size="icon" className="size-7">
+                <X className="size-4" />
+              </Button>
+            </FileUploadItemDelete>
+          </FileUploadItem>
+        ))}
+      </FileUploadList>
+    </FileUpload>
+  );
+}

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -1,0 +1,1420 @@
+"use client";
+
+/* eslint-disable react-hooks/immutability, @next/next/no-img-element, jsx-a11y/role-supports-aria-props --
+   Vendored diceui FileUpload primitive (installed via the @diceui registry, see components.json).
+   It uses an intentional external-store pattern + direct DOM file assignment for drag-and-drop,
+   which the React-Compiler immutability rule and a couple of a11y/img rules flag. Left as-shipped
+   to keep upstream parity; behaviour is correct at runtime. */
+
+import {
+  FileArchiveIcon,
+  FileAudioIcon,
+  FileCodeIcon,
+  FileCogIcon,
+  FileIcon,
+  FileTextIcon,
+  FileVideoIcon,
+} from "lucide-react";
+import {
+  Direction as DirectionPrimitive,
+  Slot as SlotPrimitive,
+} from "radix-ui";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { useAsRef } from "@/hooks/use-as-ref";
+import { useLazyRef } from "@/hooks/use-lazy-ref";
+
+const ROOT_NAME = "FileUpload";
+const DROPZONE_NAME = "FileUploadDropzone";
+const TRIGGER_NAME = "FileUploadTrigger";
+const LIST_NAME = "FileUploadList";
+const ITEM_NAME = "FileUploadItem";
+const ITEM_PREVIEW_NAME = "FileUploadItemPreview";
+const ITEM_METADATA_NAME = "FileUploadItemMetadata";
+const ITEM_PROGRESS_NAME = "FileUploadItemProgress";
+const ITEM_DELETE_NAME = "FileUploadItemDelete";
+const CLEAR_NAME = "FileUploadClear";
+
+function formatBytes(bytes: number) {
+  if (bytes === 0) return "0 B";
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / 1024 ** i).toFixed(i ? 1 : 0)} ${sizes[i]}`;
+}
+
+function getFileIcon(file: File) {
+  const type = file.type;
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+
+  if (type.startsWith("video/")) {
+    return <FileVideoIcon />;
+  }
+
+  if (type.startsWith("audio/")) {
+    return <FileAudioIcon />;
+  }
+
+  if (
+    type.startsWith("text/") ||
+    ["txt", "md", "rtf", "pdf"].includes(extension)
+  ) {
+    return <FileTextIcon />;
+  }
+
+  if (
+    [
+      "html",
+      "css",
+      "js",
+      "jsx",
+      "ts",
+      "tsx",
+      "json",
+      "xml",
+      "php",
+      "py",
+      "rb",
+      "java",
+      "c",
+      "cpp",
+      "cs",
+    ].includes(extension)
+  ) {
+    return <FileCodeIcon />;
+  }
+
+  if (["zip", "rar", "7z", "tar", "gz", "bz2"].includes(extension)) {
+    return <FileArchiveIcon />;
+  }
+
+  if (
+    ["exe", "msi", "app", "apk", "deb", "rpm"].includes(extension) ||
+    type.startsWith("application/")
+  ) {
+    return <FileCogIcon />;
+  }
+
+  return <FileIcon />;
+}
+
+type Direction = "ltr" | "rtl";
+
+interface FileState {
+  file: File;
+  progress: number;
+  error?: string;
+  status: "idle" | "uploading" | "error" | "success";
+}
+
+interface StoreState {
+  files: Map<File, FileState>;
+  dragOver: boolean;
+  invalid: boolean;
+}
+
+type StoreAction =
+  | { type: "ADD_FILES"; files: File[] }
+  | { type: "SET_FILES"; files: File[] }
+  | { type: "SET_PROGRESS"; file: File; progress: number }
+  | { type: "SET_SUCCESS"; file: File }
+  | { type: "SET_ERROR"; file: File; error: string }
+  | { type: "REMOVE_FILE"; file: File }
+  | { type: "SET_DRAG_OVER"; dragOver: boolean }
+  | { type: "SET_INVALID"; invalid: boolean }
+  | { type: "CLEAR" };
+
+type Store = {
+  getState: () => StoreState;
+  dispatch: (action: StoreAction) => void;
+  subscribe: (listener: () => void) => () => void;
+};
+
+const StoreContext = React.createContext<Store | null>(null);
+
+function useStoreContext(consumerName: string) {
+  const context = React.useContext(StoreContext);
+  if (!context) {
+    throw new Error(`\`${consumerName}\` must be used within \`${ROOT_NAME}\``);
+  }
+  return context;
+}
+
+function useStore<T>(selector: (state: StoreState) => T): T {
+  const store = useStoreContext("useStore");
+
+  const lastValueRef = useLazyRef<{ value: T; state: StoreState } | null>(
+    () => null,
+  );
+
+  const getSnapshot = React.useCallback(() => {
+    const state = store.getState();
+    const prevValue = lastValueRef.current;
+
+    if (prevValue && prevValue.state === state) {
+      return prevValue.value;
+    }
+
+    const nextValue = selector(state);
+    lastValueRef.current = { value: nextValue, state };
+    return nextValue;
+  }, [store, selector, lastValueRef]);
+
+  return React.useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+}
+
+interface FileUploadContextValue {
+  inputId: string;
+  dropzoneId: string;
+  listId: string;
+  labelId: string;
+  disabled: boolean;
+  dir: Direction;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  urlCache: WeakMap<File, string>;
+}
+
+const FileUploadContext = React.createContext<FileUploadContextValue | null>(
+  null,
+);
+
+function useFileUploadContext(consumerName: string) {
+  const context = React.useContext(FileUploadContext);
+  if (!context) {
+    throw new Error(`\`${consumerName}\` must be used within \`${ROOT_NAME}\``);
+  }
+  return context;
+}
+
+interface FileUploadProps
+  extends Omit<React.ComponentProps<"div">, "defaultValue" | "onChange"> {
+  value?: File[];
+  defaultValue?: File[];
+  onValueChange?: (files: File[]) => void;
+  onAccept?: (files: File[]) => void;
+  onFileAccept?: (file: File) => void;
+  onFileReject?: (file: File, message: string) => void;
+  onFileValidate?: (file: File) => string | null | undefined;
+  onUpload?: (
+    files: File[],
+    options: {
+      onProgress: (file: File, progress: number) => void;
+      onSuccess: (file: File) => void;
+      onError: (file: File, error: Error) => void;
+    },
+  ) => Promise<void> | void;
+  accept?: string;
+  maxFiles?: number;
+  maxSize?: number;
+  dir?: Direction;
+  label?: string;
+  name?: string;
+  asChild?: boolean;
+  disabled?: boolean;
+  invalid?: boolean;
+  multiple?: boolean;
+  required?: boolean;
+}
+
+function FileUpload(props: FileUploadProps) {
+  const {
+    value,
+    defaultValue,
+    onValueChange,
+    onAccept,
+    onFileAccept,
+    onFileReject,
+    onFileValidate,
+    onUpload,
+    accept,
+    maxFiles,
+    maxSize,
+    dir: dirProp,
+    label,
+    name,
+    asChild,
+    disabled = false,
+    invalid = false,
+    multiple = false,
+    required = false,
+    children,
+    className,
+    ...rootProps
+  } = props;
+
+  const inputId = React.useId();
+  const dropzoneId = React.useId();
+  const listId = React.useId();
+  const labelId = React.useId();
+
+  const dir = DirectionPrimitive.useDirection(dirProp);
+  const listeners = useLazyRef(() => new Set<() => void>()).current;
+  const files = useLazyRef<Map<File, FileState>>(() => new Map()).current;
+  const urlCache = useLazyRef(() => new WeakMap<File, string>()).current;
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const isControlled = value !== undefined;
+
+  const propsRef = useAsRef({
+    onValueChange,
+    onAccept,
+    onFileAccept,
+    onFileReject,
+    onFileValidate,
+    onUpload,
+  });
+
+  const store = React.useMemo<Store>(() => {
+    let state: StoreState = {
+      files,
+      dragOver: false,
+      invalid: invalid,
+    };
+
+    function reducer(state: StoreState, action: StoreAction): StoreState {
+      switch (action.type) {
+        case "ADD_FILES": {
+          for (const file of action.files) {
+            files.set(file, {
+              file,
+              progress: 0,
+              status: "idle",
+            });
+          }
+
+          if (propsRef.current.onValueChange) {
+            const fileList = Array.from(files.values()).map(
+              (fileState) => fileState.file,
+            );
+            propsRef.current.onValueChange(fileList);
+          }
+          return { ...state, files };
+        }
+
+        case "SET_FILES": {
+          const newFileSet = new Set(action.files);
+          for (const existingFile of files.keys()) {
+            if (!newFileSet.has(existingFile)) {
+              files.delete(existingFile);
+            }
+          }
+
+          for (const file of action.files) {
+            const existingState = files.get(file);
+            if (!existingState) {
+              files.set(file, {
+                file,
+                progress: 0,
+                status: "idle",
+              });
+            }
+          }
+          return { ...state, files };
+        }
+
+        case "SET_PROGRESS": {
+          const fileState = files.get(action.file);
+          if (fileState) {
+            files.set(action.file, {
+              ...fileState,
+              progress: action.progress,
+              status: "uploading",
+            });
+          }
+          return { ...state, files };
+        }
+
+        case "SET_SUCCESS": {
+          const fileState = files.get(action.file);
+          if (fileState) {
+            files.set(action.file, {
+              ...fileState,
+              progress: 100,
+              status: "success",
+            });
+          }
+          return { ...state, files };
+        }
+
+        case "SET_ERROR": {
+          const fileState = files.get(action.file);
+          if (fileState) {
+            files.set(action.file, {
+              ...fileState,
+              error: action.error,
+              status: "error",
+            });
+          }
+          return { ...state, files };
+        }
+
+        case "REMOVE_FILE": {
+          const cachedUrl = urlCache.get(action.file);
+          if (cachedUrl) {
+            URL.revokeObjectURL(cachedUrl);
+            urlCache.delete(action.file);
+          }
+
+          files.delete(action.file);
+
+          if (propsRef.current.onValueChange) {
+            const fileList = Array.from(files.values()).map(
+              (fileState) => fileState.file,
+            );
+            propsRef.current.onValueChange(fileList);
+          }
+          return { ...state, files };
+        }
+
+        case "SET_DRAG_OVER": {
+          return { ...state, dragOver: action.dragOver };
+        }
+
+        case "SET_INVALID": {
+          return { ...state, invalid: action.invalid };
+        }
+
+        case "CLEAR": {
+          for (const file of files.keys()) {
+            const cachedUrl = urlCache.get(file);
+            if (cachedUrl) {
+              URL.revokeObjectURL(cachedUrl);
+              urlCache.delete(file);
+            }
+          }
+
+          files.clear();
+          if (propsRef.current.onValueChange) {
+            propsRef.current.onValueChange([]);
+          }
+          return { ...state, files, invalid: false };
+        }
+
+        default:
+          return state;
+      }
+    }
+
+    return {
+      getState: () => state,
+      dispatch: (action) => {
+        state = reducer(state, action);
+        for (const listener of listeners) {
+          listener();
+        }
+      },
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    };
+  }, [listeners, files, invalid, propsRef, urlCache]);
+
+  const acceptTypes = React.useMemo(
+    () => accept?.split(",").map((t) => t.trim()) ?? null,
+    [accept],
+  );
+
+  const onProgress = useLazyRef(() => {
+    let frame = 0;
+    return (file: File, progress: number) => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        store.dispatch({
+          type: "SET_PROGRESS",
+          file,
+          progress: Math.min(Math.max(0, progress), 100),
+        });
+      });
+    };
+  }).current;
+
+  React.useEffect(() => {
+    if (isControlled) {
+      store.dispatch({ type: "SET_FILES", files: value });
+    } else if (
+      defaultValue &&
+      defaultValue.length > 0 &&
+      !store.getState().files.size
+    ) {
+      store.dispatch({ type: "SET_FILES", files: defaultValue });
+    }
+  }, [value, defaultValue, isControlled, store]);
+
+  React.useEffect(() => {
+    return () => {
+      for (const file of files.keys()) {
+        const cachedUrl = urlCache.get(file);
+        if (cachedUrl) {
+          URL.revokeObjectURL(cachedUrl);
+        }
+      }
+    };
+  }, [files, urlCache]);
+
+  const onFilesUpload = React.useCallback(
+    async (files: File[]) => {
+      try {
+        for (const file of files) {
+          store.dispatch({ type: "SET_PROGRESS", file, progress: 0 });
+        }
+
+        if (propsRef.current.onUpload) {
+          await propsRef.current.onUpload(files, {
+            onProgress,
+            onSuccess: (file) => {
+              store.dispatch({ type: "SET_SUCCESS", file });
+            },
+            onError: (file, error) => {
+              store.dispatch({
+                type: "SET_ERROR",
+                file,
+                error: error.message ?? "Upload failed",
+              });
+            },
+          });
+        } else {
+          for (const file of files) {
+            store.dispatch({ type: "SET_SUCCESS", file });
+          }
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Upload failed";
+        for (const file of files) {
+          store.dispatch({
+            type: "SET_ERROR",
+            file,
+            error: errorMessage,
+          });
+        }
+      }
+    },
+    [store, propsRef, onProgress],
+  );
+
+  const onFilesChange = React.useCallback(
+    (originalFiles: File[]) => {
+      if (disabled) return;
+
+      let filesToProcess = [...originalFiles];
+      let invalid = false;
+
+      if (maxFiles) {
+        const currentCount = store.getState().files.size;
+        const remainingSlotCount = Math.max(0, maxFiles - currentCount);
+
+        if (remainingSlotCount < filesToProcess.length) {
+          const rejectedFiles = filesToProcess.slice(remainingSlotCount);
+          invalid = true;
+
+          filesToProcess = filesToProcess.slice(0, remainingSlotCount);
+
+          for (const file of rejectedFiles) {
+            let rejectionMessage = `Maximum ${maxFiles} files allowed`;
+
+            if (propsRef.current.onFileValidate) {
+              const validationMessage = propsRef.current.onFileValidate(file);
+              if (validationMessage) {
+                rejectionMessage = validationMessage;
+              }
+            }
+
+            propsRef.current.onFileReject?.(file, rejectionMessage);
+          }
+        }
+      }
+
+      const acceptedFiles: File[] = [];
+      const rejectedFiles: { file: File; message: string }[] = [];
+
+      for (const file of filesToProcess) {
+        let rejected = false;
+        let rejectionMessage = "";
+
+        if (propsRef.current.onFileValidate) {
+          const validationMessage = propsRef.current.onFileValidate(file);
+          if (validationMessage) {
+            rejectionMessage = validationMessage;
+            propsRef.current.onFileReject?.(file, rejectionMessage);
+            rejected = true;
+            invalid = true;
+            continue;
+          }
+        }
+
+        if (acceptTypes) {
+          const fileType = file.type;
+          const fileExtension = `.${file.name.split(".").pop()}`;
+
+          if (
+            !acceptTypes.some(
+              (type) =>
+                type === fileType ||
+                type === fileExtension ||
+                (type.includes("/*") &&
+                  fileType.startsWith(type.replace("/*", "/"))),
+            )
+          ) {
+            rejectionMessage = "File type not accepted";
+            propsRef.current.onFileReject?.(file, rejectionMessage);
+            rejected = true;
+            invalid = true;
+          }
+        }
+
+        if (maxSize && file.size > maxSize) {
+          rejectionMessage = "File too large";
+          propsRef.current.onFileReject?.(file, rejectionMessage);
+          rejected = true;
+          invalid = true;
+        }
+
+        if (!rejected) {
+          acceptedFiles.push(file);
+        } else {
+          rejectedFiles.push({ file, message: rejectionMessage });
+        }
+      }
+
+      if (invalid) {
+        store.dispatch({ type: "SET_INVALID", invalid });
+        setTimeout(() => {
+          store.dispatch({ type: "SET_INVALID", invalid: false });
+        }, 2000);
+      }
+
+      if (acceptedFiles.length > 0) {
+        store.dispatch({ type: "ADD_FILES", files: acceptedFiles });
+
+        if (isControlled && propsRef.current.onValueChange) {
+          const currentFiles = Array.from(store.getState().files.values()).map(
+            (f) => f.file,
+          );
+          propsRef.current.onValueChange([...currentFiles]);
+        }
+
+        if (propsRef.current.onAccept) {
+          propsRef.current.onAccept(acceptedFiles);
+        }
+
+        for (const file of acceptedFiles) {
+          propsRef.current.onFileAccept?.(file);
+        }
+
+        if (propsRef.current.onUpload) {
+          requestAnimationFrame(() => {
+            onFilesUpload(acceptedFiles);
+          });
+        }
+      }
+    },
+    [
+      store,
+      isControlled,
+      propsRef,
+      onFilesUpload,
+      maxFiles,
+      acceptTypes,
+      maxSize,
+      disabled,
+    ],
+  );
+
+  const onInputChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? []);
+      onFilesChange(files);
+      event.target.value = "";
+    },
+    [onFilesChange],
+  );
+
+  const contextValue = React.useMemo<FileUploadContextValue>(
+    () => ({
+      dropzoneId,
+      inputId,
+      listId,
+      labelId,
+      dir,
+      disabled,
+      inputRef,
+      urlCache,
+    }),
+    [dropzoneId, inputId, listId, labelId, dir, disabled, urlCache],
+  );
+
+  const RootPrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  return (
+    <StoreContext.Provider value={store}>
+      <FileUploadContext.Provider value={contextValue}>
+        <RootPrimitive
+          data-disabled={disabled ? "" : undefined}
+          data-slot="file-upload"
+          dir={dir}
+          {...rootProps}
+          className={cn("relative flex flex-col gap-2", className)}
+        >
+          {children}
+          <input
+            type="file"
+            id={inputId}
+            aria-labelledby={labelId}
+            aria-describedby={dropzoneId}
+            ref={inputRef}
+            tabIndex={-1}
+            accept={accept}
+            name={name}
+            className="sr-only"
+            disabled={disabled}
+            multiple={multiple}
+            required={required}
+            onChange={onInputChange}
+          />
+          <div id={labelId} className="sr-only">
+            {label ?? "File upload"}
+          </div>
+        </RootPrimitive>
+      </FileUploadContext.Provider>
+    </StoreContext.Provider>
+  );
+}
+
+interface FileUploadDropzoneProps extends React.ComponentProps<"div"> {
+  asChild?: boolean;
+}
+
+function FileUploadDropzone(props: FileUploadDropzoneProps) {
+  const {
+    asChild,
+    className,
+    onClick: onClickProp,
+    onDragOver: onDragOverProp,
+    onDragEnter: onDragEnterProp,
+    onDragLeave: onDragLeaveProp,
+    onDrop: onDropProp,
+    onPaste: onPasteProp,
+    onKeyDown: onKeyDownProp,
+    ...dropzoneProps
+  } = props;
+
+  const context = useFileUploadContext(DROPZONE_NAME);
+  const store = useStoreContext(DROPZONE_NAME);
+  const dragOver = useStore((state) => state.dragOver);
+  const invalid = useStore((state) => state.invalid);
+
+  const propsRef = useAsRef({
+    onClick: onClickProp,
+    onDragOver: onDragOverProp,
+    onDragEnter: onDragEnterProp,
+    onDragLeave: onDragLeaveProp,
+    onDrop: onDropProp,
+    onPaste: onPasteProp,
+    onKeyDown: onKeyDownProp,
+  });
+
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      propsRef.current.onClick?.(event);
+
+      if (event.defaultPrevented) return;
+
+      const target = event.target;
+
+      const isFromTrigger =
+        target instanceof HTMLElement &&
+        target.closest('[data-slot="file-upload-trigger"]');
+
+      if (!isFromTrigger) {
+        context.inputRef.current?.click();
+      }
+    },
+    [context.inputRef, propsRef],
+  );
+
+  const onDragOver = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      propsRef.current.onDragOver?.(event);
+
+      if (event.defaultPrevented) return;
+
+      event.preventDefault();
+      store.dispatch({ type: "SET_DRAG_OVER", dragOver: true });
+    },
+    [store, propsRef],
+  );
+
+  const onDragEnter = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      propsRef.current.onDragEnter?.(event);
+
+      if (event.defaultPrevented) return;
+
+      event.preventDefault();
+      store.dispatch({ type: "SET_DRAG_OVER", dragOver: true });
+    },
+    [store, propsRef],
+  );
+
+  const onDragLeave = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      propsRef.current.onDragLeave?.(event);
+
+      if (event.defaultPrevented) return;
+
+      const relatedTarget = event.relatedTarget;
+      if (
+        relatedTarget &&
+        relatedTarget instanceof Node &&
+        event.currentTarget.contains(relatedTarget)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      store.dispatch({ type: "SET_DRAG_OVER", dragOver: false });
+    },
+    [store, propsRef],
+  );
+
+  const onDrop = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      propsRef.current.onDrop?.(event);
+
+      if (event.defaultPrevented) return;
+
+      event.preventDefault();
+      store.dispatch({ type: "SET_DRAG_OVER", dragOver: false });
+
+      const files = Array.from(event.dataTransfer.files);
+      const inputElement = context.inputRef.current;
+      if (!inputElement) return;
+
+      const dataTransfer = new DataTransfer();
+      for (const file of files) {
+        dataTransfer.items.add(file);
+      }
+
+      inputElement.files = dataTransfer.files;
+      inputElement.dispatchEvent(new Event("change", { bubbles: true }));
+    },
+    [store, context.inputRef, propsRef],
+  );
+
+  const onPaste = React.useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      propsRef.current.onPaste?.(event);
+
+      if (event.defaultPrevented) return;
+
+      event.preventDefault();
+      store.dispatch({ type: "SET_DRAG_OVER", dragOver: false });
+
+      const items = event.clipboardData?.items;
+      if (!items) return;
+
+      const files: File[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item?.kind === "file") {
+          const file = item.getAsFile();
+          if (file) {
+            files.push(file);
+          }
+        }
+      }
+
+      if (files.length === 0) return;
+
+      const inputElement = context.inputRef.current;
+      if (!inputElement) return;
+
+      const dataTransfer = new DataTransfer();
+      for (const file of files) {
+        dataTransfer.items.add(file);
+      }
+
+      inputElement.files = dataTransfer.files;
+      inputElement.dispatchEvent(new Event("change", { bubbles: true }));
+    },
+    [store, context.inputRef, propsRef],
+  );
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      propsRef.current.onKeyDown?.(event);
+
+      if (
+        !event.defaultPrevented &&
+        (event.key === "Enter" || event.key === " ")
+      ) {
+        event.preventDefault();
+        context.inputRef.current?.click();
+      }
+    },
+    [context.inputRef, propsRef],
+  );
+
+  const DropzonePrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  return (
+    <DropzonePrimitive
+      role="region"
+      id={context.dropzoneId}
+      aria-controls={`${context.inputId} ${context.listId}`}
+      aria-disabled={context.disabled}
+      aria-invalid={invalid}
+      data-disabled={context.disabled ? "" : undefined}
+      data-dragging={dragOver ? "" : undefined}
+      data-invalid={invalid ? "" : undefined}
+      data-slot="file-upload-dropzone"
+      dir={context.dir}
+      tabIndex={context.disabled ? undefined : 0}
+      {...dropzoneProps}
+      className={cn(
+        "relative flex select-none flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-6 outline-none transition-colors hover:bg-accent/30 focus-visible:border-ring/50 data-disabled:pointer-events-none data-dragging:border-primary/30 data-invalid:border-destructive data-dragging:bg-accent/30 data-invalid:ring-destructive/20",
+        className,
+      )}
+      onClick={onClick}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onKeyDown={onKeyDown}
+      onPaste={onPaste}
+    />
+  );
+}
+
+interface FileUploadTriggerProps extends React.ComponentProps<"button"> {
+  asChild?: boolean;
+}
+
+function FileUploadTrigger(props: FileUploadTriggerProps) {
+  const { asChild, onClick: onClickProp, ...triggerProps } = props;
+
+  const context = useFileUploadContext(TRIGGER_NAME);
+
+  const propsRef = useAsRef({
+    onClick: onClickProp,
+  });
+
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      propsRef.current.onClick?.(event);
+
+      if (event.defaultPrevented) return;
+
+      context.inputRef.current?.click();
+    },
+    [context.inputRef, propsRef],
+  );
+
+  const TriggerPrimitive = asChild ? SlotPrimitive.Slot : "button";
+
+  return (
+    <TriggerPrimitive
+      type="button"
+      aria-controls={context.inputId}
+      data-disabled={context.disabled ? "" : undefined}
+      data-slot="file-upload-trigger"
+      {...triggerProps}
+      disabled={context.disabled}
+      onClick={onClick}
+    />
+  );
+}
+
+interface FileUploadListProps extends React.ComponentProps<"div"> {
+  orientation?: "horizontal" | "vertical";
+  asChild?: boolean;
+  forceMount?: boolean;
+}
+
+function FileUploadList(props: FileUploadListProps) {
+  const {
+    className,
+    orientation = "vertical",
+    asChild,
+    forceMount,
+    ...listProps
+  } = props;
+
+  const context = useFileUploadContext(LIST_NAME);
+  const fileCount = useStore((state) => state.files.size);
+  const shouldRender = forceMount || fileCount > 0;
+
+  if (!shouldRender) return null;
+
+  const ListPrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  return (
+    <ListPrimitive
+      role="list"
+      id={context.listId}
+      aria-orientation={orientation}
+      data-orientation={orientation}
+      data-slot="file-upload-list"
+      data-state={shouldRender ? "active" : "inactive"}
+      dir={context.dir}
+      {...listProps}
+      className={cn(
+        "data-[state=inactive]:fade-out-0 data-[state=active]:fade-in-0 data-[state=inactive]:slide-out-to-top-2 data-[state=active]:slide-in-from-top-2 flex flex-col gap-2 data-[state=active]:animate-in data-[state=inactive]:animate-out",
+        orientation === "horizontal" && "flex-row overflow-x-auto p-1.5",
+        className,
+      )}
+    />
+  );
+}
+
+interface FileUploadItemContextValue {
+  id: string;
+  fileState: FileState | undefined;
+  nameId: string;
+  sizeId: string;
+  statusId: string;
+  messageId: string;
+}
+
+const FileUploadItemContext =
+  React.createContext<FileUploadItemContextValue | null>(null);
+
+function useFileUploadItemContext(consumerName: string) {
+  const context = React.useContext(FileUploadItemContext);
+  if (!context) {
+    throw new Error(`\`${consumerName}\` must be used within \`${ITEM_NAME}\``);
+  }
+  return context;
+}
+
+interface FileUploadItemProps extends React.ComponentProps<"div"> {
+  value: File;
+  asChild?: boolean;
+}
+
+function FileUploadItem(props: FileUploadItemProps) {
+  const { value, asChild, className, ...itemProps } = props;
+
+  const id = React.useId();
+  const statusId = `${id}-status`;
+  const nameId = `${id}-name`;
+  const sizeId = `${id}-size`;
+  const messageId = `${id}-message`;
+
+  const context = useFileUploadContext(ITEM_NAME);
+  const fileState = useStore((state) => state.files.get(value));
+  const fileCount = useStore((state) => state.files.size);
+  const fileIndex = useStore((state) => {
+    const files = Array.from(state.files.keys());
+    return files.indexOf(value) + 1;
+  });
+
+  const itemContext = React.useMemo(
+    () => ({
+      id,
+      fileState,
+      nameId,
+      sizeId,
+      statusId,
+      messageId,
+    }),
+    [id, fileState, statusId, nameId, sizeId, messageId],
+  );
+
+  if (!fileState) return null;
+
+  const statusText = fileState.error
+    ? `Error: ${fileState.error}`
+    : fileState.status === "uploading"
+      ? `Uploading: ${fileState.progress}% complete`
+      : fileState.status === "success"
+        ? "Upload complete"
+        : "Ready to upload";
+
+  const ItemPrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  return (
+    <FileUploadItemContext.Provider value={itemContext}>
+      <ItemPrimitive
+        role="listitem"
+        id={id}
+        aria-setsize={fileCount}
+        aria-posinset={fileIndex}
+        aria-describedby={`${nameId} ${sizeId} ${statusId} ${
+          fileState.error ? messageId : ""
+        }`}
+        aria-labelledby={nameId}
+        data-slot="file-upload-item"
+        dir={context.dir}
+        {...itemProps}
+        className={cn(
+          "relative flex items-center gap-2.5 rounded-md border p-3",
+          className,
+        )}
+      >
+        {props.children}
+        <span id={statusId} className="sr-only">
+          {statusText}
+        </span>
+      </ItemPrimitive>
+    </FileUploadItemContext.Provider>
+  );
+}
+
+interface FileUploadItemPreviewProps extends React.ComponentProps<"div"> {
+  render?: (file: File, fallback: () => React.ReactNode) => React.ReactNode;
+  asChild?: boolean;
+}
+
+function FileUploadItemPreview(props: FileUploadItemPreviewProps) {
+  const { render, asChild, children, className, ...previewProps } = props;
+
+  const itemContext = useFileUploadItemContext(ITEM_PREVIEW_NAME);
+  const context = useFileUploadContext(ITEM_PREVIEW_NAME);
+
+  const getDefaultRender = React.useCallback(
+    (file: File) => {
+      if (itemContext.fileState?.file.type.startsWith("image/")) {
+        let url = context.urlCache.get(file);
+        if (!url) {
+          url = URL.createObjectURL(file);
+          context.urlCache.set(file, url);
+        }
+
+        return (
+          // biome-ignore lint/performance/noImgElement: dynamic file URLs from user uploads don't work well with Next.js Image optimization
+          <img src={url} alt={file.name} className="size-full object-cover" />
+        );
+      }
+
+      return getFileIcon(file);
+    },
+    [itemContext.fileState?.file.type, context.urlCache],
+  );
+
+  const onPreviewRender = React.useCallback(
+    (file: File) => {
+      if (render) {
+        return render(file, () => getDefaultRender(file));
+      }
+
+      return getDefaultRender(file);
+    },
+    [render, getDefaultRender],
+  );
+
+  if (!itemContext.fileState) return null;
+
+  const ItemPreviewPrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  return (
+    <ItemPreviewPrimitive
+      aria-labelledby={itemContext.nameId}
+      data-slot="file-upload-preview"
+      {...previewProps}
+      className={cn(
+        "relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded border bg-accent/50 [&>svg]:size-10",
+        className,
+      )}
+    >
+      {onPreviewRender(itemContext.fileState.file)}
+      {children}
+    </ItemPreviewPrimitive>
+  );
+}
+
+interface FileUploadItemMetadataProps extends React.ComponentProps<"div"> {
+  asChild?: boolean;
+  size?: "default" | "sm";
+}
+
+function FileUploadItemMetadata(props: FileUploadItemMetadataProps) {
+  const {
+    asChild,
+    size = "default",
+    children,
+    className,
+    ...metadataProps
+  } = props;
+
+  const context = useFileUploadContext(ITEM_METADATA_NAME);
+  const itemContext = useFileUploadItemContext(ITEM_METADATA_NAME);
+
+  if (!itemContext.fileState) return null;
+
+  const ItemMetadataPrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  return (
+    <ItemMetadataPrimitive
+      data-slot="file-upload-metadata"
+      dir={context.dir}
+      {...metadataProps}
+      className={cn("flex min-w-0 flex-1 flex-col", className)}
+    >
+      {children ?? (
+        <>
+          <span
+            id={itemContext.nameId}
+            className={cn(
+              "truncate font-medium text-sm",
+              size === "sm" && "font-normal text-[13px] leading-snug",
+            )}
+          >
+            {itemContext.fileState.file.name}
+          </span>
+          <span
+            id={itemContext.sizeId}
+            className={cn(
+              "truncate text-muted-foreground text-xs",
+              size === "sm" && "text-[11px] leading-snug",
+            )}
+          >
+            {formatBytes(itemContext.fileState.file.size)}
+          </span>
+          {itemContext.fileState.error && (
+            <span
+              id={itemContext.messageId}
+              className="text-destructive text-xs"
+            >
+              {itemContext.fileState.error}
+            </span>
+          )}
+        </>
+      )}
+    </ItemMetadataPrimitive>
+  );
+}
+interface FileUploadItemProgressProps extends React.ComponentProps<"div"> {
+  variant?: "linear" | "circular" | "fill";
+  size?: number;
+  asChild?: boolean;
+  forceMount?: boolean;
+}
+
+function FileUploadItemProgress(props: FileUploadItemProgressProps) {
+  const {
+    variant = "linear",
+    size = 40,
+    asChild,
+    forceMount,
+    className,
+    ...progressProps
+  } = props;
+
+  const itemContext = useFileUploadItemContext(ITEM_PROGRESS_NAME);
+
+  if (!itemContext.fileState) return null;
+
+  const shouldRender = forceMount || itemContext.fileState.progress !== 100;
+
+  if (!shouldRender) return null;
+
+  const ItemProgressPrimitive = asChild ? SlotPrimitive.Slot : "div";
+
+  switch (variant) {
+    case "circular": {
+      const circumference = 2 * Math.PI * ((size - 4) / 2);
+      const strokeDashoffset =
+        circumference - (itemContext.fileState.progress / 100) * circumference;
+
+      return (
+        <ItemProgressPrimitive
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={itemContext.fileState.progress}
+          aria-valuetext={`${itemContext.fileState.progress}%`}
+          aria-labelledby={itemContext.nameId}
+          data-slot="file-upload-progress"
+          {...progressProps}
+          className={cn(
+            "absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
+            className,
+          )}
+        >
+          <svg
+            className="-rotate-90 transform"
+            width={size}
+            height={size}
+            viewBox={`0 0 ${size} ${size}`}
+            fill="none"
+            stroke="currentColor"
+          >
+            <circle
+              className="text-primary/20"
+              strokeWidth="2"
+              cx={size / 2}
+              cy={size / 2}
+              r={(size - 4) / 2}
+            />
+            <circle
+              className="text-primary transition-[stroke-dashoffset] duration-300 ease-linear"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={strokeDashoffset}
+              cx={size / 2}
+              cy={size / 2}
+              r={(size - 4) / 2}
+            />
+          </svg>
+        </ItemProgressPrimitive>
+      );
+    }
+
+    case "fill": {
+      const progressPercentage = itemContext.fileState.progress;
+      const topInset = 100 - progressPercentage;
+
+      return (
+        <ItemProgressPrimitive
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progressPercentage}
+          aria-valuetext={`${progressPercentage}%`}
+          aria-labelledby={itemContext.nameId}
+          data-slot="file-upload-progress"
+          {...progressProps}
+          className={cn(
+            "absolute inset-0 bg-primary/50 transition-[clip-path] duration-300 ease-linear",
+            className,
+          )}
+          style={{
+            clipPath: `inset(${topInset}% 0% 0% 0%)`,
+          }}
+        />
+      );
+    }
+
+    default:
+      return (
+        <ItemProgressPrimitive
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={itemContext.fileState.progress}
+          aria-valuetext={`${itemContext.fileState.progress}%`}
+          aria-labelledby={itemContext.nameId}
+          data-slot="file-upload-progress"
+          {...progressProps}
+          className={cn(
+            "relative h-1.5 w-full overflow-hidden rounded-full bg-primary/20",
+            className,
+          )}
+        >
+          <div
+            className="h-full w-full flex-1 bg-primary transition-transform duration-300 ease-linear"
+            style={{
+              transform: `translateX(-${100 - itemContext.fileState.progress}%)`,
+            }}
+          />
+        </ItemProgressPrimitive>
+      );
+  }
+}
+
+interface FileUploadItemDeleteProps extends React.ComponentProps<"button"> {
+  asChild?: boolean;
+}
+
+function FileUploadItemDelete(props: FileUploadItemDeleteProps) {
+  const { asChild, onClick: onClickProp, ...deleteProps } = props;
+
+  const store = useStoreContext(ITEM_DELETE_NAME);
+  const itemContext = useFileUploadItemContext(ITEM_DELETE_NAME);
+
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClickProp?.(event);
+
+      if (!itemContext.fileState || event.defaultPrevented) return;
+
+      store.dispatch({
+        type: "REMOVE_FILE",
+        file: itemContext.fileState.file,
+      });
+    },
+    [store, itemContext.fileState, onClickProp],
+  );
+
+  if (!itemContext.fileState) return null;
+
+  const ItemDeletePrimitive = asChild ? SlotPrimitive.Slot : "button";
+
+  return (
+    <ItemDeletePrimitive
+      type="button"
+      aria-controls={itemContext.id}
+      aria-describedby={itemContext.nameId}
+      data-slot="file-upload-item-delete"
+      {...deleteProps}
+      onClick={onClick}
+    />
+  );
+}
+
+interface FileUploadClearProps extends React.ComponentProps<"button"> {
+  forceMount?: boolean;
+  asChild?: boolean;
+}
+
+function FileUploadClear(props: FileUploadClearProps) {
+  const {
+    asChild,
+    forceMount,
+    disabled,
+    onClick: onClickProp,
+    ...clearProps
+  } = props;
+
+  const context = useFileUploadContext(CLEAR_NAME);
+  const store = useStoreContext(CLEAR_NAME);
+  const fileCount = useStore((state) => state.files.size);
+
+  const isDisabled = disabled || context.disabled;
+
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClickProp?.(event);
+
+      if (event.defaultPrevented) return;
+
+      store.dispatch({ type: "CLEAR" });
+    },
+    [store, onClickProp],
+  );
+
+  const shouldRender = forceMount || fileCount > 0;
+
+  if (!shouldRender) return null;
+
+  const ClearPrimitive = asChild ? SlotPrimitive.Slot : "button";
+
+  return (
+    <ClearPrimitive
+      type="button"
+      aria-controls={context.listId}
+      data-slot="file-upload-clear"
+      data-disabled={isDisabled ? "" : undefined}
+      {...clearProps}
+      disabled={isDisabled}
+      onClick={onClick}
+    />
+  );
+}
+
+export {
+  FileUpload,
+  FileUploadClear,
+  FileUploadDropzone,
+  FileUploadItem,
+  FileUploadItemDelete,
+  FileUploadItemMetadata,
+  FileUploadItemPreview,
+  FileUploadItemProgress,
+  FileUploadList,
+  type FileUploadProps,
+  FileUploadTrigger,
+  useStore as useFileUpload,
+};

--- a/src/hooks/use-as-ref.ts
+++ b/src/hooks/use-as-ref.ts
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+import { useIsomorphicLayoutEffect } from "@/hooks/use-isomorphic-layout-effect";
+
+function useAsRef<T>(props: T) {
+  const ref = React.useRef<T>(props);
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = props;
+  });
+
+  return ref;
+}
+
+export { useAsRef };

--- a/src/hooks/use-isomorphic-layout-effect.ts
+++ b/src/hooks/use-isomorphic-layout-effect.ts
@@ -1,0 +1,6 @@
+import * as React from "react";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
+export { useIsomorphicLayoutEffect };

--- a/src/hooks/use-lazy-ref.ts
+++ b/src/hooks/use-lazy-ref.ts
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+function useLazyRef<T>(fn: () => T) {
+  const ref = React.useRef<T | null>(null);
+
+  if (ref.current === null) {
+    ref.current = fn();
+  }
+
+  return ref as React.RefObject<T>;
+}
+
+export { useLazyRef };

--- a/src/lib/api/media.ts
+++ b/src/lib/api/media.ts
@@ -109,12 +109,17 @@ export function getStorageUsage(): Promise<StorageUsage> {
   return api.get<StorageUsage>(`/v1/storage/usage`);
 }
 
-export function uploadMedia(
-  file: File,
-): Promise<{ mediaId: string; publicUrl: string; sizeBytes: number; deduped: boolean }> {
+export interface MediaUploadResult {
+  mediaId: string;
+  publicUrl: string;
+  sizeBytes: number;
+  deduped: boolean;
+}
+
+export function uploadMedia(file: File): Promise<MediaUploadResult> {
   const form = new FormData();
   form.append("file", file);
-  return api.postForm(`/v1/media/upload`, form);
+  return api.postForm<MediaUploadResult>(`/v1/media/upload`, form);
 }
 
 export function deleteMedia(id: string): Promise<{ deletedCount: number; freedBytes: number }> {


### PR DESCRIPTION
## PR7 — Smart Delete + sidebar meter + reusable MediaUploader

Completes the Media Manager surface and extracts upload into a reusable helper.

- **SmartDelete** — advisory cleanup banner + wizard (4 categories, multi-select + per-category select-all, running reclaimable total, chunked bulk soft-delete). Advisory only.
- **SidebarStorageMeter** — always-visible compact meter in the sidebar footer (hidden when collapsed), shared `["storage-usage"]` query.
- **MediaUploader** (`components/media/media-uploader.tsx`) — **reusable** upload helper wrapping the shadcnblocks-PRO file-upload dropzone (diceui `FileUpload` primitive, via `@diceui` registry) + the R2 endpoint + per-file progress/preview. Decoupled via `onUploaded`, so any surface can use it (Media Manager, PR8 placeholder picker, composers). Retrofits PR6's hand-rolled dropzone.

### shadcnblocks-PRO audit
Per `feedback_shadcnblocks_first` (which I'd missed on PR6): audited every media surface — only the upload dropzone had a fitting PRO block (now used); grid/meter/wizard are app-specific (catalog is marketing/landing blocks). Vendored diceui file-upload carries a scoped eslint-disable.

### Reviews
Review #1 (subagent) confirmed the MediaUploader↔diceui `onUpload` contract is correct. Fixes: 200-id bulk-delete chunking, true category totals via `meta.total` + re-run hint, duplicate reclaimable estimate. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
