### PR TITLE
fix(strategist): compact editor toolbar so buttons stop wrapping

### DIFF
--- a/src/app/dashboard/strategist/[id]/page.tsx
+++ b/src/app/dashboard/strategist/[id]/page.tsx
@@ -1474,11 +1474,11 @@ function WriteTab({ idea, ideaId, onRefresh }: { idea: IdeaDetail; ideaId: strin
             />
           )}
         </div>
-        <div className="flex flex-wrap gap-2 items-center">
-          <Button onClick={handleSave} disabled={saving || finalized}>
+        <div className="flex flex-wrap gap-1.5 items-center">
+          <Button size="sm" onClick={handleSave} disabled={saving || finalized}>
             {saving && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}Save
           </Button>
-          <Button variant="outline" onClick={generate} disabled={generating || finalized}>
+          <Button size="sm" variant="outline" onClick={generate} disabled={generating || finalized}>
             {generating ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Sparkles className="mr-1.5 h-4 w-4" />}
             Regenerate
           </Button>

--- a/src/components/composer/ai-compose-toolbar.tsx
+++ b/src/components/composer/ai-compose-toolbar.tsx
@@ -252,7 +252,7 @@ export function AiComposeToolbar({
                     type="button"
                     size="sm"
                     variant="ghost"
-                    className="h-7 gap-1.5 px-2 text-xs"
+                    className="h-7 gap-1 px-1.5 text-xs"
                     onClick={() => fire(meta.op)}
                     disabled={disabled}
                   >
@@ -282,7 +282,7 @@ export function AiComposeToolbar({
                         type="button"
                         size="sm"
                         variant="ghost"
-                        className="h-7 gap-1.5 px-2 text-xs"
+                        className="h-7 gap-1 px-1.5 text-xs"
                         disabled={text.trim().length === 0}
                       >
                         <Mic2 className="size-3.5" />
@@ -348,7 +348,7 @@ export function AiComposeToolbar({
                       type="button"
                       size="sm"
                       variant="ghost"
-                      className="h-7 gap-1.5 px-2 text-xs"
+                      className="h-7 gap-1 px-1.5 text-xs"
                       onClick={() => fire(meta.op)}
                       disabled={disabled}
                     >


### PR DESCRIPTION
The Write-stage editor button rows cramped on the narrower editor column (the 2-col grid with the citations rail), pushing one button to the next line.

- **Action row** (Save / Regenerate / emoji / Finalize): buttons -> `size="sm"`, gap 2->1.5. The `ml-auto` Finalize was the one wrapping.
- **AiComposeToolbar** (shared): per-button padding `px-2`->`px-1.5`, gap `1.5`->`1` -> narrower bar. Labels retained.

If it still wraps at some widths, the next lever is switching the AI toolbar to icon-only (`compact`, with tooltips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)