### PR TITLE
fix(dev-crons): add jobs-runner button to LinkedIn + Sources toolbars

### DIFF
--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -217,8 +217,12 @@ function PageShell({ children, loading }: { children?: React.ReactNode; loading?
   const queryClient = useQueryClient();
   return (
     <div className="space-y-6">
+      {/* jobs-runner is required AFTER linkedin-post-sync on dev: the sync cron
+          ENQUEUES a linkedin_post_sync job (it doesn't drain inline), so click
+          linkedin-post-sync first, then jobs-runner to actually run it and
+          populate posts + KPIs. */}
       <CronToolbar
-        crons={["linkedin-post-sync", "performance-sync", "linkedin-retention-cleanup"]}
+        crons={["linkedin-post-sync", "jobs-runner", "performance-sync", "linkedin-retention-cleanup"]}
         onTriggered={() => {
           queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
           queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });

--- a/src/app/dashboard/content/sources/page.tsx
+++ b/src/app/dashboard/content/sources/page.tsx
@@ -156,8 +156,11 @@ function TrustedSourcesSurface() {
 
   return (
     <div className="space-y-6">
+      {/* jobs-runner drains the source_fetch / discovery jobs these crons
+          enqueue (they don't inline-drain on dev) — click the scheduler/runner
+          first, then jobs-runner to actually fetch source content. */}
       <CronToolbar
-        crons={["discovery-runner", "refresh-recommendations", "source-fetch-scheduler"]}
+        crons={["discovery-runner", "refresh-recommendations", "source-fetch-scheduler", "jobs-runner"]}
         onTriggered={() => {
           void queryClient.invalidateQueries({ queryKey: ["trusted-sources"] });
           void queryClient.invalidateQueries({ queryKey: ["citations"] });


### PR DESCRIPTION
On dev, Vercel crons don't fire, and `linkedin-post-sync` / `source-fetch-scheduler` / `discovery-runner` **enqueue jobs without inline-draining** (`drainInDev` not set). Their toolbars lacked a `jobs-runner` button, so clicking the cron left the job **pending with nothing to process it** — LinkedIn posts/KPIs and source content never populated on dev.

Added `jobs-runner` to the **LinkedIn** and **Sources** page toolbars (the News Desk + Beehiiv pages already had it). Flow on dev: click the cron → click `jobs-runner`. `jobs-runner` is in the api dev-cron whitelist; toolbar auto-hides in prod. Config + comments only; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)