### PR TITLE
feat(meta): WhatsApp Embedded Signup connect UI (minute-to-live)

### DIFF
--- a/src/app/dashboard/content/channels.config.ts
+++ b/src/app/dashboard/content/channels.config.ts
@@ -225,6 +225,9 @@ export const CHANNELS: readonly ChannelConfig[] = [
     // Virtual Meta capability — see facebook-pages note above.
     providerKey: "whatsapp",
     status: "available",
+    // Self-serve connect via Embedded Signup lives on its own in-app page
+    // (not the generic /dashboard/integrations OAuth grid).
+    dashboardPath: "/dashboard/content/whatsapp",
   },
   {
     slug: "slack",

--- a/src/app/dashboard/content/page.tsx
+++ b/src/app/dashboard/content/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -53,21 +53,23 @@ export default function ContentChannelsHubPage() {
     // auto-redirect from re-firing on tab focus, but that's gone now.)
   });
 
+  // Bind `data?.integrations` to a local so the memo's source dep matches what
+  // React Compiler infers (it widened `data?.integrations` to `data`). Stable
+  // reference across refetches that return the same content → no map churn.
+  const integrations = data?.integrations;
   const connections = useMemo<ConnectionMap>(() => {
     const map: ConnectionMap = new Map();
     // Flatten Meta — one `facebook` connection becomes 4 virtual rows
     // (facebook_pages, instagram, meta_ads, whatsapp) so per-capability
     // connection state lights up independently in the hub.
     const flat = flattenMetaIntegration(
-      Array.isArray(data?.integrations) ? data.integrations : [],
+      Array.isArray(integrations) ? integrations : [],
     );
     for (const integ of flat) {
       map.set(integ.provider, integ);
     }
     return map;
-    // Memo on `data?.integrations` (not `data`) so refetches that return the
-    // same content reference don't churn the map and re-render every row.
-  }, [data?.integrations]);
+  }, [integrations]);
 
   const cronToolbar = (
     <CronToolbar
@@ -163,7 +165,11 @@ function ChannelRow({ channel, integration, connectionStateUnknown }: ChannelRow
 
   const handleAction = () => {
     if (channel.status === "coming_soon" || connectionStateUnknown) return;
-    if (isConnected && channel.dashboardPath) {
+    // Channels that connect via their own in-app page (e.g. WhatsApp Embedded
+    // Signup, status "available") route there for both connect and manage;
+    // "live" channels route to their dashboard once connected. Everything else
+    // falls back to the integrations OAuth grid.
+    if (channel.dashboardPath && (isConnected || channel.status === "available")) {
       router.push(channel.dashboardPath);
     } else {
       router.push("/dashboard/integrations");
@@ -270,13 +276,32 @@ function ChannelLogo({ channel }: { channel: ChannelConfig }) {
  * for a brand-new connection that has never run).
  */
 function useLastSyncedLabel(lastSyncAt: string | undefined): string | undefined {
+  // Sample "now" in an effect, never during render: calling Date.now() /
+  // new Date() during render is impure and defeats React Compiler memoization.
+  // Null until mounted → no label flash and SSR-safe (server + first client
+  // render agree on `undefined`).
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    // Defer to a microtask so it's neither an impure render-time read nor a
+    // synchronous effect setState (both are lint-flagged); guard unmount.
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setNow(Date.now());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [lastSyncAt]);
+
   return useMemo(() => {
-    if (!lastSyncAt) return undefined;
-    const ts = new Date(lastSyncAt).getTime();
+    if (!lastSyncAt || now === null) return undefined;
+    // Date.parse is pure (deterministic for a given string); new Date(str) is
+    // flagged impure by the compiler.
+    const ts = Date.parse(lastSyncAt);
     if (Number.isNaN(ts)) return undefined;
     // Clamp to 0 — server/client clock skew can produce a small negative
     // diff right after a fresh sync; show "Just synced" instead of nothing.
-    const diffMs = Math.max(0, Date.now() - ts);
+    const diffMs = Math.max(0, now - ts);
     if (diffMs < 30_000) return "Just synced";
 
     const minute = 60_000;
@@ -296,7 +321,7 @@ function useLastSyncedLabel(lastSyncAt: string | undefined): string | undefined 
       return `Last synced ${days} days ago — check connection`;
     }
     return `Last synced ${days} day${days === 1 ? "" : "s"} ago`;
-  }, [lastSyncAt]);
+  }, [lastSyncAt, now]);
 }
 
 function HubSkeleton() {

--- a/src/app/dashboard/content/whatsapp/page.tsx
+++ b/src/app/dashboard/content/whatsapp/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { WhatsAppEmbeddedSignup } from "@/components/integrations/whatsapp-embedded-signup";
+
+export default function WhatsAppConnectPage() {
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6 p-4 md:p-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">WhatsApp</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Connect your WhatsApp Business account to message customers directly
+          from PeakHour — order updates, reminders, and support, all in one place.
+        </p>
+      </div>
+
+      <WhatsAppEmbeddedSignup />
+    </div>
+  );
+}

--- a/src/components/integrations/whatsapp-embedded-signup.tsx
+++ b/src/components/integrations/whatsapp-embedded-signup.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, ApiError } from "@/lib/api";
+import { useFacebookSdk, type FacebookLoginResponse } from "@/hooks/use-facebook-sdk";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { WhatsAppIcon } from "@/components/ui/brand-icons";
+import { CheckCircle2, AlertCircle, Loader2, Sparkles } from "lucide-react";
+
+const APP_ID = process.env.NEXT_PUBLIC_META_APP_ID;
+const CONFIG_ID = process.env.NEXT_PUBLIC_META_ES_CONFIG_ID;
+
+/** Result returned by POST /v1/meta/whatsapp/embedded-signup. */
+interface ConnectResult {
+  status: "connected";
+  wabaId: string;
+  phoneNumberId: string;
+  appSubscribed: boolean;
+  phoneRegistered: boolean;
+  account: {
+    name: string;
+    phoneNumbers: Array<{ id: string; displayPhoneNumber: string; verifiedName: string }>;
+  };
+}
+
+type Phase = "idle" | "launching" | "connecting" | "connected" | "error";
+
+/** Meta's session-info postMessage payload (the slice we use). */
+interface SessionInfoMessage {
+  type?: string;
+  event?: string;
+  data?: { waba_id?: string; phone_number_id?: string };
+}
+
+const FB_ORIGINS = new Set([
+  "https://www.facebook.com",
+  "https://web.facebook.com",
+  "https://business.facebook.com",
+]);
+
+export function WhatsAppEmbeddedSignup({
+  onConnected,
+}: {
+  onConnected?: (result: ConnectResult) => void;
+}) {
+  const sdkState = useFacebookSdk(APP_ID);
+  const configured = Boolean(APP_ID && CONFIG_ID);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ConnectResult | null>(null);
+
+  // The code (from FB.login) and the WABA/phone ids (from the session-info
+  // postMessage) can arrive in either order — collect both in refs and POST
+  // only once both are present. `completing` guards against a double-submit
+  // when the second piece lands.
+  const codeRef = useRef<string | null>(null);
+  const sessionRef = useRef<{ wabaId: string; phoneNumberId: string } | null>(null);
+  const completingRef = useRef(false);
+
+  const reset = () => {
+    codeRef.current = null;
+    sessionRef.current = null;
+    completingRef.current = false;
+  };
+
+  const complete = useCallback(async () => {
+    if (completingRef.current) return;
+    if (!codeRef.current || !sessionRef.current) return;
+    completingRef.current = true;
+    setPhase("connecting");
+    setError(null);
+    try {
+      const res = await api.post<ConnectResult>(
+        "/v1/meta/whatsapp/embedded-signup",
+        {
+          code: codeRef.current,
+          wabaId: sessionRef.current.wabaId,
+          phoneNumberId: sessionRef.current.phoneNumberId,
+        },
+      );
+      setResult(res);
+      setPhase("connected");
+      onConnected?.(res);
+    } catch (err) {
+      setPhase("error");
+      setError(
+        err instanceof ApiError
+          ? err.message
+          : "We couldn’t finish connecting your WhatsApp account. Please try again.",
+      );
+    } finally {
+      reset();
+    }
+  }, [onConnected]);
+
+  // Capture the WABA + phone ids from Meta's Embedded Signup session-info event.
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (!FB_ORIGINS.has(event.origin)) return;
+      let payload: SessionInfoMessage;
+      try {
+        payload = typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+      } catch {
+        return;
+      }
+      if (payload?.type !== "WA_EMBEDDED_SIGNUP") return;
+      // FINISH (and the legacy FINISH_ONLY_WABA) carry the ids. A CANCEL means
+      // the user closed the flow before finishing.
+      if (payload.event === "CANCEL") {
+        if (phase === "launching") {
+          setPhase("idle");
+          reset();
+        }
+        return;
+      }
+      const wabaId = payload.data?.waba_id;
+      const phoneNumberId = payload.data?.phone_number_id;
+      if (wabaId && phoneNumberId) {
+        sessionRef.current = { wabaId, phoneNumberId };
+        void complete();
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [complete, phase]);
+
+  const launch = useCallback(() => {
+    if (sdkState !== "ready" || !window.FB || !CONFIG_ID) return;
+    reset();
+    setError(null);
+    setResult(null);
+    setPhase("launching");
+
+    window.FB.login(
+      (response: FacebookLoginResponse) => {
+        const code = response?.authResponse?.code;
+        if (!code) {
+          // User closed/declined the popup, or no code came back.
+          if (!sessionRef.current) {
+            setPhase("idle");
+            reset();
+          }
+          return;
+        }
+        codeRef.current = code;
+        void complete();
+      },
+      {
+        config_id: CONFIG_ID,
+        response_type: "code",
+        override_default_response_type: true,
+        extras: { sessionInfoVersion: "3" },
+      },
+    );
+  }, [sdkState, complete]);
+
+  // ── Connected state ──────────────────────────────────────────
+  if (phase === "connected" && result) {
+    const phone = result.account.phoneNumbers[0];
+    return (
+      <Card className="border-green-500/40 bg-green-500/5">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <span className="flex size-10 items-center justify-center rounded-full bg-green-500/15">
+              <CheckCircle2 className="size-5 text-green-600" />
+            </span>
+            <div>
+              <CardTitle className="text-base">WhatsApp connected</CardTitle>
+              <CardDescription>
+                {result.account.name}
+                {phone ? ` · ${phone.displayPhoneNumber}` : ""}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          You’re live. You can reply to customers right away; sending campaigns
+          needs an approved message template.
+          {!result.phoneRegistered && (
+            <p className="mt-2 text-amber-600">
+              We’re finishing your number setup in the background — if sending
+              isn’t available yet, give it a minute.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Connect card ─────────────────────────────────────────────
+  const busy = phase === "launching" || phase === "connecting";
+  const disabled = !configured || sdkState !== "ready" || busy;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <span className="flex size-10 items-center justify-center rounded-full bg-[#25D366]/15">
+            <WhatsAppIcon className="size-5 text-[#25D366]" />
+          </span>
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              Connect WhatsApp
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+                <Sparkles className="size-3" /> Live in a minute
+              </span>
+            </CardTitle>
+            <CardDescription>
+              Connect your WhatsApp Business number to message customers from
+              PeakHour. No account yet? You can create one in the same step.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Button onClick={launch} disabled={disabled} size="lg" className="gap-2">
+          {busy ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              {phase === "connecting" ? "Finishing setup…" : "Opening WhatsApp…"}
+            </>
+          ) : (
+            <>
+              <WhatsAppIcon className="size-4" />
+              Connect WhatsApp
+            </>
+          )}
+        </Button>
+
+        {!configured && (
+          <p className="flex items-start gap-2 text-sm text-muted-foreground">
+            <AlertCircle className="mt-0.5 size-4 shrink-0" />
+            WhatsApp connection isn’t configured yet. Set{" "}
+            <code className="rounded bg-muted px-1">NEXT_PUBLIC_META_APP_ID</code>{" "}
+            and{" "}
+            <code className="rounded bg-muted px-1">NEXT_PUBLIC_META_ES_CONFIG_ID</code>.
+          </p>
+        )}
+
+        {configured && sdkState === "loading" && (
+          <p className="text-sm text-muted-foreground">Loading WhatsApp…</p>
+        )}
+        {configured && sdkState === "error" && (
+          <p className="flex items-center gap-2 text-sm text-red-600">
+            <AlertCircle className="size-4" />
+            Couldn’t load the WhatsApp connector. Check your connection and
+            refresh.
+          </p>
+        )}
+
+        {phase === "error" && error && (
+          <p className="flex items-start gap-2 text-sm text-red-600">
+            <AlertCircle className="mt-0.5 size-4 shrink-0" />
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/integrations/whatsapp-embedded-signup.tsx
+++ b/src/components/integrations/whatsapp-embedded-signup.tsx
@@ -12,10 +12,15 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { WhatsAppIcon } from "@/components/ui/brand-icons";
-import { CheckCircle2, AlertCircle, Loader2, Sparkles } from "lucide-react";
+import { CheckCircle2, AlertCircle, Loader2, Sparkles, Info } from "lucide-react";
 
 const APP_ID = process.env.NEXT_PUBLIC_META_APP_ID;
 const CONFIG_ID = process.env.NEXT_PUBLIC_META_ES_CONFIG_ID;
+
+/** How long to wait for BOTH the auth code and the WABA/phone ids before
+ *  giving up — guards against a missed Meta FINISH event leaving the UI
+ *  spinning forever. */
+const WATCHDOG_MS = 90_000;
 
 /** Result returned by POST /v1/meta/whatsapp/embedded-signup. */
 interface ConnectResult {
@@ -32,18 +37,36 @@ interface ConnectResult {
 
 type Phase = "idle" | "launching" | "connecting" | "connected" | "error";
 
-/** Meta's session-info postMessage payload (the slice we use). */
-interface SessionInfoMessage {
-  type?: string;
-  event?: string;
-  data?: { waba_id?: string; phone_number_id?: string };
+/**
+ * Deep-search a parsed postMessage payload for the WABA + phone-number ids.
+ * Meta's Embedded Signup session-info event has varied in nesting across SDK
+ * versions (`data.waba_id` vs `data.data.waba_id`); searching by key name is
+ * robust to that and to future shape changes. Only string id values are read —
+ * nothing from the payload is executed.
+ */
+function findSignupIds(obj: unknown): { wabaId?: string; phoneNumberId?: string } {
+  const out: { wabaId?: string; phoneNumberId?: string } = {};
+  const visit = (o: unknown, depth: number) => {
+    if (!o || typeof o !== "object" || depth > 6) return;
+    for (const [k, v] of Object.entries(o as Record<string, unknown>)) {
+      if (k === "waba_id" && typeof v === "string") out.wabaId = v;
+      else if (k === "phone_number_id" && typeof v === "string") out.phoneNumberId = v;
+      else if (v && typeof v === "object") visit(v, depth + 1);
+    }
+  };
+  visit(obj, 0);
+  return out;
 }
 
-const FB_ORIGINS = new Set([
-  "https://www.facebook.com",
-  "https://web.facebook.com",
-  "https://business.facebook.com",
-]);
+/** Accept messages only from Facebook origins. */
+function isFacebookOrigin(origin: string): boolean {
+  try {
+    const host = new URL(origin).hostname;
+    return host === "facebook.com" || host.endsWith(".facebook.com");
+  } catch {
+    return false;
+  }
+}
 
 export function WhatsAppEmbeddedSignup({
   onConnected,
@@ -59,13 +82,20 @@ export function WhatsAppEmbeddedSignup({
 
   // The code (from FB.login) and the WABA/phone ids (from the session-info
   // postMessage) can arrive in either order — collect both in refs and POST
-  // only once both are present. `completing` guards against a double-submit
-  // when the second piece lands.
+  // only once both are present. `completingRef` guards against a double-submit.
   const codeRef = useRef<string | null>(null);
   const sessionRef = useRef<{ wabaId: string; phoneNumberId: string } | null>(null);
   const completingRef = useRef(false);
+  const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const reset = () => {
+  const clearWatchdog = () => {
+    if (watchdogRef.current) {
+      clearTimeout(watchdogRef.current);
+      watchdogRef.current = null;
+    }
+  };
+
+  const resetPieces = () => {
     codeRef.current = null;
     sessionRef.current = null;
     completingRef.current = false;
@@ -75,6 +105,7 @@ export function WhatsAppEmbeddedSignup({
     if (completingRef.current) return;
     if (!codeRef.current || !sessionRef.current) return;
     completingRef.current = true;
+    clearWatchdog(); // both pieces in hand — the POST owns the outcome now
     setPhase("connecting");
     setError(null);
     try {
@@ -97,32 +128,31 @@ export function WhatsAppEmbeddedSignup({
           : "We couldn’t finish connecting your WhatsApp account. Please try again.",
       );
     } finally {
-      reset();
+      resetPieces();
     }
   }, [onConnected]);
 
   // Capture the WABA + phone ids from Meta's Embedded Signup session-info event.
   useEffect(() => {
     function onMessage(event: MessageEvent) {
-      if (!FB_ORIGINS.has(event.origin)) return;
-      let payload: SessionInfoMessage;
+      if (!isFacebookOrigin(event.origin)) return;
+      let payload: { type?: string; event?: string } & Record<string, unknown>;
       try {
         payload = typeof event.data === "string" ? JSON.parse(event.data) : event.data;
       } catch {
         return;
       }
       if (payload?.type !== "WA_EMBEDDED_SIGNUP") return;
-      // FINISH (and the legacy FINISH_ONLY_WABA) carry the ids. A CANCEL means
-      // the user closed the flow before finishing.
+
       if (payload.event === "CANCEL") {
-        if (phase === "launching") {
-          setPhase("idle");
-          reset();
-        }
+        // User closed the flow before finishing.
+        clearWatchdog();
+        if (phase === "launching") setPhase("idle");
+        resetPieces();
         return;
       }
-      const wabaId = payload.data?.waba_id;
-      const phoneNumberId = payload.data?.phone_number_id;
+
+      const { wabaId, phoneNumberId } = findSignupIds(payload);
       if (wabaId && phoneNumberId) {
         sessionRef.current = { wabaId, phoneNumberId };
         void complete();
@@ -132,21 +162,38 @@ export function WhatsAppEmbeddedSignup({
     return () => window.removeEventListener("message", onMessage);
   }, [complete, phase]);
 
+  // Tear down the watchdog if the component unmounts mid-flow.
+  useEffect(() => () => clearWatchdog(), []);
+
   const launch = useCallback(() => {
     if (sdkState !== "ready" || !window.FB || !CONFIG_ID) return;
-    reset();
+    resetPieces();
+    clearWatchdog();
     setError(null);
     setResult(null);
     setPhase("launching");
+
+    // Watchdog: if we never collect both code + ids (e.g. Meta's FINISH event
+    // is blocked or never arrives), don't spin forever.
+    watchdogRef.current = setTimeout(() => {
+      if (completingRef.current) return; // POST already started
+      resetPieces();
+      setPhase("error");
+      setError(
+        "We didn’t hear back from WhatsApp. Please try connecting again.",
+      );
+    }, WATCHDOG_MS);
 
     window.FB.login(
       (response: FacebookLoginResponse) => {
         const code = response?.authResponse?.code;
         if (!code) {
-          // User closed/declined the popup, or no code came back.
+          // User closed/declined the popup, or no code came back. If the
+          // session ids haven't arrived either, return to idle.
           if (!sessionRef.current) {
+            clearWatchdog();
             setPhase("idle");
-            reset();
+            resetPieces();
           }
           return;
         }
@@ -221,6 +268,14 @@ export function WhatsAppEmbeddedSignup({
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        <p className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+          <Info className="mt-0.5 size-4 shrink-0" />
+          Have ready a phone number that can receive an SMS or call and is{" "}
+          <strong className="font-medium text-foreground">not</strong> currently
+          active on the WhatsApp or WhatsApp Business app — Meta verifies it in
+          the popup.
+        </p>
+
         <Button onClick={launch} disabled={disabled} size="lg" className="gap-2">
           {busy ? (
             <>
@@ -249,7 +304,10 @@ export function WhatsAppEmbeddedSignup({
           <p className="text-sm text-muted-foreground">Loading WhatsApp…</p>
         )}
         {configured && sdkState === "error" && (
-          <p className="flex items-center gap-2 text-sm text-red-600">
+          <p
+            role="alert"
+            className="flex items-center gap-2 text-sm text-red-600"
+          >
             <AlertCircle className="size-4" />
             Couldn’t load the WhatsApp connector. Check your connection and
             refresh.
@@ -257,7 +315,10 @@ export function WhatsAppEmbeddedSignup({
         )}
 
         {phase === "error" && error && (
-          <p className="flex items-start gap-2 text-sm text-red-600">
+          <p
+            role="alert"
+            className="flex items-start gap-2 text-sm text-red-600"
+          >
             <AlertCircle className="mt-0.5 size-4 shrink-0" />
             {error}
           </p>

--- a/src/hooks/use-facebook-sdk.ts
+++ b/src/hooks/use-facebook-sdk.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Loads the Facebook JS SDK once and initialises it for WhatsApp Embedded
+ * Signup. Returns a load state so callers can gate the Connect button.
+ *
+ * The SDK version is pinned to v25.0 to match the backend Graph version
+ * (helpers/meta.ts). `appId` comes from NEXT_PUBLIC_META_APP_ID — when it's
+ * absent the hook reports "unconfigured" so the UI can render a clear
+ * not-set-up state instead of a dead button.
+ */
+
+declare global {
+  interface Window {
+    // The FB SDK is an external global; we only call a narrow slice of it.
+    FB?: {
+      init: (params: Record<string, unknown>) => void;
+      login: (
+        cb: (response: FacebookLoginResponse) => void,
+        opts: Record<string, unknown>,
+      ) => void;
+    };
+    fbAsyncInit?: () => void;
+  }
+}
+
+export interface FacebookLoginResponse {
+  authResponse?: { code?: string; accessToken?: string } | null;
+  status?: string;
+}
+
+export type FacebookSdkState =
+  | "unconfigured"
+  | "loading"
+  | "ready"
+  | "error";
+
+const SDK_SRC = "https://connect.facebook.net/en_US/sdk.js";
+const SDK_SCRIPT_ID = "facebook-jssdk";
+const GRAPH_VERSION = "v25.0";
+
+// Module-level latch: once the SDK has initialised in this browser session we
+// stay ready across component remounts. Kept out of React state (and out of
+// `window`) so the lazy initializer below is SSR-safe (false on the server)
+// and we never need a synchronous setState inside the effect.
+let fbReady = false;
+
+export function useFacebookSdk(appId: string | undefined): FacebookSdkState {
+  const [state, setState] = useState<FacebookSdkState>(() =>
+    !appId ? "unconfigured" : fbReady ? "ready" : "loading",
+  );
+
+  useEffect(() => {
+    // Nothing to load: no app id, or the SDK already initialised this session.
+    if (!appId || fbReady) return;
+
+    let cancelled = false;
+
+    window.fbAsyncInit = () => {
+      try {
+        window.FB?.init({
+          appId,
+          autoLogAppEvents: true,
+          xfbml: false,
+          version: GRAPH_VERSION,
+        });
+        fbReady = true;
+        if (!cancelled) setState("ready");
+      } catch {
+        if (!cancelled) setState("error");
+      }
+    };
+
+    // Inject the SDK script once. If FB was already present (latch missed,
+    // e.g. another loader on the page), initialise via the same callback path
+    // on a microtask — never a synchronous setState inside the effect.
+    if (window.FB) {
+      queueMicrotask(() => window.fbAsyncInit?.());
+    } else if (!document.getElementById(SDK_SCRIPT_ID)) {
+      const script = document.createElement("script");
+      script.id = SDK_SCRIPT_ID;
+      script.src = SDK_SRC;
+      script.async = true;
+      script.defer = true;
+      script.crossOrigin = "anonymous";
+      script.onerror = () => {
+        if (!cancelled) setState("error");
+      };
+      document.body.appendChild(script);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appId]);
+
+  return state;
+}


### PR DESCRIPTION
## What
The SME-facing **WhatsApp Embedded Signup** connect experience (pairs with peakhour-api #453).

- **`useFacebookSdk`** — loads + inits the FB JS SDK (v25.0, pinned to the backend Graph version), gated on `NEXT_PUBLIC_META_APP_ID`; SSR-safe (module latch + lazy init, no synchronous effect setState).
- **`<WhatsAppEmbeddedSignup>`** — `FB.login` with config `NEXT_PUBLIC_META_ES_CONFIG_ID` (code flow, sessionInfoVersion 3); collects the auth code (login callback) **and** `{waba_id, phone_number_id}` (Meta `WA_EMBEDDED_SIGNUP` postMessage) in either order; POSTs once via the CSRF-aware api client. Premium states: idle / launching / connecting / connected / error + unconfigured + SDK-load-error.
- Hosted at `/dashboard/content/whatsapp`; the Channels Hub WhatsApp action now routes here.

## Review (2 rounds + Senior Eng Review Director pass)
Director caught and **all fixed**:
- **Watchdog (90s)** — a missed Meta `FINISH` event can no longer leave the button spinning forever; returns a retryable error.
- **Robust session parse** — deep `waba_id`/`phone_number_id` search (resilient to ES event nesting) + origin widened to any `*.facebook.com` (a too-narrow allowlist silently dropped the event).
- **Discoverability** — the page + hub action were orphaned (routed to `/dashboard/integrations`); now routed to the connect page.
- **Pre-flight guidance** (number not on personal WhatsApp) + `role="alert"` errors.

Also fixed **pre-existing** lint/correctness bugs in `content/page.tsx` (per request): React-Compiler-unpreservable `connections` memo; impure `new Date()`/`Date.now()` in `useLastSyncedLabel` during render. `tsc` + `eslint` clean.

## Requires
- **`NEXT_PUBLIC_META_APP_ID`** on Vercel (config_id already set). Until then the button shows a clear unconfigured state.

## Known follow-ups (tracked, before broad SME GA)
Live WABA end-to-end test (token re-exchange / registration / first send); connection-status read on mount (reload currently re-shows Connect); post-connect "send a test message" handoff + template setup; per-WhatsApp disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)