### PR TITLE
feat(shopify): Connect Shopify dialog with shop-domain input

### DIFF
--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -268,6 +268,12 @@ export default function IntegrationsPage() {
 
   async function handleConnect(provider: string, authType: string) {
     const realProvider = resolveProvider(provider);
+    // Shopify is OAuth2 but its authorize host is per-store — collect the
+    // shop domain in a dialog first, then redirect with ?shop=.
+    if (realProvider === "shopify") {
+      setConnectModal("shopify");
+      return;
+    }
     if (authType === "oauth2") {
       window.location.href = `${API_BASE_URL}/v1/integrations/${realProvider}/authorize`;
     } else if (authType === "api_key") {
@@ -630,7 +636,127 @@ export default function IntegrationsPage() {
           handleApiKeyConnect("beehiiv", apiKey, { publicationId })
         }
       />
+
+      {/* Shopify connect modal — collects the store domain, then redirects
+          into the per-store OAuth authorize URL. */}
+      <ShopifyConnectModal
+        open={connectModal === "shopify"}
+        onClose={() => setConnectModal(null)}
+      />
     </div>
+  );
+}
+
+// ── Shopify Connect Modal ──────────────────────────────────────────
+
+/** Mirror of the server-side normalizeShopDomain — accepts "acme",
+ *  "acme.myshopify.com", or a full URL and returns the canonical domain,
+ *  or null if it can't be coerced into a valid myshopify domain. */
+function normalizeShopDomain(input: string): string | null {
+  if (!input) return null;
+  let s = input.trim().toLowerCase();
+  s = s.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  if (!s.includes(".")) s = `${s}.myshopify.com`;
+  return /^[a-z0-9][a-z0-9-]*\.myshopify\.com$/.test(s) ? s : null;
+}
+
+function ShopifyConnectModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [domain, setDomain] = useState("");
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState("");
+
+  function reset() {
+    setDomain("");
+    setError("");
+    setConnecting(false);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const shop = normalizeShopDomain(domain);
+    if (!shop) {
+      setError("Enter a valid store domain, e.g. your-store.myshopify.com");
+      return;
+    }
+    setConnecting(true);
+    // Redirect into the per-store OAuth authorize URL. The API validates
+    // the shop again server-side and signs it into the OAuth state.
+    window.location.href = `${API_BASE_URL}/v1/integrations/shopify/authorize?shop=${encodeURIComponent(shop)}`;
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) {
+          reset();
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#96BF48] text-white">
+              <ShopifyIcon className="h-5 w-5" />
+            </div>
+            <div>
+              <DialogTitle>Connect Shopify</DialogTitle>
+              <DialogDescription>
+                Sync your catalog and orders to power your store assistant
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="shopify-domain">Store domain</Label>
+            <Input
+              id="shopify-domain"
+              placeholder="your-store.myshopify.com"
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              disabled={connecting}
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              Your permanent Shopify domain &mdash; find it in Shopify admin under
+              {" "}<span className="font-medium">Settings &rarr; Domains</span>. You&rsquo;ll
+              approve the connection on Shopify next.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={connecting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={connecting || !domain.trim()} className="gap-1.5">
+              {connecting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Redirecting...
+                </>
+              ) : (
+                "Continue to Shopify"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -26,6 +26,7 @@ import {
   Shield,
   Tags,
   CheckCircle2,
+  AlertCircle,
   Pencil,
   X,
   Check,
@@ -99,6 +100,7 @@ function SettingsContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [justConnectedProvider, setJustConnectedProvider] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   // Edit state
   const [editingBusiness, setEditingBusiness] = useState(false);
@@ -158,6 +160,10 @@ function SettingsContent() {
       // the LinkedIn identity/me read.
       queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
       queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
+    } else if (searchParams?.get("integration") === "error") {
+      setConnectError(
+        oauthErrorMessage(searchParams.get("provider"), searchParams.get("msg")),
+      );
     }
   }, [searchParams, queryClient]);
 
@@ -189,6 +195,13 @@ function SettingsContent() {
         <div className="flex items-center gap-2 rounded-lg bg-green-500/10 border border-green-500/20 p-4 text-sm text-green-700 dark:text-green-400">
           <CheckCircle2 className="h-4 w-4 shrink-0" />
           {formatProviderName(justConnectedProvider)} connected successfully!
+        </div>
+      )}
+
+      {connectError !== null && (
+        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-4 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {connectError}
         </div>
       )}
 
@@ -427,6 +440,30 @@ function formatProviderName(slug: string): string {
       .map((w) => (w[0] ? w[0].toUpperCase() + w.slice(1) : w))
       .join(" ")
   );
+}
+
+// Friendly copy for the OAuth callback's ?integration=error&msg=<code>.
+// Codes are emitted by peakhour-api integrations/routes.ts. Unknown codes
+// fall through to a generic message so a new backend code never renders raw.
+function oauthErrorMessage(provider: string | null, msg: string | null): string {
+  const name = formatProviderName(provider ?? "");
+  switch (msg) {
+    case "store_already_connected":
+      return `That Shopify store is already connected to another business. Each store can be linked to one business at a time.`;
+    case "invalid_shop":
+      return `That doesn't look like a valid Shopify store domain. Use your permanent your-store.myshopify.com address.`;
+    case "shop_mismatch":
+      return `The store that approved the connection didn't match the one you entered. Please try connecting ${name} again.`;
+    case "hmac_invalid":
+    case "state_mismatch":
+    case "state_expired":
+    case "invalid_state":
+      return `We couldn't verify that ${name} connection securely. Please try again.`;
+    case "misconfigured":
+      return `${name} isn't fully configured yet. Please contact support.`;
+    default:
+      return `We couldn't finish connecting ${name}. Please try again.`;
+  }
 }
 
 function SettingRow({ label, value }: { label: string; value?: React.ReactNode }) {


### PR DESCRIPTION
## What

Shopify is OAuth2 but its authorize host is **per-store**, so the Connect button can't redirect blindly like LinkedIn/Meta. This adds a dialog (mirroring the Beehiiv connect-modal pattern) that collects the store domain first, then redirects to `{API}/v1/integrations/shopify/authorize?shop=<domain>`.

Companion to **peakhour-api#<api-pr>** and **peakhour-mongodb#198**.

## Changes
- `handleConnect` special-cases `shopify` to open the dialog instead of redirecting.
- New `ShopifyConnectModal` — single store-domain input, client-side normalisation matching the server validator (`acme` / `acme.myshopify.com` / full URL → canonical domain), inline validation, then `window.location.href` into the authorize URL. The API re-validates and signs the shop into the OAuth state.

## Verification
`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
