### PR TITLE
fix(repurpose): drop redundant hashtags passthrough (no double-render)

### DIFF
--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -117,8 +117,12 @@ function adaptationsToChannels(
   return Array.from(seen.values()).map((a) => ({
     channel: a.platform,
     payload: {
+      // Hashtags are inlined into `content` at generation (api write-x
+      // appendHashtags), and the publishers post the text only — they never
+      // read payload.hashtags. Passing it separately just double-renders the
+      // tags (inline in the body AND as chips in the calendar drawer), so we
+      // intentionally drop the redundant field.
       text: a.content,
-      ...(a.hashtags && a.hashtags.length > 0 ? { hashtags: a.hashtags } : {}),
     },
   }));
 }


### PR DESCRIPTION
## Why
Follow-up to api #491 (hashtags now inlined into the tweet `content`). The repurpose→scheduler seed still copied `a.hashtags` into `payload.hashtags`, and the calendar drawer renders **both** the (now hashtag-inlined) `payload.text` **and** `payload.hashtags` as chips → tags shown twice for X.

## What
Drop the `payload.hashtags` passthrough in `adaptationsToChannels`. Safe because:
- publishers post `payload.text` only — **none read `payload.hashtags`** (verified across x/linkedin/beehiiv adapters), so it was display-only;
- the tags now live in the text itself.

No publish behavior change; removes the cosmetic duplicate.

## Test
- `npx tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)