### PR TITLE
fix(integrations): stop the LinkedIn reconnect loop

### DIFF
--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -832,6 +832,15 @@ function IntegrationCard({
   const Icon = PROVIDER_ICONS[integration.provider] || Plug;
   const colorClass = PROVIDER_COLORS[integration.provider] || "bg-muted";
   const isComingSoon = integration.availability === "coming_soon";
+  // A connection that already has a token but isn't `active` (stale scope /
+  // revoked / errored). Reconnecting it starts a fresh OAuth which makes
+  // the provider issue a NEW token and invalidate the current one — so we
+  // gate it behind a confirm to stop accidental token-killing reconnects
+  // (the LinkedIn reconnect loop). A truly fresh/disconnected provider gets
+  // the plain one-click Connect.
+  const isRecoverable = ["needs_reauth", "expired", "error"].includes(
+    integration.status ?? "",
+  );
 
   return (
     <Card className={`group relative overflow-hidden transition-all hover:shadow-md ${
@@ -990,14 +999,34 @@ function IntegrationCard({
           <p className="text-[11px] text-muted-foreground">Coming soon</p>
         ) : (
           <div className="space-y-1.5">
-            <Button
-              size="sm"
-              className="w-full gap-1.5 h-8 text-xs"
-              onClick={onConnect}
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {isMetaVirtual(integration.provider) ? "Connect with Meta" : "Connect"}
-            </Button>
+            {isRecoverable ? (
+              <>
+                <ConfirmDialog
+                  trigger={
+                    <Button size="sm" className="w-full gap-1.5 h-8 text-xs">
+                      <ExternalLink className="h-3.5 w-3.5" />
+                      Reconnect
+                    </Button>
+                  }
+                  title={`Reconnect ${integration.name}?`}
+                  description="This starts a fresh sign-in and replaces the current access token — the provider invalidates the previous one. Only reconnect if posting is actually failing; repeated reconnects are what break the connection."
+                  confirmLabel="Reconnect"
+                  onConfirm={onConnect}
+                />
+                {integration.lastError && (
+                  <p className="text-[10px] text-destructive truncate">{integration.lastError}</p>
+                )}
+              </>
+            ) : (
+              <Button
+                size="sm"
+                className="w-full gap-1.5 h-8 text-xs"
+                onClick={onConnect}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                {isMetaVirtual(integration.provider) ? "Connect with Meta" : "Connect"}
+              </Button>
+            )}
             {isMetaVirtual(integration.provider) && (
               <p className="text-[10px] text-center text-muted-foreground">
                 One login connects all Meta services

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/providers/auth-provider";
 import { api, ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
@@ -93,6 +94,7 @@ function SettingsContent() {
   const { org } = useAuth();
   const { formatCurrency } = useLocale();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const [orgDetails, setOrgDetails] = useState<OrgDetails | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -148,8 +150,16 @@ function SettingsContent() {
   useEffect(() => {
     if (searchParams?.get("integration") === "connected") {
       setJustConnectedProvider(searchParams.get("provider") ?? "");
+      // Refetch integration status everywhere immediately after a successful
+      // OAuth. Otherwise the content/composer pages keep their cached
+      // pre-connect state and show a stale "Connect" CTA — which invites a
+      // needless reconnect that revokes the token we just issued (the
+      // LinkedIn reconnect loop). These keys cover the content-hub gate and
+      // the LinkedIn identity/me read.
+      queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
+      queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
     }
-  }, [searchParams]);
+  }, [searchParams, queryClient]);
 
   useEffect(() => {
     if (!org?._id) return;


### PR DESCRIPTION
## Problem
On a single dev environment with one connection, LinkedIn Content drops ~every 10 min and the user must reconnect repeatedly. Diagnosis (live DB):
- We already use the **Authorization Code Flow**; LinkedIn grants a **60-day** token + 1-year refresh token (so it's **not** a 10-min/sandbox-token or wrong-flow issue).
- The token is **`REVOKED` (65601), not expired** — LinkedIn invalidates the prior token whenever a **new** one is issued for the same member+app.
- With no second environment and no token-issuing cron, the only thing issuing a new token is a **reconnect**. So: stale/over-eager "Connect" CTA → user reconnects → new token revokes the valid one → breaks → shows "Connect" again. **The reconnect is what breaks it.**

## Fixes
1. **Refetch after connect** — Settings invalidates `content-hub-integrations` + `linkedin-me` on `?integration=connected`, so the content/composer pages immediately show "Connected" instead of a stale "Connect" that invites a needless reconnect.
2. **Reconnect confirm guard** — a connection that has a token but isn't `active` (`needs_reauth`/`expired`/`error`) now shows **"Reconnect" behind a confirm** ("replaces the current token — only reconnect if posting is actually failing"), instead of a one-click "Connect" that silently kills a recoverable token. Fresh/disconnected providers keep one-click Connect.

## Test
- `npx tsc --noEmit` ✅
- Note: this reduces accidental reconnects. A live isolation test (one reconnect, then leave it ~15 min while monitoring the DB) is still recommended to rule out any backend revoker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)