### PR TITLE
feat(media): PR8 — per-placeholder Pick-from-library + Upload (closes newsletter gap)

### DIFF
--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -1396,7 +1396,11 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
           onGenerate={handleGeneratePlaceholder}
           onSupplyUrl={(i, url) => handleResolvePlaceholder(i, url, "supplied")}
           onPickFromLibrary={(i, url, mediaId) => handleResolvePlaceholder(i, url, "uploaded", mediaId)}
-          busy={saving}
+          /* Disable ALL per-row actions while any row is resolving/generating:
+             each handler maps over the prop-derived placeholders array, so a
+             concurrent second-row write would build on a stale array and clobber
+             the first row's just-set resolution (review M4). */
+          busy={saving || generatingPlaceholderIdx !== null || resolvingPlaceholderIdx !== null}
           finalized={finalized}
           generatingIndex={generatingPlaceholderIdx}
           resolvingIndex={resolvingPlaceholderIdx}

--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -9,6 +9,7 @@ import { api } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { LibraryMediaPicker } from "@/components/media/library-media-picker";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { ChannelIcon } from "@/components/ui/channel-icon";
@@ -175,6 +176,8 @@ interface ImagePlaceholder {
   styleHints?: string[];
   status: "placeholder" | "generated" | "uploaded" | "supplied" | "deleted";
   resolvedImageUrl?: string;
+  /** cnt_media row backing resolvedImageUrl (set on library-pick / upload). */
+  mediaId?: string;
 }
 
 interface IdeaDetail {
@@ -753,6 +756,7 @@ function ImagePlaceholderRail({
   onDelete,
   onGenerate,
   onSupplyUrl,
+  onPickFromLibrary,
   busy,
   finalized,
   generatingIndex,
@@ -763,6 +767,8 @@ function ImagePlaceholderRail({
   onGenerate: (index: number) => void;
   /** Resolve a placeholder from an external URL (status "supplied"). */
   onSupplyUrl: (index: number, url: string) => void;
+  /** Resolve from the media library / an upload (status "uploaded"). */
+  onPickFromLibrary: (index: number, url: string, mediaId: string) => void;
   busy: boolean;
   finalized: boolean;
   generatingIndex: number | null;
@@ -775,7 +781,7 @@ function ImagePlaceholderRail({
         <CardTitle className="text-sm flex items-center gap-2"><ImageIcon className="h-4 w-4" /> Image placeholders <span className="text-muted-foreground font-normal">({placeholders.length})</span></CardTitle>
         <CardDescription className="text-xs">
           {finalized
-            ? "Text finalized — Generate an image with AI or paste an image URL per placeholder. Delete what you don't want first."
+            ? "Text finalized — per placeholder: Generate with AI, paste an image URL, or pick from your media library (Library also uploads). Delete what you don't want first."
             : "Delete what you don't want; Finalize text to unlock image generation."}
         </CardDescription>
       </CardHeader>
@@ -789,6 +795,7 @@ function ImagePlaceholderRail({
               onDelete={onDelete}
               onGenerate={onGenerate}
               onSupplyUrl={onSupplyUrl}
+              onPickFromLibrary={onPickFromLibrary}
               busy={busy}
               finalized={finalized}
               isGenerating={generatingIndex === i}
@@ -806,8 +813,9 @@ function ImagePlaceholderRail({
  * parent rail stays stateless. Resolution paths:
  *   - Generate  → AI image pipeline (status "generated"), gated on finalize
  *   - Paste URL → external URL        (status "supplied"),  gated on finalize
- * (Library pick — status "uploaded" — lands with the Media Manager / R2
- * workstream; the data model + handler already accept it.)
+ *   - Library   → pick from cnt_media OR upload (status "uploaded" + mediaId),
+ *                 gated on finalize — via <LibraryMediaPicker> (Media Manager
+ *                 / R2). Closes the newsletter image-placeholder gap.
  */
 function PlaceholderCard({
   p,
@@ -815,6 +823,7 @@ function PlaceholderCard({
   onDelete,
   onGenerate,
   onSupplyUrl,
+  onPickFromLibrary,
   busy,
   finalized,
   isGenerating,
@@ -825,6 +834,7 @@ function PlaceholderCard({
   onDelete: (index: number) => void;
   onGenerate: (index: number) => void;
   onSupplyUrl: (index: number, url: string) => void;
+  onPickFromLibrary: (index: number, url: string, mediaId: string) => void;
   busy: boolean;
   finalized: boolean;
   isGenerating: boolean;
@@ -889,6 +899,23 @@ function PlaceholderCard({
           >
             {isResolving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Link2 className="h-3 w-3" />} Paste URL
           </button>
+          <LibraryMediaPicker
+            maxSelection={1}
+            onSelect={(assets) => {
+              const a = assets[0];
+              if (a) onPickFromLibrary(index, a.url, a.id);
+            }}
+            trigger={
+              <button
+                type="button"
+                disabled={rowBusy || !finalized}
+                className="text-xs font-medium px-2.5 py-1 rounded border bg-background hover:bg-accent disabled:opacity-40 flex items-center gap-1"
+                title={finalized ? "Choose from your media library or upload" : "Finalize text first to unlock"}
+              >
+                <ImageIcon className="h-3 w-3" /> Library
+              </button>
+            }
+          />
         </div>
         {urlOpen && (
           <div className="mt-2 flex items-center gap-1.5">
@@ -1236,11 +1263,14 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
     index: number,
     resolvedImageUrl: string,
     status: "supplied" | "uploaded",
+    mediaId?: string,
   ) {
     setResolvingPlaceholderIdx(index);
     try {
       const next = placeholders.map((p, i) =>
-        i === index ? { ...p, resolvedImageUrl, status } : p,
+        i === index
+          ? { ...p, resolvedImageUrl, status, ...(mediaId ? { mediaId } : {}) }
+          : p,
       );
       await api.put(`/v1/content/ideas/${ideaId}/content`, { imagePlaceholders: next });
       toast.success(`Image ${index + 1} set`);
@@ -1365,6 +1395,7 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
           onDelete={handleDeletePlaceholder}
           onGenerate={handleGeneratePlaceholder}
           onSupplyUrl={(i, url) => handleResolvePlaceholder(i, url, "supplied")}
+          onPickFromLibrary={(i, url, mediaId) => handleResolvePlaceholder(i, url, "uploaded", mediaId)}
           busy={saving}
           finalized={finalized}
           generatingIndex={generatingPlaceholderIdx}

--- a/src/components/media/library-media-picker.tsx
+++ b/src/components/media/library-media-picker.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { MediaPicker } from "@/components/composer/media-picker";
+import type { MediaAsset } from "@/components/composer/types";
+import { listMedia, uploadMedia, type MediaItem } from "@/lib/api/media";
+
+/**
+ * <LibraryMediaPicker> — the composer MediaPicker primitive wired to the
+ * real cnt_media / R2 backend (Media Manager plan §7). Closes the
+ * newsletter image-placeholder "pick from library" + "upload" gap.
+ *
+ * Reusable anywhere a stored image is needed (strategist Images stage,
+ * composers, …): the Library tab searches cnt_media, the Upload tab stores
+ * to R2 via the shared endpoint, and onSelect returns the chosen assets.
+ * Generate is intentionally omitted here — placeholder AI generation has
+ * its own dedicated button + finalize gate.
+ */
+function toAsset(m: MediaItem): MediaAsset {
+  return {
+    id: m.id,
+    url: m.publicUrl,
+    mime: m.mimeType,
+    width: m.width,
+    height: m.height,
+    bytes: m.sizeBytes,
+    alt: m.aiOrigin?.prompt,
+    source: m.source === "ai_generated" ? "ai_image" : "upload",
+    createdAt: m.createdAt,
+  };
+}
+
+export function LibraryMediaPicker({
+  trigger,
+  maxSelection,
+  onSelect,
+}: {
+  trigger?: React.ReactNode;
+  maxSelection?: number;
+  onSelect: (assets: MediaAsset[]) => void;
+}) {
+  return (
+    <MediaPicker
+      accept="image"
+      trigger={trigger}
+      maxSelection={maxSelection}
+      onSelect={onSelect}
+      onSearch={async (query, _kind, signal) => {
+        // The list endpoint has no server-side search; pull the first page
+        // and filter client-side over the AI prompt / type (matches the
+        // Media Manager page's search). Good enough for v1 picking.
+        const { items } = await listMedia({ status: "active", limit: 60 });
+        if (signal.aborted) return [];
+        const q = query.trim().toLowerCase();
+        const filtered = q
+          ? items.filter(
+              (m) =>
+                m.aiOrigin?.prompt?.toLowerCase().includes(q) ||
+                m.mimeType.toLowerCase().includes(q),
+            )
+          : items;
+        return filtered.map(toAsset);
+      }}
+      onUpload={async (files) => {
+        // Sequential so a quota rejection stops the batch cleanly; the
+        // picker surfaces the thrown error as a toast.
+        const created: MediaAsset[] = [];
+        for (const file of files) {
+          const res = await uploadMedia(file);
+          created.push({
+            id: res.mediaId,
+            url: res.publicUrl,
+            mime: file.type,
+            bytes: res.sizeBytes,
+            source: "upload",
+            createdAt: new Date().toISOString(),
+          });
+        }
+        return created;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## PR8 — closes the newsletter image-placeholder gap 🎯

The original driver of the whole R2 workstream: the strategist Images stage now lets every placeholder resolve via **Generate / Paste URL / Library (pick OR upload)**.

- **LibraryMediaPicker** (`components/media/library-media-picker.tsx`): reusable wrapper binding the existing composer `MediaPicker` to the real cnt_media/R2 backend — Library tab → `listMedia`, Upload tab → `uploadMedia` (R2). Reusable by composers too.
- **PlaceholderCard** gains a "Library" button (gated on finalize) → picker → resolves the placeholder with `status:"uploaded"` + `resolvedImageUrl` + **`mediaId`** (the cnt_ideas field added in PR1).
- `handleResolvePlaceholder` now persists `mediaId`; type + rail/card threading updated.

### Reviews
Review #1 (subagent) cleared the two top risks (mediaId is always a valid ObjectId hex; the disabled trigger inside SheetTrigger does NOT bypass the finalize gate). Fix `M4`: all per-row actions now disable while any row is resolving/generating (prevents a stale-array cross-row clobber). `H3` (PUT /content lacks server-side imagePlaceholders validation) is a pre-existing api gap flagged for follow-up — PR8 is safe (client sends valid data). tsc + eslint clean; strategist rules-of-hooks already resolved.

### ⚠️ Note
Picking shows real media only once R2-backed assets exist (uploads/AI-gen). The wiring is complete and correct; end-to-end visible result needs R2 (deferred) + PR3 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
