### PR TITLE
feat(news): Approve & schedule button on the News Desk queue (N5)

### DIFF
--- a/src/app/dashboard/content/news/components/approve-news-sheet.tsx
+++ b/src/app/dashboard/content/news/components/approve-news-sheet.tsx
@@ -94,7 +94,7 @@ function ApproveBody({
   // per-channel payloads and the source (both derived server-side from
   // the reviewed idea); forwards only the scheduling parameters.
   const commit = (body: CommitPlanRequest): Promise<CommitPlanResponse> =>
-    api.post<CommitPlanResponse>(`/v1/content/ideas/${idea._id}/schedule`, {
+    api.post<CommitPlanResponse>(`/v1/content/ideas/${idea._id}/approve-schedule`, {
       channels: body.channels.map((c) => ({
         channel: c.channel,
         ...(c.connectionId ? { connectionId: c.connectionId } : {}),

--- a/src/app/dashboard/content/news/components/approve-news-sheet.tsx
+++ b/src/app/dashboard/content/news/components/approve-news-sheet.tsx
@@ -23,8 +23,8 @@ import type { NewsIdea } from "../types";
  *
  * Approving an idea = scheduling it: the human's "go" IS the approval.
  * The commit is routed (via SchedulerComposer's `commit` override) to
- * POST /v1/content/ideas/:id/schedule, which flips the idea out of the
- * queue AND commits the publish plan atomically server-side — so a
+ * POST /v1/content/ideas/:id/approve-schedule, which flips the idea out
+ * of the queue AND commits the publish plan atomically server-side — so a
  * failed commit can't leave an orphan plan or a stuck idea.
  *
  * The publish text + source are derived server-side from the reviewed

--- a/src/app/dashboard/content/news/components/approve-news-sheet.tsx
+++ b/src/app/dashboard/content/news/components/approve-news-sheet.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { SchedulerComposer } from "@/components/scheduler";
+import { api } from "@/lib/api";
+import { sourceTextHash } from "@/lib/scheduler/source-hash";
+import type {
+  CommitPlanRequest,
+  CommitPlanResponse,
+} from "@/lib/scheduler/types";
+import type { NewsIdea } from "../types";
+
+/**
+ * <ApproveNewsSheet/> — the News Desk (N5) 1-tap approve. Opens the
+ * shared <SchedulerComposer/> pre-filled from a corroborated, brand-voice
+ * news draft sitting in the approval queue (cnt_ideas status "review").
+ *
+ * Approving an idea = scheduling it: the human's "go" IS the approval.
+ * The commit is routed (via SchedulerComposer's `commit` override) to
+ * POST /v1/content/ideas/:id/schedule, which flips the idea out of the
+ * queue AND commits the publish plan atomically server-side — so a
+ * failed commit can't leave an orphan plan or a stuck idea.
+ *
+ * The publish text + source are derived server-side from the reviewed
+ * content; the body below only carries scheduling parameters (channels,
+ * time, timezone, stagger, auto-approve). The `source`/`payload` passed
+ * to the composer drive its preview only.
+ */
+
+export interface ApproveNewsSheetProps {
+  idea: NewsIdea | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a successful approve+schedule so the host can
+   *  invalidate the queue and close the sheet. */
+  onApproved?: () => void;
+}
+
+export function ApproveNewsSheet({
+  idea,
+  open,
+  onOpenChange,
+  onApproved,
+}: ApproveNewsSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto p-0 sm:max-w-xl">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle className="text-base">Approve &amp; schedule</SheetTitle>
+          <SheetDescription className="text-xs">
+            Pick when this corroborated draft publishes. Approving it
+            schedules it on the channels below.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 px-6 py-4">
+          {idea ? (
+            <ApproveBody idea={idea} onApproved={onApproved} />
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ApproveBody({
+  idea,
+  onApproved,
+}: {
+  idea: NewsIdea;
+  onApproved?: () => void;
+}) {
+  const text = (
+    idea.content?.plainText ||
+    idea.content?.subject ||
+    idea.description ||
+    idea.title ||
+    ""
+  ).trim();
+  const title = idea.content?.subject || idea.title;
+  const channelKeys = idea.channels?.length ? idea.channels : ["x"];
+
+  const channels = channelKeys.map((channel) => ({
+    channel,
+    payload: { text },
+  }));
+
+  // Commit override → the News Desk approve endpoint. Strips the
+  // per-channel payloads and the source (both derived server-side from
+  // the reviewed idea); forwards only the scheduling parameters.
+  const commit = (body: CommitPlanRequest): Promise<CommitPlanResponse> =>
+    api.post<CommitPlanResponse>(`/v1/content/ideas/${idea._id}/schedule`, {
+      channels: body.channels.map((c) => ({
+        channel: c.channel,
+        ...(c.connectionId ? { connectionId: c.connectionId } : {}),
+        ...(c.preferredLocalTime
+          ? { preferredLocalTime: c.preferredLocalTime }
+          : {}),
+        ...(c.publishViaReminder !== undefined
+          ? { publishViaReminder: c.publishViaReminder }
+          : {}),
+      })),
+      ...(body.staggerStrategy ? { staggerStrategy: body.staggerStrategy } : {}),
+      canonicalScheduledAtUtc: body.canonicalScheduledAtUtc,
+      timezone: body.timezone,
+      ...(body.autoApprove ? { autoApprove: body.autoApprove } : {}),
+      ...(body.title ? { title: body.title } : {}),
+    });
+
+  return (
+    <SchedulerComposer
+      source={{
+        sourceType: "idea",
+        sourceRef: idea._id,
+        sourceTextHash: sourceTextHash(text),
+      }}
+      title={title}
+      channels={channels}
+      commit={commit}
+      submitLabel="Approve & schedule"
+      onScheduled={() => onApproved?.()}
+    />
+  );
+}

--- a/src/app/dashboard/content/news/page.tsx
+++ b/src/app/dashboard/content/news/page.tsx
@@ -17,8 +17,9 @@ import type { NewsIdea } from "./types";
  * /dashboard/content/news — News Desk (N5). The autonomous newsroom's approval
  * queue: corroborated, brand-voice, plagiarism-checked news drafts awaiting a
  * human's go (cnt_ideas source="trending", status="review"), each showing the
- * sources that back it. Read-only v1 — the 1-tap approve (reusing the scheduler)
- * is a follow-up.
+ * sources that back it. Each draft can be approved (= scheduled) in one tap via
+ * the shared SchedulerComposer, which commits through POST
+ * /v1/content/ideas/:id/approve-schedule.
  */
 export default function NewsDeskPage() {
   const queryClient = useQueryClient();

--- a/src/app/dashboard/content/news/page.tsx
+++ b/src/app/dashboard/content/news/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Newspaper, AlertCircle } from "lucide-react";
+import { Newspaper, AlertCircle, CalendarPlus } from "lucide-react";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { api, ApiError } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SourcesPanel } from "./components/sources-panel";
+import { ApproveNewsSheet } from "./components/approve-news-sheet";
 import type { NewsIdea } from "./types";
 
 /**
@@ -19,6 +22,7 @@ import type { NewsIdea } from "./types";
  */
 export default function NewsDeskPage() {
   const queryClient = useQueryClient();
+  const [approving, setApproving] = useState<NewsIdea | null>(null);
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["news-ideas"],
@@ -29,13 +33,14 @@ export default function NewsDeskPage() {
 
   const ideas = data ?? [];
 
+  const invalidateQueue = () =>
+    void queryClient.invalidateQueries({ queryKey: ["news-ideas"] });
+
   return (
     <div className="space-y-6">
       <CronToolbar
         crons={["news-classify", "news-corroborate", "news-compose"]}
-        onTriggered={() => {
-          void queryClient.invalidateQueries({ queryKey: ["news-ideas"] });
-        }}
+        onTriggered={invalidateQueue}
       />
 
       <header>
@@ -62,15 +67,27 @@ export default function NewsDeskPage() {
       ) : (
         <div className="space-y-4">
           {ideas.map((idea) => (
-            <NewsCard key={idea._id} idea={idea} />
+            <NewsCard key={idea._id} idea={idea} onApprove={() => setApproving(idea)} />
           ))}
         </div>
       )}
+
+      <ApproveNewsSheet
+        idea={approving}
+        open={approving !== null}
+        onOpenChange={(next) => {
+          if (!next) setApproving(null);
+        }}
+        onApproved={() => {
+          setApproving(null);
+          invalidateQueue();
+        }}
+      />
     </div>
   );
 }
 
-function NewsCard({ idea }: { idea: NewsIdea }) {
+function NewsCard({ idea, onApprove }: { idea: NewsIdea; onApprove: () => void }) {
   const preview = idea.content?.plainText ?? idea.description ?? "";
   const confidence = typeof idea.recommendationStrength === "number" ? idea.recommendationStrength : undefined;
   return (
@@ -90,6 +107,11 @@ function NewsCard({ idea }: { idea: NewsIdea }) {
         {preview && <p className="line-clamp-4 whitespace-pre-wrap text-sm text-muted-foreground">{preview}</p>}
         <div className="rounded-md border bg-muted/30 p-3">
           <SourcesPanel provenance={idea.sourceProvenance} />
+        </div>
+        <div className="flex justify-end">
+          <Button size="sm" onClick={onApprove} className="gap-1.5">
+            <CalendarPlus className="size-3.5" /> Approve &amp; schedule
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/app/dashboard/content/news/types.ts
+++ b/src/app/dashboard/content/news/types.ts
@@ -1,7 +1,7 @@
 /**
  * News Desk (N5) — the autonomous newsroom's approval queue. Shows corroborated,
  * brand-voice news drafts (cnt_ideas source="trending", status="review") with the
- * sources that back each story. Read-only v1 (1-tap approve is a follow-up).
+ * sources that back each story. Drafts are approved (= scheduled) in one tap.
  *
  * Shapes mirror GET /v1/content/ideas (peakhour-api content route).
  */

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -88,8 +88,8 @@ export interface SchedulerComposerProps {
    * Override for the commit call. Defaults to `scheduler.commitPlan`
    * (POST /v1/scheduler/plans). Surfaces that need the commit to run
    * through a different endpoint — e.g. the News Desk approve, which
-   * POSTs to /v1/content/ideas/:id/schedule so the idea status flip and
-   * the plan commit happen atomically server-side — pass their own
+   * POSTs to /v1/content/ideas/:id/approve-schedule so the idea status
+   * flip and the plan commit happen atomically server-side — pass their own
    * function. It receives the exact body the composer would have sent
    * and must return the same CommitPlanResponse shape.
    */

--- a/src/components/scheduler/scheduler-composer.tsx
+++ b/src/components/scheduler/scheduler-composer.tsx
@@ -84,6 +84,18 @@ export interface SchedulerComposerProps {
   /** Called after a successful commit; the parent typically closes
    *  the sheet or navigates to /dashboard/calendar. */
   onScheduled?: (result: CommitPlanResponse) => void;
+  /**
+   * Override for the commit call. Defaults to `scheduler.commitPlan`
+   * (POST /v1/scheduler/plans). Surfaces that need the commit to run
+   * through a different endpoint — e.g. the News Desk approve, which
+   * POSTs to /v1/content/ideas/:id/schedule so the idea status flip and
+   * the plan commit happen atomically server-side — pass their own
+   * function. It receives the exact body the composer would have sent
+   * and must return the same CommitPlanResponse shape.
+   */
+  commit?: (body: CommitPlanRequest) => Promise<CommitPlanResponse>;
+  /** Override the commit button label (default "Schedule"). */
+  submitLabel?: string;
   className?: string;
 }
 
@@ -102,6 +114,8 @@ export function SchedulerComposer({
   initialAnchor,
   initialTimezone,
   onScheduled,
+  commit,
+  submitLabel,
   className,
 }: SchedulerComposerProps) {
   const [anchor, setAnchor] = useState<Date>(initialAnchor ?? defaultAnchor());
@@ -197,7 +211,7 @@ export function SchedulerComposer({
         // the server's plan check.
         ...(autoApproveAuthorized && autoApprove ? { autoApprove: true } : {}),
       };
-      const result = await scheduler.commitPlan(body);
+      const result = await (commit ?? scheduler.commitPlan)(body);
       toast.success(
         `Scheduled across ${result.scheduledItemIds.length} channel${
           result.scheduledItemIds.length === 1 ? "" : "s"
@@ -370,7 +384,7 @@ export function SchedulerComposer({
         size="lg"
       >
         <CalendarPlus className="h-4 w-4" />
-        {submitting ? "Scheduling…" : "Schedule"}
+        {submitting ? "Scheduling…" : (submitLabel ?? "Schedule")}
       </Button>
     </div>
   );


### PR DESCRIPTION
## What
Each draft in the News Desk approval queue (`/dashboard/content/news`) gets an **"Approve & schedule"** button that opens the shared `<SchedulerComposer/>` pre-filled from the idea. Approving = scheduling.

## How
- Adds a backward-compatible optional `commit?` override prop to `<SchedulerComposer/>` (defaults to `scheduler.commitPlan`; the 7 existing callers are unaffected) + a `submitLabel?` prop.
- The News Desk approve sheet passes a `commit` that POSTs to **`/v1/content/ideas/:id/approve-schedule`** (peakhour-api PR #472), which flips the idea out of the queue and commits the publish plan atomically server-side. The override strips the per-channel payload + source (both derived server-side from the reviewed idea) and forwards only scheduling params.
- On success the `["news-ideas"]` query invalidates and the idea drops out of the list.

## Depends on
peakhour-api **#472** (`POST /ideas/:id/approve-schedule`). Merge that first.

## Test plan
- Open `/dashboard/content/news`, click **Approve & schedule** on a draft → composer opens pre-filled → schedule → toast + idea leaves the queue → plan visible on `/dashboard/calendar`.
- Verify the existing composer surfaces (LinkedIn/X/repurpose/calendar compose) are unchanged.