### PR TITLE
feat(linkedin): poll composer (CMA Phase D5 UI)

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/poll-editor.test.ts
+++ b/src/app/dashboard/content/linkedin/_components/poll-editor.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { emptyPoll, isPollValid, type PollState } from "./poll-editor";
+
+describe("emptyPoll", () => {
+  it("starts with two blank options and a default duration", () => {
+    expect(emptyPoll()).toEqual({ question: "", options: ["", ""], duration: "SEVEN_DAYS" });
+  });
+});
+
+describe("isPollValid", () => {
+  const base: PollState = { question: "Best framework?", options: ["A", "B"], duration: "ONE_DAY" };
+
+  it("accepts a question with 2 non-blank options", () => {
+    expect(isPollValid(base)).toBe(true);
+  });
+
+  it("accepts up to 4 options", () => {
+    expect(isPollValid({ ...base, options: ["A", "B", "C", "D"] })).toBe(true);
+  });
+
+  it("rejects an empty / whitespace-only question", () => {
+    expect(isPollValid({ ...base, question: "" })).toBe(false);
+    expect(isPollValid({ ...base, question: "   " })).toBe(false);
+  });
+
+  it("rejects a question longer than 140 chars", () => {
+    expect(isPollValid({ ...base, question: "x".repeat(141) })).toBe(false);
+    expect(isPollValid({ ...base, question: "x".repeat(140) })).toBe(true);
+  });
+
+  it("rejects fewer than 2 non-blank options (blanks dropped)", () => {
+    expect(isPollValid({ ...base, options: ["A", "   "] })).toBe(false);
+    expect(isPollValid({ ...base, options: ["A", ""] })).toBe(false);
+  });
+
+  it("rejects more than 4 options", () => {
+    expect(isPollValid({ ...base, options: ["A", "B", "C", "D", "E"] })).toBe(false);
+  });
+
+  it("rejects an option longer than 30 chars", () => {
+    expect(isPollValid({ ...base, options: ["A", "y".repeat(31)] })).toBe(false);
+    expect(isPollValid({ ...base, options: ["A", "y".repeat(30)] })).toBe(true);
+  });
+});

--- a/src/app/dashboard/content/linkedin/_components/poll-editor.test.ts
+++ b/src/app/dashboard/content/linkedin/_components/poll-editor.test.ts
@@ -1,44 +1,65 @@
 import { describe, it, expect } from "vitest";
 import { emptyPoll, isPollValid, type PollState } from "./poll-editor";
 
+/** Build a PollState from plain option strings (the editor stores {id,text}). */
+function pollFrom(question: string, options: string[]): PollState {
+  return {
+    question,
+    options: options.map((text, i) => ({ id: `opt-${i}`, text })),
+    duration: "ONE_DAY",
+  };
+}
+
 describe("emptyPoll", () => {
-  it("starts with two blank options and a default duration", () => {
-    expect(emptyPoll()).toEqual({ question: "", options: ["", ""], duration: "SEVEN_DAYS" });
+  it("starts with two blank options (with ids) and a default duration", () => {
+    const p = emptyPoll();
+    expect(p.question).toBe("");
+    expect(p.duration).toBe("SEVEN_DAYS");
+    expect(p.options).toHaveLength(2);
+    expect(p.options.every((o) => o.text === "")).toBe(true);
+    // ids are present and distinct so React keys are stable across edits
+    expect(p.options[0].id).not.toBe(p.options[1].id);
   });
 });
 
 describe("isPollValid", () => {
-  const base: PollState = { question: "Best framework?", options: ["A", "B"], duration: "ONE_DAY" };
-
-  it("accepts a question with 2 non-blank options", () => {
-    expect(isPollValid(base)).toBe(true);
+  it("accepts a question with 2 non-blank distinct options", () => {
+    expect(isPollValid(pollFrom("Best framework?", ["A", "B"]))).toBe(true);
   });
 
   it("accepts up to 4 options", () => {
-    expect(isPollValid({ ...base, options: ["A", "B", "C", "D"] })).toBe(true);
+    expect(isPollValid(pollFrom("Q", ["A", "B", "C", "D"]))).toBe(true);
   });
 
   it("rejects an empty / whitespace-only question", () => {
-    expect(isPollValid({ ...base, question: "" })).toBe(false);
-    expect(isPollValid({ ...base, question: "   " })).toBe(false);
+    expect(isPollValid(pollFrom("", ["A", "B"]))).toBe(false);
+    expect(isPollValid(pollFrom("   ", ["A", "B"]))).toBe(false);
   });
 
-  it("rejects a question longer than 140 chars", () => {
-    expect(isPollValid({ ...base, question: "x".repeat(141) })).toBe(false);
-    expect(isPollValid({ ...base, question: "x".repeat(140) })).toBe(true);
+  it("rejects a question longer than 140 chars (140 ok)", () => {
+    expect(isPollValid(pollFrom("x".repeat(141), ["A", "B"]))).toBe(false);
+    expect(isPollValid(pollFrom("x".repeat(140), ["A", "B"]))).toBe(true);
   });
 
   it("rejects fewer than 2 non-blank options (blanks dropped)", () => {
-    expect(isPollValid({ ...base, options: ["A", "   "] })).toBe(false);
-    expect(isPollValid({ ...base, options: ["A", ""] })).toBe(false);
+    expect(isPollValid(pollFrom("Q", ["A", "   "]))).toBe(false);
+    expect(isPollValid(pollFrom("Q", ["A", ""]))).toBe(false);
   });
 
   it("rejects more than 4 options", () => {
-    expect(isPollValid({ ...base, options: ["A", "B", "C", "D", "E"] })).toBe(false);
+    expect(isPollValid(pollFrom("Q", ["A", "B", "C", "D", "E"]))).toBe(false);
   });
 
-  it("rejects an option longer than 30 chars", () => {
-    expect(isPollValid({ ...base, options: ["A", "y".repeat(31)] })).toBe(false);
-    expect(isPollValid({ ...base, options: ["A", "y".repeat(30)] })).toBe(true);
+  it("rejects an option longer than 30 chars (30 ok, trim-before-length)", () => {
+    expect(isPollValid(pollFrom("Q", ["A", "y".repeat(31)]))).toBe(false);
+    expect(isPollValid(pollFrom("Q", ["A", "y".repeat(30)]))).toBe(true);
+    // length is measured AFTER trimming
+    expect(isPollValid(pollFrom("Q", ["A", "  " + "y".repeat(30) + "  "]))).toBe(true);
+  });
+
+  it("rejects duplicate options (case-insensitive, trimmed)", () => {
+    expect(isPollValid(pollFrom("Q", ["Yes", "Yes"]))).toBe(false);
+    expect(isPollValid(pollFrom("Q", ["Yes", " yes "]))).toBe(false);
+    expect(isPollValid(pollFrom("Q", ["Yes", "No"]))).toBe(true);
   });
 });

--- a/src/app/dashboard/content/linkedin/_components/poll-editor.tsx
+++ b/src/app/dashboard/content/linkedin/_components/poll-editor.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ListChecks, Plus, X } from "lucide-react";
+import type { LinkedInPollDuration } from "@/lib/api/linkedin-content";
+
+// Mirror the LinkedIn Poll API limits (confirmed vs live 202605 poll-post-api).
+export const POLL_QUESTION_MAX = 140;
+export const POLL_OPTION_MAX = 30;
+export const POLL_MIN_OPTIONS = 2;
+export const POLL_MAX_OPTIONS = 4;
+
+export interface PollState {
+  question: string;
+  /** Always holds 2–4 entries in the editor; blanks are dropped on submit. */
+  options: string[];
+  duration: LinkedInPollDuration;
+}
+
+/** A fresh poll with two empty options and a sensible default duration. */
+export function emptyPoll(): PollState {
+  return { question: "", options: ["", ""], duration: "SEVEN_DAYS" };
+}
+
+/**
+ * Whether the poll is publishable: a non-empty question within length, and
+ * 2–4 non-blank options each within length. Mirrors the server's
+ * `buildPollContent` rules so the button state matches the API.
+ */
+export function isPollValid(poll: PollState): boolean {
+  const question = poll.question.trim();
+  if (question.length === 0 || question.length > POLL_QUESTION_MAX) return false;
+  const options = poll.options.map((o) => o.trim()).filter((o) => o.length > 0);
+  if (options.length < POLL_MIN_OPTIONS || options.length > POLL_MAX_OPTIONS) return false;
+  return options.every((o) => o.length <= POLL_OPTION_MAX);
+}
+
+const DURATION_LABELS: Record<LinkedInPollDuration, string> = {
+  ONE_DAY: "1 day",
+  THREE_DAYS: "3 days",
+  SEVEN_DAYS: "1 week",
+  FOURTEEN_DAYS: "2 weeks",
+};
+const DURATION_ORDER: LinkedInPollDuration[] = [
+  "ONE_DAY",
+  "THREE_DAYS",
+  "SEVEN_DAYS",
+  "FOURTEEN_DAYS",
+];
+
+/**
+ * Poll editor block (CMA D5). Controlled — the composer owns the `PollState`
+ * so it can validate + submit it. A poll is an exclusive content block, so the
+ * composer hides the link/carousel affordances while this is mounted.
+ */
+export function PollEditor({
+  value,
+  onChange,
+  onRemove,
+}: {
+  value: PollState;
+  onChange: (next: PollState) => void;
+  onRemove: () => void;
+}) {
+  const setOption = (index: number, text: string) => {
+    const options = value.options.slice();
+    options[index] = text;
+    onChange({ ...value, options });
+  };
+  const addOption = () => {
+    if (value.options.length >= POLL_MAX_OPTIONS) return;
+    onChange({ ...value, options: [...value.options, ""] });
+  };
+  const removeOption = (index: number) => {
+    if (value.options.length <= POLL_MIN_OPTIONS) return;
+    onChange({ ...value, options: value.options.filter((_, i) => i !== index) });
+  };
+
+  const questionTooLong = value.question.trim().length > POLL_QUESTION_MAX;
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex items-center justify-between">
+        <Label className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted-foreground">
+          <ListChecks className="size-3.5" /> Poll
+        </Label>
+        <Button type="button" variant="ghost" size="sm" onClick={onRemove}>
+          <X className="size-3.5 mr-1" /> Remove poll
+        </Button>
+      </div>
+
+      <div className="space-y-1.5">
+        <Input
+          value={value.question}
+          onChange={(e) => onChange({ ...value, question: e.target.value })}
+          placeholder="Ask a question…"
+          maxLength={POLL_QUESTION_MAX}
+          aria-label="Poll question"
+          aria-invalid={questionTooLong}
+        />
+        <p className="text-right text-[11px] text-muted-foreground tabular-nums">
+          {value.question.trim().length}/{POLL_QUESTION_MAX}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {value.options.map((opt, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <Input
+              value={opt}
+              onChange={(e) => setOption(i, e.target.value)}
+              placeholder={`Option ${i + 1}`}
+              maxLength={POLL_OPTION_MAX}
+              aria-label={`Poll option ${i + 1}`}
+            />
+            {value.options.length > POLL_MIN_OPTIONS && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8 shrink-0"
+                onClick={() => removeOption(i)}
+                aria-label={`Remove option ${i + 1}`}
+              >
+                <X className="size-3.5" />
+              </Button>
+            )}
+          </div>
+        ))}
+        {value.options.length < POLL_MAX_OPTIONS && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={addOption}
+            className="h-7 gap-1.5 px-2 text-xs"
+          >
+            <Plus className="size-3.5" /> Add option
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="poll-duration" className="text-xs uppercase tracking-wide text-muted-foreground">
+          Poll duration
+        </Label>
+        <Select
+          value={value.duration}
+          onValueChange={(d) => onChange({ ...value, duration: d as LinkedInPollDuration })}
+        >
+          <SelectTrigger id="poll-duration">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DURATION_ORDER.map((d) => (
+              <SelectItem key={d} value={d}>
+                {DURATION_LABELS[d]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/content/linkedin/_components/poll-editor.tsx
+++ b/src/app/dashboard/content/linkedin/_components/poll-editor.tsx
@@ -19,29 +19,49 @@ export const POLL_OPTION_MAX = 30;
 export const POLL_MIN_OPTIONS = 2;
 export const POLL_MAX_OPTIONS = 4;
 
+/** An editor option. The `id` is a stable React key so removing an option
+ *  mid-edit doesn't smear focus/caret across the remaining inputs (index keys
+ *  would). It never leaves the editor — submit sends only the text. */
+export interface PollOption {
+  id: string;
+  text: string;
+}
+
 export interface PollState {
   question: string;
   /** Always holds 2–4 entries in the editor; blanks are dropped on submit. */
-  options: string[];
+  options: PollOption[];
   duration: LinkedInPollDuration;
+}
+
+function newOption(): PollOption {
+  return { id: crypto.randomUUID(), text: "" };
 }
 
 /** A fresh poll with two empty options and a sensible default duration. */
 export function emptyPoll(): PollState {
-  return { question: "", options: ["", ""], duration: "SEVEN_DAYS" };
+  return { question: "", options: [newOption(), newOption()], duration: "SEVEN_DAYS" };
+}
+
+/** Normalize an option for comparison/dedup (trim + case-fold). */
+function normalizeOption(text: string): string {
+  return text.trim().toLowerCase();
 }
 
 /**
  * Whether the poll is publishable: a non-empty question within length, and
- * 2–4 non-blank options each within length. Mirrors the server's
- * `buildPollContent` rules so the button state matches the API.
+ * 2–4 non-blank, DISTINCT options each within length. Mirrors the server's
+ * `buildPollContent` rules (LinkedIn also rejects duplicate option text), so
+ * the publish button state matches what the API will accept.
  */
 export function isPollValid(poll: PollState): boolean {
   const question = poll.question.trim();
   if (question.length === 0 || question.length > POLL_QUESTION_MAX) return false;
-  const options = poll.options.map((o) => o.trim()).filter((o) => o.length > 0);
-  if (options.length < POLL_MIN_OPTIONS || options.length > POLL_MAX_OPTIONS) return false;
-  return options.every((o) => o.length <= POLL_OPTION_MAX);
+  const texts = poll.options.map((o) => o.text.trim()).filter((o) => o.length > 0);
+  if (texts.length < POLL_MIN_OPTIONS || texts.length > POLL_MAX_OPTIONS) return false;
+  if (texts.some((o) => o.length > POLL_OPTION_MAX)) return false;
+  const distinct = new Set(texts.map((o) => o.toLowerCase()));
+  return distinct.size === texts.length;
 }
 
 const DURATION_LABELS: Record<LinkedInPollDuration, string> = {
@@ -71,21 +91,29 @@ export function PollEditor({
   onChange: (next: PollState) => void;
   onRemove: () => void;
 }) {
-  const setOption = (index: number, text: string) => {
-    const options = value.options.slice();
-    options[index] = text;
-    onChange({ ...value, options });
+  const setOption = (id: string, text: string) => {
+    onChange({
+      ...value,
+      options: value.options.map((o) => (o.id === id ? { ...o, text } : o)),
+    });
   };
   const addOption = () => {
     if (value.options.length >= POLL_MAX_OPTIONS) return;
-    onChange({ ...value, options: [...value.options, ""] });
+    onChange({ ...value, options: [...value.options, newOption()] });
   };
-  const removeOption = (index: number) => {
+  const removeOption = (id: string) => {
     if (value.options.length <= POLL_MIN_OPTIONS) return;
-    onChange({ ...value, options: value.options.filter((_, i) => i !== index) });
+    onChange({ ...value, options: value.options.filter((o) => o.id !== id) });
   };
 
-  const questionTooLong = value.question.trim().length > POLL_QUESTION_MAX;
+  // Flag any option whose (trimmed, case-folded) text duplicates another so we
+  // can show an inline hint instead of letting LinkedIn reject the post.
+  const seen = new Map<string, number>();
+  for (const o of value.options) {
+    const key = normalizeOption(o.text);
+    if (key) seen.set(key, (seen.get(key) ?? 0) + 1);
+  }
+  const hasDuplicates = [...seen.values()].some((n) => n > 1);
 
   return (
     <div className="space-y-3 rounded-md border p-3">
@@ -105,7 +133,6 @@ export function PollEditor({
           placeholder="Ask a question…"
           maxLength={POLL_QUESTION_MAX}
           aria-label="Poll question"
-          aria-invalid={questionTooLong}
         />
         <p className="text-right text-[11px] text-muted-foreground tabular-nums">
           {value.question.trim().length}/{POLL_QUESTION_MAX}
@@ -113,29 +140,36 @@ export function PollEditor({
       </div>
 
       <div className="space-y-2">
-        {value.options.map((opt, i) => (
-          <div key={i} className="flex items-center gap-2">
-            <Input
-              value={opt}
-              onChange={(e) => setOption(i, e.target.value)}
-              placeholder={`Option ${i + 1}`}
-              maxLength={POLL_OPTION_MAX}
-              aria-label={`Poll option ${i + 1}`}
-            />
-            {value.options.length > POLL_MIN_OPTIONS && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-8 shrink-0"
-                onClick={() => removeOption(i)}
-                aria-label={`Remove option ${i + 1}`}
-              >
-                <X className="size-3.5" />
-              </Button>
-            )}
-          </div>
-        ))}
+        {value.options.map((opt, i) => {
+          const isDup = opt.text.trim().length > 0 && (seen.get(normalizeOption(opt.text)) ?? 0) > 1;
+          return (
+            <div key={opt.id} className="flex items-center gap-2">
+              <Input
+                value={opt.text}
+                onChange={(e) => setOption(opt.id, e.target.value)}
+                placeholder={`Option ${i + 1}`}
+                maxLength={POLL_OPTION_MAX}
+                aria-label={`Poll option ${i + 1}`}
+                aria-invalid={isDup}
+              />
+              {value.options.length > POLL_MIN_OPTIONS && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 shrink-0"
+                  onClick={() => removeOption(opt.id)}
+                  aria-label={`Remove option ${i + 1}`}
+                >
+                  <X className="size-3.5" />
+                </Button>
+              )}
+            </div>
+          );
+        })}
+        {hasDuplicates && (
+          <p className="text-xs text-destructive">Poll options must be unique.</p>
+        )}
         {value.options.length < POLL_MAX_OPTIONS && (
           <Button
             type="button"

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -36,6 +36,7 @@ import {
   ChevronDown,
   GalleryHorizontalEnd,
   Link2,
+  ListChecks,
   Loader2,
   Mic,
   Send,
@@ -61,6 +62,7 @@ import {
   type RewriteHookResponse,
 } from "@/lib/api/linkedin-content";
 import { CarouselPreviewDialog } from "./carousel-preview-dialog";
+import { PollEditor, emptyPoll, isPollValid, type PollState } from "./poll-editor";
 import { ApiError } from "@/lib/api";
 import { rewriteContent, createDraft, updateDraft, type ComposerDraftRef } from "@/lib/api/content";
 import { insertAtCaret } from "@/lib/composer/caret";
@@ -162,6 +164,10 @@ export function PostComposer({ identity, seedText }: Props) {
   const [showLink, setShowLink] = useState(false);
   const [linkUrl, setLinkUrl] = useState("");
   const [linkTitle, setLinkTitle] = useState("");
+  // Poll (CMA D5). null = no poll. A poll is an exclusive content block, so
+  // turning it on clears the link, and carousel/schedule are disabled while it
+  // is active (the carousel + scheduler paths don't carry a poll).
+  const [poll, setPoll] = useState<PollState | null>(null);
   const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
 
   // Author picker — discriminated union string keys for the Select.
@@ -344,23 +350,42 @@ export function PostComposer({ identity, seedText }: Props) {
     setLinkUrl("");
     setLinkTitle("");
     setShowLink(false);
+    setPoll(null);
     setVariants(null);
     setDraftId(null);
     setMode("compose");
   }
+
+  /** Toggle the poll editor. Turning it on clears the link (a poll is an
+   *  exclusive content block); turning it off drops the poll fields. */
+  const togglePoll = useCallback(() => {
+    setPoll((prev) => {
+      if (prev) return null;
+      setShowLink(false);
+      setLinkUrl("");
+      setLinkTitle("");
+      return emptyPoll();
+    });
+  }, []);
 
   const remaining = MAX_LEN - text.length;
   const tooLong = remaining < 0;
   const empty = text.trim().length === 0;
   const linkInvalid = showLink && linkUrl.trim().length > 0 && !isProbablyUrl(linkUrl);
   const anyPending = publish.isPending || carousel.isPending;
-  const publishDisabled = empty || tooLong || anyPending || linkInvalid;
-  const scheduleDisabled = empty || tooLong || linkInvalid;
+  // A poll, when active, must be complete before publish. The commentary
+  // (text) is still required — it shows above the poll.
+  const pollActive = poll !== null;
+  const pollOk = !pollActive || isPollValid(poll);
+  const publishDisabled = empty || tooLong || anyPending || linkInvalid || !pollOk;
+  // Scheduling + carousel don't carry a poll, so they're unavailable while a
+  // poll is active.
+  const scheduleDisabled = empty || tooLong || linkInvalid || pollActive;
   // Carousel needs enough text to split into slides; a link card doesn't
   // apply to a carousel (it's a document post), so a pending/invalid link
   // doesn't block it — but the min-length + pending guards do.
   const carouselTooShort = text.trim().length < CAROUSEL_MIN_CHARS;
-  const carouselDisabled = empty || tooLong || carouselTooShort || anyPending;
+  const carouselDisabled = empty || tooLong || carouselTooShort || anyPending || pollActive;
 
   function onSubmit() {
     if (publishDisabled) return;
@@ -376,7 +401,15 @@ export function PostComposer({ identity, seedText }: Props) {
       visibility: effectiveVisibility,
     };
 
-    if (showLink && linkUrl.trim()) {
+    if (poll) {
+      // A poll is exclusive — never combine it with a link. Trim the question
+      // and drop blank options (the server validates 2–4 / lengths too).
+      body.poll = {
+        question: poll.question.trim(),
+        options: poll.options.map((o) => o.trim()).filter((o) => o.length > 0),
+        duration: poll.duration,
+      };
+    } else if (showLink && linkUrl.trim()) {
       body.link = {
         url: linkUrl.trim(),
         title: linkTitle.trim() || undefined,
@@ -567,11 +600,18 @@ export function PostComposer({ identity, seedText }: Props) {
         label: showLink ? "Link attached" : "Attach a link",
         group: "Compose",
         icon: Link2,
-        disabled: showLink,
+        disabled: showLink || pollActive,
         run: () => setShowLink(true),
       },
+      {
+        id: "toggle-poll",
+        label: pollActive ? "Remove poll" : "Add a poll",
+        group: "Compose",
+        icon: ListChecks,
+        run: togglePoll,
+      },
     ],
-    [handleAiAction, text, empty, scheduleDisabled, showLink],
+    [handleAiAction, text, empty, scheduleDisabled, showLink, pollActive, togglePoll],
   );
 
   // ── Schedule view ───────────────────────────────────────────────
@@ -698,6 +738,22 @@ export function PostComposer({ identity, seedText }: Props) {
           </Button>
           <Button
             type="button"
+            variant={pollActive ? "secondary" : "outline"}
+            size="sm"
+            onClick={togglePoll}
+            aria-pressed={pollActive}
+            className="gap-1.5"
+            title={
+              pollActive
+                ? "Remove the poll"
+                : "Add a poll (question + 2–4 options). Your text shows above the poll."
+            }
+          >
+            <ListChecks className="size-4" />
+            Poll
+          </Button>
+          <Button
+            type="button"
             variant="outline"
             size="sm"
             onClick={onCarousel}
@@ -783,7 +839,7 @@ export function PostComposer({ identity, seedText }: Props) {
 
       <div className="flex items-center gap-2">
         <EmojiPickerTrigger onInsert={insertSnippet} />
-        {!showLink && (
+        {!showLink && !pollActive && (
           <Button type="button" variant="ghost" size="sm" onClick={() => setShowLink(true)} className="h-7 gap-1.5 px-2 text-xs">
             <Link2 className="size-3.5" /> Add link
           </Button>
@@ -806,6 +862,10 @@ export function PostComposer({ identity, seedText }: Props) {
           onPick={applyVariant}
           onDismiss={() => setVariants(null)}
         />
+      )}
+
+      {poll && (
+        <PollEditor value={poll} onChange={setPoll} onRemove={() => setPoll(null)} />
       )}
 
       {showLink && (

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -357,15 +357,14 @@ export function PostComposer({ identity, seedText }: Props) {
   }
 
   /** Toggle the poll editor. Turning it on clears the link (a poll is an
-   *  exclusive content block); turning it off drops the poll fields. */
+   *  exclusive content block); clearing the link on toggle-off is a harmless
+   *  no-op (the link affordance is hidden while a poll is active). All four
+   *  setters batch in the one event tick — no nested-updater impurity. */
   const togglePoll = useCallback(() => {
-    setPoll((prev) => {
-      if (prev) return null;
-      setShowLink(false);
-      setLinkUrl("");
-      setLinkTitle("");
-      return emptyPoll();
-    });
+    setPoll((prev) => (prev ? null : emptyPoll()));
+    setShowLink(false);
+    setLinkUrl("");
+    setLinkTitle("");
   }, []);
 
   const remaining = MAX_LEN - text.length;
@@ -406,7 +405,7 @@ export function PostComposer({ identity, seedText }: Props) {
       // and drop blank options (the server validates 2–4 / lengths too).
       body.poll = {
         question: poll.question.trim(),
-        options: poll.options.map((o) => o.trim()).filter((o) => o.length > 0),
+        options: poll.options.map((o) => o.text.trim()).filter((o) => o.length > 0),
         duration: poll.duration,
       };
     } else if (showLink && linkUrl.trim()) {
@@ -615,8 +614,12 @@ export function PostComposer({ identity, seedText }: Props) {
   );
 
   // ── Schedule view ───────────────────────────────────────────────
-  // Early return is AFTER all hooks above — safe.
-  if (mode === "schedule") {
+  // Early return is AFTER all hooks above — safe. Guarded on !pollActive:
+  // the scheduler payload carries no poll, so a poll must never reach this
+  // branch (every entry into schedule mode is already gated on pollActive —
+  // this is belt-and-suspenders so a future entry point can't silently
+  // schedule a poll as plain text).
+  if (mode === "schedule" && !pollActive) {
     return (
       <ComposerShell
         mode="schedule"
@@ -733,6 +736,11 @@ export function PostComposer({ identity, seedText }: Props) {
             onClick={() => setMode("schedule")}
             disabled={scheduleDisabled}
             className="gap-1.5"
+            title={
+              pollActive
+                ? "Polls can't be scheduled yet — publish now, or remove the poll to schedule."
+                : undefined
+            }
           >
             <CalendarClock className="size-4" /> Schedule
           </Button>

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -6,12 +6,26 @@ export type LinkedInAuthor =
   | { type: "person" }
   | { type: "org"; pageId: string };
 
+/** How long a LinkedIn poll accepts votes. */
+export type LinkedInPollDuration = "ONE_DAY" | "THREE_DAYS" | "SEVEN_DAYS" | "FOURTEEN_DAYS";
+
+/** Native LinkedIn poll (CMA D5). 2–4 options; question ≤140, options ≤30
+ *  each. A poll is an exclusive content block (no link/images). */
+export interface LinkedInPollInput {
+  question: string;
+  options: string[];
+  duration: LinkedInPollDuration;
+}
+
 export interface PublishLinkedInPostInput {
   author: LinkedInAuthor;
   commentary: string;
   visibility?: LinkedInVisibility;
   link?: { url: string; title?: string; description?: string };
   imageUrns?: string[];
+  /** Native poll content (CMA D5). Mutually exclusive with `link`/images;
+   *  `commentary` still shows as the text above the poll. */
+  poll?: LinkedInPollInput;
   /** Optional cnt_ideas pointer — wires the post into the source-usage
    *  audit pipeline so retrieved-source citations + claim extraction
    *  fire when this LinkedIn post ships. Omit for ad-hoc posts. */


### PR DESCRIPTION
## What

Adds a **Poll** option to the LinkedIn composer so users can create the native poll posts shipped in peakhour-api **#515**.

- "Poll" toggle → a `PollEditor` (question ≤140, **2–4 options** ≤30 each, duration: 1 day / 3 days / 1 week / 2 weeks).
- A poll is an **exclusive content block**: turning it on clears the link; **Carousel + Schedule are disabled** while a poll is active (neither path carries a poll). Commentary (the composer text) is still required — it shows above the poll.
- `/publish` gains the `poll` payload on the api client (`LinkedInPollInput`).

## How

- New `PollEditor` with pure `isPollValid` / `emptyPoll` helpers mirroring the server's `buildPollContent` rules (count, lengths, **distinct options**, trim-before-length).
- Options carry a stable `id` so removing one mid-edit doesn't smear focus/caret.
- Duplicate options are rejected client-side (case-insensitive, trimmed) with an inline hint, so a user never hits LinkedIn's raw duplicate-option 400.
- Schedule view guarded on `!pollActive` (defense-in-depth against silently scheduling a poll as plain text).

## Tests

9 unit tests for the pure validators (count/length/blank/dedup/trim/boundary). `tsc --noEmit` + `eslint` clean.

## Review

Two full rounds (manual + general-purpose subagent each). Round 1 caught a React-purity bug in the toggle (nested setState), the index-key caret smear, and the missing duplicate-option guard — all fixed in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)