### PR TITLE
feat(meta): public /data-deletion page (policy + status-by-code)

### DIFF
--- a/src/app/data-deletion/page.tsx
+++ b/src/app/data-deletion/page.tsx
@@ -1,0 +1,213 @@
+import type { Metadata } from "next";
+import { SITE } from "@/lib/utils";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Data Deletion - PeakHour",
+  description:
+    "Request deletion of your data from PeakHour and check the status of a data-deletion request.",
+};
+
+type DeletionStatus = {
+  status: "received" | "processing" | "completed" | "failed";
+  trigger: string;
+  requestedAt: string;
+  completedAt?: string;
+};
+
+/**
+ * Look up a data-deletion request by its confirmation code via the public
+ * (unauthenticated) status endpoint. Returns null when no code is supplied,
+ * the request isn't found, or the API is unreachable — the page degrades to
+ * the static policy in every one of those cases.
+ */
+async function fetchStatus(code: string): Promise<DeletionStatus | null> {
+  const base = process.env.NEXT_PUBLIC_API_URL ?? "";
+  if (!base) return null;
+  try {
+    const res = await fetch(
+      `${base}/v1/webhooks/meta/data-deletion/status?code=${encodeURIComponent(code)}`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    const json = (await res.json()) as { found?: boolean } & DeletionStatus;
+    return json.found ? json : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatUtc(iso?: string): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : `${d.toUTCString()}`;
+}
+
+function StatusBlock({
+  code,
+  status,
+}: {
+  code: string;
+  status: DeletionStatus | null;
+}) {
+  const requestedAt = formatUtc(status?.requestedAt);
+  const completedAt = formatUtc(status?.completedAt);
+
+  let tone = "border-border";
+  let heading = "Request not found";
+  let body =
+    "We couldn’t find a data-deletion request for that reference code. The link may be incomplete — please check it, or contact us using the details below.";
+
+  if (status) {
+    if (status.status === "completed") {
+      tone = "border-green-500/40 bg-green-500/5";
+      heading = "Your data has been deleted";
+      body =
+        "We’ve removed the personal data associated with your Meta connection (profile details and access tokens we held). No further action is needed.";
+    } else if (status.status === "failed") {
+      tone = "border-red-500/40 bg-red-500/5";
+      heading = "We hit a problem";
+      body =
+        "We couldn’t finish your deletion request automatically. Our team has been notified and will complete it. If you’d like an update, contact us with your reference code below.";
+    } else {
+      // received | processing
+      tone = "border-amber-500/40 bg-amber-500/5";
+      heading = "Your request is being processed";
+      body =
+        "We’ve received your data-deletion request and are processing it. You can revisit this page with your reference code to check progress.";
+    }
+  }
+
+  return (
+    <section className={`rounded-lg border p-5 ${tone}`}>
+      <h2 className="text-lg font-semibold text-foreground">{heading}</h2>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{body}</p>
+      <dl className="mt-4 space-y-1 text-xs text-muted-foreground">
+        <div>
+          <span className="font-medium text-foreground">Reference code:</span>{" "}
+          <span className="font-mono">{code}</span>
+        </div>
+        {requestedAt && (
+          <div>
+            <span className="font-medium text-foreground">Requested:</span> {requestedAt}
+          </div>
+        )}
+        {completedAt && (
+          <div>
+            <span className="font-medium text-foreground">Completed:</span> {completedAt}
+          </div>
+        )}
+      </dl>
+    </section>
+  );
+}
+
+export default async function DataDeletionPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ code?: string }>;
+}) {
+  const { code } = await searchParams;
+  const status = code ? await fetchStatus(code) : null;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <h1 className="text-3xl font-bold">Data Deletion</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: {SITE.legalLastUpdated}
+        </p>
+
+        {code && (
+          <div className="mt-8">
+            <StatusBlock code={code} status={status} />
+          </div>
+        )}
+
+        <div className="mt-8 space-y-8 text-sm leading-relaxed text-muted-foreground">
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">
+              Deleting your data from PeakHour
+            </h2>
+            <p className="mt-2">
+              PeakHour (peakhour.ai) is an AI-powered marketing platform. When you connect a
+              Meta account (Facebook, Instagram, or WhatsApp Business), we store the connection
+              details needed to operate the integration on your behalf. You can ask us to delete
+              that data at any time, and you control the connection from the platform that
+              granted it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">How to request deletion</h2>
+            <p className="mt-2">There are two ways to have your data deleted:</p>
+            <ul className="mt-2 list-disc space-y-2 pl-6">
+              <li>
+                <strong className="text-foreground">From Facebook:</strong> open{" "}
+                <span className="font-medium">
+                  Facebook → Settings &amp; privacy → Settings → Apps and Websites
+                </span>
+                , remove <strong className="text-foreground">PeakHour</strong>, and choose to
+                request deletion of your data. Facebook notifies us automatically and we delete
+                your connection data, then give you a reference code to track the request on this
+                page.
+              </li>
+              <li>
+                <strong className="text-foreground">By email:</strong> write to{" "}
+                <a className="text-foreground underline" href={`mailto:${SITE.contactPrivacy}`}>
+                  {SITE.contactPrivacy}
+                </a>{" "}
+                from the email on your PeakHour account and we’ll process the deletion for you.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">What we delete</h2>
+            <p className="mt-2">
+              We delete the personal data tied to your Meta connection — the profile information
+              (name, profile details, email where provided) and the access tokens we hold to
+              operate the integration. Once deleted, PeakHour can no longer act on your Meta
+              account and the connection is removed.
+            </p>
+            <p className="mt-2">
+              Content created within a PeakHour organization (for example, published posts and
+              business records) is owned and controlled by that organization and is governed by
+              our{" "}
+              <a className="text-foreground underline" href="/privacy-policy">
+                Privacy Policy
+              </a>{" "}
+              and the organization’s own retention settings.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">Checking your request</h2>
+            <p className="mt-2">
+              If you arrived here from a Facebook deletion request, your reference code is in the
+              link (e.g. <span className="font-mono">/data-deletion?code=…</span>) and the status
+              is shown at the top of this page. You can revisit the same link any time to check
+              progress.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">Contact</h2>
+            <p className="mt-2">
+              Questions about a deletion request? Email{" "}
+              <a className="text-foreground underline" href={`mailto:${SITE.contactPrivacy}`}>
+                {SITE.contactPrivacy}
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/data-deletion/page.tsx
+++ b/src/app/data-deletion/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { SITE } from "@/lib/utils";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
@@ -11,7 +12,6 @@ export const metadata: Metadata = {
 
 type DeletionStatus = {
   status: "received" | "processing" | "completed" | "failed";
-  trigger: string;
   requestedAt: string;
   completedAt?: string;
 };
@@ -177,9 +177,9 @@ export default async function DataDeletionPage({
               Content created within a PeakHour organization (for example, published posts and
               business records) is owned and controlled by that organization and is governed by
               our{" "}
-              <a className="text-foreground underline" href="/privacy-policy">
+              <Link className="text-foreground underline" href="/privacy-policy">
                 Privacy Policy
-              </a>{" "}
+              </Link>{" "}
               and the organization’s own retention settings.
             </p>
           </section>


### PR DESCRIPTION
## What
The public page Meta's **Data Deletion Request** callback URL points at: `peakhour.ai/data-deletion?code=...`. Meta's App Review reviewer (and end users) land here, so it must exist and work.

Async server component (Next 16):
- **Always** renders the data-deletion policy — how to request deletion (remove PeakHour from Facebook → Apps & Websites, or email privacy@peakhour.ai), **what we delete** (the Meta connection's PII + access tokens; org-owned content is governed by the Privacy Policy), and contact.
- When `?code=` is present, calls the public **`GET /v1/webhooks/meta/data-deletion/status`** endpoint (peakhour-api #452) and shows a friendly **completed / processing / failed / not-found** state with the reference code + timestamps.
- Degrades to the static policy if the API is unreachable or the code is missing/unknown. **No PII rendered** (the endpoint returns only lifecycle fields).

## Pairs with
- peakhour-api **#452** (the callback purge + status endpoint) — merged.
- peakhour-mongodb **#164** (tracking schema) — merged.

Together these complete Meta's required data-deletion contract for App Review.

## Review
- Two-round workflow. Review #1 (subagent + manual): PASS, no HIGH/MEDIUM; applied the two LOW polish items in a fix commit (Next `<Link>` for internal nav; dropped unused `trigger`).
- `tsc --noEmit` + `eslint` clean. Convention parity with `privacy-policy/page.tsx` (Header/Footer/SITE/Metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)