### PR TITLE
feat(news): News Desk surface — approval queue + Sources panel + cron toolbar (N5)

### DIFF
--- a/src/app/dashboard/content/news/components/sources-panel.tsx
+++ b/src/app/dashboard/content/news/components/sources-panel.tsx
@@ -1,0 +1,65 @@
+import { ExternalLink } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { NewsSourceProvenance } from "../types";
+
+/** Hostname for display, or the raw value if it doesn't parse. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * The Sources panel — the visible "multi-source, no bluff" proof on a news draft
+ * (News Desk req. #4). Lists the corroborating sources from the idea's
+ * sourceProvenance[] with their role + trust, primary first.
+ */
+export function SourcesPanel({ provenance }: { provenance?: NewsSourceProvenance[] }) {
+  if (!provenance?.length) {
+    return <p className="text-xs text-muted-foreground">No sources recorded.</p>;
+  }
+  // Primary first, then supporting, then validation.
+  const order: Record<string, number> = { primary: 0, supporting: 1, validation: 2 };
+  const sorted = [...provenance].sort((a, b) => (order[a.contribution] ?? 9) - (order[b.contribution] ?? 9));
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground">
+        Backed by {provenance.length} {provenance.length === 1 ? "source" : "sources"}
+      </p>
+      <ul className="space-y-1.5">
+        {sorted.map((p, i) => (
+          <li key={p.sourceId ?? p.externalUrl ?? i} className="flex items-center gap-2 text-sm">
+            <Badge
+              variant={p.contribution === "primary" ? "default" : "secondary"}
+              className="shrink-0 text-[10px] capitalize"
+            >
+              {p.contribution}
+            </Badge>
+            {p.externalUrl ? (
+              <a
+                href={p.externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-w-0 items-center gap-1 truncate text-primary hover:underline"
+                title={p.externalUrl}
+              >
+                <span className="truncate">{hostOf(p.externalUrl)}</span>
+                <ExternalLink className="size-3 shrink-0" aria-hidden />
+              </a>
+            ) : (
+              <span className="truncate text-muted-foreground">{p.sourceType} source</span>
+            )}
+            {typeof p.trustScoreAtTime === "number" && (
+              <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
+                trust {Math.round(p.trustScoreAtTime * 100)}%
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/dashboard/content/news/page.tsx
+++ b/src/app/dashboard/content/news/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Newspaper, AlertCircle } from "lucide-react";
+import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { api, ApiError } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SourcesPanel } from "./components/sources-panel";
+import type { NewsIdea } from "./types";
+
+/**
+ * /dashboard/content/news — News Desk (N5). The autonomous newsroom's approval
+ * queue: corroborated, brand-voice, plagiarism-checked news drafts awaiting a
+ * human's go (cnt_ideas source="trending", status="review"), each showing the
+ * sources that back it. Read-only v1 — the 1-tap approve (reusing the scheduler)
+ * is a follow-up.
+ */
+export default function NewsDeskPage() {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["news-ideas"],
+    queryFn: () => api.get<NewsIdea[]>("/v1/content/ideas?source=trending&status=review&limit=50"),
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  const ideas = data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <CronToolbar
+        crons={["news-classify", "news-corroborate", "news-compose"]}
+        onTriggered={() => {
+          void queryClient.invalidateQueries({ queryKey: ["news-ideas"] });
+        }}
+      />
+
+      <header>
+        <h2 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
+          <Newspaper className="size-6" aria-hidden /> News Desk
+        </h2>
+        <p className="text-muted-foreground">
+          Corroborated, brand-voice news drafts awaiting your go. Each shows the sources that back it — multi-source verified, refactored, never copied.
+        </p>
+      </header>
+
+      {isError ? (
+        <ErrorBlock error={error} />
+      ) : isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-40" />)}
+        </div>
+      ) : ideas.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            No news drafts in the queue. As your sources are classified and corroborated, the Wire Desk composes drafts here for approval.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {ideas.map((idea) => (
+            <NewsCard key={idea._id} idea={idea} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NewsCard({ idea }: { idea: NewsIdea }) {
+  const preview = idea.content?.plainText ?? idea.description ?? "";
+  const confidence = typeof idea.recommendationStrength === "number" ? idea.recommendationStrength : undefined;
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 pb-2">
+        <h3 className="font-semibold leading-snug">{idea.content?.subject || idea.title}</h3>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {idea.channels?.map((ch) => (
+            <Badge key={ch} variant="outline" className="text-[10px] uppercase">{ch}</Badge>
+          ))}
+          {confidence !== undefined && (
+            <Badge variant="secondary" className="text-[10px]">Confidence {confidence}%</Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {preview && <p className="line-clamp-4 whitespace-pre-wrap text-sm text-muted-foreground">{preview}</p>}
+        <div className="rounded-md border bg-muted/30 p-3">
+          <SourcesPanel provenance={idea.sourceProvenance} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ErrorBlock({ error }: { error: unknown }) {
+  const message = error instanceof ApiError ? error.message : "Could not load the News Desk queue.";
+  return (
+    <div className="flex items-start gap-3 py-6">
+      <AlertCircle aria-hidden className="mt-0.5 size-5 shrink-0 text-destructive" />
+      <div className="space-y-1">
+        <p className="text-sm font-medium">Couldn&apos;t load the queue</p>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/content/news/types.ts
+++ b/src/app/dashboard/content/news/types.ts
@@ -1,0 +1,31 @@
+/**
+ * News Desk (N5) — the autonomous newsroom's approval queue. Shows corroborated,
+ * brand-voice news drafts (cnt_ideas source="trending", status="review") with the
+ * sources that back each story. Read-only v1 (1-tap approve is a follow-up).
+ *
+ * Shapes mirror GET /v1/content/ideas (peakhour-api content route).
+ */
+
+export interface NewsSourceProvenance {
+  sourceId?: string;
+  externalUrl?: string;
+  sourceType: "trusted" | "general" | "web_search" | "internal_library";
+  contribution: "primary" | "supporting" | "validation";
+  snippet?: string;
+  capturedAt?: string;
+  trustScoreAtTime?: number;
+}
+
+export interface NewsIdea {
+  _id: string;
+  title: string;
+  description?: string;
+  status: string;
+  source: string;
+  channels?: string[];
+  content?: { subject?: string; plainText?: string; wordCount?: number };
+  sourceProvenance?: NewsSourceProvenance[];
+  recommendationTags?: string[];
+  recommendationStrength?: number;
+  createdAt?: string;
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -94,6 +94,7 @@ const NAV_GROUPS: NavGroup[] = [
         subItems: [
           { href: "/dashboard/content", label: "Library" },
           { href: "/dashboard/content/sources", label: "Sources" },
+          { href: "/dashboard/content/news", label: "News Desk" },
           { href: "/dashboard/strategist", label: "Strategist" },
           { href: "/dashboard/calendar", label: "Calendar" },
           { href: "/dashboard/media", label: "Media" },


### PR DESCRIPTION
## What
`/dashboard/content/news` — the autonomous newsroom's **approval queue**. Shows corroborated, brand-voice, plagiarism-checked news drafts (`cnt_ideas` source=trending, status=review) awaiting a human's go. Each card renders the composed draft + confidence + the **Sources panel** (`sourceProvenance`, primary-first, with trust + links) — the visible multi-source-verified, refactored-not-copied proof (News Desk req. #4).

- Mounts the **contextual CronToolbar** (`news-classify`/`news-corroborate`/`news-compose`) per the cron-toolbar pattern — moves the news crons off hub-only.
- Nav entry under Content. **Read-only v1**; the 1-tap approve (reusing the existing scheduler) is the next increment.

## Validation
`tsc` + `eslint` clean. Reviewed: the `api.get` envelope-unwrap returns `NewsIdea[]` correctly (matches the strategist page convention); SourcesPanel safe on missing fields; nav active-state prefix-collision handled. No FeatureGate by design (read-only; empty state for non-news businesses).

Pairs with api #471 (provenance in GET /ideas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)