### PR TITLE
feat(news): news-corroborate cron metadata for /cms/crons (News N2 follow-on)

### DIFF
--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -216,6 +216,19 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       return `Queued news classification for ${businesses} ${plural(businesses, "business")} (${jobs} ${plural(jobs, "job")}).`;
     },
   },
+  "news-corroborate": {
+    label: "Corroborate breaking news",
+    frequency: "Runs hourly",
+    description:
+      "For each News Desk business, queues the corroboration gate — clusters breaking items across independent sources, scores a confidence tier, and records which sources back each story. Records clusters only; it does not publish anything.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return null;
+      const businesses = num(d.businesses);
+      if (businesses === 0) return "No News Desk businesses are enabled yet.";
+      return `Queued news corroboration for ${businesses} ${plural(businesses, "business")}.`;
+    },
+  },
   "trial-expiry-sweep": {
     label: "Check trial expiries",
     frequency: "Runs daily at 3:30 AM UTC",


### PR DESCRIPTION
Surfaces the new `news-corroborate` cron on `/cms/crons` with a friendly label, hourly frequency, description (notes it records clusters and publishes nothing), and a queued-count summarizer. The News Desk page's `<CronToolbar/>` band lands with N5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)