### PR TITLE
feat(news): news-classify cron metadata for /cms/crons (News N1 follow-on)

### DIFF
--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -202,6 +202,19 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Decides which of your trusted sources are due for a refresh and queues their fetch.",
   },
+  "news-classify": {
+    label: "Classify breaking news",
+    frequency: "Runs every 15 minutes",
+    description:
+      "For each News Desk business, queues classification of recently-fetched news (breaking status, urgency, topic, geography) so the corroboration gate can cluster the breaking items.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return null;
+      const enqueued = num(d.enqueued);
+      if (num(d.businesses) === 0) return "No News Desk businesses are enabled yet.";
+      return `Queued news classification for ${enqueued} ${plural(enqueued, "business")}.`;
+    },
+  },
   "trial-expiry-sweep": {
     label: "Check trial expiries",
     frequency: "Runs daily at 3:30 AM UTC",

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -210,9 +210,10 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     summarize: (data) => {
       const d = asRecord(data);
       if (!d) return null;
-      const enqueued = num(d.enqueued);
-      if (num(d.businesses) === 0) return "No News Desk businesses are enabled yet.";
-      return `Queued news classification for ${enqueued} ${plural(enqueued, "business")}.`;
+      const businesses = num(d.businesses);
+      if (businesses === 0) return "No News Desk businesses are enabled yet.";
+      const jobs = num(d.enqueued);
+      return `Queued news classification for ${businesses} ${plural(businesses, "business")} (${jobs} ${plural(jobs, "job")}).`;
     },
   },
   "trial-expiry-sweep": {


### PR DESCRIPTION
## What
Surfaces the new `news-classify` cron (peakhour-api) on the central `/cms/crons` hub with a friendly label, frequency, description, and a queued-count summarizer (reports businesses + jobs queued after the general/trusted scope split).

The News Desk page's own `<CronToolbar/>` band lands with N5 (the News Desk surface).

### Related
peakhour-api `feat/news-classify-cron`, peakhour-mongodb #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)