### PR TITLE
chore(brand): rename "PeakHour" → "Peakhour" across the app

### DIFF
--- a/src/app/auth/accept-invite/page.tsx
+++ b/src/app/auth/accept-invite/page.tsx
@@ -119,7 +119,7 @@ function AcceptInviteContent() {
                 You&apos;re invited to {orgName}
               </h2>
               <p className="text-muted-foreground">
-                Create your PeakHour account to join the team. We&apos;ll send a
+                Create your Peakhour account to join the team. We&apos;ll send a
                 sign-in link to <strong>{email}</strong>.
               </p>
               <Button onClick={handleSignup} className="w-full">

--- a/src/app/cms/layout.tsx
+++ b/src/app/cms/layout.tsx
@@ -170,7 +170,7 @@ function CmsShell({ children }: { children: React.ReactNode }) {
                   </div>
                   <div className="grid flex-1 text-left leading-tight">
                     <span className="truncate text-sm font-semibold">
-                      PeakHour CMS
+                      Peakhour CMS
                     </span>
                     <span className="truncate text-xs text-muted-foreground">
                       Internal Admin

--- a/src/app/cms/overview/page.tsx
+++ b/src/app/cms/overview/page.tsx
@@ -22,7 +22,7 @@ export default function CmsOverviewPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">CMS Overview</h1>
         <p className="text-sm text-muted-foreground">
-          Internal administration dashboard for PeakHour.
+          Internal administration dashboard for Peakhour.
         </p>
       </div>
 

--- a/src/app/cms/team/page.tsx
+++ b/src/app/cms/team/page.tsx
@@ -123,7 +123,7 @@ export default function CmsTeamPage() {
         <div>
           <h2 className="text-2xl font-bold tracking-tight">CMS Team</h2>
           <p className="text-muted-foreground mt-1">
-            Manage who has access to the PeakHour admin panel
+            Manage who has access to the Peakhour admin panel
           </p>
         </div>
         {isSuperAdmin && (
@@ -153,7 +153,7 @@ export default function CmsTeamPage() {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Add CMS Team Member</CardTitle>
-            <CardDescription>The user must have an existing PeakHour account</CardDescription>
+            <CardDescription>The user must have an existing Peakhour account</CardDescription>
           </CardHeader>
           <CardContent>
             <form

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -3,9 +3,9 @@ import { Sparkles } from "lucide-react";
 import { SITE } from "@/lib/utils";
 
 export const metadata: Metadata = {
-  title: "PeakHour — Agentic AI Marketing Platform",
+  title: "Peakhour — Agentic AI Marketing Platform",
   description:
-    "PeakHour is an agentic AI marketing platform. Autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock. Launching soon.",
+    "Peakhour is an agentic AI marketing platform. Autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock. Launching soon.",
 };
 
 /**

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,15 +4,15 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 
 export const metadata: Metadata = {
-  title: "Contact Us - PeakHour",
+  title: "Contact Us - Peakhour",
   description:
-    "Get in touch with the PeakHour team — we'd love to hear from you.",
+    "Get in touch with the Peakhour team — we'd love to hear from you.",
 };
 
 const CONTACT_CHANNELS = [
   {
     title: "General Inquiries",
-    description: "Questions about PeakHour, partnerships, or anything else.",
+    description: "Questions about Peakhour, partnerships, or anything else.",
     email: "hello@peakhour.ai",
     icon: (
       <svg
@@ -88,7 +88,7 @@ export default function ContactPage() {
             Get in touch
           </h1>
           <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
-            Have a question, feedback, or want to explore how PeakHour can work
+            Have a question, feedback, or want to explore how Peakhour can work
             for your business? We&apos;d love to hear from you.
           </p>
         </section>
@@ -137,7 +137,7 @@ export default function ContactPage() {
 
             <div className="mt-12">
               <p className="text-muted-foreground">
-                Ready to see PeakHour in action?
+                Ready to see Peakhour in action?
               </p>
               <Link
                 href="/auth"

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -4,9 +4,9 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 
 export const metadata: Metadata = {
-  title: "Cookie Policy - PeakHour",
+  title: "Cookie Policy - Peakhour",
   description:
-    "PeakHour cookie policy — the cookies and similar technologies we use, why we use them, and how to control them.",
+    "Peakhour cookie policy — the cookies and similar technologies we use, why we use them, and how to control them.",
 };
 
 export default function CookiePolicyPage() {

--- a/src/app/dashboard/content/whatsapp/page.tsx
+++ b/src/app/dashboard/content/whatsapp/page.tsx
@@ -9,7 +9,7 @@ export default function WhatsAppConnectPage() {
         <h1 className="text-2xl font-semibold tracking-tight">WhatsApp</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Connect your WhatsApp Business account to message customers directly
-          from PeakHour — order updates, reminders, and support, all in one place.
+          from Peakhour — order updates, reminders, and support, all in one place.
         </p>
       </div>
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -213,7 +213,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
                   </div>
                   <div className="grid flex-1 text-left leading-tight">
                     <span className="truncate text-sm font-semibold">
-                      PeakHour
+                      Peakhour
                     </span>
                     <span className="truncate text-xs text-muted-foreground">
                       AI Marketing

--- a/src/app/data-deletion/page.tsx
+++ b/src/app/data-deletion/page.tsx
@@ -5,9 +5,9 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 
 export const metadata: Metadata = {
-  title: "Data Deletion - PeakHour",
+  title: "Data Deletion - Peakhour",
   description:
-    "Request deletion of your data from PeakHour and check the status of a data-deletion request.",
+    "Request deletion of your data from Peakhour and check the status of a data-deletion request.",
 };
 
 type DeletionStatus = {
@@ -130,10 +130,10 @@ export default async function DataDeletionPage({
         <div className="mt-8 space-y-8 text-sm leading-relaxed text-muted-foreground">
           <section>
             <h2 className="text-lg font-semibold text-foreground">
-              Deleting your data from PeakHour
+              Deleting your data from Peakhour
             </h2>
             <p className="mt-2">
-              PeakHour (peakhour.ai) is an AI-powered marketing platform. When you connect a
+              Peakhour (peakhour.ai) is an AI-powered marketing platform. When you connect a
               Meta account (Facebook, Instagram, or WhatsApp Business), we store the connection
               details needed to operate the integration on your behalf. You can ask us to delete
               that data at any time, and you control the connection from the platform that
@@ -150,7 +150,7 @@ export default async function DataDeletionPage({
                 <span className="font-medium">
                   Facebook → Settings &amp; privacy → Settings → Apps and Websites
                 </span>
-                , remove <strong className="text-foreground">PeakHour</strong>, and choose to
+                , remove <strong className="text-foreground">Peakhour</strong>, and choose to
                 request deletion of your data. Facebook notifies us automatically and we delete
                 your connection data, then give you a reference code to track the request on this
                 page.
@@ -160,7 +160,7 @@ export default async function DataDeletionPage({
                 <a className="text-foreground underline" href={`mailto:${SITE.contactPrivacy}`}>
                   {SITE.contactPrivacy}
                 </a>{" "}
-                from the email on your PeakHour account and we’ll process the deletion for you.
+                from the email on your Peakhour account and we’ll process the deletion for you.
               </li>
             </ul>
           </section>
@@ -170,11 +170,11 @@ export default async function DataDeletionPage({
             <p className="mt-2">
               We delete the personal data tied to your Meta connection — the profile information
               (name, profile details, email where provided) and the access tokens we hold to
-              operate the integration. Once deleted, PeakHour can no longer act on your Meta
+              operate the integration. Once deleted, Peakhour can no longer act on your Meta
               account and the connection is removed.
             </p>
             <p className="mt-2">
-              Content created within a PeakHour organization (for example, published posts and
+              Content created within a Peakhour organization (for example, published posts and
               business records) is owned and controlled by that organization and is governed by
               our{" "}
               <Link className="text-foreground underline" href="/privacy-policy">

--- a/src/app/help/data-retention/page.tsx
+++ b/src/app/help/data-retention/page.tsx
@@ -5,9 +5,9 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 
 export const metadata: Metadata = {
-  title: "Data Retention - PeakHour",
+  title: "Data Retention - Peakhour",
   description:
-    "How long PeakHour keeps the data it pulls from connected platforms, and why.",
+    "How long Peakhour keeps the data it pulls from connected platforms, and why.",
 };
 
 /**
@@ -36,7 +36,7 @@ export default function DataRetentionPage() {
             <p className="mt-2">
               Connected platforms (LinkedIn, Meta, X, and others) place limits
               on how long partners are allowed to keep the data their APIs
-              return. PeakHour respects those limits. When a panel in your
+              return. Peakhour respects those limits. When a panel in your
               dashboard says &ldquo;last 48 hours&rdquo; or &ldquo;last 2
               days&rdquo;, that&apos;s not a product choice &mdash; it&apos;s
               the platform&apos;s data-storage rule.
@@ -58,7 +58,7 @@ export default function DataRetentionPage() {
               >
                 published here
               </a>
-              ) classify the data in three groups. PeakHour applies the
+              ) classify the data in three groups. Peakhour applies the
               corresponding storage limit to each:
             </p>
             <div className="mt-4 overflow-x-auto">
@@ -69,7 +69,7 @@ export default function DataRetentionPage() {
                     <th className="py-2 pr-4 font-medium">
                       What it includes
                     </th>
-                    <th className="py-2 font-medium">PeakHour retention</th>
+                    <th className="py-2 font-medium">Peakhour retention</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y">
@@ -94,7 +94,7 @@ export default function DataRetentionPage() {
                     </td>
                     <td className="py-3 pr-4 align-top">
                       Posts from a LinkedIn Company Page that you, the
-                      authenticated administrator, manage through PeakHour.
+                      authenticated administrator, manage through Peakhour.
                     </td>
                     <td className="py-3 align-top">
                       <span className="font-medium text-foreground">
@@ -162,7 +162,7 @@ export default function DataRetentionPage() {
                 <span className="font-medium text-foreground">
                   Long-term trends (planned):
                 </span>{" "}
-                under the aggregated-marketing-data allowance, PeakHour
+                under the aggregated-marketing-data allowance, Peakhour
                 will retain anonymous counts, scores, and recency markers
                 so the trend in engagement survives even after the raw
                 comment trail is deleted. The writer that populates this
@@ -176,7 +176,7 @@ export default function DataRetentionPage() {
               4. Disconnecting a LinkedIn account
             </h2>
             <p className="mt-2">
-              When you disconnect a LinkedIn account from PeakHour, we
+              When you disconnect a LinkedIn account from Peakhour, we
               stop calling the LinkedIn API on its behalf. The
               social-activity rows we already collected drop out at the
               next scheduled cleanup under the same retention rules
@@ -201,9 +201,9 @@ export default function DataRetentionPage() {
             </h2>
             <p className="mt-2">
               Today this page covers LinkedIn, the only platform whose
-              dashboard PeakHour ships to users. Meta, X, and other
+              dashboard Peakhour ships to users. Meta, X, and other
               platforms each publish their own data-retention rules. As
-              PeakHour adds dashboards for each platform, this page will
+              Peakhour adds dashboards for each platform, this page will
               gain a section per platform with the same structure as the
               LinkedIn table above.
             </p>
@@ -221,7 +221,7 @@ export default function DataRetentionPage() {
               >
                 Contact
               </Link>
-              . For the full picture of what PeakHour stores and why, see
+              . For the full picture of what Peakhour stores and why, see
               the{" "}
               <Link
                 href="/privacy-policy"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,9 +19,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "PeakHour — Agentic AI Marketing Platform",
+  title: "Peakhour — Agentic AI Marketing Platform",
   description:
-    "PeakHour is an agentic AI marketing platform: autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock.",
+    "Peakhour is an agentic AI marketing platform: autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock.",
 };
 
 export default async function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -189,7 +189,7 @@ export default async function Home() {
                 Agentic AI Marketing Platform
               </Badge>
               <h1 className="text-4xl font-bold tracking-tight text-pretty sm:text-5xl lg:text-6xl">
-                Every hour is PeakHour
+                Every hour is Peakhour
               </h1>
               <p className="max-w-2xl text-lg text-muted-foreground lg:text-xl">
                 Autonomous AI agents turn your content into high-performing campaigns

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -4,8 +4,8 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy - PeakHour",
-  description: "PeakHour privacy policy — how we collect, use, and protect your data.",
+  title: "Privacy Policy - Peakhour",
+  description: "Peakhour privacy policy — how we collect, use, and protect your data.",
 };
 
 export default function PrivacyPolicyPage() {
@@ -167,7 +167,7 @@ export default function PrivacyPolicyPage() {
               4.1 How Anonymized Data Improves the Platform for Everyone
             </h3>
             <p className="mt-2">
-              PeakHour gets smarter over time. As more campaigns run across the platform,
+              Peakhour gets smarter over time. As more campaigns run across the platform,
               our AI learns which ad angles perform best for different industries, which
               headlines drive higher engagement, and which optimization patterns deliver
               the best results. This means every user benefits from the collective

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -4,8 +4,8 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 
 export const metadata: Metadata = {
-  title: "Terms of Service - PeakHour",
-  description: "PeakHour terms of service — the agreement between you and PeakHour.",
+  title: "Terms of Service - Peakhour",
+  description: "Peakhour terms of service — the agreement between you and Peakhour.",
 };
 
 export default function TermsPage() {
@@ -42,7 +42,7 @@ export default function TermsPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground">2. Description of Service</h2>
             <p className="mt-2">
-              PeakHour is an AI-powered marketing automation platform that:
+              Peakhour is an AI-powered marketing automation platform that:
             </p>
             <ul className="mt-2 list-disc space-y-1 pl-6">
               <li>Analyzes your content across multiple dimensions using artificial intelligence.</li>
@@ -170,7 +170,7 @@ export default function TermsPage() {
               </li>
               <li>
                 Advertising spend is charged directly by the advertising platforms (e.g.,
-                LinkedIn), not by PeakHour. You are responsible for all charges incurred on
+                LinkedIn), not by Peakhour. You are responsible for all charges incurred on
                 your advertising platform accounts.
               </li>
               <li>
@@ -307,7 +307,7 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold text-foreground">10. Intellectual Property</h2>
             <p className="mt-2">
               The Service, including its design, features, code, AI models, and documentation,
-              is owned by PeakHour and protected by intellectual property laws. Nothing in
+              is owned by Peakhour and protected by intellectual property laws. Nothing in
               these Terms grants you any right to our trademarks, logos, or brand assets.
             </p>
           </section>
@@ -345,7 +345,7 @@ export default function TermsPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground">13. Indemnification</h2>
             <p className="mt-2">
-              You agree to indemnify and hold PeakHour harmless from any claims, damages,
+              You agree to indemnify and hold Peakhour harmless from any claims, damages,
               losses, or expenses (including reasonable attorneys&apos; fees) arising from:
             </p>
             <ul className="mt-2 list-disc space-y-1 pl-6">
@@ -409,7 +409,7 @@ export default function TermsPage() {
             <ul className="mt-2 list-disc space-y-1 pl-6">
               <li>
                 <strong>Entire Agreement:</strong> these Terms, together with the Privacy
-                Policy, constitute the entire agreement between you and PeakHour.
+                Policy, constitute the entire agreement between you and Peakhour.
               </li>
               <li>
                 <strong>Severability:</strong> if any provision is held invalid or

--- a/src/components/integrations/whatsapp-embedded-signup.tsx
+++ b/src/components/integrations/whatsapp-embedded-signup.tsx
@@ -366,7 +366,7 @@ export function WhatsAppEmbeddedSignup({
             </CardTitle>
             <CardDescription>
               Connect your WhatsApp Business number to message customers from
-              PeakHour. No account yet? You can create one in the same step.
+              Peakhour. No account yet? You can create one in the same step.
             </CardDescription>
           </div>
         </div>

--- a/src/components/molecules/chat-panel.tsx
+++ b/src/components/molecules/chat-panel.tsx
@@ -67,7 +67,7 @@ export function ChatPanel() {
               <Bot className="size-4 text-primary" />
             </div>
             <div className="flex-1">
-              <p className="text-sm font-semibold leading-none">PeakHour AI</p>
+              <p className="text-sm font-semibold leading-none">Peakhour AI</p>
               <p className="text-[11px] text-muted-foreground">Ask me anything about your content strategy</p>
             </div>
             <Button variant="ghost" size="icon" className="size-7" onClick={clearChat} title="Clear chat">

--- a/src/components/molecules/elapsed-timer.tsx
+++ b/src/components/molecules/elapsed-timer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * PeakHour branded elapsed timer — shows time ticking while an async
+ * Peakhour branded elapsed timer — shows time ticking while an async
  * operation is in progress. Reusable across strategist, content gen, etc.
  *
  * Modes:

--- a/src/components/molecules/feedback-widget.tsx
+++ b/src/components/molecules/feedback-widget.tsx
@@ -94,7 +94,7 @@ export function FeedbackWidget() {
         <SheetHeader>
           <SheetTitle>Send Feedback</SheetTitle>
           <SheetDescription>
-            Help us improve PeakHour. Report a bug, request a feature, or share
+            Help us improve Peakhour. Report a bug, request a feature, or share
             your ideas.
           </SheetDescription>
         </SheetHeader>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,7 @@ export function cn(...inputs: ClassValue[]) {
 
 /** Shared site / legal metadata — single source of truth */
 export const SITE = {
-  name: "PeakHour",
+  name: "Peakhour",
   legalLastUpdated: "June 1, 2026",
   /** Operating legal entity (data controller / data fiduciary). */
   company: {


### PR DESCRIPTION
## What
Brand casing decision: the official spelling is **Peakhour** (capital P only), not "PeakHour". This sweeps all **54** user-facing occurrences across **20 files** — `SITE.name`, page titles/metadata, layouts, legal pages, and component copy.

## Safety
- Pure **display-string** change. `grep` confirmed **no** identifier-adjacent usages (nothing like `PeakHourFoo`/`fooPeakHour`).
- URLs and package/project names stay lowercase (`peakhour.ai`, `peakhour-b2c`) — untouched.
- No keys, config values, or external-matching strings changed.

## Verification
`next build` validated before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)