### PR TITLE
feat(b2c): content hub renders from the resolved catalog

### DIFF
--- a/src/app/dashboard/content/channels-from-catalog.ts
+++ b/src/app/dashboard/content/channels-from-catalog.ts
@@ -1,0 +1,70 @@
+import type { ResolvedIntegration } from "@/lib/catalog";
+import type { ChannelCategory, ChannelConfig, ChannelLifecycle } from "./channels.config";
+
+/**
+ * Maps the resolved platform catalog (CMS-driven, org-personalized, env-gated)
+ * into the hub's ChannelConfig shape, so the Content Channels hub renders from
+ * the catalog instead of the hardcoded channels.config.ts — while the existing
+ * render logic (ChannelRow/StatusBadge/ChannelLogo/tabs) stays untouched.
+ *
+ * Two mappings carry the weight:
+ *
+ *  1. cfg_integrations.category (the platform enum) → the hub's tab. Anything
+ *     unmapped falls into "Web & SEO" rather than being dropped — the hub must
+ *     never silently hide a connectable channel just because a new category
+ *     value appeared. (The resolver already strips adminOnly/internal infra
+ *     rows, so only user-facing connectors reach here.)
+ *
+ *  2. resolver `surfacedState` → ChannelLifecycle. A connectable row with a
+ *     dashboardPath is "live" (it has a manage surface); connectable without
+ *     one is "available" (connect via the OAuth grid); coming_soon stays
+ *     coming_soon; deprecated/locked/dev_only collapse to "available" so they
+ *     remain reachable (the connect/manage routing + the API gates handle the
+ *     rest).
+ */
+
+const CATEGORY_TO_TAB: Record<string, ChannelCategory> = {
+  newsletter: "Newsletters",
+  social_publish: "Social",
+  social_engage: "Social",
+  social_ads: "Ads",
+  ecommerce: "Web & SEO",
+  analytics: "Web & SEO",
+  messaging: "Messaging",
+  telephony: "Messaging",
+};
+
+const FALLBACK_TAB: ChannelCategory = "Web & SEO";
+
+function toLifecycle(i: ResolvedIntegration): ChannelLifecycle {
+  switch (i.surfacedState) {
+    case "connectable":
+      return i.display?.dashboardPath ? "live" : "available";
+    case "coming_soon":
+      return "coming_soon";
+    // deprecated (existing connections work), locked (visible-but-gated), and
+    // dev_only (non-prod testers) all remain reachable as "available".
+    default:
+      return "available";
+  }
+}
+
+export function mapCatalogToChannels(integrations: ResolvedIntegration[]): ChannelConfig[] {
+  // No filtering here — the resolver already strips adminOnly/internal in all
+  // envs and in_development/hidden in prod; dev_only rows are intentionally
+  // shown in non-prod so testers can exercise them.
+  return integrations
+    .map((i) => ({
+      slug: i.key,
+      name: i.name,
+      description: i.tagline ?? i.comingSoon?.copy ?? "",
+      category: CATEGORY_TO_TAB[i.category] ?? FALLBACK_TAB,
+      // The catalog `key` is the int_connections.provider value, so it doubles
+      // as the connection-lookup key (matches flattenMetaIntegration output).
+      providerKey: i.key,
+      status: toLifecycle(i),
+      dashboardPath: i.display?.dashboardPath,
+      logoUrl: i.display?.iconUrl,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/app/dashboard/content/channels-from-catalog.ts
+++ b/src/app/dashboard/content/channels-from-catalog.ts
@@ -49,9 +49,19 @@ const DROP_CATEGORIES = new Set([
 
 const FALLBACK_TAB: ChannelCategory = "Web & SEO";
 
+// Connectors that connect via their OWN in-app page (not the OAuth grid) — e.g.
+// WhatsApp Embedded Signup. The old config encoded this as status:"available"
+// + dashboardPath, but the seed collapses "available"→"live", losing the
+// distinction. Forcing these back to "available" preserves the correct routing
+// (ChannelRow routes "available" + dashboardPath to the in-app page for a
+// not-yet-connected channel). STOPGAP: replace with a `connectInApp` flag on
+// cfg_integrations once the schema/seed carry it.
+const IN_APP_CONNECT_KEYS = new Set(["whatsapp"]);
+
 function toLifecycle(i: ResolvedIntegration): ChannelLifecycle {
   switch (i.surfacedState) {
     case "connectable":
+      if (IN_APP_CONNECT_KEYS.has(i.key)) return "available";
       return i.display?.dashboardPath ? "live" : "available";
     case "coming_soon":
       return "coming_soon";
@@ -63,18 +73,20 @@ function toLifecycle(i: ResolvedIntegration): ChannelLifecycle {
 }
 
 export function mapCatalogToChannels(integrations: ResolvedIntegration[]): ChannelConfig[] {
-  // The resolver already strips adminOnly/internal in all envs and
-  // in_development/hidden in prod; dev_only rows are intentionally shown in
-  // non-prod so testers can exercise them. We additionally drop pure-infra
-  // categories that aren't content connectors.
+  // The resolver strips adminOnly/internal rows in all envs and
+  // in_development/hidden in prod; this filter ADDITIONALLY drops infra
+  // categories (a separate gate the resolver doesn't apply). dev_only rows are
+  // intentionally shown in non-prod so testers can exercise them.
   return integrations
     .filter((i) => !DROP_CATEGORIES.has(i.category))
     .map((i) => ({
       slug: i.key,
       name: i.name,
       // Seed writes the one-liner into `description`; `tagline` is the
-      // CMS-curated override. Fall back through both so the row never blanks.
-      description: i.tagline ?? i.description ?? i.comingSoon?.copy ?? "",
+      // CMS-curated override. Truthiness pick (not ??) so an operator-blanked
+      // "" tagline still falls through to the seed description.
+      description:
+        i.tagline?.trim() || i.description?.trim() || i.comingSoon?.copy?.trim() || "",
       category: CATEGORY_TO_TAB[i.category] ?? FALLBACK_TAB,
       // The catalog `key` is the int_connections.provider value, so it doubles
       // as the connection-lookup key (matches flattenMetaIntegration output).

--- a/src/app/dashboard/content/channels-from-catalog.ts
+++ b/src/app/dashboard/content/channels-from-catalog.ts
@@ -32,7 +32,20 @@ const CATEGORY_TO_TAB: Record<string, ChannelCategory> = {
   analytics: "Web & SEO",
   messaging: "Messaging",
   telephony: "Messaging",
+  crm: "Web & SEO",
 };
+
+// Pure-infra categories that are NOT content connectors — drop them from the
+// hub even if a future CMS row makes one public (the content hub is a curated
+// connector surface; the integrations grid shows everything). `other` is NOT
+// here — it's the bucket WordPress ships under, so it keeps the Web & SEO tab.
+const DROP_CATEGORIES = new Set([
+  "ai_provider",
+  "data_provider",
+  "webhook",
+  "payment",
+  "storage",
+]);
 
 const FALLBACK_TAB: ChannelCategory = "Web & SEO";
 
@@ -50,14 +63,18 @@ function toLifecycle(i: ResolvedIntegration): ChannelLifecycle {
 }
 
 export function mapCatalogToChannels(integrations: ResolvedIntegration[]): ChannelConfig[] {
-  // No filtering here — the resolver already strips adminOnly/internal in all
-  // envs and in_development/hidden in prod; dev_only rows are intentionally
-  // shown in non-prod so testers can exercise them.
+  // The resolver already strips adminOnly/internal in all envs and
+  // in_development/hidden in prod; dev_only rows are intentionally shown in
+  // non-prod so testers can exercise them. We additionally drop pure-infra
+  // categories that aren't content connectors.
   return integrations
+    .filter((i) => !DROP_CATEGORIES.has(i.category))
     .map((i) => ({
       slug: i.key,
       name: i.name,
-      description: i.tagline ?? i.comingSoon?.copy ?? "",
+      // Seed writes the one-liner into `description`; `tagline` is the
+      // CMS-curated override. Fall back through both so the row never blanks.
+      description: i.tagline ?? i.description ?? i.comingSoon?.copy ?? "",
       category: CATEGORY_TO_TAB[i.category] ?? FALLBACK_TAB,
       // The catalog `key` is the int_connections.provider value, so it doubles
       // as the connection-lookup key (matches flattenMetaIntegration output).

--- a/src/app/dashboard/content/page.tsx
+++ b/src/app/dashboard/content/page.tsx
@@ -13,11 +13,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollableTabsList } from "@/components/scrollable-tabslist";
 import { flattenMetaIntegration } from "@/lib/integrations-meta";
+import type { ResolvedCatalog } from "@/lib/catalog";
 import {
   CHANNELS,
   CHANNEL_CATEGORIES,
   type ChannelConfig,
 } from "./channels.config";
+import { mapCatalogToChannels } from "./channels-from-catalog";
 
 interface ApiIntegration {
   provider: string;
@@ -56,6 +58,22 @@ export default function ContentChannelsHubPage() {
   // Bind `data?.integrations` to a local so the memo's source dep matches what
   // React Compiler infers (it widened `data?.integrations` to `data`). Stable
   // reference across refetches that return the same content → no map churn.
+  // Channel list is now CMS-driven: resolved from the org-personalized platform
+  // catalog. Falls back to the static channels.config.ts if the catalog can't
+  // be loaded, so the hub never renders empty.
+  const { data: catalog } = useQuery({
+    queryKey: ["content-hub-catalog"],
+    queryFn: () => api.get<ResolvedCatalog>("/v1/platform/catalog"),
+    staleTime: 30_000,
+  });
+  const channels = useMemo<ChannelConfig[]>(
+    () =>
+      catalog?.integrations?.length
+        ? mapCatalogToChannels(catalog.integrations)
+        : [...CHANNELS],
+    [catalog],
+  );
+
   const integrations = data?.integrations;
   const connections = useMemo<ConnectionMap>(() => {
     const map: ConnectionMap = new Map();
@@ -123,7 +141,7 @@ export default function ContentChannelsHubPage() {
         </ScrollableTabsList>
 
         <TabsContent value={ALL_TAB} className="mt-6 space-y-3">
-          {CHANNELS.map((channel) => (
+          {channels.map((channel) => (
             <ChannelRow
               key={channel.slug}
               channel={channel}
@@ -135,7 +153,7 @@ export default function ContentChannelsHubPage() {
 
         {CHANNEL_CATEGORIES.map((category) => (
           <TabsContent key={category} value={category} className="mt-6 space-y-3">
-            {CHANNELS.filter((c) => c.category === category).map((channel) => (
+            {channels.filter((c) => c.category === category).map((channel) => (
               <ChannelRow
                 key={channel.slug}
                 channel={channel}


### PR DESCRIPTION
## Context

Un-hardcodes the authenticated **Content Channels hub** so CMS lifecycle/gating toggles drive what the dashboard shows. Builds on the resolver (api #474) + landing (b2c #260). Plan: `~/.claude/plans/lexical-orbiting-emerson.md`.

## What's in this PR

- **`channels-from-catalog.ts`**: `mapCatalogToChannels()` — cfg category → hub tab (infra categories dropped; unmapped → "Web & SEO" catch-all), `surfacedState` → lifecycle (connectable+dashboardPath → live; connectable → available; coming_soon stays; deprecated/locked/dev_only → reachable), carrying `display.dashboardPath`/`iconUrl`. Catalog `key` = `int_connections.provider` (connection-lookup key).
- **`content/page.tsx`**: fetches `/v1/platform/catalog` (authenticated, org-resolved) via React Query, renders from the mapped channels, **falls back to the static `channels.config.ts`** if the catalog can't load. All render logic + Meta flatten + connection lookup unchanged.

`channels.config.ts` retained as the typed fallback + `ChannelCategory`/`ChannelConfig` source (intentionally not fully retired).

## Verification

- `tsc --noEmit` + `eslint` clean.
- Review traced the seed round-trip: Meta virtual providers (facebook_pages/instagram/meta_ads/whatsapp) exist as catalog keys → connection state aligns; live channels (beehiiv/linkedin/x) carry `display.dashboardPath` → map to "live".

## Review

Double-reviewed (manual + subagent). 1 HIGH (empty descriptions — seed writes `description` not `tagline`) + LOW (infra-category leak) fixed in a separate commit. Three suspected regressions (Meta alignment, LinkedIn dedupe, dashboardPath) were traced through the seed and confirmed NOT regressions.

> NOTE: needs a runtime smoke on dev (hub renders catalog channels in the right tabs; connection state lights up; coming_soon disables connect) before prod — seed category/provider-key alignment is only fully confirmable live. Folded into the Director UI/UX audit + verification gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)