### PR TITLE
fix(beehiiv): eliminate horizontal scroll via responsive columns

### DIFF
--- a/src/app/dashboard/content/beehiiv/columns.tsx
+++ b/src/app/dashboard/content/beehiiv/columns.tsx
@@ -330,7 +330,11 @@ export function getContentColumns(
       <DataTableColumnHeader column={column} title="Title" />
     ),
     cell: ({ row }) => (
-      <div className="max-w-sm">
+      // Title is the flexible column — it grows with available width
+      // (xs → sm as breakpoints widen) and truncates rather than forcing
+      // horizontal scroll. The secondary columns below are progressively
+      // hidden on narrower viewports (meta `hidden <bp>:table-cell`).
+      <div className="max-w-50 xl:max-w-xs 2xl:max-w-sm">
         {/* Dropped `font-medium` on the title — the cell was reading
           * as too bold against the surrounding row text. Default body
           * weight (font-normal / 400) is sleeker; the title's visual
@@ -401,7 +405,7 @@ export function getContentColumns(
       const badge = (
         <Badge
           variant="outline"
-          className={`max-w-60 truncate text-xs lg:max-w-80 ${ct === "unclassified" ? "text-muted-foreground italic" : ""}`}
+          className={`max-w-36 truncate text-xs lg:max-w-52 ${ct === "unclassified" ? "text-muted-foreground italic" : ""}`}
         >
           {labelText}
           {/* Inline "auto" marker — only when the deterministic source-derived
@@ -443,6 +447,13 @@ export function getContentColumns(
     id: "sectors",
     accessorFn: (row) => row.tags?.sectors?.map((s) => s.name).join(", ") ?? "",
     header: "Sectors",
+    // Progressive disclosure — hidden until xl to keep the table inside
+    // the viewport. Still filterable via the Sectors facet chip regardless
+    // of column visibility (the column stays in the table model).
+    meta: {
+      thClassName: "hidden xl:table-cell",
+      tdClassName: "hidden xl:table-cell",
+    },
     cell: ({ row }) => {
       const sectors = row.original.tags?.sectors;
       const derived = row.original.tags?.sectorsDerived === true;
@@ -480,6 +491,10 @@ export function getContentColumns(
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Sentiment" />
     ),
+    meta: {
+      thClassName: "hidden lg:table-cell",
+      tdClassName: "hidden lg:table-cell",
+    },
     cell: ({ row }) => {
       const value = row.original.tags?.sentiment;
       if (!value) return null;
@@ -586,6 +601,10 @@ export function getContentColumns(
     id: "shelfLife",
     accessorFn: (row) => row.tags?.shelfLife ?? "",
     header: "Shelf Life",
+    meta: {
+      thClassName: "hidden 2xl:table-cell",
+      tdClassName: "hidden 2xl:table-cell",
+    },
     cell: ({ row }) => {
       const text = label(SHELF_LIFE_LABELS, row.original.tags?.shelfLife);
       return (
@@ -606,8 +625,12 @@ export function getContentColumns(
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Published" />
     ),
+    meta: {
+      thClassName: "hidden lg:table-cell",
+      tdClassName: "hidden lg:table-cell",
+    },
     cell: ({ row }) => (
-      <span className="text-xs text-muted-foreground">
+      <span className="text-xs text-muted-foreground whitespace-nowrap">
         {formatDate(row.original.publishedAt, prefs)}
       </span>
     ),


### PR DESCRIPTION
## Why
The Beehiiv library table forced a horizontal scrollbar — 9 columns at large min-widths exceeded the content area, wasting space and hurting readability.

## What
Progressive disclosure so the table fits at any desktop width and the primary columns get the freed space:

- **Secondary columns hide on narrower viewports** (they stay in the table model, so their **facet filter chips keep working** regardless of visibility):
  - Sentiment + Published → `lg`
  - Sectors → `xl`
  - Shelf Life → `2xl`
- **Title is now the flexible column** — `max-w-50 → xs → sm` by breakpoint, truncating instead of pushing width.
- **Subtype badge tightened** — `max-w-36 / lg:max-w-52` (was `max-w-60 / lg:max-w-80`).

Always-visible core: Title · Format · Subtype · Ad Score · Repurpose. The existing `overflow-x-auto` stays as a graceful fallback for very narrow viewports.

Implementation reuses the table render's existing `meta.thClassName` / `meta.tdClassName` hooks (same mechanism the sticky actions column already uses).

## Test
- `npx tsc --noEmit` ✅
- `npx eslint` (columns) ✅ 0 problems
- Visual: at lg/xl/2xl the table fills width with no horizontal scroll; facet chips for hidden columns still filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)