### PR TITLE
feat(linkedin): carousel preview-and-publish UI (review before posting)

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
+++ b/src/app/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
@@ -37,12 +37,16 @@ export function CarouselPreviewDialog({
   preview,
   author,
   visibility,
+  targetLabel,
   onClose,
   onPublished,
 }: {
   preview: CarouselPreviewResult;
   author: LinkedInAuthor;
   visibility: LinkedInVisibility;
+  /** Human label for where this publishes (e.g. a Page name) — shown so the
+   *  user knows the target before posting. */
+  targetLabel: string;
   onClose: () => void;
   onPublished: () => void;
 }) {
@@ -100,8 +104,10 @@ export function CarouselPreviewDialog({
             <GalleryHorizontalEnd className="size-4" /> Review your carousel
           </DialogTitle>
           <DialogDescription>
-            {preview.slideCount} slide{preview.slideCount === 1 ? "" : "s"} — publishes as a swipeable
-            document post on LinkedIn.
+            {preview.slideCount} slide{preview.slideCount === 1 ? "" : "s"} — publishing as{" "}
+            <span className="font-medium text-foreground">{targetLabel}</span> (
+            {visibility === "PUBLIC" ? "Public" : visibility === "CONNECTIONS" ? "Connections" : "Signed-in members"})
+            as a swipeable document post.
           </DialogDescription>
         </DialogHeader>
 
@@ -113,7 +119,7 @@ export function CarouselPreviewDialog({
           </p>
         )}
 
-        <div className="h-[460px] w-full overflow-hidden rounded-md border bg-muted/30">
+        <div className="h-115 w-full overflow-hidden rounded-md border bg-muted/30">
           <iframe src={preview.previewUrl} title="Carousel preview" className="h-full w-full" />
         </div>
 
@@ -132,11 +138,20 @@ export function CarouselPreviewDialog({
             className="resize-none text-sm"
             aria-label="Carousel post text"
           />
-          <span
-            className={`text-[11px] tabular-nums ${tooLong ? "text-destructive" : "text-muted-foreground"}`}
-          >
-            {commentary.length}/{COMMENTARY_MAX}
-          </span>
+          <div className="flex items-center justify-between">
+            {tooLong ? (
+              <span className="text-[11px] text-destructive">
+                Trim to {COMMENTARY_MAX} characters to publish.
+              </span>
+            ) : (
+              <span />
+            )}
+            <span
+              className={`text-[11px] tabular-nums ${tooLong ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {commentary.length}/{COMMENTARY_MAX}
+            </span>
+          </div>
         </div>
 
         <DialogFooter>

--- a/src/app/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
+++ b/src/app/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { GalleryHorizontalEnd, ImageOff, Loader2, Send } from "lucide-react";
+import { ApiError } from "@/lib/api";
+import {
+  linkedInContentApi,
+  type CarouselPreviewResult,
+  type LinkedInAuthor,
+  type LinkedInVisibility,
+} from "@/lib/api/linkedin-content";
+
+/** LinkedIn commentary cap (matches the server). */
+const COMMENTARY_MAX = 3000;
+
+/**
+ * Review-and-publish modal for a generated carousel. Renders the preview PDF,
+ * lets the user edit the post text, and publishes via the previewKey (no
+ * regeneration → no second image-gen charge). A RECONNECT_REQUIRED /
+ * NOT_CONNECTED error surfaces a Reconnect CTA; PREVIEW_EXPIRED tells the user
+ * to regenerate.
+ */
+export function CarouselPreviewDialog({
+  preview,
+  author,
+  visibility,
+  onClose,
+  onPublished,
+}: {
+  preview: CarouselPreviewResult;
+  author: LinkedInAuthor;
+  visibility: LinkedInVisibility;
+  onClose: () => void;
+  onPublished: () => void;
+}) {
+  const [commentary, setCommentary] = useState(preview.commentary);
+  const imagesMissing = preview.imagesGenerated < preview.slideCount;
+  const tooLong = commentary.length > COMMENTARY_MAX;
+
+  const publish = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.publishCarousel({
+        author,
+        previewKey: preview.previewKey,
+        commentary: commentary.trim() || undefined,
+        title: preview.title,
+        visibility,
+      }),
+    onSuccess: () => {
+      toast.success("Carousel published to LinkedIn.");
+      onPublished();
+    },
+    onError: (err: unknown) => {
+      if (
+        err instanceof ApiError &&
+        (err.code === "RECONNECT_REQUIRED" || err.code === "NOT_CONNECTED")
+      ) {
+        toast.error("Reconnect LinkedIn to publish.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => {
+              window.location.href = "/dashboard/integrations";
+            },
+          },
+        });
+        return;
+      }
+      if (err instanceof ApiError && err.code === "PREVIEW_EXPIRED") {
+        toast.error("This preview expired — close and generate the carousel again.");
+        return;
+      }
+      toast.error(err instanceof ApiError ? err.message : "Couldn't publish the carousel.");
+    },
+  });
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        // Don't let an outside-click/escape close mid-publish.
+        if (!o && !publish.isPending) onClose();
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GalleryHorizontalEnd className="size-4" /> Review your carousel
+          </DialogTitle>
+          <DialogDescription>
+            {preview.slideCount} slide{preview.slideCount === 1 ? "" : "s"} — publishes as a swipeable
+            document post on LinkedIn.
+          </DialogDescription>
+        </DialogHeader>
+
+        {imagesMissing && (
+          <p className="flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50/60 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300">
+            <ImageOff className="size-3.5 shrink-0" />
+            Slide images couldn&apos;t be generated — this carousel is text-only. You can publish it
+            as-is, or cancel and try again.
+          </p>
+        )}
+
+        <div className="h-[460px] w-full overflow-hidden rounded-md border bg-muted/30">
+          <iframe src={preview.previewUrl} title="Carousel preview" className="h-full w-full" />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="carousel-commentary"
+            className="text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Post text (shown above the carousel)
+          </Label>
+          <Textarea
+            id="carousel-commentary"
+            value={commentary}
+            onChange={(e) => setCommentary(e.target.value)}
+            rows={3}
+            className="resize-none text-sm"
+            aria-label="Carousel post text"
+          />
+          <span
+            className={`text-[11px] tabular-nums ${tooLong ? "text-destructive" : "text-muted-foreground"}`}
+          >
+            {commentary.length}/{COMMENTARY_MAX}
+          </span>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose} disabled={publish.isPending}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => publish.mutate()}
+            disabled={tooLong || publish.isPending}
+            aria-busy={publish.isPending}
+            className="gap-1.5"
+          >
+            {publish.isPending ? (
+              <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <Send className="size-4" />
+            )}
+            {publish.isPending ? "Publishing…" : "Publish carousel"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
+++ b/src/app/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
@@ -52,7 +52,8 @@ export function CarouselPreviewDialog({
 }) {
   const [commentary, setCommentary] = useState(preview.commentary);
   const imagesMissing = preview.imagesGenerated < preview.slideCount;
-  const tooLong = commentary.length > COMMENTARY_MAX;
+  // Gate on the TRIMMED length — that's what publish actually sends.
+  const tooLong = commentary.trim().length > COMMENTARY_MAX;
 
   const publish = useMutation({
     mutationFn: () =>

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -56,9 +56,11 @@ import {
   type LinkedInIdentity,
   type LinkedInVoiceCard,
   type PublishLinkedInPostInput,
-  type RepurposeCarouselInput,
+  type CarouselPreviewInput,
+  type CarouselPreviewResult,
   type RewriteHookResponse,
 } from "@/lib/api/linkedin-content";
+import { CarouselPreviewDialog } from "./carousel-preview-dialog";
 import { ApiError } from "@/lib/api";
 import { rewriteContent, createDraft, updateDraft, type ComposerDraftRef } from "@/lib/api/content";
 import { insertAtCaret } from "@/lib/composer/caret";
@@ -312,20 +314,15 @@ export function PostComposer({ identity, seedText }: Props) {
   // Carousel — repurpose the composer text into a swipeable LinkedIn document
   // post (one AI-rendered slide per section). Long-running (~30–60s): the
   // button shows a patient pending state while the server renders slides.
+  // STEP 1 — generate a preview (server renders slides + a PDF and stashes it;
+  // NO LinkedIn call). On success we open the review dialog; the user approves
+  // and publishes from there (step 2). `carouselPreview` non-null = dialog open.
+  const [carouselPreview, setCarouselPreview] = useState<CarouselPreviewResult | null>(null);
   const carousel = useMutation({
-    mutationFn: (input: RepurposeCarouselInput) => linkedInContentApi.repurposeCarousel(input),
-    onSuccess: (res) => {
-      resetComposer();
-      setFeedback({
-        kind: "success",
-        message: `Carousel published to LinkedIn — ${res.slideCount} slide${res.slideCount === 1 ? "" : "s"}.${
-          res.documentAvailable ? "" : " It may take a moment to finish processing on LinkedIn."
-        }`,
-      });
-      queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
-    },
+    mutationFn: (input: CarouselPreviewInput) => linkedInContentApi.previewCarousel(input),
+    onSuccess: (res) => setCarouselPreview(res),
     onError: (err: unknown) => {
-      const message = err instanceof ApiError ? err.message : "Couldn't build the carousel.";
+      const message = err instanceof ApiError ? err.message : "Couldn't build the carousel preview.";
       setFeedback({ kind: "error", message });
     },
   });
@@ -385,13 +382,15 @@ export function PostComposer({ identity, seedText }: Props) {
   function onCarousel() {
     if (carouselDisabled) return;
     setFeedback(null);
-    const author: LinkedInAuthor = isOrgAuthor
-      ? { type: "org", pageId: authorKey.slice("org:".length) }
-      : { type: "person" };
-    // The composer text IS the source the server splits into slides; the
-    // post text above the carousel defaults server-side.
-    carousel.mutate({ author, newsletterText: text.trim(), visibility: effectiveVisibility });
+    // The composer text IS the source the server splits into slides. Author +
+    // visibility are chosen at publish time (in the preview dialog).
+    carousel.mutate({ newsletterText: text.trim() });
   }
+
+  // Author for the publish step, derived from the composer's picker.
+  const carouselAuthor: LinkedInAuthor = isOrgAuthor
+    ? { type: "org", pageId: authorKey.slice("org:".length) }
+    : { type: "person" };
 
   // ── Caret-aware snippet insertion ───────────────────────────────
   // The ONE path every insert takes (emoji glyph, AI pull-quote, AI
@@ -700,7 +699,7 @@ export function PostComposer({ identity, seedText }: Props) {
             title={
               carouselTooShort
                 ? "Write a few sentences first — a carousel splits your text into slides."
-                : "Turn this text into a swipeable LinkedIn carousel (PDF, one image per slide). Takes ~30–60s."
+                : "Generate a swipeable LinkedIn carousel and review it before publishing. Takes ~30–60s."
             }
           >
             {carousel.isPending ? (
@@ -708,7 +707,7 @@ export function PostComposer({ identity, seedText }: Props) {
             ) : (
               <GalleryHorizontalEnd className="size-4" />
             )}
-            {carousel.isPending ? "Building carousel…" : "Carousel"}
+            {carousel.isPending ? "Generating preview…" : "Carousel"}
           </Button>
           <Button onClick={onSubmit} disabled={publishDisabled} aria-busy={publish.isPending}>
             <Send className="size-4 mr-1.5" />
@@ -840,6 +839,20 @@ export function PostComposer({ identity, seedText }: Props) {
         </div>
       )}
 
+      {carouselPreview && (
+        <CarouselPreviewDialog
+          preview={carouselPreview}
+          author={carouselAuthor}
+          visibility={effectiveVisibility}
+          onClose={() => setCarouselPreview(null)}
+          onPublished={() => {
+            setCarouselPreview(null);
+            resetComposer();
+            setFeedback({ kind: "success", message: "Carousel published to LinkedIn." });
+            queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
+          }}
+        />
+      )}
     </ComposerShell>
   );
 }

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -318,6 +318,13 @@ export function PostComposer({ identity, seedText }: Props) {
   // NO LinkedIn call). On success we open the review dialog; the user approves
   // and publishes from there (step 2). `carouselPreview` non-null = dialog open.
   const [carouselPreview, setCarouselPreview] = useState<CarouselPreviewResult | null>(null);
+  // Publish target snapshotted at preview time so a later author/visibility
+  // change can't silently retarget the generated post.
+  const [carouselTarget, setCarouselTarget] = useState<{
+    author: LinkedInAuthor;
+    visibility: LinkedInVisibility;
+    label: string;
+  } | null>(null);
   const carousel = useMutation({
     mutationFn: (input: CarouselPreviewInput) => linkedInContentApi.previewCarousel(input),
     onSuccess: (res) => setCarouselPreview(res),
@@ -382,15 +389,16 @@ export function PostComposer({ identity, seedText }: Props) {
   function onCarousel() {
     if (carouselDisabled) return;
     setFeedback(null);
-    // The composer text IS the source the server splits into slides. Author +
-    // visibility are chosen at publish time (in the preview dialog).
+    // The composer text IS the source the server splits into slides. Snapshot
+    // the publish target NOW (the dialog shows + uses it) so changing the
+    // picker during the ~30–60s preview can't retarget the post.
+    const author: LinkedInAuthor = isOrgAuthor
+      ? { type: "org", pageId: authorKey.slice("org:".length) }
+      : { type: "person" };
+    const label = authorOptions.find((o) => o.value === authorKey)?.label ?? "your feed";
+    setCarouselTarget({ author, visibility: effectiveVisibility, label });
     carousel.mutate({ newsletterText: text.trim() });
   }
-
-  // Author for the publish step, derived from the composer's picker.
-  const carouselAuthor: LinkedInAuthor = isOrgAuthor
-    ? { type: "org", pageId: authorKey.slice("org:".length) }
-    : { type: "person" };
 
   // ── Caret-aware snippet insertion ───────────────────────────────
   // The ONE path every insert takes (emoji glyph, AI pull-quote, AI
@@ -839,14 +847,19 @@ export function PostComposer({ identity, seedText }: Props) {
         </div>
       )}
 
-      {carouselPreview && (
+      {carouselPreview && carouselTarget && (
         <CarouselPreviewDialog
           preview={carouselPreview}
-          author={carouselAuthor}
-          visibility={effectiveVisibility}
-          onClose={() => setCarouselPreview(null)}
+          author={carouselTarget.author}
+          visibility={carouselTarget.visibility}
+          targetLabel={carouselTarget.label}
+          onClose={() => {
+            setCarouselPreview(null);
+            setCarouselTarget(null);
+          }}
           onPublished={() => {
             setCarouselPreview(null);
+            setCarouselTarget(null);
             resetComposer();
             setFeedback({ kind: "success", message: "Carousel published to LinkedIn." });
             queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -346,12 +346,6 @@ export const linkedInContentApi = {
    * caller should show a patient pending state. `newsletterText` must be ≥50
    * chars. Returns the published post id + slide/document metadata.
    */
-  repurposeCarousel: (body: RepurposeCarouselInput) =>
-    api.post<CarouselResult>(
-      "/v1/linkedin/content/repurpose-newsletter-carousel",
-      body,
-    ),
-
   /**
    * STEP 1 of the carousel flow: generate the carousel PDF and stash it as a
    * temp object — does NOT publish, and makes no LinkedIn call (so a revoked
@@ -412,17 +406,6 @@ export interface CreateCommentInput {
   text: string;
   /** Composite parent comment URN — set to reply to a comment, not the post. */
   parentCommentUrn?: string;
-}
-
-export interface RepurposeCarouselInput {
-  author: LinkedInAuthor;
-  /** The long-form source to split into slides (≥50 chars). */
-  newsletterText: string;
-  /** Optional post text shown above the carousel; defaults server-side. */
-  commentary?: string;
-  visibility?: LinkedInVisibility;
-  /** Slide count; the splitter clamps to [2, maxSlides]. */
-  count?: number;
 }
 
 export interface CarouselResult {

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -351,7 +351,61 @@ export const linkedInContentApi = {
       "/v1/linkedin/content/repurpose-newsletter-carousel",
       body,
     ),
+
+  /**
+   * STEP 1 of the carousel flow: generate the carousel PDF and stash it as a
+   * temp object — does NOT publish, and makes no LinkedIn call (so a revoked
+   * token doesn't block previewing). LONG-RUNNING (~30–60s — a slide image per
+   * section). Returns a `previewUrl` to render + the `previewKey` to pass to
+   * `publishCarousel`.
+   */
+  previewCarousel: (body: CarouselPreviewInput) =>
+    api.post<CarouselPreviewResult>(
+      "/v1/linkedin/content/repurpose-newsletter-carousel/preview",
+      body,
+    ),
+
+  /**
+   * STEP 2: publish a previewed carousel to LinkedIn by its `previewKey`. The
+   * server re-screens the (possibly edited) commentary, posts, and cleans up
+   * the temp object. A 403 `RECONNECT_REQUIRED` / 400 `NOT_CONNECTED` means the
+   * LinkedIn token needs a reconnect.
+   */
+  publishCarousel: (body: CarouselPublishInput) =>
+    api.post<CarouselResult>(
+      "/v1/linkedin/content/repurpose-newsletter-carousel/publish",
+      body,
+    ),
 };
+
+export interface CarouselPreviewInput {
+  /** Long-form source to split into slides (≥50 chars). */
+  newsletterText: string;
+  newsletterDraftId?: string;
+  newsletterTitle?: string;
+  commentary?: string;
+  count?: number;
+}
+
+export interface CarouselPreviewResult {
+  /** Opaque key for the stored preview PDF — pass to publishCarousel. */
+  previewKey: string;
+  /** Public URL to render the preview PDF for review. */
+  previewUrl: string;
+  slideCount: number;
+  imagesGenerated: number;
+  /** Server-derived post text above the carousel (editable before publish). */
+  commentary: string;
+  title: string;
+}
+
+export interface CarouselPublishInput {
+  author: LinkedInAuthor;
+  previewKey: string;
+  commentary?: string;
+  title?: string;
+  visibility?: LinkedInVisibility;
+}
 
 export interface CreateCommentInput {
   author: LinkedInAuthor;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,6 +39,11 @@ function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
+    // Allow framing https subresources — the LinkedIn carousel preview renders
+    // a PDF served from the R2 media origin in an <iframe>. Consistent with the
+    // img-src `https:` allowance; `frame-ancestors 'none'` still blocks anyone
+    // from framing US.
+    "frame-src 'self' https:",
     connectSrc,
     "frame-ancestors 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## What

Wires the LinkedIn composer's **Carousel** button to the new two-step backend ([peakhour-api #511](https://github.com/travelxp/peakhour-api/pull/511)): **generate a preview the user can see**, then **publish** — instead of generate-and-publish in one shot. Directly answers "why does it upload before I can see and approve it?"

- **API client:** `previewCarousel` (step 1 → `previewKey` + `previewUrl` + `slideCount` + `commentary`) and `publishCarousel` (step 2 → post by `previewKey`). Removes the now-dead atomic `repurposeCarousel`.
- **Composer:** the Carousel button now calls `previewCarousel` ("Generating preview…") and opens a review dialog. The publish **target (author + visibility) is snapshotted at preview time** so a picker change during the ~30–60s render can't retarget the post.
- **`CarouselPreviewDialog`:** renders the preview PDF (`<iframe>`), shows the publish target, an **editable post-text** field (3000 cap, with a trim hint), a **text-only warning** when slide images couldn't be generated, and Publish/Cancel. Publish posts via `previewKey` (no regeneration → no second image-gen charge); `RECONNECT_REQUIRED`/`NOT_CONNECTED` → Reconnect toast, `PREVIEW_EXPIRED` → regenerate hint.
- **CSP:** added `frame-src 'self' https:` (the preview PDF is served cross-origin from the R2 media host; `default-src 'self'` was blocking the iframe). Consistent with the existing `img-src https:`; `frame-ancestors 'none'` still blocks framing us.

## Tests
`tsc` + `eslint` clean; vitest green (19).

## Depends on (config, your side)
The carousel only fully works once: `AI_GATEWAY_URL` is set (else text-only slides), R2 is configured, the R2 bucket has a `carousel-previews/` lifecycle/TTL rule (#511 follow-up), and LinkedIn is reconnected (fresh token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)