### PR TITLE
fix(strategist): WriteTab horizontal scroll / empty space on the right

### DIFF
--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -1284,8 +1284,14 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
   const citations = idea.content?.dataCitations;
   const isNewsletter = !idea.contentFormat || idea.contentFormat === "newsletter";
 
+  // minmax(0,1fr) — NOT 1fr — so the editor column can shrink below its
+  // content's min-content width. A bare `1fr` track keeps its implicit
+  // `min-width:auto`, so a long unbreakable token (a URL in a citation, a
+  // mono HTML line in the editor) forces the track wider than the
+  // viewport, pushing the fixed 320px rail out and creating the empty gap
+  // + horizontal scroll on the right.
   return (
-    <div className={citations?.length ? "grid gap-4 lg:grid-cols-[1fr_320px]" : ""}>
+    <div className={citations?.length ? "grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]" : ""}>
       {/* Routed through the shared <ComposerShell> for cross-surface
           consistency with LinkedIn / X. Voice chip + AI toolbar mounted;
           the AI toolbar is gated to Edit mode (it operates on the HTML


### PR DESCRIPTION
## Problem
On the Strategist detail page (Write step), an **empty space on the right** appears with a **horizontal scrollbar** once a draft has been generated.

## Root cause
The WriteTab editor wraps in `lg:grid-cols-[1fr_320px]`, which only activates when the draft has **data citations** — i.e. right after **Generate First Draft** succeeds, which is when the new image/citations rail (the "button addition": Pick / Upload / Generate) renders in the fixed 320px right column.

A bare `1fr` grid track keeps its implicit `min-width:auto`, so it **cannot shrink below its content's min-content width**. A long unbreakable token (a URL in a citation, a `font-mono` HTML line in the editor) forces the `1fr` track wider than the viewport, pushing the 320px rail out and creating the empty gap + horizontal scroll.

## Fix
```diff
- lg:grid-cols-[1fr_320px]
+ lg:grid-cols-[minmax(0,1fr)_320px]
```
`minmax(0,1fr)` removes the implicit `auto` minimum so the editor column can shrink, and inner content (`w-full` / `overflow-auto`) handles its own width. No visual change when content already fits.

## Verification
Diagnosed from code (the grid is the only width-special declaration in the entire strategist subtree, and it activates exactly when the symptom appears). `eslint` clean. **Recommend a quick visual confirm after deploy**, since the authed page wasn't reproducible locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)