### PR TITLE
feat(legal): compliance-grade Privacy/Cookie/Terms + reach legal pages through coming-soon gate

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -52,9 +52,27 @@ export default function ComingSoonPage() {
         </div>
       </div>
 
-      <p className="absolute bottom-6 text-xs text-muted-foreground">
-        © {SITE.name}. All rights reserved.
-      </p>
+      <footer className="absolute inset-x-0 bottom-6 flex flex-col items-center gap-3 px-6 text-xs text-muted-foreground">
+        {/* Plain <a> (not next/link) so these resolve straight through the
+            coming-soon gate, which allowlists the legal routes. */}
+        <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+          <a href="/privacy-policy" className="transition-colors hover:text-foreground">
+            Privacy Policy
+          </a>
+          <a href="/terms" className="transition-colors hover:text-foreground">
+            Terms of Service
+          </a>
+          <a href="/cookie-policy" className="transition-colors hover:text-foreground">
+            Cookie Policy
+          </a>
+          <a href="/data-deletion" className="transition-colors hover:text-foreground">
+            Data Deletion
+          </a>
+        </nav>
+        <p>
+          © {new Date().getFullYear()} {SITE.company.legalName}. All rights reserved.
+        </p>
+      </footer>
     </main>
   );
 }

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import { SITE } from "@/lib/utils";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Cookie Policy - PeakHour",
+  description:
+    "PeakHour cookie policy — the cookies and similar technologies we use, why we use them, and how to control them.",
+};
+
+export default function CookiePolicyPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <h1 className="text-3xl font-bold">Cookie Policy</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: {SITE.legalLastUpdated}
+        </p>
+
+        <div className="mt-8 space-y-8 text-sm leading-relaxed text-muted-foreground">
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">1. Introduction</h2>
+            <p className="mt-2">
+              This Cookie Policy explains how {SITE.company.legalName} (&quot;{SITE.name}&quot;,
+              &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) uses cookies and similar technologies on the
+              {SITE.name} platform at peakhour.ai (the &quot;Service&quot;). It should be read
+              together with our{" "}
+              <a href="/privacy-policy" className="text-foreground underline">
+                Privacy Policy
+              </a>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">2. What Are Cookies?</h2>
+            <p className="mt-2">
+              Cookies are small text files placed on your device when you visit a website.
+              They are widely used to make websites work, to remember your session, and to
+              provide information to the site&apos;s operator. &quot;Similar technologies&quot; include
+              local storage and session storage, which a site can use to store information in
+              your browser for comparable purposes.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">3. Cookies We Use</h2>
+            <p className="mt-2">
+              {SITE.name} is built to be privacy-respecting and uses only the cookies and
+              browser storage necessary to operate the Service. We do <strong>not</strong> use
+              advertising cookies, and we do <strong>not</strong> use cookies to track you
+              across other websites.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">3.1 Strictly Necessary</h3>
+            <ul className="mt-2 list-disc space-y-1 pl-6">
+              <li>
+                <strong>Authentication &amp; session cookies:</strong> keep you signed in and
+                maintain your secure session. These are <code>httpOnly</code> cookies that
+                cannot be read by JavaScript.
+              </li>
+              <li>
+                <strong>OAuth state cookies:</strong> short-lived cookies used during
+                third-party authorization flows (e.g., Meta, Google, LinkedIn, X) to protect
+                against cross-site request forgery.
+              </li>
+              <li>
+                <strong>Security cookies:</strong> used to protect the Service and detect
+                abuse.
+              </li>
+            </ul>
+
+            <h3 className="mt-4 font-medium text-foreground">3.2 Functional / Preferences</h3>
+            <ul className="mt-2 list-disc space-y-1 pl-6">
+              <li>
+                Browser storage that remembers your in-app preferences (such as theme or UI
+                settings) so the Service behaves the way you expect.
+              </li>
+            </ul>
+
+            <p className="mt-3">
+              Because these cookies are strictly necessary for the Service to function, they
+              are set without requiring consent; blocking them may prevent you from signing in
+              or using core features.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">4. Analytics</h2>
+            <p className="mt-2">
+              Where we measure aggregate usage to improve the Service, we use
+              privacy-friendly, aggregated analytics that do not rely on advertising cookies
+              and are not used to identify you individually or track you across other sites.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">5. Managing Cookies</h2>
+            <p className="mt-2">
+              You can control and delete cookies through your browser settings, and most
+              browsers let you block cookies entirely. Because the cookies we use are
+              strictly necessary, blocking or deleting them may stop you from signing in or
+              using parts of the Service. Guidance for the major browsers is available in
+              their respective help centers (Chrome, Safari, Edge, and Firefox).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">6. Do Not Track</h2>
+            <p className="mt-2">
+              Because we do not track you across third-party websites or serve targeted
+              advertising, we do not alter our practices in response to browser
+              &quot;Do Not Track&quot; signals; there is no cross-site tracking to disable.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">7. Changes to This Policy</h2>
+            <p className="mt-2">
+              We may update this Cookie Policy from time to time. We will post the updated
+              version on this page and revise the &quot;Last updated&quot; date above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">8. Contact Us</h2>
+            <p className="mt-2">
+              Questions about this Cookie Policy can be sent to:
+            </p>
+            <p className="mt-2">
+              {SITE.company.legalName}
+              <br />
+              {SITE.company.address}
+              <br />
+              Email:{" "}
+              <a href={`mailto:${SITE.contactPrivacy}`} className="text-foreground underline">
+                {SITE.contactPrivacy}
+              </a>
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -23,10 +23,19 @@ export default function PrivacyPolicyPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground">1. Introduction</h2>
             <p className="mt-2">
-              PeakHour (&quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) operates the PeakHour platform
-              (peakhour.ai), an AI-powered marketing automation service. This Privacy Policy
-              explains how we collect, use, disclose, and safeguard your information when you
-              use our website and services (collectively, the &quot;Service&quot;).
+              This Privacy Policy explains how {SITE.company.legalName} (&quot;{SITE.name}&quot;,
+              &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) — the company that operates the {SITE.name}{" "}
+              platform at peakhour.ai, an AI-powered marketing automation service (the
+              &quot;Service&quot;) — collects, uses, discloses, and safeguards your information when
+              you use our website and services.
+            </p>
+            <p className="mt-2">
+              {SITE.name} is a product of {SITE.company.legalName}, registered office at{" "}
+              {SITE.company.address}. For the EU/UK General Data Protection Regulation
+              (&quot;GDPR&quot;), {SITE.company.legalName} is the data &quot;controller&quot;; under
+              India&apos;s Digital Personal Data Protection Act, 2023 (&quot;DPDP Act&quot;), it is the
+              &quot;Data Fiduciary&quot; that determines the purpose and means of processing your
+              personal data.
             </p>
             <p className="mt-2">
               By accessing or using the Service, you agree to this Privacy Policy. If you do
@@ -59,17 +68,43 @@ export default function PrivacyPolicyPage() {
 
             <h3 className="mt-4 font-medium text-foreground">2.2 Information from Third-Party Platforms</h3>
             <p className="mt-2">
-              When you connect third-party accounts (e.g., LinkedIn, Beehiiv), we receive:
+              When you connect a third-party account, you authorize that platform — through
+              its OAuth consent screen — to share specific data with us. We request only the
+              permissions (&quot;scopes&quot;) needed to provide the features you enable, and we
+              process that data solely to deliver the Service to you (see Section 12,
+              &quot;Third-Party Platform Data &amp; Developer-Program Compliance&quot;). Depending on
+              the integrations you connect, we may receive:
             </p>
             <ul className="mt-2 list-disc space-y-1 pl-6">
               <li>
-                <strong>LinkedIn:</strong> basic profile information, ad account details,
-                company page information, campaign performance metrics, and lead generation
-                form responses, as authorized through OAuth.
+                <strong>Meta (Facebook, Instagram, Ads &amp; WhatsApp Business):</strong> your
+                public profile and email; the Facebook Pages and Instagram Business accounts
+                you manage, their content and engagement/insights metrics; ad accounts,
+                campaigns and performance data; and, where you connect WhatsApp Business,
+                your WhatsApp Business Account(s), phone numbers, message templates and
+                messaging metadata — each only as authorized through Meta&apos;s OAuth and
+                subject to the Meta Platform Terms and Developer Policies.
               </li>
               <li>
-                <strong>Beehiiv:</strong> newsletter content, subscriber metrics, and
-                publication details via API integration.
+                <strong>X (formerly Twitter):</strong> basic profile information and the
+                posts, engagement metrics and advertising data you authorize, subject to the
+                X Developer Agreement and Policy.
+              </li>
+              <li>
+                <strong>LinkedIn:</strong> basic profile information, organization/company
+                page information, ad account details, campaign performance metrics, and lead
+                generation form responses, as authorized through OAuth and subject to the
+                LinkedIn API Terms of Use.
+              </li>
+              <li>
+                <strong>Google:</strong> where you connect Google services (e.g., analytics
+                or business profiles), the account, profile and metrics data you authorize,
+                handled in accordance with the Google API Services User Data Policy,
+                including its Limited Use requirements.
+              </li>
+              <li>
+                <strong>Beehiiv and other publishing tools:</strong> newsletter content,
+                subscriber metrics, and publication details via API integration.
               </li>
             </ul>
 
@@ -241,14 +276,25 @@ export default function PrivacyPolicyPage() {
             <p className="mt-2">We do not sell your personal information. We share information only as follows:</p>
             <ul className="mt-2 list-disc space-y-1 pl-6">
               <li>
-                <strong>Service providers:</strong> third-party vendors that help us operate
-                the Service (hosting, payment processing, AI providers, email delivery).
-                These providers are contractually bound to protect your data.
+                <strong>Service providers (sub-processors):</strong> vetted third-party
+                vendors that help us operate the Service — including cloud hosting,
+                database and object storage, AI/ML model providers, payment processing
+                (Stripe), and transactional email delivery. These providers act on our
+                instructions under written contracts (including data-processing terms and,
+                where applicable, Standard Contractual Clauses) that require them to protect
+                your data and use it only to provide their service to us. A current list of
+                material sub-processors is available on request from{" "}
+                <a href={`mailto:${SITE.contactPrivacy}`} className="text-foreground underline">
+                  {SITE.contactPrivacy}
+                </a>
+                .
               </li>
               <li>
-                <strong>Connected platforms:</strong> when you authorize us to manage
-                campaigns, we share ad creatives and targeting data with platforms like
-                LinkedIn as necessary to run your campaigns.
+                <strong>Connected platforms:</strong> when you authorize us to publish
+                content or manage campaigns, we share the content, ad creatives, targeting
+                and configuration data necessary to carry out your instructions with the
+                platforms you connect (e.g., Meta, X, LinkedIn, Google). We share with each
+                platform only what is needed to perform the action you requested.
               </li>
               <li>
                 <strong>Legal requirements:</strong> when required by law, regulation, legal
@@ -295,7 +341,12 @@ export default function PrivacyPolicyPage() {
             </ul>
             <p className="mt-2">
               We do not use advertising or tracking cookies. You can configure your browser
-              to block cookies, but this may prevent you from using the Service.
+              to block cookies, but this may prevent you from using the Service. For full
+              details of the cookies we set and their purposes, see our{" "}
+              <a href="/cookie-policy" className="text-foreground underline">
+                Cookie Policy
+              </a>
+              .
             </p>
           </section>
 
@@ -374,7 +425,181 @@ export default function PrivacyPolicyPage() {
           </section>
 
           <section>
-            <h2 className="text-lg font-semibold text-foreground">12. Changes to This Policy</h2>
+            <h2 className="text-lg font-semibold text-foreground">
+              12. Third-Party Platform Data &amp; Developer-Program Compliance
+            </h2>
+            <p className="mt-2">
+              Where the Service accesses data through a third-party platform&apos;s API
+              (&quot;Platform Data&quot;), we comply with that platform&apos;s developer terms and
+              policies. As a general rule, we use Platform Data <strong>only</strong> to
+              provide and improve the features you have enabled, we do <strong>not</strong>{" "}
+              sell or rent Platform Data, we do <strong>not</strong> use it for our own
+              advertising or to build independent user profiles, we retain it only for as
+              long as needed to deliver the Service, and we delete it when you disconnect the
+              integration, close your account, or ask us to.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">12.1 Meta Platform (Facebook, Instagram, Ads, WhatsApp)</h3>
+            <p className="mt-2">
+              Our use and transfer of information received from Meta APIs adheres to the{" "}
+              <a href="https://developers.facebook.com/terms/" className="text-foreground underline" target="_blank" rel="noopener noreferrer">
+                Meta Platform Terms
+              </a>{" "}
+              and Developer Policies. Meta Platform Data is used solely to provide the
+              publishing, analytics, advertising and WhatsApp Business features you enable; it
+              is never sold, and it is not used for any purpose other than delivering those
+              features to you. You may revoke our access at any time from your Meta account
+              settings, and you may request deletion of data we hold via our{" "}
+              <a href="/data-deletion" className="text-foreground underline">
+                Data Deletion
+              </a>{" "}
+              page.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">12.2 Google</h3>
+            <p className="mt-2">
+              Where you connect Google services, our use and transfer of information received
+              from Google APIs adheres to the{" "}
+              <a href="https://developers.google.com/terms/api-services-user-data-policy" className="text-foreground underline" target="_blank" rel="noopener noreferrer">
+                Google API Services User Data Policy
+              </a>
+              , including its <strong>Limited Use</strong> requirements. We do not transfer or
+              use Google user data for serving advertisements, we do not sell it, and we do not
+              allow humans to read it except as expressly permitted (e.g., with your consent,
+              for security, or to comply with law).
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">12.3 X (formerly Twitter)</h3>
+            <p className="mt-2">
+              Our access to and use of X content and data complies with the X Developer
+              Agreement and Policy. We use X data only to provide the features you enable and
+              cease using, and delete, such data when you revoke access or as required by X.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">12.4 LinkedIn</h3>
+            <p className="mt-2">
+              Our use of LinkedIn data complies with the LinkedIn API Terms of Use and is
+              limited to the authorized purposes for which you connected your LinkedIn account.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">12.5 Microsoft and other providers</h3>
+            <p className="mt-2">
+              Where you connect Microsoft or other third-party services, we comply with the
+              applicable provider&apos;s API terms and use the data only to deliver the features
+              you have enabled.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">12.6 Revoking access</h3>
+            <p className="mt-2">
+              You can disconnect any integration at any time from your account settings or
+              from the relevant platform&apos;s app/connected-apps settings. On disconnection we
+              revoke the stored access tokens and stop accessing that platform&apos;s data.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">13. Legal Bases for Processing (EEA / UK)</h2>
+            <p className="mt-2">
+              If you are in the European Economic Area or the United Kingdom, we process your
+              personal data on one or more of the following legal bases under the GDPR:
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-6">
+              <li>
+                <strong>Performance of a contract</strong> (Art. 6(1)(b)) — to create and
+                operate your account and provide the Service you request.
+              </li>
+              <li>
+                <strong>Legitimate interests</strong> (Art. 6(1)(f)) — to secure, maintain,
+                analyze and improve the Service, prevent fraud and abuse, and communicate with
+                you about the Service, balanced against your rights and freedoms.
+              </li>
+              <li>
+                <strong>Consent</strong> (Art. 6(1)(a)) — where we rely on your consent (for
+                example, certain optional integrations or communications); you may withdraw it
+                at any time without affecting prior processing.
+              </li>
+              <li>
+                <strong>Legal obligation</strong> (Art. 6(1)(c)) — to comply with applicable
+                law, tax and accounting requirements, and lawful requests.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">14. Region-Specific Privacy Rights</h2>
+
+            <h3 className="mt-4 font-medium text-foreground">14.1 European Economic Area &amp; United Kingdom (GDPR)</h3>
+            <p className="mt-2">
+              In addition to the rights in Section 9, you have the right to lodge a complaint
+              with your local supervisory authority (in the UK, the Information
+              Commissioner&apos;s Office). Where processing is based on consent or contract and is
+              carried out by automated means, you also have the right to data portability.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">14.2 California (CCPA / CPRA)</h3>
+            <p className="mt-2">
+              If you are a California resident, you have the right to know what personal
+              information we collect and how we use and disclose it, to request access and
+              deletion, to correct inaccurate information, and to be free from discrimination
+              for exercising these rights. You may use an authorized agent to submit requests.
+            </p>
+            <p className="mt-2">
+              <strong>
+                We do not &quot;sell&quot; or &quot;share&quot; your personal information as those terms are
+                defined under the CCPA/CPRA,
+              </strong>{" "}
+              and we have not done so in the preceding twelve months.
+            </p>
+
+            <h3 className="mt-4 font-medium text-foreground">14.3 India (DPDP Act, 2023)</h3>
+            <p className="mt-2">
+              If you are in India, you have the right to access a summary of your personal data
+              and our processing, to correction and erasure of your data, to nominate another
+              person to exercise your rights in the event of death or incapacity, and to
+              readily-available grievance redressal (see Section 15). Where we process your
+              data on the basis of consent, you may withdraw that consent at any time with
+              effect going forward. If you remain dissatisfied after contacting our Grievance
+              Officer, you may approach the Data Protection Board of India.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">15. Grievance Redressal (India)</h2>
+            <p className="mt-2">
+              In accordance with the DPDP Act, 2023 and applicable Information Technology
+              rules, {SITE.company.legalName} has appointed a Grievance Officer to address
+              questions or complaints about this Privacy Policy and the processing of your
+              personal data:
+            </p>
+            <p className="mt-2">
+              {SITE.grievanceOfficer.name}, {SITE.company.legalName}
+              <br />
+              {SITE.company.address}
+              <br />
+              Email:{" "}
+              <a href={`mailto:${SITE.grievanceOfficer.email}`} className="text-foreground underline">
+                {SITE.grievanceOfficer.email}
+              </a>
+            </p>
+            <p className="mt-2">
+              We will acknowledge grievances promptly and aim to resolve them within the
+              timeframes required by applicable law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">16. Governing Law &amp; Jurisdiction</h2>
+            <p className="mt-2">
+              This Privacy Policy and any dispute arising out of or relating to it or the
+              processing of your personal data are governed by the laws of India, and the
+              courts at Mumbai, Maharashtra shall have exclusive jurisdiction, without
+              prejudice to any mandatory data-protection or consumer rights available to you
+              under the laws of your country of residence.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">17. Changes to This Policy</h2>
             <p className="mt-2">
               We may update this Privacy Policy from time to time. We will notify you of
               material changes by posting the new policy on this page and updating the
@@ -384,14 +609,23 @@ export default function PrivacyPolicyPage() {
           </section>
 
           <section>
-            <h2 className="text-lg font-semibold text-foreground">13. Contact Us</h2>
+            <h2 className="text-lg font-semibold text-foreground">18. Contact Us</h2>
             <p className="mt-2">
-              If you have questions about this Privacy Policy or our data practices, contact us at:
+              If you have questions about this Privacy Policy or our data practices, contact:
             </p>
             <p className="mt-2">
-              Email:{" "}
+              {SITE.company.legalName}
+              <br />
+              {SITE.company.address}
+              <br />
+              Privacy:{" "}
               <a href={`mailto:${SITE.contactPrivacy}`} className="text-foreground underline">
                 {SITE.contactPrivacy}
+              </a>
+              <br />
+              Grievance Officer (India):{" "}
+              <a href={`mailto:${SITE.grievanceOfficer.email}`} className="text-foreground underline">
+                {SITE.grievanceOfficer.email}
               </a>
             </p>
           </section>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -24,9 +24,12 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold text-foreground">1. Agreement to Terms</h2>
             <p className="mt-2">
               These Terms of Service (&quot;Terms&quot;) constitute a legally binding
-              agreement between you (&quot;you&quot; or &quot;User&quot;) and PeakHour
-              (&quot;we&quot;, &quot;us&quot;, or &quot;Company&quot;) governing your access
-              to and use of peakhour.ai and all associated services (the &quot;Service&quot;).
+              agreement between you (&quot;you&quot; or &quot;User&quot;) and{" "}
+              {SITE.company.legalName}, a company incorporated in India with its registered
+              office at {SITE.company.address}, which operates the {SITE.name} platform
+              (&quot;{SITE.name}&quot;, &quot;we&quot;, &quot;us&quot;, or &quot;Company&quot;), governing your
+              access to and use of peakhour.ai and all associated services (the
+              &quot;Service&quot;).
             </p>
             <p className="mt-2">
               By creating an account or using the Service, you agree to be bound by these
@@ -389,10 +392,15 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold text-foreground">16. Governing Law and Disputes</h2>
             <p className="mt-2">
               These Terms shall be governed by and construed in accordance with the laws of
-              the jurisdiction in which PeakHour is incorporated, without regard to conflict
-              of law principles. Any disputes arising from these Terms or the Service shall
-              be resolved through binding arbitration, except where prohibited by applicable
-              law.
+              India, without regard to conflict-of-law principles. Subject to the arbitration
+              provision below, the courts at Mumbai, Maharashtra shall have exclusive
+              jurisdiction over any dispute arising out of or relating to these Terms or the
+              Service. Any such dispute shall be referred to and finally resolved by binding
+              arbitration seated in Mumbai, India, conducted in English by a sole arbitrator
+              under the Arbitration and Conciliation Act, 1996, except where such arbitration
+              is prohibited by applicable law. Nothing in this clause limits any mandatory
+              consumer or data-protection rights available to you under the laws of your
+              country of residence.
             </p>
           </section>
 
@@ -424,6 +432,10 @@ export default function TermsPage() {
               For questions about these Terms, contact us at:
             </p>
             <p className="mt-2">
+              {SITE.company.legalName}
+              <br />
+              {SITE.company.address}
+              <br />
               Email:{" "}
               <a href={`mailto:${SITE.contactLegal}`} className="text-foreground underline">
                 {SITE.contactLegal}

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -5,7 +5,8 @@ const FOOTER_LINKS = [
   { href: "/contact", label: "Contact" },
   { href: "/privacy-policy", label: "Privacy Policy" },
   { href: "/terms", label: "Terms of Service" },
-  { href: "/help/data-retention", label: "Data Retention" },
+  { href: "/cookie-policy", label: "Cookie Policy" },
+  { href: "/data-deletion", label: "Data Deletion" },
 ] as const;
 
 export function Footer() {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,8 +8,19 @@ export function cn(...inputs: ClassValue[]) {
 /** Shared site / legal metadata — single source of truth */
 export const SITE = {
   name: "PeakHour",
-  legalLastUpdated: "February 14, 2026",
+  legalLastUpdated: "June 1, 2026",
+  /** Operating legal entity (data controller / data fiduciary). */
+  company: {
+    legalName: "Celebrities Management Private Limited",
+    address:
+      "5th Floor, Tech Web Centre, Link Road, Oshiwara, Mumbai 400102, Maharashtra, India",
+  },
   contactPrivacy: "privacy@peakhour.ai",
   contactLegal: "legal@peakhour.ai",
   contactGeneral: "hello@peakhour.ai",
+  /** India DPDP Act, 2023 — published Grievance Officer contact. */
+  grievanceOfficer: {
+    name: "Grievance Officer",
+    email: "grievance@peakhour.ai",
+  },
 } as const;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -86,9 +86,23 @@ export function middleware(req: NextRequest) {
     !revokePreview &&
     !!previewSecret &&
     req.cookies.get(PREVIEW_COOKIE)?.value === previewSecret;
+  // Legal / compliance pages stay PUBLICLY reachable even while the
+  // coming-soon gate is on — Meta, Google, X, LinkedIn etc. fetch these
+  // URLs to validate app/developer onboarding, and they must resolve to
+  // the real document (not the teaser) before launch.
+  const PUBLIC_LEGAL_PATHS = [
+    "/privacy-policy",
+    "/terms",
+    "/cookie-policy",
+    "/data-deletion",
+  ];
+  const isPublicLegal = PUBLIC_LEGAL_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
   const gated =
     comingSoon &&
     pathname !== "/coming-soon" &&
+    !isPublicLegal &&
     !grantPreview &&
     !hasPreviewCookie;
 


### PR DESCRIPTION
## Why
Meta Tech Provider onboarding (and Google/X/LinkedIn developer programs) require a **publicly reachable** Privacy Policy URL that meets their platform-data obligations. Two gaps blocked that:

1. **The coming-soon gate rewrote *every* route to the teaser** — so `peakhour.ai/privacy-policy` returned the teaser, not the policy. Partners couldn't validate it.
2. The existing policy didn't name a legal entity or carry the platform-developer compliance language those programs check for.

## What changed

### Legal pages (senior-counsel-grade draft)
- **Privacy Policy** → 18 sections. Names **Celebrities Management Private Limited (CMPL)**, Mumbai as controller/Data Fiduciary; discloses the real Meta/X/Google/LinkedIn/Beehiiv data sources; adds a **Third-Party Platform Data & Developer-Program Compliance** section (Meta Platform Terms, **Google API Limited Use**, X Developer Policy, LinkedIn API Terms, Microsoft); sub-processors; GDPR legal bases; region-specific rights (EEA/UK, **California CCPA/CPRA no-sale/share**, **India DPDP**); **Grievance Officer**; India governing law.
- **Cookie Policy** → new `/cookie-policy` page (necessary/functional cookies, cookieless analytics, DNT).
- **Terms** → names CMPL, India governing law + Mumbai arbitration seat, entity in contact.

### Gate + wiring (the actual unblocker)
- **`middleware.ts`**: allowlist `/privacy-policy`, `/terms`, `/cookie-policy`, `/data-deletion` so they resolve in production even with `COMING_SOON=true`.
- **`coming-soon`**: legal-links footer (plain `<a>` so they pass straight through the gate).
- **`footer`**: adds Cookie Policy + Data Deletion.
- **`SITE`** (`lib/utils.ts`): company legal entity + Grievance Officer; `legalLastUpdated` bumped.

## Verification
- `next build` green — 66/66 routes, incl. new `/cookie-policy` and `/privacy-policy`.
- `eslint` clean on all touched files.

## ⚖️ Note
Submission-ready **draft** prepared to a corporate-counsel standard — **final review by retained counsel recommended** before relying on it for the Meta/Google filings (esp. DPDP cross-border + arbitration clauses).

## Suggested follow-ups (not in this PR)
Acceptable Use Policy; Data Processing Addendum (GDPR Art. 28) + public Sub-processors list; Refund/Cancellation Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)