### PR TITLE
fix(strategist): make the whole kanban card draggable (not just the grip)

### DIFF
--- a/src/app/dashboard/strategist/components/kanban-card.tsx
+++ b/src/app/dashboard/strategist/components/kanban-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useRouter } from "next/navigation";
@@ -73,27 +74,39 @@ export function KanbanCard({ idea, onChanged }: { idea: PipelineIdea; onChanged?
   const progress = STATUS_PROGRESS[idea.status] ?? 0;
   const progressPct = Math.round((progress / TOTAL_STEPS) * 100);
 
+  // The WHOLE card is the drag handle (dnd listeners below). To still allow
+  // "click to open", we record the pointer-down position and only navigate
+  // when the pointer barely moved — a real drag moves >8px (the sensor's
+  // activation distance), so it won't trigger navigation.
+  const downPos = useRef<{ x: number; y: number } | null>(null);
+
   return (
     <div
       ref={setNodeRef}
       style={style}
+      {...attributes}
+      {...listeners}
+      onPointerDownCapture={(e) => { downPos.current = { x: e.clientX, y: e.clientY }; }}
+      onClick={(e) => {
+        const d = downPos.current;
+        if (d && (Math.abs(e.clientX - d.x) > 8 || Math.abs(e.clientY - d.y) > 8)) return; // was a drag
+        router.push(`/dashboard/strategist/${idea._id}`);
+      }}
       className={cn(
-        "group cursor-pointer rounded-lg border bg-card p-3 shadow-sm transition-all duration-150",
+        "group cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-all duration-150 active:cursor-grabbing",
         "hover:shadow-md hover:border-primary/20",
         isDragging && "opacity-50 shadow-lg ring-2 ring-primary/20",
       )}
-      onClick={() => router.push(`/dashboard/strategist/${idea._id}`)}
     >
-      {/* Title row with drag handle */}
+      {/* Title row — grip is now just a visual "draggable" cue; the whole
+          card carries the drag listeners. */}
       <div className="flex items-start gap-1.5">
-        <button
-          {...attributes}
-          {...listeners}
-          className="mt-0.5 cursor-grab text-muted-foreground/30 opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing"
-          onClick={(e) => e.stopPropagation()}
+        <span
+          aria-hidden
+          className="mt-0.5 text-muted-foreground/30 opacity-0 transition-opacity group-hover:opacity-100"
         >
           <GripVertical className="size-3.5" />
-        </button>
+        </span>
         <h4 className="flex-1 text-sm font-medium leading-snug line-clamp-2">
           {idea.title}
         </h4>
@@ -103,6 +116,9 @@ export function KanbanCard({ idea, onChanged }: { idea: PipelineIdea; onChanged?
         {/* Star/Delete — always visible when starred (shows the pin), else
             revealed on hover like the drag handle. */}
         <div
+          // Keep drags that start on the star/delete buttons from moving the
+          // card (the whole card is the drag handle now).
+          onPointerDown={(e) => e.stopPropagation()}
           className={cn(
             "shrink-0 transition-opacity",
             idea.starred ? "opacity-100" : "opacity-0 group-hover:opacity-100",


### PR DESCRIPTION
## Problem
Drag-and-drop still felt broken after #268: the dnd listeners were only on the **tiny grip handle** (hover-revealed, top-left), so dragging the **card body** just navigated to the idea's detail page.

## Fix
The **whole card** is now the drag handle (listeners moved to the card root; grip is a visual cue only). **Click-to-open is preserved** via a pointer-down position guard — a real drag moves >8px (the sensor's activation distance) so it won't trigger navigation; a click (no move) opens the idea. The Star/Delete buttons stop pointer-down propagation so using them never starts a drag.

Together with #268 (drop-target resolution), drag-and-drop between columns now works by grabbing anywhere on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
