### PR TITLE
fix(strategist): kanban drag-and-drop no-op on populated columns

### DIFF
--- a/src/app/dashboard/strategist/components/kanban-board.tsx
+++ b/src/app/dashboard/strategist/components/kanban-board.tsx
@@ -48,10 +48,25 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
     if (!over) return;
 
     const ideaId = active.id as string;
-    const dropColumnKey = over.id as string;
+    const overId = over.id as string;
 
-    // Map column key to the first status in that group (drop target)
-    const targetCol = PIPELINE_COLUMNS.find((c) => c.key === dropColumnKey);
+    // Resolve which COLUMN was dropped onto. `over` is either the column
+    // droppable (id = column key) OR — when dropping onto a column that
+    // already has cards — one of its cards (a sortable droppable, id =
+    // idea._id). Previously we only handled the column-key case, so any
+    // drop onto a populated column silently no-opped (the visible "drag
+    // and drop not working" bug). Map a card-over back to its column.
+    let targetCol = PIPELINE_COLUMNS.find((c) => c.key === overId);
+    if (!targetCol) {
+      for (const [status, ideas] of Object.entries(localData)) {
+        if (ideas.some((i) => i._id === overId)) {
+          targetCol = PIPELINE_COLUMNS.find((c) =>
+            (c.statuses as readonly string[]).includes(status),
+          );
+          break;
+        }
+      }
+    }
     if (!targetCol) return;
 
     // Find the idea's current status


### PR DESCRIPTION
## Problem
Drag-and-drop in the Content Pipeline kanban "didn't work" — cards wouldn't move between columns.

## Cause
Cards are `@dnd-kit` `useSortable` items, so each card is also a droppable. Dropping a card onto a column that **already has cards** makes `over.id` a **card id** (`idea._id`), not the column key. But `handleDragEnd` only resolved a target column when `over.id === column key`, so it silently returned — nothing moved. Only dropping onto an **empty** column's "Drop here" zone worked.

## Fix
When `over.id` isn't a column key, map the hovered card back to its owning column (card's status → column) and use that as the drop target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)