### PR TITLE
feat(autopilot): Content > Autopilot home (nav + page + 3 lanes)

### DIFF
--- a/src/app/dashboard/content/autopilot/_components/autopilot-empty.tsx
+++ b/src/app/dashboard/content/autopilot/_components/autopilot-empty.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { Rocket, Plug } from "lucide-react";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/ui/empty";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Cold-start state — a brand-new business with no connected channels and
+ * no history. Critical UX: a wall of empty graphs reads as "broken". This
+ * frames the moment as "your autopilot is warming up" with one clear next
+ * action, so the first impression is momentum, not emptiness.
+ */
+export function AutopilotEmpty() {
+  return (
+    <Empty className="rounded-xl border border-dashed py-16">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Rocket className="size-6" />
+        </EmptyMedia>
+        <EmptyTitle>Your autopilot is warming up</EmptyTitle>
+        <EmptyDescription>
+          Connect your first channel and the engine starts drafting, scheduling,
+          and surfacing what needs your approval — right here.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button asChild>
+          <Link href="/dashboard/integrations">
+            <Plug className="size-4" />
+            Connect a channel
+          </Link>
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/src/app/dashboard/content/autopilot/_components/autopilot-status.tsx
+++ b/src/app/dashboard/content/autopilot/_components/autopilot-status.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { CheckCircle2, Clock, AlertTriangle, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { AutopilotState } from "@/hooks/use-home-summary";
+
+/**
+ * The autopilot status chip — the one-glance answer to "is my content
+ * engine working, waiting on me, or stuck?" Plain language, no jargon.
+ * This is the emotional anchor of the page: it tells an owner whether the
+ * thing they're paying for is alive.
+ */
+
+const STYLES: Record<
+  AutopilotState,
+  { label: string; icon: LucideIcon; dot: string; ring: string; text: string }
+> = {
+  working: {
+    label: "Autopilot is working",
+    icon: CheckCircle2,
+    dot: "bg-emerald-500",
+    ring: "border-emerald-200 bg-emerald-50 dark:border-emerald-900/50 dark:bg-emerald-950/40",
+    text: "text-emerald-700 dark:text-emerald-400",
+  },
+  waiting: {
+    label: "Waiting on you",
+    icon: Clock,
+    dot: "bg-amber-500",
+    ring: "border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-950/40",
+    text: "text-amber-700 dark:text-amber-400",
+  },
+  stalled: {
+    label: "Needs attention",
+    icon: AlertTriangle,
+    dot: "bg-rose-500",
+    ring: "border-rose-200 bg-rose-50 dark:border-rose-900/50 dark:bg-rose-950/40",
+    text: "text-rose-700 dark:text-rose-400",
+  },
+};
+
+function formatLastRun(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const mins = Math.round((Date.now() - then) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}
+
+export function AutopilotStatus({
+  state,
+  reason,
+  lastRunAt,
+}: {
+  state: AutopilotState;
+  reason: string;
+  lastRunAt: string | null;
+}) {
+  const s = STYLES[state];
+  const Icon = s.icon;
+  const lastRun = formatLastRun(lastRunAt);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border px-3.5 py-2.5",
+        s.ring,
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="relative flex size-2.5 shrink-0">
+        {state !== "stalled" && (
+          <span
+            className={cn(
+              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-60",
+              s.dot,
+            )}
+          />
+        )}
+        <span className={cn("relative inline-flex size-2.5 rounded-full", s.dot)} />
+      </span>
+      <Icon className={cn("size-4 shrink-0", s.text)} />
+      <span className={cn("text-sm font-semibold", s.text)}>{s.label}</span>
+      <span className="text-sm text-muted-foreground">— {reason}</span>
+      {lastRun && (
+        <span className="ml-auto text-xs text-muted-foreground/70">
+          last run {lastRun}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/content/autopilot/_components/channel-widgets.tsx
+++ b/src/app/dashboard/content/autopilot/_components/channel-widgets.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Link from "next/link";
+import { Plus, ChevronRight } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { ChannelWidget } from "@/hooks/use-home-summary";
+import { Sparkline } from "./sparkline";
+
+/**
+ * Per-channel widgets — one card per CONNECTED channel (the server only
+ * returns connected ones, so the grid never bloats with "available"
+ * logos the way the old Library page did). Each card is a launchpad:
+ * health at a glance, the four pending chips, a 7-day trend, a one-click
+ * "add content" (⊕) into that channel's composer, and a click-anywhere
+ * jump to the channel workspace.
+ */
+
+const HEALTH_DOT: Record<ChannelWidget["health"], string> = {
+  healthy: "bg-emerald-500",
+  attention: "bg-rose-500",
+  disconnected: "bg-muted-foreground/40",
+};
+
+const HEALTH_LABEL: Record<ChannelWidget["health"], string> = {
+  healthy: "Connected and healthy",
+  attention: "Needs reconnecting",
+  disconnected: "Disconnected",
+};
+
+function Chip({
+  count,
+  label,
+  tone,
+}: {
+  count: number;
+  label: string;
+  tone: "amber" | "rose" | "muted";
+}) {
+  if (count <= 0) return null;
+  const tones = {
+    amber:
+      "bg-amber-100 text-amber-700 dark:bg-amber-950/60 dark:text-amber-400",
+    rose: "bg-rose-100 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400",
+    muted: "bg-muted text-muted-foreground",
+  } as const;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+        tones[tone],
+      )}
+    >
+      <span className="tabular-nums">{count}</span>
+      <span className="font-normal">{label}</span>
+    </span>
+  );
+}
+
+function ChannelCard({ channel }: { channel: ChannelWidget }) {
+  const { counts } = channel;
+  const hasChips =
+    counts.needsApproval > 0 ||
+    counts.needsAttention > 0 ||
+    counts.scheduled > 0 ||
+    counts.ideas > 0;
+
+  return (
+    <Card className="group relative gap-0 overflow-hidden p-0 transition-shadow hover:shadow-md">
+      {/* Click-anywhere overlay to the channel workspace (sits under the
+          interactive ⊕ button, which stops propagation via its own link). */}
+      <Link
+        href={channel.openHref}
+        className="absolute inset-0 z-0"
+        aria-label={`Open ${channel.name}`}
+      />
+
+      <div className="relative z-10 flex items-start justify-between gap-2 p-4 pb-2">
+        <div className="flex items-center gap-2">
+          <ChannelIconCompact channel={channel.key} size={18} />
+          <span className="font-semibold">{channel.name}</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  "size-2 rounded-full",
+                  HEALTH_DOT[channel.health],
+                )}
+                aria-label={HEALTH_LABEL[channel.health]}
+              />
+            </TooltipTrigger>
+            <TooltipContent>{HEALTH_LABEL[channel.health]}</TooltipContent>
+          </Tooltip>
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              href={channel.openHref}
+              className="relative z-20 inline-flex size-7 items-center justify-center rounded-full border bg-background text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+              aria-label={`Add content for ${channel.name}`}
+            >
+              <Plus className="size-4" />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent>Add content</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="relative z-10 min-h-[2rem] px-4">
+        {hasChips ? (
+          <div className="flex flex-wrap gap-1.5">
+            <Chip count={counts.needsApproval} label="to approve" tone="amber" />
+            <Chip count={counts.needsAttention} label="needs attention" tone="rose" />
+            <Chip count={counts.scheduled} label="scheduled" tone="muted" />
+            <Chip count={counts.ideas} label="ideas" tone="muted" />
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground/70">
+            {channel.health === "attention"
+              ? "Reconnect to resume publishing"
+              : "Nothing pending — quiet and healthy"}
+          </p>
+        )}
+      </div>
+
+      <div className="relative z-10 mt-3 flex items-end justify-between gap-2 px-4 pb-3">
+        <div className="h-7">
+          <Sparkline data={channel.spark} />
+        </div>
+        <span className="inline-flex items-center gap-0.5 text-xs font-medium text-muted-foreground transition-colors group-hover:text-foreground">
+          Open
+          <ChevronRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+        </span>
+      </div>
+    </Card>
+  );
+}
+
+export function ChannelWidgets({ channels }: { channels: ChannelWidget[] }) {
+  return (
+    <div>
+      <h2 className="mb-2 text-sm font-semibold text-muted-foreground">
+        Channels
+      </h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {channels.map((ch) => (
+          <ChannelCard key={ch.key} channel={ch} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/content/autopilot/_components/kpi-row.tsx
+++ b/src/app/dashboard/content/autopilot/_components/kpi-row.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Send, Inbox, CalendarClock, type LucideIcon } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { HomeSummary } from "@/hooks/use-home-summary";
+
+/**
+ * Three honest, glanceable KPIs. We deliberately resist a wall of charts
+ * (a CEO-level decision): these three answer "did it ship, what do I owe
+ * it, what's coming" — the only numbers that change behaviour. "Needs you"
+ * is emphasised because it's the one that drives a return visit.
+ */
+
+interface Kpi {
+  key: keyof HomeSummary["kpis"];
+  label: string;
+  icon: LucideIcon;
+  hint: string;
+  emphasise?: boolean;
+}
+
+const KPIS: Kpi[] = [
+  {
+    key: "publishedThisWeek",
+    label: "Published this week",
+    icon: Send,
+    hint: "Posts the engine shipped in the last 7 days",
+  },
+  {
+    key: "needsYou",
+    label: "Needs you",
+    icon: Inbox,
+    hint: "Approvals, failed sends, and reconnects waiting on you",
+    emphasise: true,
+  },
+  {
+    key: "scheduledUpcoming",
+    label: "Scheduled",
+    icon: CalendarClock,
+    hint: "Posts queued to publish on their own",
+  },
+];
+
+export function KpiRow({ kpis }: { kpis: HomeSummary["kpis"] }) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {KPIS.map((k) => {
+        const value = kpis[k.key];
+        const Icon = k.icon;
+        const active = k.emphasise && value > 0;
+        return (
+          <Card
+            key={k.key}
+            className={cn(
+              "gap-0 p-4 transition-colors",
+              active && "border-amber-300 bg-amber-50/60 dark:border-amber-900/60 dark:bg-amber-950/30",
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-muted-foreground">
+                {k.label}
+              </span>
+              <Icon
+                className={cn(
+                  "size-4 text-muted-foreground/60",
+                  active && "text-amber-600 dark:text-amber-500",
+                )}
+              />
+            </div>
+            <div
+              className={cn(
+                "mt-1 text-3xl font-semibold tabular-nums tracking-tight",
+                active && "text-amber-700 dark:text-amber-400",
+              )}
+            >
+              {value}
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground/70">{k.hint}</p>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/dashboard/content/autopilot/_components/needs-you-rail.tsx
+++ b/src/app/dashboard/content/autopilot/_components/needs-you-rail.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+import {
+  PlugZap,
+  AlertCircle,
+  CheckSquare,
+  ChevronRight,
+  CheckCircle2,
+  type LucideIcon,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChannelIconCompact } from "@/components/ui/channel-icon";
+import { cn } from "@/lib/utils";
+import type { RailItem, RailItemType } from "@/hooks/use-home-summary";
+
+/**
+ * The "Needs you" rail — the hero of the Autopilot Home and the single
+ * biggest driver of a return visit. It surfaces exactly what's waiting on
+ * the human, in priority order (reconnect → failed → approve), each row a
+ * one-click jump to the place the action gets done.
+ *
+ * This is intentionally an approval/attention surface, not a compose
+ * console — it reflects the autopilot positioning: the engine did the
+ * work, you just unblock it.
+ */
+
+const TYPE_META: Record<
+  RailItemType,
+  { icon: LucideIcon; verb: string; tone: string; iconColor: string }
+> = {
+  reconnect: {
+    icon: PlugZap,
+    verb: "Reconnect",
+    tone: "border-l-rose-500",
+    iconColor: "text-rose-500",
+  },
+  failed: {
+    icon: AlertCircle,
+    verb: "Fix",
+    tone: "border-l-rose-500",
+    iconColor: "text-rose-500",
+  },
+  approve: {
+    icon: CheckSquare,
+    verb: "Review",
+    tone: "border-l-amber-500",
+    iconColor: "text-amber-500",
+  },
+};
+
+export function NeedsYouRail({
+  items,
+  totalCount,
+}: {
+  items: RailItem[];
+  totalCount: number;
+}) {
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      <CardHeader className="flex flex-row items-center justify-between gap-2 border-b bg-muted/30 px-4 py-3 [.border-b]:pb-3">
+        <CardTitle className="text-base">Needs you</CardTitle>
+        {totalCount > 0 && (
+          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-700 dark:bg-amber-950/60 dark:text-amber-400">
+            {totalCount}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {items.length === 0 ? (
+          <div className="flex flex-col items-center gap-1.5 px-4 py-10 text-center">
+            <CheckCircle2 className="size-7 text-emerald-500" />
+            <p className="text-sm font-medium">You&apos;re all caught up</p>
+            <p className="text-xs text-muted-foreground">
+              Nothing needs your attention. The autopilot will surface work here
+              as it comes up.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {items.map((item) => {
+              const meta = TYPE_META[item.type];
+              const Icon = meta.icon;
+              return (
+                <li key={`${item.type}-${item.refId}`}>
+                  <Link
+                    href={item.ctaHref}
+                    className={cn(
+                      "group flex items-center gap-3 border-l-2 px-4 py-3 transition-colors hover:bg-muted/50",
+                      meta.tone,
+                    )}
+                  >
+                    <Icon className={cn("size-4 shrink-0", meta.iconColor)} />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">{item.title}</p>
+                      <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <span className="font-medium text-foreground/70">
+                          {meta.verb}
+                        </span>
+                        {item.channel && (
+                          <>
+                            <span aria-hidden>·</span>
+                            <ChannelIconCompact channel={item.channel} size={12} />
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <ChevronRight className="size-4 shrink-0 text-muted-foreground/40 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/content/autopilot/_components/sparkline.tsx
+++ b/src/app/dashboard/content/autopilot/_components/sparkline.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Tiny inline-SVG sparkline for the channel widgets — a 7-day impressions
+ * trend. Deliberately dependency-free (no recharts per-widget overhead):
+ * it's a decorative micro-trend, not an interactive chart. Renders nothing
+ * when there's no series or the series is flat-zero, so a channel with no
+ * analytics yet shows a clean gap rather than a misleading flat line.
+ */
+export function Sparkline({
+  data,
+  className,
+  width = 96,
+  height = 28,
+}: {
+  data: number[];
+  className?: string;
+  width?: number;
+  height?: number;
+}) {
+  if (!data || data.length < 2) return null;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  if (max <= 0) return null; // all-zero → no trend to show
+
+  const range = max - min || 1;
+  const stepX = width / (data.length - 1);
+  const points = data.map((v, i) => {
+    const x = i * stepX;
+    // Inset by 2px top/bottom so the stroke isn't clipped.
+    const y = height - 2 - ((v - min) / range) * (height - 4);
+    return [x, y] as const;
+  });
+
+  const linePath = points
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`)
+    .join(" ");
+  const areaPath = `${linePath} L${width},${height} L0,${height} Z`;
+  const gradId = `spark-grad-${width}-${height}`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn("overflow-visible text-primary", className)}
+      aria-hidden="true"
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={areaPath} fill={`url(#${gradId})`} stroke="none" />
+      <path
+        d={linePath}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/app/dashboard/content/autopilot/page.tsx
+++ b/src/app/dashboard/content/autopilot/page.tsx
@@ -60,7 +60,7 @@ export default function AutopilotHomePage() {
     if (isProd) router.replace("/dashboard/content");
   }, [isProd, router]);
 
-  const { data, isLoading, isError, refetch } = useHomeSummary();
+  const { data, isLoading, isError, refetch } = useHomeSummary({ enabled: !isProd });
 
   if (isProd) return null;
 

--- a/src/app/dashboard/content/autopilot/page.tsx
+++ b/src/app/dashboard/content/autopilot/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { useHomeSummary, homeSummaryKey } from "@/hooks/use-home-summary";
+import { AutopilotStatus } from "./_components/autopilot-status";
+import { KpiRow } from "./_components/kpi-row";
+import { NeedsYouRail } from "./_components/needs-you-rail";
+import { ChannelWidgets } from "./_components/channel-widgets";
+import { AutopilotEmpty } from "./_components/autopilot-empty";
+
+/**
+ * Content > Autopilot — the entitlement-composed content command center.
+ * Answers "what did the engine do, and what does it need from me?" via the
+ * autopilot status chip, three honest KPIs, the Needs-you approval rail
+ * (the hero), and per-channel widgets.
+ *
+ * Ships DARK in production: the page route is gated on
+ * NEXT_PUBLIC_VERCEL_ENV (mirrors the in_development surfacing state of the
+ * content.autopilot_home feature) so it's visible in non-prod for
+ * side-by-side comparison with the existing Library page, and 404-style
+ * redirected in prod until we flip it on. The nav item is gated the same
+ * way in the dashboard layout.
+ */
+
+function isProductionEnv(): boolean {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+}
+
+function LoadingState() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-12 w-full rounded-xl" />
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Skeleton className="h-24 rounded-xl" />
+        <Skeleton className="h-24 rounded-xl" />
+        <Skeleton className="h-24 rounded-xl" />
+      </div>
+      <Skeleton className="h-48 w-full rounded-xl" />
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="h-40 rounded-xl" />
+        <Skeleton className="h-40 rounded-xl" />
+        <Skeleton className="h-40 rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+export default function AutopilotHomePage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const isProd = isProductionEnv();
+
+  // Hard guard: a direct prod URL must not render the dark page.
+  useEffect(() => {
+    if (isProd) router.replace("/dashboard/content");
+  }, [isProd, router]);
+
+  const { data, isLoading, isError, refetch } = useHomeSummary();
+
+  if (isProd) return null;
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      <CronToolbar
+        crons={["publish-scheduled", "publish-retry", "recurring-spawn"]}
+        onTriggered={() =>
+          queryClient.invalidateQueries({ queryKey: homeSummaryKey })
+        }
+      />
+
+      {/* Header */}
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Autopilot</h1>
+        <p className="text-sm text-muted-foreground">
+          What your content engine did, and what it needs from you.
+        </p>
+      </div>
+
+      {isLoading && <LoadingState />}
+
+      {isError && !isLoading && (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed py-16 text-center">
+          <p className="text-sm font-medium">Couldn&apos;t load your autopilot</p>
+          <p className="max-w-sm text-xs text-muted-foreground">
+            We hit a snag fetching your summary. Your data is safe — try again.
+          </p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {data && !isLoading && (
+        <div className="flex flex-col gap-5">
+          <AutopilotStatus
+            state={data.autopilot.state}
+            reason={data.autopilot.reason}
+            lastRunAt={data.autopilot.lastRunAt}
+          />
+
+          {data.channels.length === 0 ? (
+            <AutopilotEmpty />
+          ) : (
+            <>
+              <KpiRow kpis={data.kpis} />
+              <NeedsYouRail items={data.needsYou} totalCount={data.kpis.needsYou} />
+              <ChannelWidgets channels={data.channels} />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -75,6 +75,13 @@ interface NavGroup {
   items: NavItem[];
 }
 
+// Autopilot Home ships dark: surfaced only in non-prod (mirrors the
+// content.autopilot_home feature's in_development state) so it can run
+// side-by-side with Library for comparison before launch. NEXT_PUBLIC_*
+// is build-inlined, so this static const is safe at module scope. The
+// page route enforces the same gate server-trip-free via a redirect.
+const SHOW_AUTOPILOT = process.env.NEXT_PUBLIC_VERCEL_ENV !== "production";
+
 const NAV_GROUPS: NavGroup[] = [
   {
     label: "",
@@ -92,6 +99,11 @@ const NAV_GROUPS: NavGroup[] = [
         // owners visit them rarely. Per the LinkedIn 360 plan §3.3 IA
         // decision (with the Seasonal Events addition).
         subItems: [
+          // Autopilot leads the mental model: status → act, then the
+          // existing ingest → ground → plan → publish chain below.
+          ...(SHOW_AUTOPILOT
+            ? [{ href: "/dashboard/content/autopilot", label: "Autopilot" }]
+            : []),
           { href: "/dashboard/content", label: "Library" },
           { href: "/dashboard/content/sources", label: "Sources" },
           { href: "/dashboard/content/news", label: "News Desk" },

--- a/src/hooks/use-home-summary.ts
+++ b/src/hooks/use-home-summary.ts
@@ -71,10 +71,14 @@ export interface HomeSummary {
 
 export const homeSummaryKey = ["home", "summary"] as const;
 
-export function useHomeSummary() {
+export function useHomeSummary(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: homeSummaryKey,
     queryFn: () => api.get<HomeSummary>("/v1/home/summary"),
+    // Caller can disable the fetch entirely — the page passes `!isProd`
+    // so the dark-in-prod build issues zero network chatter before its
+    // redirect fires.
+    enabled: options?.enabled ?? true,
     // The rail/widgets reflect cron-moved state; 60s keeps it fresh
     // without hammering. Stop on error so a stale auth cookie doesn't
     // spin one failed request per minute on this route.

--- a/src/hooks/use-home-summary.ts
+++ b/src/hooks/use-home-summary.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+/**
+ * Data hook for the Autopilot Home (Content > Autopilot).
+ *
+ * Backed by GET /v1/home/summary — one round trip returns the KPIs, the
+ * autopilot status, the priority-ordered Needs-you rail, and per-channel
+ * widgets. Polls on a gentle cadence because the underlying data
+ * (scheduled items, pipeline runs) is moved by crons; the page also wires
+ * a CronToolbar (non-prod) whose onTriggered invalidates this key for an
+ * instant refresh after a manual trigger.
+ */
+
+export type AutopilotState = "working" | "waiting" | "stalled";
+export type ChannelHealth = "healthy" | "attention" | "disconnected";
+export type RailItemType = "reconnect" | "failed" | "approve";
+
+export interface RailItem {
+  type: RailItemType;
+  channel: string;
+  refId: string;
+  title: string;
+  ctaHref: string;
+}
+
+export interface ChannelWidget {
+  key: string;
+  name: string;
+  health: ChannelHealth;
+  counts: {
+    needsApproval: number;
+    scheduled: number;
+    needsAttention: number;
+    ideas: number;
+  };
+  /** 7-day impressions series, oldest → newest. Empty when no series exists. */
+  spark: number[];
+  openHref: string;
+}
+
+export interface CommerceLane {
+  connected: boolean;
+  productCount: number | null;
+  contentCount: number | null;
+  /** Deferred — money-loop attribution lands in a later PR. */
+  moneyLoop: {
+    revenueAttributed?: number;
+    orders?: number;
+    topDriver?: string;
+    currency?: string;
+  } | null;
+}
+
+export interface HomeSummary {
+  generatedAt: string;
+  entitlements: { marketing: boolean; commerce: boolean };
+  kpis: {
+    publishedThisWeek: number;
+    needsYou: number;
+    scheduledUpcoming: number;
+  };
+  autopilot: { state: AutopilotState; reason: string; lastRunAt: string | null };
+  needsYou: RailItem[];
+  channels: ChannelWidget[];
+  commerce: CommerceLane | null;
+  moveOfTheWeek: unknown | null;
+}
+
+export const homeSummaryKey = ["home", "summary"] as const;
+
+export function useHomeSummary() {
+  return useQuery({
+    queryKey: homeSummaryKey,
+    queryFn: () => api.get<HomeSummary>("/v1/home/summary"),
+    // The rail/widgets reflect cron-moved state; 60s keeps it fresh
+    // without hammering. Stop on error so a stale auth cookie doesn't
+    // spin one failed request per minute on this route.
+    refetchInterval: (q) => (q.state.error ? false : 60_000),
+    refetchIntervalInBackground: false,
+    staleTime: 30_000,
+  });
+}


### PR DESCRIPTION
## What
The new **Content → Autopilot** page — an entitlement-composed content command center wired to `GET /v1/home/summary`. **PR-3 of 4.** It takes over the role the Library page plays as the content entry point; **Library is kept untouched** and rendered alongside (in non-prod) for side-by-side comparison.

## Surfaces (top → bottom)
- **Autopilot status chip** — plain-language *working / waiting on you / needs attention*; the emotional anchor proving the engine is alive (pulse dot, `aria-live`).
- **3 honest KPIs** — *Published this week / Needs you / Scheduled*. Deliberately **no vanity graph wall** (CEO call); "Needs you" is emphasised as the return-visit driver.
- **Needs-you rail (hero)** — priority-ordered approvals / fixes / reconnects, each a one-click jump; an "all caught up" state when empty.
- **Per-channel widgets** — *connected channels only* (no logo bloat), health dot + the four pending chips + a dependency-free 7-day sparkline + ⊕ add-content + click-anywhere → channel workspace.
- **Cold-start "warming up" empty state** — never a wall of empty graphs.

## Ships DARK
The nav item (`layout.tsx`, module-scope `SHOW_AUTOPILOT`) and the page route (redirect guard + `enabled:!isProd` on the query) are gated on `NEXT_PUBLIC_VERCEL_ENV !== "production"`, mirroring the `in_development` surfacing of `content.autopilot_home`. Visible in non-prod, redirects to Library in prod until launch. Zero prod network chatter.

## Notes
- UI built from the in-house design-system primitives (Card / Badge / Tooltip / Empty / channel-icon), consistent with how Library itself is built. (The shadcn registry MCP wasn't reachable from the session cwd; primitives match the same ecosystem.)
- `CronToolbar` (non-prod) covers the publish/recurring crons that move the rail + widget data and invalidates the query on manual trigger — per the project CronToolbar rule.
- Active-nav: the existing `hasMoreSpecificSibling` logic correctly lights only Autopilot (not Library) on the deeper route.

## Verification
`tsc` clean · `eslint` clean · `next build` compiles `/dashboard/content/autopilot`. Manual + subagent review done (all 7 axes PASS: dark-in-prod gating, type/payload match, no nested `<a>`, sparkline NaN-safety, query-key stability, active-nav, ⊕ focusability). The one optional note (suppress prod fetch) was applied as a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)