### PR TITLE
feat(b2c): coming-soon gate + teaser + Agentic AI Marketing Platform rebrand

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -44,7 +44,7 @@ export default function ComingSoonPage() {
         </p>
 
         <div className="mt-2 inline-flex items-center gap-2 rounded-full border bg-muted/40 px-5 py-2.5 text-sm font-medium text-muted-foreground">
-          <span className="relative flex size-2">
+          <span className="relative flex size-2" aria-hidden>
             <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary/60" />
             <span className="relative inline-flex size-2 rounded-full bg-primary" />
           </span>

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import { Sparkles } from "lucide-react";
+import { SITE } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "PeakHour — Agentic AI Marketing Platform",
+  description:
+    "PeakHour is an agentic AI marketing platform. Autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock. Launching soon.",
+};
+
+/**
+ * Standalone pre-launch teaser. Served for EVERY route in production while the
+ * coming-soon gate is on (see middleware.ts) — deliberately self-contained
+ * (no Header/Footer that link into the gated app). Pure teaser: no signup/
+ * capture. Preview locally at /coming-soon, or set COMING_SOON=true to exercise
+ * the full gate in dev.
+ */
+export default function ComingSoonPage() {
+  return (
+    <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 text-center">
+      {/* Subtle backdrop (standard utilities — no brittle arbitrary theme()). */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-1/2 bg-gradient-to-b from-primary/5 to-transparent"
+      />
+
+      <div className="mx-auto flex max-w-2xl flex-col items-center gap-7">
+        <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          <Sparkles className="size-3.5" aria-hidden />
+          Agentic AI Marketing Platform
+        </span>
+
+        <h1 className="text-pretty text-5xl font-bold tracking-tight sm:text-6xl lg:text-7xl">
+          Every hour is{" "}
+          <span className="bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
+            {SITE.name}
+          </span>
+        </h1>
+
+        <p className="max-w-xl text-balance text-lg text-muted-foreground">
+          Autonomous AI agents that analyze your content, create campaigns, and
+          optimize performance across every channel — around the clock, so your
+          marketing runs at its peak even when you&rsquo;re off.
+        </p>
+
+        <div className="mt-2 inline-flex items-center gap-2 rounded-full border bg-muted/40 px-5 py-2.5 text-sm font-medium text-muted-foreground">
+          <span className="relative flex size-2">
+            <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary/60" />
+            <span className="relative inline-flex size-2 rounded-full bg-primary" />
+          </span>
+          Launching soon
+        </div>
+      </div>
+
+      <p className="absolute bottom-6 text-xs text-muted-foreground">
+        © {SITE.name}. All rights reserved.
+      </p>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,9 +19,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "PeakHour - AI Marketing Department",
+  title: "PeakHour — Agentic AI Marketing Platform",
   description:
-    "Your AI-powered marketing team. Content intelligence, creative factory, and optimization engine — all in one platform.",
+    "PeakHour is an agentic AI marketing platform: autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock.",
 };
 
 export default async function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -186,21 +186,24 @@ export default async function Home() {
             <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
               <Badge variant="outline" className="gap-1.5 px-3 py-1">
                 <Sparkles className="size-3" />
-                AI-Powered Marketing
+                Agentic AI Marketing Platform
               </Badge>
               <h1 className="text-4xl font-bold tracking-tight text-pretty sm:text-5xl lg:text-6xl">
-                Your AI Marketing Department
+                Every hour is PeakHour
               </h1>
               <p className="max-w-2xl text-lg text-muted-foreground lg:text-xl">
-                PeakHour turns your content into high-performing ads across every
-                platform. Content intelligence, creative factory, and optimization
-                engine — all powered by AI, all on autopilot.
+                Autonomous AI agents turn your content into high-performing campaigns
+                across every channel — analyzing, creating, and optimizing around the
+                clock, so your marketing runs at its peak even when you&rsquo;re off.
               </p>
-              <div className="flex w-full flex-col justify-center gap-3 sm:flex-row">
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
                 {cta.disabled ? (
-                  <Button size="lg" disabled>
+                  // Pre-launch teaser: an intentional "Launching soon" pill, not a
+                  // dead/greyed CTA (which reads as a bug).
+                  <span className="inline-flex items-center gap-2 rounded-full border bg-muted/40 px-5 py-2.5 text-sm font-medium text-muted-foreground">
+                    <Sparkles className="size-4" aria-hidden />
                     {cta.label}
-                  </Button>
+                  </span>
                 ) : (
                   <Button asChild size="lg" className="gap-2">
                     <Link href={cta.href}>
@@ -210,7 +213,7 @@ export default async function Home() {
                   </Button>
                 )}
                 <Button asChild variant="outline" size="lg">
-                  <Link href="#how-it-works">How it works</Link>
+                  <Link href="#how-it-works">See how it works</Link>
                 </Button>
               </div>
             </div>
@@ -301,11 +304,7 @@ export default async function Home() {
                   ? "More integrations rolling out as we launch"
                   : "More integrations coming soon"}
               </span>
-              {cta.disabled ? (
-                <Button variant="outline" size="sm" disabled>
-                  {cta.label}
-                </Button>
-              ) : (
+              {!cta.disabled && (
                 <Button asChild variant="outline" size="sm">
                   <Link href={cta.href}>
                     {cta.label}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,14 +11,51 @@ const apiOrigin = (() => {
 })();
 
 export function middleware(req: NextRequest) {
+  const { pathname, searchParams } = req.nextUrl;
+
+  // Next.js prefetch / RSC / server-action requests. The CSP nonce dance must
+  // NOT touch these (it can break RSC streaming) — previously they were excluded
+  // from the middleware entirely via the matcher `missing` block. We now let the
+  // middleware run on them so the coming-soon gate can rewrite them too (so the
+  // real app never loads — even for a crafted RSC request), but we skip the
+  // nonce/CSP work for them, preserving the prior behavior.
+  const h = req.headers;
+  const isPassthrough =
+    h.get("next-router-prefetch") !== null ||
+    h.get("purpose") === "prefetch" ||
+    h.get("next-action") !== null ||
+    h.get("rsc") !== null;
+
+  // ── Coming-soon gate ────────────────────────────────────────────────
+  // When COMING_SOON=true (set it in Vercel's Production env), EVERY route is
+  // rewritten to the standalone /coming-soon teaser — the real app never loads
+  // for the public. The team bypasses with `?preview=<COMING_SOON_PREVIEW_SECRET>`
+  // (sets a 1-week httpOnly cookie); `?preview=off` clears it. To preview the
+  // teaser in dev, visit /coming-soon directly, or set COMING_SOON=true locally
+  // and use the preview secret to get back into the app.
+  const comingSoon = process.env.COMING_SOON === "true";
+  const previewSecret = process.env.COMING_SOON_PREVIEW_SECRET ?? "";
+  const PREVIEW_COOKIE = "ph_preview";
+  const previewParam = searchParams.get("preview");
+  const revokePreview = previewParam === "off";
+  const grantPreview = !!previewSecret && previewParam === previewSecret;
+  const hasPreviewCookie =
+    !revokePreview &&
+    !!previewSecret &&
+    req.cookies.get(PREVIEW_COOKIE)?.value === previewSecret;
+  const gated =
+    comingSoon &&
+    pathname !== "/coming-soon" &&
+    !grantPreview &&
+    !hasPreviewCookie;
+
+  // CSP + nonce — computed for the full-document path only.
   const nonce = btoa(
     String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
   );
-
   const scriptSrc = isDev
     ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
     : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
-
   const connectSrc = [
     "connect-src 'self'",
     apiOrigin,
@@ -29,7 +66,6 @@ export function middleware(req: NextRequest) {
   ]
     .filter(Boolean)
     .join(" ");
-
   const csp = [
     "default-src 'self'",
     scriptSrc,
@@ -50,37 +86,19 @@ export function middleware(req: NextRequest) {
   // framework-injected <script> tags. Required for 'strict-dynamic' to work.
   reqHeaders.set("content-security-policy", csp);
 
-  // ── Coming-soon gate ────────────────────────────────────────────────
-  // When COMING_SOON=true (set it in Vercel's Production env), every route is
-  // rewritten to the standalone /coming-soon teaser — the real app never loads
-  // for the public. The team bypasses with `?preview=<COMING_SOON_PREVIEW_SECRET>`
-  // (sets a session cookie); `?preview=off` clears it. To preview the teaser in
-  // dev, either visit /coming-soon directly, or set COMING_SOON=true locally and
-  // use the preview secret to get back into the app.
-  const comingSoon = process.env.COMING_SOON === "true";
-  const previewSecret = process.env.COMING_SOON_PREVIEW_SECRET ?? "";
-  const PREVIEW_COOKIE = "ph_preview";
-  const { pathname, searchParams } = req.nextUrl;
-  const previewParam = searchParams.get("preview");
-  const revokePreview = previewParam === "off";
-  const grantPreview = !!previewSecret && previewParam === previewSecret;
-  const hasPreviewCookie =
-    !revokePreview &&
-    !!previewSecret &&
-    req.cookies.get(PREVIEW_COOKIE)?.value === previewSecret;
-
-  const gated =
-    comingSoon &&
-    pathname !== "/coming-soon" &&
-    !grantPreview &&
-    !hasPreviewCookie;
-
   let res: NextResponse;
   if (gated) {
     const url = req.nextUrl.clone();
     url.pathname = "/coming-soon";
     url.search = "";
-    res = NextResponse.rewrite(url, { request: { headers: reqHeaders } });
+    // Full-document gated request → carry the nonce so the teaser HTML matches;
+    // passthrough (rsc/prefetch/action) gated request → plain rewrite.
+    res = isPassthrough
+      ? NextResponse.rewrite(url)
+      : NextResponse.rewrite(url, { request: { headers: reqHeaders } });
+  } else if (isPassthrough) {
+    // Preserve prior behavior: middleware did not modify these requests.
+    res = NextResponse.next();
   } else {
     res = NextResponse.next({ request: { headers: reqHeaders } });
   }
@@ -97,20 +115,13 @@ export function middleware(req: NextRequest) {
     res.cookies.delete(PREVIEW_COOKIE);
   }
 
-  res.headers.set("Content-Security-Policy", csp);
+  if (!isPassthrough) res.headers.set("Content-Security-Policy", csp);
   return res;
 }
 
 export const config = {
-  matcher: [
-    {
-      source: "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
-      missing: [
-        { type: "header", key: "next-router-prefetch" },
-        { type: "header", key: "purpose", value: "prefetch" },
-        { type: "header", key: "next-action" },
-        { type: "header", key: "rsc" },
-      ],
-    },
-  ],
+  // No `missing` exclusions — the gate must see prefetch/rsc/next-action
+  // requests too (so a crafted RSC request can't pull a gated route). The
+  // middleware skips the nonce/CSP work for those internally.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,7 +50,53 @@ export function middleware(req: NextRequest) {
   // framework-injected <script> tags. Required for 'strict-dynamic' to work.
   reqHeaders.set("content-security-policy", csp);
 
-  const res = NextResponse.next({ request: { headers: reqHeaders } });
+  // ── Coming-soon gate ────────────────────────────────────────────────
+  // When COMING_SOON=true (set it in Vercel's Production env), every route is
+  // rewritten to the standalone /coming-soon teaser — the real app never loads
+  // for the public. The team bypasses with `?preview=<COMING_SOON_PREVIEW_SECRET>`
+  // (sets a session cookie); `?preview=off` clears it. To preview the teaser in
+  // dev, either visit /coming-soon directly, or set COMING_SOON=true locally and
+  // use the preview secret to get back into the app.
+  const comingSoon = process.env.COMING_SOON === "true";
+  const previewSecret = process.env.COMING_SOON_PREVIEW_SECRET ?? "";
+  const PREVIEW_COOKIE = "ph_preview";
+  const { pathname, searchParams } = req.nextUrl;
+  const previewParam = searchParams.get("preview");
+  const revokePreview = previewParam === "off";
+  const grantPreview = !!previewSecret && previewParam === previewSecret;
+  const hasPreviewCookie =
+    !revokePreview &&
+    !!previewSecret &&
+    req.cookies.get(PREVIEW_COOKIE)?.value === previewSecret;
+
+  const gated =
+    comingSoon &&
+    pathname !== "/coming-soon" &&
+    !grantPreview &&
+    !hasPreviewCookie;
+
+  let res: NextResponse;
+  if (gated) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/coming-soon";
+    url.search = "";
+    res = NextResponse.rewrite(url, { request: { headers: reqHeaders } });
+  } else {
+    res = NextResponse.next({ request: { headers: reqHeaders } });
+  }
+
+  if (grantPreview) {
+    res.cookies.set(PREVIEW_COOKIE, previewSecret, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: !isDev,
+      path: "/",
+      maxAge: 60 * 60 * 24 * 7, // 1 week
+    });
+  } else if (revokePreview) {
+    res.cookies.delete(PREVIEW_COOKIE);
+  }
+
   res.headers.set("Content-Security-Policy", csp);
   return res;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,49 @@ const apiOrigin = (() => {
   }
 })();
 
+/**
+ * Build the per-request CSP + the request headers that carry the nonce (so
+ * Next.js can stamp it onto framework `<script>` tags for 'strict-dynamic').
+ * Only needed for full-document requests — prefetch/rsc/server-action requests
+ * deliberately get no nonce/CSP (it can break RSC streaming).
+ */
+function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
+  const nonce = btoa(
+    String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
+  );
+  const scriptSrc = isDev
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
+  const connectSrc = [
+    "connect-src 'self'",
+    apiOrigin,
+    "https://*.vercel-insights.com",
+    "https://vitals.vercel-insights.com",
+    "https://*.vercel-analytics.com",
+    isDev ? "ws: wss: http://localhost:* ws://localhost:*" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const csp = [
+    "default-src 'self'",
+    scriptSrc,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    connectSrc,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+  ].join("; ");
+
+  const reqHeaders = new Headers(req.headers);
+  reqHeaders.set("x-nonce", nonce);
+  reqHeaders.set("content-security-policy", csp);
+  return { csp, reqHeaders };
+}
+
 export function middleware(req: NextRequest) {
   const { pathname, searchParams } = req.nextUrl;
 
@@ -49,58 +92,26 @@ export function middleware(req: NextRequest) {
     !grantPreview &&
     !hasPreviewCookie;
 
-  // CSP + nonce — computed for the full-document path only.
-  const nonce = btoa(
-    String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
-  );
-  const scriptSrc = isDev
-    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
-  const connectSrc = [
-    "connect-src 'self'",
-    apiOrigin,
-    "https://*.vercel-insights.com",
-    "https://vitals.vercel-insights.com",
-    "https://*.vercel-analytics.com",
-    isDev ? "ws: wss: http://localhost:* ws://localhost:*" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const csp = [
-    "default-src 'self'",
-    scriptSrc,
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data: blob: https:",
-    "font-src 'self' data:",
-    connectSrc,
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "object-src 'none'",
-    "upgrade-insecure-requests",
-  ].join("; ");
-
-  const reqHeaders = new Headers(req.headers);
-  reqHeaders.set("x-nonce", nonce);
-  // Next.js extracts the nonce from this request header and stamps it onto
-  // framework-injected <script> tags. Required for 'strict-dynamic' to work.
-  reqHeaders.set("content-security-policy", csp);
-
   let res: NextResponse;
   if (gated) {
     const url = req.nextUrl.clone();
     url.pathname = "/coming-soon";
     url.search = "";
-    // Full-document gated request → carry the nonce so the teaser HTML matches;
-    // passthrough (rsc/prefetch/action) gated request → plain rewrite.
-    res = isPassthrough
-      ? NextResponse.rewrite(url)
-      : NextResponse.rewrite(url, { request: { headers: reqHeaders } });
+    if (isPassthrough) {
+      res = NextResponse.rewrite(url);
+    } else {
+      // Full-document gated request → carry the nonce so the teaser HTML matches.
+      const { csp, reqHeaders } = buildCsp(req);
+      res = NextResponse.rewrite(url, { request: { headers: reqHeaders } });
+      res.headers.set("Content-Security-Policy", csp);
+    }
   } else if (isPassthrough) {
     // Preserve prior behavior: middleware did not modify these requests.
     res = NextResponse.next();
   } else {
+    const { csp, reqHeaders } = buildCsp(req);
     res = NextResponse.next({ request: { headers: reqHeaders } });
+    res.headers.set("Content-Security-Policy", csp);
   }
 
   if (grantPreview) {
@@ -115,7 +126,6 @@ export function middleware(req: NextRequest) {
     res.cookies.delete(PREVIEW_COOKIE);
   }
 
-  if (!isPassthrough) res.headers.set("Content-Security-Policy", csp);
   return res;
 }
 


### PR DESCRIPTION
## Context

Pre-launch **stealth gate** for peakhour.ai: in production, serve ONLY a teaser — the real app never loads for the public — plus the "Agentic AI Marketing Platform" rebrand and the "Every hour is PeakHour" hero.

## What's in this PR

- **`middleware.ts` — coming-soon gate**: when `COMING_SOON=true` (set in Vercel's **Production** env), every page route is rewritten to `/coming-soon`. Team bypass via `?preview=<COMING_SOON_PREVIEW_SECRET>` (1-week httpOnly cookie); `?preview=off` clears it. CSP/nonce still applied to the teaser. Inert when `COMING_SOON` is unset.
- **`app/coming-soon/page.tsx`**: standalone branded teaser (no Header/Footer into the gated app) — "Every hour is PeakHour", *Agentic AI Marketing Platform* eyebrow, "Launching soon" pulse. Pure teaser, no capture.
- **Rebrand**: meta title/description + hero → PeakHour brand + "Agentic AI Marketing Platform" descriptor; H1 "Every hour is PeakHour"; the platform-stage `closed` landing CTA is now an intentional "Launching soon" pill, not a dead button.

## Env vars

- `COMING_SOON=true` — turns the gate on (set in Vercel Production only).
- `COMING_SOON_PREVIEW_SECRET=<random>` — the team bypass secret (server-only, NOT `NEXT_PUBLIC`).

## Preview in development

- Teaser only: `npm run dev` → open `/coming-soon` (gate off by default).
- Full gate: set `COMING_SOON=true` + `COMING_SOON_PREVIEW_SECRET=…` in `.env.local`; every route shows the teaser; `?preview=<secret>` gets you back into the app, `?preview=off` exits.

## Verification

`tsc --noEmit` + `eslint` clean. Under security-focused review (bypass holes, rewrite loop, CSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)