### PR TITLE
feat(landing): reposition to Autonomous Customer Engagement + launch-partner

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,58 +1,136 @@
 import type { Metadata } from "next";
-import { Sparkles } from "lucide-react";
+import { Sparkles, ShoppingBag, Megaphone, ArrowRight } from "lucide-react";
 import { SITE } from "@/lib/utils";
 
 export const metadata: Metadata = {
-  title: "Peakhour — Agentic AI Marketing Platform",
+  title: "Peakhour — Autonomous Customer Engagement",
   description:
-    "Peakhour is an agentic AI marketing platform. Autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock. Launching soon.",
+    "Peakhour helps businesses stay responsive, uncover growth opportunities, and automate customer engagement across WhatsApp, web, voice and more — without needing a dedicated marketing team. Two solutions, one platform: Peakhour Commerce and Peakhour Marketing. Launching soon.",
 };
 
 /**
  * Standalone pre-launch teaser. Served for EVERY route in production while the
  * coming-soon gate is on (see middleware.ts) — deliberately self-contained
- * (no Header/Footer that link into the gated app). Pure teaser: no signup/
- * capture. Preview locally at /coming-soon, or set COMING_SOON=true to exercise
- * the full gate in dev.
+ * (no Header/Footer that link into the gated app). Preview locally at
+ * /coming-soon, or set COMING_SOON=true to exercise the full gate in dev.
+ *
+ * Positioning: one Peakhour platform with two solution entry points
+ * (Commerce + Marketing). Links use plain <a> so they resolve straight
+ * through the coming-soon gate — /launch-partner is allowlisted in
+ * middleware alongside the legal routes; #commerce / #marketing are
+ * in-page anchors (no separate gated routes to loop back on).
  */
 export default function ComingSoonPage() {
   return (
-    <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 text-center">
+    <main className="relative flex min-h-screen flex-col overflow-hidden">
       {/* Subtle backdrop (standard utilities — no brittle arbitrary theme()). */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-1/2 bg-gradient-to-b from-primary/5 to-transparent"
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-1/2 bg-linear-to-b from-primary/5 to-transparent"
       />
 
-      <div className="mx-auto flex max-w-2xl flex-col items-center gap-7">
-        <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          <Sparkles className="size-3.5" aria-hidden />
-          Agentic AI Marketing Platform
-        </span>
-
-        <h1 className="text-pretty text-5xl font-bold tracking-tight sm:text-6xl lg:text-7xl">
-          Every hour is{" "}
-          <span className="bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
-            {SITE.name}
+      {/* ── Hero ─────────────────────────────────────────────── */}
+      <section className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+        <div className="mx-auto flex max-w-2xl flex-col items-center gap-7">
+          <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            <Sparkles className="size-3.5" aria-hidden />
+            Autonomous Customer Engagement
           </span>
-        </h1>
 
-        <p className="max-w-xl text-balance text-lg text-muted-foreground">
-          Autonomous AI agents that analyze your content, create campaigns, and
-          optimize performance across every channel — around the clock, so your
-          marketing runs at its peak even when you&rsquo;re off.
-        </p>
+          <h1 className="text-pretty text-5xl font-bold tracking-tight sm:text-6xl lg:text-7xl">
+            Every hour is{" "}
+            <span className="bg-linear-to-r from-primary to-primary/60 bg-clip-text text-transparent">
+              {SITE.name}
+            </span>
+          </h1>
 
-        <div className="mt-2 inline-flex items-center gap-2 rounded-full border bg-muted/40 px-5 py-2.5 text-sm font-medium text-muted-foreground">
-          <span className="relative flex size-2" aria-hidden>
-            <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary/60" />
-            <span className="relative inline-flex size-2 rounded-full bg-primary" />
-          </span>
-          Launching soon
+          <p className="max-w-xl text-balance text-lg text-muted-foreground">
+            {SITE.name} helps businesses stay responsive, uncover growth
+            opportunities, and automate customer engagement across WhatsApp,
+            web, voice and more &mdash; without needing a dedicated marketing
+            team.
+          </p>
+
+          <div className="mt-2 flex flex-col items-center gap-3 sm:flex-row">
+            <a
+              href="/launch-partner"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              Become a Launch Partner
+              <ArrowRight className="size-4" aria-hidden />
+            </a>
+            <a
+              href="#commerce"
+              className="inline-flex items-center justify-center gap-2 rounded-full border px-6 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted/60"
+            >
+              Explore Peakhour Commerce
+            </a>
+          </div>
         </div>
-      </div>
+      </section>
 
-      <footer className="absolute inset-x-0 bottom-6 flex flex-col items-center gap-3 px-6 text-xs text-muted-foreground">
+      {/* ── Built for growing businesses ─────────────────────── */}
+      <section className="mx-auto w-full max-w-5xl px-6 pb-28">
+        <h2 className="text-center text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Built for growing businesses
+        </h2>
+
+        <div className="mt-8 grid gap-5 sm:grid-cols-2">
+          {/* Commerce */}
+          <div
+            id="commerce"
+            className="group flex scroll-mt-24 flex-col rounded-2xl border bg-card p-7 text-left transition-colors hover:border-foreground/20"
+          >
+            <span className="inline-flex size-11 items-center justify-center rounded-xl border bg-muted/40 text-foreground">
+              <ShoppingBag className="size-5" aria-hidden />
+            </span>
+            <h3 className="mt-5 text-xl font-semibold tracking-tight">
+              Peakhour Commerce
+            </h3>
+            <p className="mt-2 text-pretty text-sm leading-relaxed text-muted-foreground">
+              For Shopify, WooCommerce and D2C brands that want to recover
+              carts, re-engage customers, and grow revenue with less manual
+              effort.
+            </p>
+            {/* Pre-launch, "Learn more" routes to the launch-partner capture.
+                Swap to /commerce once the solution page ships post-launch. */}
+            <a
+              href="/launch-partner"
+              className="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-foreground transition-colors group-hover:gap-2.5"
+            >
+              Learn more
+              <ArrowRight className="size-4" aria-hidden />
+            </a>
+          </div>
+
+          {/* Marketing */}
+          <div
+            id="marketing"
+            className="group flex scroll-mt-24 flex-col rounded-2xl border bg-card p-7 text-left transition-colors hover:border-foreground/20"
+          >
+            <span className="inline-flex size-11 items-center justify-center rounded-xl border bg-muted/40 text-foreground">
+              <Megaphone className="size-5" aria-hidden />
+            </span>
+            <h3 className="mt-5 text-xl font-semibold tracking-tight">
+              Peakhour Marketing
+            </h3>
+            <p className="mt-2 text-pretty text-sm leading-relaxed text-muted-foreground">
+              For publishers, brands and marketing teams that want to create,
+              optimize and automate campaigns across channels.
+            </p>
+            <a
+              href="/launch-partner"
+              className="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-foreground transition-colors group-hover:gap-2.5"
+            >
+              Learn more
+              <ArrowRight className="size-4" aria-hidden />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Footer (normal flow — page now scrolls past one viewport) ── */}
+      <footer className="mt-auto flex flex-col items-center gap-3 px-6 pb-8 text-center text-xs text-muted-foreground">
         {/* Plain <a> (not next/link) so these resolve straight through the
             coming-soon gate, which allowlists the legal routes. */}
         <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">

--- a/src/app/launch-partner/page.tsx
+++ b/src/app/launch-partner/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from "next";
+import { ArrowLeft, Mail } from "lucide-react";
+import { SITE } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Become a Launch Partner — Peakhour",
+  description:
+    "Join the Peakhour launch partner program. Work directly with our team to shape Peakhour Commerce and Peakhour Marketing, and get early access ahead of public launch.",
+};
+
+const PARTNER_EMAIL = SITE.contactGeneral;
+const MAILTO = `mailto:${PARTNER_EMAIL}?subject=${encodeURIComponent(
+  "Peakhour Launch Partner",
+)}&body=${encodeURIComponent(
+  "Hi Peakhour team,\n\nWe'd like to join as a launch partner.\n\nBusiness name:\nWebsite:\nWhat we sell / publish:\nPlatform (Shopify / WooCommerce / other):\nWhat we'd love help with:\n\nThanks!",
+)}`;
+
+/**
+ * Pre-launch "Become a Launch Partner" capture. Self-contained (no Header/
+ * Footer that link into the gated app), same monochrome aesthetic as the
+ * coming-soon teaser. Reachable through the coming-soon gate because
+ * /launch-partner is allowlisted in middleware (alongside the legal routes).
+ *
+ * V1 is intentionally a mailto capture (no backend / no new collection) —
+ * pre-launch volume is low and a thread with the team is the right first
+ * touch. Swap for a real form + API when volume warrants it.
+ */
+export default function LaunchPartnerPage() {
+  return (
+    <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 text-center">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-1/2 bg-linear-to-b from-primary/5 to-transparent"
+      />
+
+      <div className="mx-auto flex max-w-xl flex-col items-center gap-7">
+        <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Launch Partner Program
+        </span>
+
+        <h1 className="text-pretty text-4xl font-bold tracking-tight sm:text-5xl">
+          Build {SITE.name} with us
+        </h1>
+
+        <p className="max-w-lg text-balance text-lg text-muted-foreground">
+          We&rsquo;re onboarding a small group of launch partners ahead of public
+          launch. Work directly with our team, shape the roadmap for Peakhour
+          Commerce and Peakhour Marketing, and get early access &mdash; with
+          hands-on setup.
+        </p>
+
+        <a
+          href={MAILTO}
+          className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+        >
+          <Mail className="size-4" aria-hidden />
+          Email us to apply
+        </a>
+
+        <p className="text-xs text-muted-foreground">
+          Or write to{" "}
+          <a
+            href={`mailto:${PARTNER_EMAIL}`}
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            {PARTNER_EMAIL}
+          </a>
+        </p>
+
+        <a
+          href="/coming-soon"
+          className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" aria-hidden />
+          Back
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -86,23 +86,28 @@ export function middleware(req: NextRequest) {
     !revokePreview &&
     !!previewSecret &&
     req.cookies.get(PREVIEW_COOKIE)?.value === previewSecret;
-  // Legal / compliance pages stay PUBLICLY reachable even while the
-  // coming-soon gate is on — Meta, Google, X, LinkedIn etc. fetch these
-  // URLs to validate app/developer onboarding, and they must resolve to
-  // the real document (not the teaser) before launch.
-  const PUBLIC_LEGAL_PATHS = [
+  // Pages that stay PUBLICLY reachable even while the coming-soon gate is on.
+  // Two reasons: (1) legal/compliance pages — Meta, Google, X, LinkedIn etc.
+  // fetch these URLs to validate app/developer onboarding, and they must
+  // resolve to the real document (not the teaser) before launch; (2) the
+  // pre-launch /launch-partner capture, linked from the coming-soon CTAs.
+  // This is a plain allowlist entry on the already-running middleware — it
+  // adds NO new edge function (the middleware runs on every request for the
+  // CSP nonce regardless).
+  const PUBLIC_PATHS = [
     "/privacy-policy",
     "/terms",
     "/cookie-policy",
     "/data-deletion",
+    "/launch-partner",
   ];
-  const isPublicLegal = PUBLIC_LEGAL_PATHS.some(
+  const isPublicPath = PUBLIC_PATHS.some(
     (p) => pathname === p || pathname.startsWith(`${p}/`),
   );
   const gated =
     comingSoon &&
     pathname !== "/coming-soon" &&
-    !isPublicLegal &&
+    !isPublicPath &&
     !grantPreview &&
     !hasPreviewCookie;
 


### PR DESCRIPTION
## What

Repositions the production pre-launch **coming-soon** page from *"Agentic AI Marketing Platform"* to **"Autonomous Customer Engagement"** — one platform, two solution entry points (Peakhour Commerce + Peakhour Marketing) — and adds a **Become a Launch Partner** funnel.

Implements the brief shared by Prashant (with one refinement, below).

## Changes
- **`coming-soon/page.tsx`** — new hero badge + subheadline (broader, human, no jargon; headline kept). Primary CTA *Become a Launch Partner* → `/launch-partner`; secondary *Explore Peakhour Commerce* → `#commerce`. New "Built for growing businesses" section with two solution cards (stack on mobile, side-by-side desktop). Footer moved to normal flow (page now scrolls past one viewport). Metadata updated.
- **`launch-partner/page.tsx`** (new) — self-contained pre-launch capture, same monochrome aesthetic, mailto-based (no backend / no new collection at this volume).
- **`middleware.ts`** — `/launch-partner` added to the existing gate allowlist (`PUBLIC_LEGAL_PATHS` → `PUBLIC_PATHS`).

## Refinement vs. the brief
The brief linked CTAs to `/commerce`, `/marketing`, `/launch-partner`. Behind the coming-soon gate, standalone `/commerce` and `/marketing` routes would **loop back to the teaser**, so those are implemented as **in-page anchors** (`#commerce` / `#marketing`) and card "Learn more" CTAs point to `/launch-partner` pre-launch (swap to real solution pages post-launch — noted in code comments). Only `/launch-partner` ships as a real allowlisted route.

## Edge cost note
Adding `/launch-partner` to the allowlist adds **no new edge function** — the middleware already runs on every request (CSP nonce for `strict-dynamic` + the gate), and the gate cannot move to `layout.js` without losing the per-request nonce and weakening RSC/prefetch protection.

## Verification
- `tsc --noEmit` ✅ · `eslint` on changed files ✅ · subagent diff review — no material defects (gate boundary safe, a11y/Tailwind-v4 correct, links resolve through the gate).

## Deploy
Lands on **master → dev preview** on merge. Production **promote held** for explicit sign-off (bundles with the queued prior-session promote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)