### PR TITLE
feat(strategist): reusable Star + Delete control on pipeline cards

### DIFF
--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { ChannelIcon } from "@/components/ui/channel-icon";
 import { PipelineStatusBadge } from "../components/status-badge";
 import { PipelineStepper, STAGE_PANEL_MAP } from "../components/pipeline-stepper";
+import { IdeaCardActions } from "../components/idea-card-actions";
 import { RejectReasonDialog } from "@/components/molecules/reject-reason-dialog";
 import {
   ComposerShell,
@@ -185,6 +186,7 @@ interface IdeaDetail {
   title: string;
   description?: string;
   status: string;
+  starred?: boolean;
   source?: string;
   sector?: string;
   targetAudience?: string;
@@ -344,9 +346,24 @@ export default function IdeaDetailPage() {
               <p className="mt-1 max-w-2xl text-muted-foreground">{idea.description}</p>
             )}
           </div>
-          <div className="flex flex-wrap gap-2">
-            {idea.sector && <Badge variant="outline">{idea.sector}</Badge>}
-            {idea.contentType && <Badge variant="secondary">{idea.contentType}</Badge>}
+          <div className="flex flex-col items-end gap-2">
+            <IdeaCardActions
+              ideaId={idea._id}
+              title={idea.title}
+              starred={!!idea.starred}
+              size="md"
+              onChanged={(change) => {
+                if (change.deleted) {
+                  router.push("/dashboard/strategist");
+                } else {
+                  queryClient.invalidateQueries({ queryKey: ["idea-detail", ideaId] });
+                }
+              }}
+            />
+            <div className="flex flex-wrap justify-end gap-2">
+              {idea.sector && <Badge variant="outline">{idea.sector}</Badge>}
+              {idea.contentType && <Badge variant="secondary">{idea.contentType}</Badge>}
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/dashboard/strategist/components/idea-card-actions.tsx
+++ b/src/app/dashboard/strategist/components/idea-card-actions.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { Star, Trash2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { setIdeaStarred, deleteIdea } from "@/lib/api/content";
+import { cn } from "@/lib/utils";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * Reusable Star + Delete control for any pipeline idea card/header.
+ *
+ * - Star toggles a pin (optimistic). A starred idea is protected: the Delete
+ *   button is disabled (and the API refuses with 409 as a backstop) until it's
+ *   unstarred — "cannot be deleted unless unstarred".
+ * - Delete asks for confirmation, then permanently removes the idea.
+ *
+ * Self-contained (owns its API calls + busy state); the host passes the idea
+ * id/title/starred and an `onChanged` callback to refresh its own list/view.
+ * Stops click propagation so it can sit on a clickable card without triggering
+ * navigation.
+ */
+export function IdeaCardActions({
+  ideaId,
+  title,
+  starred,
+  onChanged,
+  size = "sm",
+}: {
+  ideaId: string;
+  title: string;
+  starred: boolean;
+  /** Called after a successful star toggle or delete so the host can refresh. */
+  onChanged?: (change: { starred?: boolean; deleted?: boolean }) => void;
+  size?: "sm" | "md";
+}) {
+  const [optimisticStarred, setOptimisticStarred] = useState(starred);
+  const [busyStar, setBusyStar] = useState(false);
+  const [busyDelete, setBusyDelete] = useState(false);
+  const iconCls = size === "sm" ? "size-3.5" : "size-4";
+
+  async function toggleStar(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (busyStar) return;
+    const next = !optimisticStarred;
+    setOptimisticStarred(next);
+    setBusyStar(true);
+    try {
+      await setIdeaStarred(ideaId, next);
+      onChanged?.({ starred: next });
+    } catch {
+      setOptimisticStarred(!next); // revert
+      toast.error("Couldn't update star");
+    } finally {
+      setBusyStar(false);
+    }
+  }
+
+  async function confirmDelete() {
+    if (busyDelete) return;
+    setBusyDelete(true);
+    try {
+      await deleteIdea(ideaId);
+      toast.success("Idea deleted");
+      onChanged?.({ deleted: true });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't delete idea");
+    } finally {
+      setBusyDelete(false);
+    }
+  }
+
+  return (
+    <TooltipProvider delayDuration={250}>
+      {/* Stop propagation so actions never trigger the card's own onClick. */}
+      <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={toggleStar}
+              disabled={busyStar}
+              aria-pressed={optimisticStarred}
+              aria-label={optimisticStarred ? "Unstar" : "Star"}
+              className="rounded p-1 text-muted-foreground/50 transition-colors hover:bg-accent hover:text-amber-500"
+            >
+              {busyStar ? (
+                <Loader2 className={cn(iconCls, "animate-spin")} />
+              ) : (
+                <Star className={cn(iconCls, optimisticStarred && "fill-amber-400 text-amber-500")} />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{optimisticStarred ? "Unstar" : "Star (protect from delete)"}</TooltipContent>
+        </Tooltip>
+
+        <AlertDialog>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* span wrapper keeps the tooltip working while the button is disabled */}
+              <span className="inline-flex">
+                <AlertDialogTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={optimisticStarred || busyDelete}
+                    aria-label="Delete idea"
+                    className="rounded p-1 text-muted-foreground/50 transition-colors hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/50"
+                  >
+                    {busyDelete ? <Loader2 className={cn(iconCls, "animate-spin")} /> : <Trash2 className={iconCls} />}
+                  </button>
+                </AlertDialogTrigger>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{optimisticStarred ? "Unstar to delete" : "Delete"}</TooltipContent>
+          </Tooltip>
+          <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this idea?</AlertDialogTitle>
+              <AlertDialogDescription>
+                &ldquo;{title}&rdquo; will be removed from your pipeline. We archive it (not
+                destroyed) and use the signal to improve your future recommendations. Star an
+                idea first if you want to keep it.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/app/dashboard/strategist/components/kanban-board.tsx
+++ b/src/app/dashboard/strategist/components/kanban-board.tsx
@@ -130,6 +130,7 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
               id={col.key}
               label={col.label}
               ideas={ideas}
+              onChanged={onRefresh}
             />
           );
         })}

--- a/src/app/dashboard/strategist/components/kanban-card.tsx
+++ b/src/app/dashboard/strategist/components/kanban-card.tsx
@@ -6,12 +6,14 @@ import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Sparkles, GripVertical } from "lucide-react";
+import { IdeaCardActions } from "./idea-card-actions";
 
 export interface PipelineIdea {
   _id: string;
   title: string;
   description?: string;
   status: string;
+  starred?: boolean;
   source?: string;
   sector?: string;
   targetAudience?: string;
@@ -51,7 +53,7 @@ function getPriorityLabel(score?: number): { label: string; className: string } 
   return { label: "Low", className: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400" };
 }
 
-export function KanbanCard({ idea }: { idea: PipelineIdea }) {
+export function KanbanCard({ idea, onChanged }: { idea: PipelineIdea; onChanged?: () => void }) {
   const router = useRouter();
   const {
     attributes,
@@ -98,6 +100,21 @@ export function KanbanCard({ idea }: { idea: PipelineIdea }) {
         {idea.source === "ai_suggested" && (
           <Sparkles className="size-3 shrink-0 text-amber-500 mt-0.5" />
         )}
+        {/* Star/Delete — always visible when starred (shows the pin), else
+            revealed on hover like the drag handle. */}
+        <div
+          className={cn(
+            "shrink-0 transition-opacity",
+            idea.starred ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+          )}
+        >
+          <IdeaCardActions
+            ideaId={idea._id}
+            title={idea.title}
+            starred={!!idea.starred}
+            onChanged={() => onChanged?.()}
+          />
+        </div>
       </div>
 
       {/* Tags + priority row */}

--- a/src/app/dashboard/strategist/components/kanban-column.tsx
+++ b/src/app/dashboard/strategist/components/kanban-column.tsx
@@ -18,10 +18,12 @@ export function KanbanColumn({
   id,
   label,
   ideas,
+  onChanged,
 }: {
   id: string;
   label: string;
   ideas: PipelineIdea[];
+  onChanged?: () => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const dotColor = COLUMN_COLORS[id] || "bg-muted-foreground";
@@ -56,7 +58,7 @@ export function KanbanColumn({
             </div>
           )}
           {ideas.map((idea) => (
-            <KanbanCard key={idea._id} idea={idea} />
+            <KanbanCard key={idea._id} idea={idea} onChanged={onChanged} />
           ))}
         </div>
       </SortableContext>

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -130,3 +130,16 @@ export function getVoiceCards(params: { channel?: string; category?: string } = 
   if (params.category) query.category = params.category;
   return api.get<VoiceCardDoc[]>("/v1/content/voice-cards", query);
 }
+
+// ── Pipeline card actions: star (pin / delete-protection) + delete ──────
+
+/** Set or clear the star on an idea. A starred idea is protected from
+ *  deletion (the delete endpoint refuses until it's unstarred). */
+export function setIdeaStarred(ideaId: string, starred: boolean) {
+  return api.patch<{ starred: boolean }>(`/v1/content/ideas/${ideaId}/star`, { starred });
+}
+
+/** Permanently delete an idea. Rejects (409) if the idea is starred. */
+export function deleteIdea(ideaId: string) {
+  return api.delete<{ deleted: boolean }>(`/v1/content/ideas/${ideaId}`);
+}


### PR DESCRIPTION
Adds a reusable **`<IdeaCardActions>`** (Star + Delete) used across the pipeline UIs, fulfilling the request for a delete/star option "across all UI's of the pipeline."

- **Star** toggles a pin (optimistic). A starred idea is **delete-protected** — the Delete button is disabled ("Unstar to delete"); the API also enforces 409.
- **Delete** confirms, then removes the idea from the board. Server-side this **soft-archives + emits a `user_feedback` signal** (per the deletion-as-feedback decision), so the confirm copy says "archived + used to improve recommendations," not "permanently destroyed."

Wired into the **kanban cards** (star always visible when pinned, else hover-revealed; `onChanged` refreshes the board) and the **idea detail header** (`onChanged` refetches, or routes back to the pipeline on delete). Adds API client `setIdeaStarred` / `deleteIdea`.

Depends on: mongodb#187 (`starred` field — applied to dev) + peakhour-api#478 (endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)