### PR TITLE
feat(tasks): compact rows + filters via DataTable helper

### DIFF
--- a/src/app/dashboard/tasks/columns.tsx
+++ b/src/app/dashboard/tasks/columns.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { StatusBadge } from "@/components/molecules/status-badge";
+import { ElapsedTimer } from "@/components/molecules/elapsed-timer";
+import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
+import { DataTableColumnHeader } from "@/components/molecules/data-table";
+import { formatDate } from "@/lib/locale";
+import type { Job, JobDetail } from "@/hooks/use-jobs";
+
+/**
+ * Callbacks the page wires into the columns. Expansion state + the cancel
+ * mutation live in the page (they need React-Query + per-row UI state);
+ * the column defs stay pure and just call back.
+ */
+export interface TaskColumnsCtx {
+  isExpanded: (id: string) => boolean;
+  toggleExpand: (id: string) => void;
+  onCancel: (job: Job) => void;
+}
+
+function isActiveJob(job: Job): boolean {
+  return job.status === "running" || job.status === "pending";
+}
+
+export function getTaskColumns(ctx: TaskColumnsCtx): ColumnDef<Job, unknown>[] {
+  return [
+    {
+      // The searchable / sortable label. accessorFn returns the friendly
+      // name so the toolbar's global search matches what the user reads.
+      id: "task",
+      accessorFn: (row) => row.displayName || formatKind(row.kind),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Task" />,
+      enableHiding: false,
+      cell: ({ row }) => {
+        const job = row.original;
+        const hasChildren = job.childrenTotal != null && job.childrenTotal > 0;
+        const expanded = ctx.isExpanded(job._id);
+        return (
+          <div className="flex items-start gap-1.5">
+            {hasChildren ? (
+              <button
+                type="button"
+                aria-label={expanded ? "Hide batches" : "Show batches"}
+                className="mt-0.5 shrink-0 text-muted-foreground hover:text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  ctx.toggleExpand(job._id);
+                }}
+              >
+                {expanded ? (
+                  <ChevronDown className="size-4" />
+                ) : (
+                  <ChevronRight className="size-4" />
+                )}
+              </button>
+            ) : (
+              <span className="w-4 shrink-0" aria-hidden />
+            )}
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">
+                {job.displayName || formatKind(job.kind)}
+              </div>
+              {job.displayHint && (
+                <div className="truncate text-xs text-muted-foreground">
+                  {job.displayHint}
+                </div>
+              )}
+              {hasChildren && (
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    ctx.toggleExpand(job._id);
+                  }}
+                >
+                  {job.childrenTotal} batch{job.childrenTotal === 1 ? "" : "es"}
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      // Hidden — drives the "Type" faceted-filter chip only (kind is the
+      // machine value; we never render a raw-kind column). initialVisibility
+      // keeps it out of the rendered table.
+      accessorKey: "kind",
+      header: "Type",
+      enableSorting: false,
+      filterFn: (row, id, value) => {
+        if (!Array.isArray(value) || value.length === 0) return true;
+        return value.includes(String(row.getValue(id)));
+      },
+    },
+    {
+      id: "status",
+      accessorFn: (row) => statusForBadge(row),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      cell: ({ row }) => {
+        const job = row.original;
+        const active = isActiveJob(job);
+        return (
+          <div className="flex flex-col gap-1">
+            <StatusBadge status={statusForBadge(job)} dot={active} />
+            {job.cancelRequested && active && (
+              <span className="text-xs text-amber-600">Cancelling…</span>
+            )}
+            {job.status === "failed" && (
+              <span className="text-xs text-amber-700 dark:text-amber-400">
+                Hit a snag — retry
+              </span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      id: "progress",
+      enableSorting: false,
+      header: "Progress",
+      cell: ({ row }) => {
+        const job = row.original;
+        const total = job.progress?.totalUnits ?? 0;
+        const done = job.progress?.processedUnits ?? 0;
+        const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+        if (total > 0) {
+          return (
+            <div className="w-32 space-y-1">
+              <div className="flex items-center justify-between text-xs text-muted-foreground tabular-nums">
+                <span>{pct}%</span>
+                <span>
+                  {done}/{total}
+                </span>
+              </div>
+              <Progress value={pct} className="h-1.5" />
+            </div>
+          );
+        }
+        if (isActiveJob(job)) {
+          return (
+            <span className="text-xs text-muted-foreground">
+              {job.progress?.currentLabel || "Working…"}
+            </span>
+          );
+        }
+        return <span className="text-xs text-muted-foreground">—</span>;
+      },
+    },
+    {
+      id: "started",
+      accessorFn: (row) => row.createdAt,
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Started" />,
+      cell: ({ row }) => {
+        const job = row.original;
+        return (
+          <div className="whitespace-nowrap text-xs text-muted-foreground">
+            <div>{formatDate(job.createdAt, null)}</div>
+            {isActiveJob(job) && (
+              <ElapsedTimer running startedAt={job.createdAt} etaMs={job.progress?.etaMs} />
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      id: "actions",
+      enableSorting: false,
+      enableHiding: false,
+      header: () => <span className="sr-only">Actions</span>,
+      cell: ({ row }) => {
+        const job = row.original;
+        if (!isActiveJob(job) || job.cancelRequested) return null;
+        return (
+          <div className="text-right">
+            <ConfirmDialog
+              trigger={
+                <Button variant="ghost" size="sm" className="h-7 text-xs">
+                  Cancel
+                </Button>
+              }
+              title="Cancel this task?"
+              description="In-flight work will finish, then everything else stops. You can restart later."
+              confirmLabel="Cancel task"
+              onConfirm={() => ctx.onCancel(job)}
+            />
+          </div>
+        );
+      },
+    },
+  ];
+}
+
+// ── Shared helpers ───────────────────────────────────────────────
+
+/**
+ * Map raw kind to a human label for jobs without a `displayName`.
+ * displayName is set at submit time and should always be present going
+ * forward; this is a fallback for ad-hoc enqueues.
+ */
+export function formatKind(kind: string): string {
+  switch (kind) {
+    case "content_analyse":
+      return "Re-analysing content library";
+    case "tag_drafts":
+      return "Tagging batch";
+    case "voice_card_refresh":
+      return "Refreshing brand voice";
+    case "beehiiv_sync_full":
+      return "Syncing Beehiiv";
+    default:
+      return kind.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+}
+
+/**
+ * Map job.status to the label rendered in the badge. Synthetic labels
+ * (queued, cancelling, in_progress) read better than the raw enum.
+ * StatusBadge's STATUS_MAP knows about all of these.
+ */
+export function statusForBadge(job: Job | JobDetail): string {
+  if (job.cancelRequested && (job.status === "running" || job.status === "pending")) {
+    return "cancelling";
+  }
+  if (job.status === "pending") return "queued";
+  if (job.status === "running") return "in_progress";
+  return job.status;
+}

--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -206,7 +206,7 @@ export default function TasksPage() {
                 {table.getRowModel().rows.length ? (
                   table.getRowModel().rows.map((row) => (
                     <JobRowGroup
-                      key={row.id}
+                      key={`${row.id}:${focusJobId === row.original._id}`}
                       job={row.original}
                       focused={focusJobId === row.original._id}
                       expanded={isExpanded(row.original._id)}
@@ -225,7 +225,7 @@ export default function TasksPage() {
                 ) : (
                   <TableRow>
                     <TableCell
-                      colSpan={columns.length}
+                      colSpan={table.getVisibleLeafColumns().length}
                       className="h-24 text-center text-muted-foreground"
                     >
                       No tasks match your filters.
@@ -265,12 +265,15 @@ function JobRowGroup({
 }) {
   const rowRef = useRef<HTMLTableRowElement>(null);
   const [highlighted, setHighlighted] = useState(focused);
+  // Mount-only: scroll into view + ring, then fade. The parent keys this
+  // group by row id + focused-ness, so an in-place ?jobId change remounts
+  // the affected rows and re-runs this — no setState-in-effect needed.
   useEffect(() => {
     if (!focused) return;
     rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     const timer = setTimeout(() => setHighlighted(false), 2500);
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once per mount
   }, []);
 
   const hasChildren = job.childrenTotal != null && job.childrenTotal > 0;

--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -1,33 +1,43 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { flexRender } from "@tanstack/react-table";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusBadge } from "@/components/molecules/status-badge";
-import { useQueryClient } from "@tanstack/react-query";
+import {
+  useDataTable,
+  FacetedFilter,
+  DataTablePagination,
+  type FacetedFilterOption,
+} from "@/components/molecules/data-table";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
-import { ElapsedTimer } from "@/components/molecules/elapsed-timer";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
 import { ListChecks, Loader2 } from "lucide-react";
 import { toast } from "sonner";
-import { formatDate } from "@/lib/locale";
+import { cn } from "@/lib/utils";
 import {
   useJobs,
   useJobDetail,
   useCancelJob,
   type Job,
-  type JobDetail,
 } from "@/hooks/use-jobs";
+import { getTaskColumns, formatKind } from "./columns";
+
+type TaskFilter = "active" | "completed" | "all";
 
 export default function TasksPage() {
   const queryClient = useQueryClient();
@@ -36,6 +46,68 @@ export default function TasksPage() {
 
   const { data: active, isLoading: activeLoading } = useJobs("active");
   const { data: recent, isLoading: recentLoading } = useJobs("recent");
+
+  // Deep-linked jobs may be in either bucket — default to "all" so the
+  // linked row is always present to highlight; otherwise default to the
+  // ongoing view.
+  const [filter, setFilter] = useState<TaskFilter>(focusJobId ? "all" : "active");
+
+  const activeRows = useMemo(() => active?.rows ?? [], [active]);
+  const recentRows = useMemo(() => recent?.rows ?? [], [recent]);
+  const rows = useMemo(() => {
+    if (filter === "active") return activeRows;
+    if (filter === "completed") return recentRows;
+    return [...activeRows, ...recentRows];
+  }, [filter, activeRows, recentRows]);
+
+  const loading =
+    (filter === "active" && activeLoading && !active) ||
+    (filter === "completed" && recentLoading && !recent) ||
+    (filter === "all" && (activeLoading || recentLoading) && !active && !recent);
+
+  // ── Expansion (batch drill-down) ──────────────────────────────
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const toggleExpand = useCallback(
+    (id: string) => setExpanded((prev) => ({ ...prev, [id]: !prev[id] })),
+    [],
+  );
+  const isExpanded = useCallback((id: string) => !!expanded[id], [expanded]);
+
+  // ── Cancel ────────────────────────────────────────────────────
+  const cancelMutation = useCancelJob();
+  const onCancel = useCallback(
+    (job: Job) => {
+      cancelMutation.mutate(job._id, {
+        onSuccess: () => toast.success("Cancellation requested"),
+        onError: (err: Error) =>
+          toast.error(err.message || "Failed to cancel task"),
+      });
+    },
+    [cancelMutation],
+  );
+
+  const columns = useMemo(
+    () => getTaskColumns({ isExpanded, toggleExpand, onCancel }),
+    [isExpanded, toggleExpand, onCancel],
+  );
+
+  const { table, globalFilter, setGlobalFilter } = useDataTable<Job>({
+    data: rows,
+    columns,
+    getRowId: (row) => row._id,
+    // "kind" backs the Type filter chip but is never rendered as a column.
+    initialVisibility: { kind: false },
+    pageSize: 25,
+  });
+
+  // Type filter options — unique kinds present in the current bucket,
+  // labelled with the same friendly map the rows use.
+  const typeOptions: FacetedFilterOption[] = useMemo(() => {
+    const kinds = Array.from(new Set(rows.map((r) => r.kind)));
+    return kinds
+      .sort()
+      .map((k) => ({ value: k, label: formatKind(k) }));
+  }, [rows]);
 
   return (
     <div className="space-y-6">
@@ -50,185 +122,178 @@ export default function TasksPage() {
         </p>
       </div>
 
-      {/* In-progress section */}
-      <section className="space-y-3">
-        <div className="flex items-center gap-2">
-          <h3 className="text-base font-semibold">In progress</h3>
-          {activeLoading && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
-        </div>
-        {activeLoading && !active ? (
-          <JobListSkeleton />
-        ) : !active?.rows.length ? (
+      {/* Button tabs: ongoing vs completed */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Tabs value={filter} onValueChange={(v) => setFilter(v as TaskFilter)}>
+          <TabsList>
+            <TabsTrigger value="active">
+              In progress{activeRows.length ? ` (${activeRows.length})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="completed">
+              Completed{recentRows.length ? ` (${recentRows.length})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="all">All</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {(activeLoading || recentLoading) && (
+          <Loader2 className="size-3 animate-spin text-muted-foreground" />
+        )}
+      </div>
+
+      {loading ? (
+        <TableSkeleton />
+      ) : rows.length === 0 ? (
+        filter === "completed" ? (
+          <p className="text-sm text-muted-foreground">
+            No completed tasks in the last 24 hours.
+          </p>
+        ) : (
           <EmptyState
             icon={ListChecks}
             title="Nothing running right now"
             description="Kick off an analysis or sync from the Content page and we'll track progress here."
           />
-        ) : (
-          <div className="space-y-3">
-            {active.rows.map((job) => (
-              <JobCard
-                key={job._id}
-                job={job}
-                expanded={focusJobId === job._id}
-                focused={focusJobId === job._id}
+        )
+      ) : (
+        <div className="space-y-3">
+          {/* Toolbar: search + Type filter chip */}
+          <div className="flex flex-wrap items-center gap-2">
+            <Input
+              placeholder="Search tasks..."
+              value={globalFilter}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              className="h-8 w-full lg:w-64"
+            />
+            {typeOptions.length > 1 && (
+              <FacetedFilter
+                column={table.getColumn("kind")}
+                title="Type"
+                options={typeOptions}
+                align="start"
               />
-            ))}
+            )}
+            {table.getState().columnFilters.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8"
+                onClick={() => table.resetColumnFilters()}
+              >
+                Clear
+              </Button>
+            )}
           </div>
-        )}
-      </section>
 
-      {/* Recent section */}
-      <section className="space-y-3">
-        <h3 className="text-base font-semibold">Recently completed</h3>
-        {recentLoading && !recent ? (
-          <JobListSkeleton />
-        ) : !recent?.rows.length ? (
-          <p className="text-sm text-muted-foreground">No completed tasks in the last 24 hours.</p>
-        ) : (
-          <div className="space-y-3">
-            {recent.rows.map((job) => (
-              <JobCard
-                key={job._id}
-                job={job}
-                expanded={focusJobId === job._id}
-                focused={focusJobId === job._id}
-              />
-            ))}
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((hg) => (
+                  <TableRow key={hg.id}>
+                    {hg.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <JobRowGroup
+                      key={row.id}
+                      job={row.original}
+                      focused={focusJobId === row.original._id}
+                      expanded={isExpanded(row.original._id)}
+                      colSpan={row.getVisibleCells().length}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id} className="align-top">
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </JobRowGroup>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-24 text-center text-muted-foreground"
+                    >
+                      No tasks match your filters.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
           </div>
-        )}
-      </section>
+
+          <DataTablePagination table={table} />
+        </div>
+      )}
     </div>
   );
 }
 
 // ── Subcomponents ────────────────────────────────────────────────
 
-function JobCard({
+/**
+ * Renders a job's main row plus (when expanded) its batch-children row.
+ * Owns the deep-link highlight: when `focused`, scrolls into view and
+ * briefly rings the row.
+ */
+function JobRowGroup({
   job,
-  expanded: initialExpanded = false,
-  focused = false,
+  focused,
+  expanded,
+  colSpan,
+  children,
 }: {
   job: Job;
-  expanded?: boolean;
-  focused?: boolean;
+  focused: boolean;
+  expanded: boolean;
+  colSpan: number;
+  children: React.ReactNode;
 }) {
-  const [expanded, setExpanded] = useState(initialExpanded);
-  const isActive = job.status === "running" || job.status === "pending";
-  const cancelMutation = useCancelJob();
-  // When a deep-link lands here with ?jobId=<id>, scroll the matched
-  // card into view and apply a brief ring so the user can spot which
-  // job they were sent to. Only fires once on mount; subsequent
-  // re-renders (poll updates etc.) don't re-trigger.
-  const cardRef = useRef<HTMLDivElement>(null);
+  const rowRef = useRef<HTMLTableRowElement>(null);
   const [highlighted, setHighlighted] = useState(focused);
   useEffect(() => {
     if (!focused) return;
-    cardRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     const timer = setTimeout(() => setHighlighted(false), 2500);
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, []);
 
-  const totalUnits = job.progress?.totalUnits ?? 0;
-  const processedUnits = job.progress?.processedUnits ?? 0;
-  const pct = totalUnits > 0 ? Math.round((processedUnits / totalUnits) * 100) : 0;
-
-  const onCancel = () => {
-    cancelMutation.mutate(job._id, {
-      onSuccess: () => toast.success("Cancellation requested"),
-      onError: (err: Error) => toast.error(err.message || "Failed to cancel task"),
-    });
-  };
+  const hasChildren = job.childrenTotal != null && job.childrenTotal > 0;
 
   return (
-    <Card
-      ref={cardRef}
-      className={
-        highlighted
-          ? "ring-2 ring-primary transition-shadow duration-300"
-          : "transition-shadow duration-300"
-      }
-    >
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <CardTitle className="text-base">
-              {job.displayName || formatKind(job.kind)}
-            </CardTitle>
-            {job.displayHint && (
-              <CardDescription className="mt-1 line-clamp-2">{job.displayHint}</CardDescription>
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <StatusBadge
-              status={statusForBadge(job)}
-              dot={isActive}
-            />
-            {isActive && (
-              <ElapsedTimer
-                running
-                startedAt={job.createdAt}
-                etaMs={job.progress?.etaMs}
-              />
-            )}
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-3 pt-0">
-        {totalUnits > 0 && (
-          <div className="space-y-1">
-            <div className="flex items-center justify-between text-xs text-muted-foreground tabular-nums">
-              <span className="truncate pr-2">
-                {job.progress?.currentLabel || (isActive ? "Working…" : `${pct}% complete`)}
-              </span>
-              <span>{processedUnits} / {totalUnits}</span>
-            </div>
-            <Progress value={pct} className="h-1.5" />
-          </div>
+    <>
+      <TableRow
+        ref={rowRef}
+        className={cn(
+          highlighted &&
+            "bg-primary/5 ring-1 ring-inset ring-primary transition-colors",
         )}
-
-        <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>Started {formatDate(job.createdAt, null)}</span>
-          <div className="flex items-center gap-2">
-            {job.childrenTotal != null && (
-              <button
-                type="button"
-                className="hover:text-foreground hover:underline"
-                onClick={() => setExpanded((v) => !v)}
-              >
-                {expanded ? "Hide" : "Show"} {job.childrenTotal} batch{job.childrenTotal === 1 ? "" : "es"}
-              </button>
-            )}
-            {isActive && !job.cancelRequested && (
-              <ConfirmDialog
-                trigger={
-                  <Button variant="ghost" size="sm" className="h-7 text-xs">
-                    Cancel
-                  </Button>
-                }
-                title="Cancel this task?"
-                description="In-flight work will finish, then everything else stops. You can restart later."
-                confirmLabel="Cancel task"
-                onConfirm={onCancel}
-              />
-            )}
-            {job.cancelRequested && isActive && (
-              <span className="text-amber-600">Cancelling…</span>
-            )}
-          </div>
-        </div>
-
-        {job.status === "failed" && (
-          <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-300">
-            We hit a snag. The team has been notified — try again or contact support.
-          </p>
-        )}
-
-        {expanded && <JobChildrenList jobId={job._id} />}
-      </CardContent>
-    </Card>
+      >
+        {children}
+      </TableRow>
+      {expanded && hasChildren && (
+        <TableRow className="bg-muted/30 hover:bg-muted/30">
+          <TableCell colSpan={colSpan} className="py-3">
+            <JobChildrenList jobId={job._id} />
+          </TableCell>
+        </TableRow>
+      )}
+    </>
   );
 }
 
@@ -236,7 +301,7 @@ function JobChildrenList({ jobId }: { jobId: string }) {
   const { data, isLoading } = useJobDetail(jobId);
   if (isLoading) {
     return (
-      <div className="space-y-2 border-t pt-3">
+      <div className="space-y-2">
         <Skeleton className="h-4 w-full" />
         <Skeleton className="h-4 w-full" />
       </div>
@@ -244,7 +309,7 @@ function JobChildrenList({ jobId }: { jobId: string }) {
   }
   if (!data?.children?.length) return null;
   return (
-    <div className="space-y-2 border-t pt-3">
+    <div className="space-y-2">
       {data.children.map((child) => {
         const total = child.progress?.totalUnits ?? 0;
         const done = child.progress?.processedUnits ?? 0;
@@ -258,7 +323,9 @@ function JobChildrenList({ jobId }: { jobId: string }) {
             <span className="min-w-0 flex-1 truncate">
               {child.displayName || `Batch ${child._id.slice(-6)}`}
             </span>
-            <span className="text-muted-foreground tabular-nums">{done} / {total}</span>
+            <span className="text-muted-foreground tabular-nums">
+              {done} / {total}
+            </span>
             <div className="w-20">
               <Progress value={pct} className="h-1" />
             </div>
@@ -269,61 +336,41 @@ function JobChildrenList({ jobId }: { jobId: string }) {
   );
 }
 
-function JobListSkeleton() {
+function TableSkeleton() {
   return (
-    <div className="space-y-3">
-      {Array.from({ length: 2 }).map((_, i) => (
-        <Card key={i}>
-          <CardHeader className="pb-3">
-            <Skeleton className="h-4 w-1/3" />
-            <Skeleton className="mt-2 h-3 w-2/3" />
-          </CardHeader>
-          <CardContent className="space-y-2 pt-0">
-            <Skeleton className="h-1.5 w-full" />
-            <Skeleton className="h-3 w-1/4" />
-          </CardContent>
-        </Card>
-      ))}
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[40%]">Task</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Progress</TableHead>
+            <TableHead>Started</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <TableRow key={i}>
+              <TableCell>
+                <Skeleton className="h-4 w-2/3" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-16" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-24" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-20" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="ml-auto h-4 w-12" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   );
-}
-
-// ── Helpers ──────────────────────────────────────────────────────
-
-/**
- * Map raw kind to a human label for jobs without a `displayName`.
- * displayName is set at submit time and should always be present going
- * forward; this is a fallback for ad-hoc enqueues.
- */
-function formatKind(kind: string): string {
-  switch (kind) {
-    case "content_analyse":
-      return "Re-analysing content library";
-    case "tag_drafts":
-      return "Tagging batch";
-    case "voice_card_refresh":
-      return "Refreshing brand voice";
-    case "beehiiv_sync_full":
-      return "Syncing Beehiiv";
-    default:
-      return kind.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-  }
-}
-
-/**
- * Pick the badge label. We surface "running" as "In Progress" via the
- * StatusBadge map, but for "pending" we want "Queued" (clearer for users).
- */
-/**
- * Map job.status to the label rendered in the badge. Synthetic labels
- * (queued, cancelling, in_progress) read better than the raw enum.
- * StatusBadge's STATUS_MAP knows about all of these.
- */
-function statusForBadge(job: Job | JobDetail): string {
-  if (job.cancelRequested && (job.status === "running" || job.status === "pending")) {
-    return "cancelling";
-  }
-  if (job.status === "pending") return "queued";
-  if (job.status === "running") return "in_progress";
-  return job.status;
 }


### PR DESCRIPTION
## What
Redesigns **/dashboard/tasks** from big card boxes to a compact, filterable **row table** — built on our reusable **`molecules/data-table`** helper (the shadcnblocks-based pattern used by the Beehiiv library), per the request to reuse "our own reusable helper which is based on shadcnblocks with button tabs, filter chips, etc." (not raw shadcn `Table`).

## How
- **Button tabs** — In progress / Completed / All — switch the job bucket (`useJobs("active")` vs `useJobs("recent")`).
- **`FacetedFilter` "Type" chip** + global search over task name (hidden `kind` column backs the chip).
- Columns extracted to `columns.tsx` (Task / Status / Progress / Started / Actions) with sortable `DataTableColumnHeader`s.
- `useDataTable` owns the table; manual body render preserves the two row-level features the self-contained `<DataTable>` can't express: **batch (children) drill-down** and the **`?jobId` deep-link highlight** (scroll-into-view + ring).
- Preserves cooperative **cancel**, `DataTablePagination`, and the dev **jobs-runner `CronToolbar`**.

## Test
- `npx tsc --noEmit` ✅
- `npx eslint` (tasks page + columns) ✅ 0 problems
- Manual: tabs, Type filter, search, expand batches, cancel, deep-link `?jobId=` highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)