### PR TITLE
feat(linkedin): surface carousel + comment in the b2c

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/feed-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/feed-panel.tsx
@@ -272,6 +272,12 @@ function CommentBox({
       toast.success("Comment posted to LinkedIn.");
       setText("");
       onClose();
+      // NOTE: we deliberately don't invalidate ["linkedin-feed"] here. The
+      // comment count shown on the row is sourced from the post-sync cron's
+      // snapshot, not live — a refetch would return the same stale count (and
+      // LinkedIn's own count lags anyway), so it'd read as a no-op refresh.
+      // The count catches up on the next sync; don't "fix" this with an
+      // invalidate.
     },
     onError: (err: unknown) => {
       if (err instanceof ApiError && err.code === "RECONNECT_REQUIRED") {

--- a/src/app/dashboard/content/linkedin/_components/feed-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/feed-panel.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Building2,
   ExternalLink,
@@ -14,15 +16,22 @@ import {
   Heart,
   Loader2,
   MessageSquare,
+  MessageSquarePlus,
+  Send,
   Share2,
   User,
+  X,
 } from "lucide-react";
 import {
   linkedInContentApi,
+  type LinkedInAuthor,
   type LinkedInFeedPost,
   type LinkedInFeedResponse,
 } from "@/lib/api/linkedin-content";
 import { RetentionFootnote } from "./retention-footnote";
+
+/** LinkedIn's comment body cap. */
+const COMMENT_MAX_LEN = 1250;
 
 /**
  * FeedPanel — the user's own PUBLISHED LinkedIn posts (personal + org),
@@ -156,6 +165,14 @@ export function FeedPanel() {
 
 function FeedRow({ post }: { post: LinkedInFeedPost }) {
   const url = linkedInPostUrl(post.linkedInPostId);
+  const [commenting, setCommenting] = useState(false);
+  // Comment as the post's own author (your member feed, or the page that
+  // published it). We can only build a valid author URN when we know the
+  // post's authorType (+ the page id for org posts), so the action is gated
+  // on a resolvable author AND a real post URN.
+  const author = postAuthor(post);
+  const canComment = author !== null && !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
+
   return (
     <li>
       <Card>
@@ -195,9 +212,131 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
             <Metric icon={MessageSquare} label="comments" value={post.performance.comments} />
             <Metric icon={Share2} label="shares" value={post.performance.shares} />
           </div>
+
+          {canComment && (
+            <div className="border-t pt-2">
+              {commenting ? (
+                <CommentBox
+                  postUrn={post.linkedInPostId as string}
+                  author={author as LinkedInAuthor}
+                  onClose={() => setCommenting(false)}
+                />
+              ) : (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-2 text-xs"
+                  onClick={() => setCommenting(true)}
+                >
+                  <MessageSquarePlus className="size-3.5" /> Add a comment
+                </Button>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
     </li>
+  );
+}
+
+/** Resolve the post's own author into a publish-author shape, or null when we
+ *  can't (unknown authorType, or an org post missing its page id) — the
+ *  comment action is hidden in that case rather than guessing an author. */
+function postAuthor(post: LinkedInFeedPost): LinkedInAuthor | null {
+  if (post.authorType === "org") {
+    const id = post.authorUrn?.split(":").pop();
+    return id ? { type: "org", pageId: id } : null;
+  }
+  if (post.authorType === "person") return { type: "person" };
+  return null;
+}
+
+/** Inline comment composer for one feed post — posts a top-level comment as
+ *  the post's author. A 403 RECONNECT_REQUIRED surfaces a Reconnect CTA (the
+ *  engagement scopes may need a fresh consent) rather than a generic error. */
+function CommentBox({
+  postUrn,
+  author,
+  onClose,
+}: {
+  postUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState("");
+  const mutation = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, { author, text: text.trim() }),
+    onSuccess: () => {
+      toast.success("Comment posted to LinkedIn.");
+      setText("");
+      onClose();
+    },
+    onError: (err: unknown) => {
+      if (err instanceof ApiError && err.code === "RECONNECT_REQUIRED") {
+        toast.error("Reconnect LinkedIn to comment.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => {
+              window.location.href = "/dashboard/integrations";
+            },
+          },
+        });
+        return;
+      }
+      toast.error(err instanceof ApiError ? err.message : "Couldn't post the comment.");
+    },
+  });
+
+  const trimmed = text.trim();
+  const tooLong = text.length > COMMENT_MAX_LEN;
+  const disabled = trimmed.length === 0 || tooLong || mutation.isPending;
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Write a comment… (e.g. a link or follow-up as your first comment)"
+        rows={2}
+        className="resize-none text-sm"
+        aria-label="Comment text"
+        autoFocus
+      />
+      <div className="flex items-center justify-between">
+        <span className={`text-[11px] tabular-nums ${tooLong ? "text-destructive" : "text-muted-foreground"}`}>
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={onClose}
+            disabled={mutation.isPending}
+          >
+            <X className="size-3.5" /> Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 gap-1.5 px-2.5 text-xs"
+            onClick={() => mutation.mutate()}
+            disabled={disabled}
+            aria-busy={mutation.isPending}
+          >
+            {mutation.isPending ? (
+              <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <Send className="size-3.5" />
+            )}
+            {mutation.isPending ? "Posting…" : "Post comment"}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -34,6 +34,7 @@ import {
 import {
   CalendarClock,
   ChevronDown,
+  GalleryHorizontalEnd,
   Link2,
   Loader2,
   Mic,
@@ -55,6 +56,7 @@ import {
   type LinkedInIdentity,
   type LinkedInVoiceCard,
   type PublishLinkedInPostInput,
+  type RepurposeCarouselInput,
   type RewriteHookResponse,
 } from "@/lib/api/linkedin-content";
 import { ApiError } from "@/lib/api";
@@ -81,6 +83,10 @@ import { sourceTextHash } from "@/lib/scheduler/source-hash";
 import { cn } from "@/lib/utils";
 
 const MAX_LEN = 3000;
+
+/** A carousel splits the text into slides, so it needs a few sentences of
+ *  substance — mirrors the server's `newsletterText` min of 50 chars. */
+const CAROUSEL_MIN_CHARS = 50;
 
 const HAS_ORG_SCOPE = "w_organization_social";
 
@@ -303,6 +309,27 @@ export function PostComposer({ identity, seedText }: Props) {
     },
   });
 
+  // Carousel — repurpose the composer text into a swipeable LinkedIn document
+  // post (one AI-rendered slide per section). Long-running (~30–60s): the
+  // button shows a patient pending state while the server renders slides.
+  const carousel = useMutation({
+    mutationFn: (input: RepurposeCarouselInput) => linkedInContentApi.repurposeCarousel(input),
+    onSuccess: (res) => {
+      resetComposer();
+      setFeedback({
+        kind: "success",
+        message: `Carousel published to LinkedIn — ${res.slideCount} slide${res.slideCount === 1 ? "" : "s"}.${
+          res.documentAvailable ? "" : " It may take a moment to finish processing on LinkedIn."
+        }`,
+      });
+      queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof ApiError ? err.message : "Couldn't build the carousel.";
+      setFeedback({ kind: "error", message });
+    },
+  });
+
   /** Clear all composition state after a successful publish/schedule.
    *  Resets draftId so the next post starts a fresh cnt_drafts row. */
   function resetComposer() {
@@ -322,8 +349,14 @@ export function PostComposer({ identity, seedText }: Props) {
   const tooLong = remaining < 0;
   const empty = text.trim().length === 0;
   const linkInvalid = showLink && linkUrl.trim().length > 0 && !isProbablyUrl(linkUrl);
-  const publishDisabled = empty || tooLong || publish.isPending || linkInvalid;
+  const anyPending = publish.isPending || carousel.isPending;
+  const publishDisabled = empty || tooLong || anyPending || linkInvalid;
   const scheduleDisabled = empty || tooLong || linkInvalid;
+  // Carousel needs enough text to split into slides; a link card doesn't
+  // apply to a carousel (it's a document post), so a pending/invalid link
+  // doesn't block it — but the min-length + pending guards do.
+  const carouselTooShort = text.trim().length < CAROUSEL_MIN_CHARS;
+  const carouselDisabled = empty || tooLong || carouselTooShort || anyPending;
 
   function onSubmit() {
     if (publishDisabled) return;
@@ -347,6 +380,17 @@ export function PostComposer({ identity, seedText }: Props) {
     }
 
     publish.mutate(body);
+  }
+
+  function onCarousel() {
+    if (carouselDisabled) return;
+    setFeedback(null);
+    const author: LinkedInAuthor = isOrgAuthor
+      ? { type: "org", pageId: authorKey.slice("org:".length) }
+      : { type: "person" };
+    // The composer text IS the source the server splits into slides; the
+    // post text above the carousel defaults server-side.
+    carousel.mutate({ author, newsletterText: text.trim(), visibility: effectiveVisibility });
   }
 
   // ── Caret-aware snippet insertion ───────────────────────────────
@@ -644,6 +688,27 @@ export function PostComposer({ identity, seedText }: Props) {
             className="gap-1.5"
           >
             <CalendarClock className="size-4" /> Schedule
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onCarousel}
+            disabled={carouselDisabled}
+            aria-busy={carousel.isPending}
+            className="gap-1.5"
+            title={
+              carouselTooShort
+                ? "Write a few sentences first — a carousel splits your text into slides."
+                : "Turn this text into a swipeable LinkedIn carousel (PDF, one image per slide). Takes ~30–60s."
+            }
+          >
+            {carousel.isPending ? (
+              <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <GalleryHorizontalEnd className="size-4" />
+            )}
+            {carousel.isPending ? "Building carousel…" : "Carousel"}
           </Button>
           <Button onClick={onSubmit} disabled={publishDisabled} aria-busy={publish.isPending}>
             <Send className="size-4 mr-1.5" />

--- a/src/app/dashboard/content/linkedin/page.tsx
+++ b/src/app/dashboard/content/linkedin/page.tsx
@@ -188,7 +188,7 @@ function LinkedInTabs({
           </CardContent>
         </Card>
         <p className="text-xs text-muted-foreground">
-          Compose with AI, schedule for later, or publish now. Carousels and media are coming.
+          Compose with AI, schedule for later, publish now, or turn a longer write-up into a swipeable carousel. Image attachments are coming.
         </p>
       </TabsContent>
 

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -325,7 +325,61 @@ export const linkedInContentApi = {
       `/v1/linkedin/content/feed${q ? `?${q}` : ""}`,
     );
   },
+
+  /**
+   * Add a comment on a post as the member or an org page. `postUrn` is the
+   * full `urn:li:share:*` / `urn:li:ugcPost:*`. Throws an ApiError with
+   * `code: "RECONNECT_REQUIRED"` (403) when LinkedIn requires the engagement
+   * (`_feed`) scopes the connection lacks — callers should surface a Reconnect
+   * CTA rather than a generic failure.
+   */
+  createComment: (postUrn: string, body: CreateCommentInput) =>
+    api.post<{ commentUrn: string }>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(postUrn)}/comments`,
+      body,
+    ),
+
+  /**
+   * Repurpose a piece of long-form text into a LinkedIn document "carousel"
+   * (PDF, one AI-rendered slide per section). LONG-RUNNING — the server
+   * generates an image per slide, so a 5-slide carousel can take 30–60s; the
+   * caller should show a patient pending state. `newsletterText` must be ≥50
+   * chars. Returns the published post id + slide/document metadata.
+   */
+  repurposeCarousel: (body: RepurposeCarouselInput) =>
+    api.post<CarouselResult>(
+      "/v1/linkedin/content/repurpose-newsletter-carousel",
+      body,
+    ),
 };
+
+export interface CreateCommentInput {
+  author: LinkedInAuthor;
+  text: string;
+  /** Composite parent comment URN — set to reply to a comment, not the post. */
+  parentCommentUrn?: string;
+}
+
+export interface RepurposeCarouselInput {
+  author: LinkedInAuthor;
+  /** The long-form source to split into slides (≥50 chars). */
+  newsletterText: string;
+  /** Optional post text shown above the carousel; defaults server-side. */
+  commentary?: string;
+  visibility?: LinkedInVisibility;
+  /** Slide count; the splitter clamps to [2, maxSlides]. */
+  count?: number;
+}
+
+export interface CarouselResult {
+  postId: string;
+  documentUrn: string;
+  slideCount: number;
+  imagesGenerated: number;
+  /** False when the document upload didn't confirm AVAILABLE before posting
+   *  (best-effort path) — the post may still be processing on LinkedIn. */
+  documentAvailable: boolean;
+}
 
 /** One published post in the LinkedIn Feed tab (GET /feed). */
 export interface LinkedInFeedPost {


### PR DESCRIPTION
## What

Makes two **already-shipped backend features** usable from the LinkedIn dashboard — they were API-only with no UI.

### Carousel (composer)
A new **"Carousel"** action next to Schedule/Publish turns the composer text (≥50 chars) into a swipeable LinkedIn **document post** (one AI-rendered slide per section). Long-running (~30–60s — a slide image is generated each), so the button shows a patient **"Building carousel…"** state and cross-disables Publish; friendly success/error feedback. The page note no longer says "Carousels are coming."

### Comment (Feed panel)
An **"Add a comment"** inline composer on each synced post — the common *first-comment* tactic (drop a link/CTA as your own first comment). Comments as the post's **own author** (member or page), 1250-char cap, no double-submit. A **403 `RECONNECT_REQUIRED`** surfaces a **Reconnect** toast (the engagement `_feed` scopes may need a fresh consent) rather than a generic error — which doubles as the live **Phase B scope-probe**: clicking it either works (legacy scopes suffice) or tells us a reconnect is needed.

### API client
`createComment(postUrn, …)` and `repurposeCarousel(…)` + their types.

## Notes
- Comment count is post-sync-cron-sourced, so the row count isn't optimistically bumped (documented inline so it isn't "fixed" with a useless invalidate).
- Reactions + replying to specific engager comments need data we don't surface yet (the engager's comment URN) — deferred.

## Checks
`tsc --noEmit` clean · `eslint` clean · existing vitest suite green (19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)