### PR TITLE
feat(news-desk): full dev-only pipeline trigger toolbar

### DIFF
--- a/src/app/dashboard/content/news/page.tsx
+++ b/src/app/dashboard/content/news/page.tsx
@@ -39,8 +39,19 @@ export default function NewsDeskPage() {
 
   return (
     <div className="space-y-6">
+      {/* Dev-only (auto-hidden in prod). The News Desk queue is fed by a
+          cron pipeline; these buttons run each stage on demand so you don't
+          wait for the schedule. Click left-to-right in pipeline order:
+          fetch sources → classify → corroborate → compose drafts → run the
+          enqueued background jobs. */}
       <CronToolbar
-        crons={["news-classify", "news-corroborate", "news-compose"]}
+        crons={[
+          "source-fetch-scheduler",
+          "news-classify",
+          "news-corroborate",
+          "news-compose",
+          "jobs-runner",
+        ]}
         onTriggered={invalidateQueue}
       />
 


### PR DESCRIPTION
Adds `source-fetch-scheduler` + `jobs-runner` to the News Desk CronToolbar (alongside the news-* crons), ordered as the pipeline runs, so a dev can trigger the whole source→classify→corroborate→compose→run-jobs flow on demand instead of waiting for cron. All 5 are whitelisted in the api dev-cron route; the toolbar auto-hides in prod. Config + comment only; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)