### PR TITLE
feat(b2c): landing renders integrations from the catalog + signup CTA

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -418,9 +418,17 @@ function AuthPageInner() {
 }
 
 // useSearchParams() must be inside a Suspense boundary (Next.js App Router).
+// A minimal full-height fallback avoids a blank prerender flash on this entry
+// flow before the client fills in the (searchParams-dependent) heading.
 export default function AuthPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center" aria-hidden>
+          <div className="size-6 animate-spin rounded-full border-2 border-muted border-t-foreground" />
+        </div>
+      }
+    >
       <AuthPageInner />
     </Suspense>
   );

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { sendMagicLink } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -73,7 +74,24 @@ const TRUST_STATS = [
   { value: "24/7", label: "autonomous optimization" },
 ] as const;
 
-export default function AuthPage() {
+// Landing CTAs route here with ?intent=waitlist|invite when the platform is
+// pre-launch (driven by cfg_platform_stage.signupMode), so the heading matches
+// the button the visitor clicked. The magic-link flow itself is unchanged —
+// only the framing differs.
+const INTENT_COPY: Record<string, { title: string; subtitle: string }> = {
+  waitlist: {
+    title: "Join the waitlist",
+    subtitle: "Enter your email — we'll send your access link as we roll out. No password needed.",
+  },
+  invite: {
+    title: "Request an invite",
+    subtitle: "Enter your email to request access. We'll be in touch with your link. No password needed.",
+  },
+};
+
+function AuthPageInner() {
+  const searchParams = useSearchParams();
+  const intentCopy = INTENT_COPY[searchParams.get("intent") ?? ""];
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   // Tick once per second while a cooldown is running so the button
@@ -329,11 +347,11 @@ export default function AuthPage() {
             <div className="w-full max-w-md space-y-8">
               <div className="text-center">
                 <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
-                  Welcome to {SITE.name}
+                  {intentCopy?.title ?? `Welcome to ${SITE.name}`}
                 </h2>
                 <p className="mt-2 text-muted-foreground">
-                  Enter your email to sign in or create your account. No
-                  password needed.
+                  {intentCopy?.subtitle ??
+                    "Enter your email to sign in or create your account. No password needed."}
                 </p>
               </div>
 
@@ -396,5 +414,14 @@ export default function AuthPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+// useSearchParams() must be inside a Suspense boundary (Next.js App Router).
+export default function AuthPage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthPageInner />
+    </Suspense>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -147,6 +147,7 @@ export default async function Home() {
     <div className="flex min-h-screen flex-col">
       {platform?.banner?.enabled && platform.banner.copy ? (
         <div
+          role="status"
           className={
             "border-b px-4 py-2 text-center text-sm " +
             (platform.banner.tone === "warn"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,15 @@ import { Footer } from "@/components/shared/footer";
 import { PricingGrid } from "@/components/marketing/pricing-grid";
 import { getPricing } from "@/lib/pricing";
 import {
+  getPublicCatalog,
+  dedupePublicIntegrations,
+  signupCta,
+} from "@/lib/catalog";
+import {
+  IntegrationBrandIcon,
+  integrationBrandColor,
+} from "@/components/marketing/integration-brand";
+import {
   LinkedinIcon,
   FacebookIcon,
   InstagramIcon,
@@ -100,8 +109,56 @@ export default async function Home() {
       ? vercelCountry.toUpperCase()
       : "DEFAULT";
   const pricing = await getPricing(country);
+
+  // Integration catalog from the platform resolver (CMS-driven, env-gated,
+  // stage-capped). Falls back to the static list below if the API is
+  // unreachable so the landing never hard-fails (mirrors the pricing fallback).
+  const catalog = await getPublicCatalog();
+  const platform = catalog?.platform;
+  const cta = signupCta(platform?.signupMode ?? "open");
+  const integrationCards = catalog
+    ? dedupePublicIntegrations(catalog.integrations).map((i) => ({
+        id: i.key,
+        name: i.name,
+        description: i.tagline ?? i.comingSoon?.copy ?? "",
+        colorClass: integrationBrandColor(i.display?.groupKey, i.key),
+        icon: (
+          <IntegrationBrandIcon
+            groupKey={i.display?.groupKey}
+            integrationKey={i.key}
+            name={i.name}
+          />
+        ),
+        comingSoon: i.surfacedState === "coming_soon",
+      }))
+    : INTEGRATIONS.map((item) => {
+        const IntIcon = item.icon;
+        return {
+          id: item.name,
+          name: item.name,
+          description: item.description,
+          colorClass: item.color,
+          icon: <IntIcon className="h-5 w-5" />,
+          comingSoon: false,
+        };
+      });
+
   return (
     <div className="flex min-h-screen flex-col">
+      {platform?.banner?.enabled && platform.banner.copy ? (
+        <div
+          className={
+            "border-b px-4 py-2 text-center text-sm " +
+            (platform.banner.tone === "warn"
+              ? "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+              : platform.banner.tone === "success"
+                ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200"
+                : "bg-blue-100 text-blue-900 dark:bg-blue-950 dark:text-blue-200")
+          }
+        >
+          {platform.banner.copy}
+        </div>
+      ) : null}
       <Header />
 
       <main>
@@ -122,12 +179,18 @@ export default async function Home() {
                 engine — all powered by AI, all on autopilot.
               </p>
               <div className="flex w-full flex-col justify-center gap-3 sm:flex-row">
-                <Button asChild size="lg" className="gap-2">
-                  <Link href="/auth">
-                    Start free
-                    <ArrowRight className="size-4" />
-                  </Link>
-                </Button>
+                {cta.disabled ? (
+                  <Button size="lg" className="gap-2" disabled>
+                    {cta.label}
+                  </Button>
+                ) : (
+                  <Button asChild size="lg" className="gap-2">
+                    <Link href={cta.href}>
+                      {cta.label}
+                      <ArrowRight className="size-4" />
+                    </Link>
+                  </Button>
+                )}
                 <Button asChild variant="outline" size="lg">
                   <Link href="#how-it-works">How it works</Link>
                 </Button>
@@ -189,33 +252,49 @@ export default async function Home() {
               </p>
             </div>
             <div className="mx-auto mt-12 grid max-w-4xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {INTEGRATIONS.map((item) => {
-                const IntIcon = item.icon;
-                return (
-                  <Card key={item.name} className="py-2 transition-shadow hover:shadow-md">
-                    <CardHeader className="flex flex-row items-center gap-3 space-y-0 pb-0">
-                      <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-white ${item.color}`}>
-                        <IntIcon className="h-5 w-5" />
-                      </div>
-                      <div>
-                        <CardTitle className="text-sm font-semibold">{item.name}</CardTitle>
+              {integrationCards.map((item) => (
+                <Card key={item.id} className="py-2 transition-shadow hover:shadow-md">
+                  <CardHeader className="flex flex-row items-center gap-3 space-y-0 pb-0">
+                    <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-white ${item.colorClass}`}>
+                      {item.icon}
+                    </div>
+                    <div className="min-w-0">
+                      <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+                        <span className="truncate">{item.name}</span>
+                        {item.comingSoon && (
+                          <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] uppercase">
+                            Soon
+                          </Badge>
+                        )}
+                      </CardTitle>
+                      {item.description && (
                         <CardDescription className="text-xs">
                           {item.description}
                         </CardDescription>
-                      </div>
-                    </CardHeader>
-                  </Card>
-                );
-              })}
+                      )}
+                    </div>
+                  </CardHeader>
+                </Card>
+              ))}
             </div>
             <div className="mt-8 flex items-center justify-center gap-3 text-sm text-muted-foreground">
-              <span>More integrations coming soon</span>
-              <Button asChild variant="outline" size="sm">
-                <Link href="/auth">
-                  Get started
-                  <ArrowRight className="ml-1 size-3" />
-                </Link>
-              </Button>
+              <span>
+                {platform && platform.stage !== "live"
+                  ? "More integrations rolling out as we launch"
+                  : "More integrations coming soon"}
+              </span>
+              {cta.disabled ? (
+                <Button variant="outline" size="sm" disabled>
+                  {cta.label}
+                </Button>
+              ) : (
+                <Button asChild variant="outline" size="sm">
+                  <Link href={cta.href}>
+                    {cta.label}
+                    <ArrowRight className="ml-1 size-3" />
+                  </Link>
+                </Button>
+              )}
             </div>
           </div>
         </section>

--- a/src/components/marketing/integration-brand.tsx
+++ b/src/components/marketing/integration-brand.tsx
@@ -1,0 +1,70 @@
+import type { ComponentType } from "react";
+import {
+  LinkedinIcon,
+  FacebookIcon,
+  InstagramIcon,
+  GoogleIcon,
+  YoutubeIcon,
+  BeehiivIcon,
+  SubstackIcon,
+  MailchimpIcon,
+  ShopifyIcon,
+  WordPressIcon,
+  TwitterIcon,
+} from "@/components/ui/brand-icons";
+
+/**
+ * Maps a catalog integration's groupKey/key to a brand glyph + accent color.
+ * The catalog carries a `display.brandColor`/`iconUrl`, but the landing uses
+ * the hand-tuned brand SVGs; this is the bridge. Keyed by `groupKey` first
+ * (linkedin_content + linkedin_ads → "linkedin"), then the raw key. Anything
+ * unmapped falls back to a styled initial circle so a brand-new catalog row
+ * still renders sensibly.
+ */
+type Brand = { Icon: ComponentType<{ className?: string }>; color: string };
+
+const BRANDS: Record<string, Brand> = {
+  linkedin: { Icon: LinkedinIcon, color: "bg-[#0A66C2]" },
+  linkedin_content: { Icon: LinkedinIcon, color: "bg-[#0A66C2]" },
+  linkedin_ads: { Icon: LinkedinIcon, color: "bg-[#0A66C2]" },
+  facebook: { Icon: FacebookIcon, color: "bg-[#0668E1]" },
+  meta: { Icon: FacebookIcon, color: "bg-[#0668E1]" },
+  meta_ads: { Icon: FacebookIcon, color: "bg-[#0668E1]" },
+  instagram: { Icon: InstagramIcon, color: "bg-[#E4405F]" },
+  google: { Icon: GoogleIcon, color: "bg-[#4285F4]" },
+  google_ads: { Icon: GoogleIcon, color: "bg-[#4285F4]" },
+  youtube: { Icon: YoutubeIcon, color: "bg-[#FF0000]" },
+  beehiiv: { Icon: BeehiivIcon, color: "bg-[#FFD100] text-black" },
+  substack: { Icon: SubstackIcon, color: "bg-[#FF6719]" },
+  mailchimp: { Icon: MailchimpIcon, color: "bg-[#FFE01B] text-black" },
+  shopify: { Icon: ShopifyIcon, color: "bg-[#96BF48]" },
+  wordpress: { Icon: WordPressIcon, color: "bg-[#21759B]" },
+  x: { Icon: TwitterIcon, color: "bg-black" },
+  x_ads: { Icon: TwitterIcon, color: "bg-black" },
+};
+
+export function IntegrationBrandIcon({
+  groupKey,
+  integrationKey,
+  name,
+  className = "h-5 w-5",
+}: {
+  groupKey?: string;
+  integrationKey: string;
+  name: string;
+  className?: string;
+}) {
+  const brand = (groupKey && BRANDS[groupKey]) || BRANDS[integrationKey];
+  if (brand) {
+    const { Icon } = brand;
+    return <Icon className={className} />;
+  }
+  // Fallback: first letter of the name.
+  return <span className="text-sm font-bold">{name.charAt(0).toUpperCase()}</span>;
+}
+
+/** Tailwind bg/text class for the icon tile — the brand color or a neutral. */
+export function integrationBrandColor(groupKey?: string, integrationKey?: string): string {
+  const brand = (groupKey && BRANDS[groupKey]) || (integrationKey ? BRANDS[integrationKey] : undefined);
+  return brand?.color ?? "bg-muted text-foreground";
+}

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,0 +1,131 @@
+/**
+ * Server-side helper for the public platform catalog from peakhour-api's
+ * `GET /v1/platform/catalog`. Replaces the hardcoded INTEGRATIONS array on the
+ * landing page (and, later, the dashboard hub's channels.config.ts).
+ *
+ * Called UNAUTHENTICATED here — the resolver returns the public view (live +
+ * coming_soon, public visibility), env-gated server-side (prod hides
+ * in_development/hidden) and capped by the global platform stage. The `platform`
+ * block drives the announcement banner + the signup CTA, so the landing and the
+ * signup flow can never disagree.
+ *
+ * The public catalog is country-independent (the resolver only applies country
+ * gates for authenticated orgs), so it's cached once with a static key. A
+ * 120s revalidate + the "platform-catalog" tag let a CMS stage change
+ * propagate via revalidateTag().
+ */
+
+import { unstable_cache as cache } from "next/cache";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+export type PlatformStage =
+  | "coming_soon"
+  | "waitlist"
+  | "founding"
+  | "invitation_only"
+  | "live";
+
+export type PlatformSignupMode = "closed" | "invite_only" | "waitlist_only" | "open";
+
+export type SurfacedState =
+  | "connectable"
+  | "locked"
+  | "coming_soon"
+  | "deprecated"
+  | "dev_only";
+
+export interface ResolvedIntegration {
+  key: string;
+  name: string;
+  tagline?: string;
+  description?: string;
+  category: string;
+  status: string;
+  surfacedState: SurfacedState;
+  cappedByPlatformStage: boolean;
+  isAvailable: boolean;
+  isLockedByFeature?: boolean;
+  isLockedByPlan?: boolean;
+  isLockedByCountry?: boolean;
+  lockReason?: string;
+  waitlistFeatureKey?: string;
+  comingSoon?: { copy?: string; eta?: string; waitlistFeatureKey?: string };
+  display?: {
+    iconUrl?: string;
+    brandColor?: string;
+    groupKey?: string;
+    sortOrder?: number;
+    connectLabel?: string;
+    dashboardPath?: string;
+  };
+}
+
+export interface PlatformBlock {
+  stage: PlatformStage;
+  signupMode: PlatformSignupMode;
+  banner?: { enabled: boolean; copy?: string; tone: "info" | "warn" | "success" };
+}
+
+export interface ResolvedCatalog {
+  integrations: ResolvedIntegration[];
+  org?: { country?: string; plan?: string };
+  platform: PlatformBlock;
+}
+
+async function fetchCatalog(): Promise<ResolvedCatalog | null> {
+  if (!API_URL) return null;
+  try {
+    const res = await fetch(`${API_URL}/v1/platform/catalog`, {
+      next: { revalidate: 120, tags: ["platform-catalog"] },
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { ok?: boolean; data?: ResolvedCatalog };
+    if (!json.ok || !json.data) return null;
+    return json.data;
+  } catch {
+    return null;
+  }
+}
+
+export const getPublicCatalog = cache(fetchCatalog, ["platform-catalog"], {
+  revalidate: 120,
+  tags: ["platform-catalog"],
+});
+
+/**
+ * Collapse the resolved catalog into one card per logical product
+ * (groupKey, falling back to key) for the marketing grid — e.g. LinkedIn
+ * Content + LinkedIn Ads render as a single "LinkedIn" card. Keeps the
+ * lowest sortOrder representative and drops dev-only rows defensively
+ * (prod already strips them; this guards a non-prod marketing build).
+ */
+export function dedupePublicIntegrations(integrations: ResolvedIntegration[]): ResolvedIntegration[] {
+  const byGroup = new Map<string, ResolvedIntegration>();
+  for (const i of integrations) {
+    if (i.surfacedState === "dev_only") continue;
+    const g = i.display?.groupKey || i.key;
+    const existing = byGroup.get(g);
+    if (!existing || (i.display?.sortOrder ?? 100) < (existing.display?.sortOrder ?? 100)) {
+      byGroup.set(g, i);
+    }
+  }
+  return Array.from(byGroup.values()).sort(
+    (a, b) => (a.display?.sortOrder ?? 100) - (b.display?.sortOrder ?? 100),
+  );
+}
+
+/** Landing-page signup CTA derived from the platform signup mode. */
+export function signupCta(mode: PlatformSignupMode): { label: string; href: string; disabled?: boolean } {
+  switch (mode) {
+    case "open":
+      return { label: "Start free", href: "/auth" };
+    case "waitlist_only":
+      return { label: "Join the waitlist", href: "/auth?intent=waitlist" };
+    case "invite_only":
+      return { label: "Request an invite", href: "/auth?intent=invite" };
+    case "closed":
+    default:
+      return { label: "Launching soon", href: "/auth", disabled: true };
+  }
+}

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -73,25 +73,41 @@ export interface ResolvedCatalog {
   platform: PlatformBlock;
 }
 
-async function fetchCatalog(): Promise<ResolvedCatalog | null> {
+/**
+ * Inner fetch — THROWS on any failure so the cache layer below never
+ * memoizes a failed/null result. A transient API 5xx must not pin the static
+ * fallback (degraded CTA + no banner) for the whole revalidate window; throwing
+ * keeps the failure out of the cache so the next request retries.
+ */
+async function fetchCatalogOrThrow(): Promise<ResolvedCatalog> {
+  const res = await fetch(`${API_URL}/v1/platform/catalog`, {
+    next: { revalidate: 120, tags: ["platform-catalog"] },
+  });
+  if (!res.ok) throw new Error(`catalog ${res.status}`);
+  const json = (await res.json()) as { ok?: boolean; data?: ResolvedCatalog };
+  if (!json.ok || !json.data) throw new Error("catalog malformed response");
+  return json.data;
+}
+
+const getCachedCatalog = cache(fetchCatalogOrThrow, ["platform-catalog"], {
+  revalidate: 120,
+  tags: ["platform-catalog"],
+});
+
+/**
+ * Public catalog, or `null` when the API is unreachable/unconfigured — callers
+ * render the static fallback. Only SUCCESSFUL responses are cached (the inner
+ * fn throws on failure), so a transient blip recovers on the next request
+ * rather than being pinned for 120s.
+ */
+export async function getPublicCatalog(): Promise<ResolvedCatalog | null> {
   if (!API_URL) return null;
   try {
-    const res = await fetch(`${API_URL}/v1/platform/catalog`, {
-      next: { revalidate: 120, tags: ["platform-catalog"] },
-    });
-    if (!res.ok) return null;
-    const json = (await res.json()) as { ok?: boolean; data?: ResolvedCatalog };
-    if (!json.ok || !json.data) return null;
-    return json.data;
+    return await getCachedCatalog();
   } catch {
     return null;
   }
 }
-
-export const getPublicCatalog = cache(fetchCatalog, ["platform-catalog"], {
-  revalidate: 120,
-  tags: ["platform-catalog"],
-});
 
 /**
  * Collapse the resolved catalog into one card per logical product


### PR DESCRIPTION
## Context

Un-hardcodes the marketing **landing page** so the CMS integration toggles + the global platform stage drive what the public site shows. Builds on the resolver (api #474) + CMS controls (#86–#89). Plan: `~/.claude/plans/lexical-orbiting-emerson.md`.

## What's in this PR

- **`lib/catalog.ts`**: `getPublicCatalog()` (unauthenticated, cached 120s + `platform-catalog` tag, mirrors `lib/pricing.ts`); `dedupePublicIntegrations` (one card per groupKey, drops `dev_only` defensively); `signupCta(signupMode)`. **Only successful responses are cached** — a transient API blip recovers next request instead of pinning the fallback.
- **`components/marketing/integration-brand.tsx`**: catalog key/groupKey → brand glyph + accent, styled initial fallback for unmapped rows.
- **`app/page.tsx`**: integration grid renders from the resolved catalog (`Soon` badge for `coming_soon`); hero + section CTAs derive from `platform.signupMode`; an announcement banner (`role="status"`) renders when enabled. Static `INTEGRATIONS` kept as the fallback when the API is unreachable.
- **`app/auth/page.tsx`**: reads `?intent=waitlist|invite` and shows matching heading/copy so the CTA label and destination agree.

## Verification

- `tsc --noEmit` + `eslint` clean. Fallback path verified null-safe (no catalog → "Start free", no banner, static grid).

## Review

Double-reviewed (manual + subagent). 1 HIGH (CTA/intent mismatch) + 1 MEDIUM (transient-failure cached as null) + LOW a11y fixed in a separate commit. Fallback correctness, dedupe, banner XSS-safety all verified.

> Note: needs a runtime smoke (landing renders from a live catalog; stage flip changes CTA) — folded into the Director UI/UX audit + verification gate before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)