### PR TITLE
feat(linkedin): org @mention composer (CMA Phase D4 UI)

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/commentary-segments.test.ts
+++ b/src/app/dashboard/content/linkedin/_components/commentary-segments.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildCommentarySegments, type ResolvedMention } from "./commentary-segments";
+
+const acme: ResolvedMention = { name: "Acme Corp", urn: "urn:li:organization:123" };
+
+describe("buildCommentarySegments", () => {
+  it("returns null when there are no mentions (caller uses raw commentary)", () => {
+    expect(buildCommentarySegments("Hello #world", [])).toBeNull();
+  });
+
+  it("returns null when recorded mentions don't appear in the text", () => {
+    // user deleted the inserted mention → fall back to raw commentary
+    expect(buildCommentarySegments("just plain text", [acme])).toBeNull();
+  });
+
+  it("splits text + a mention into ordered segments", () => {
+    expect(buildCommentarySegments("Thanks @Acme Corp for the help", [acme])).toEqual([
+      { type: "text", value: "Thanks " },
+      { type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" },
+      { type: "text", value: " for the help" },
+    ]);
+  });
+
+  it("emits a mention at the very start", () => {
+    expect(buildCommentarySegments("@Acme Corp ships", [acme])).toEqual([
+      { type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" },
+      { type: "text", value: " ships" },
+    ]);
+  });
+
+  it("converts #hashtags to hashtag segments when in segment mode", () => {
+    expect(buildCommentarySegments("Hi @Acme Corp #growth #b2b", [acme])).toEqual([
+      { type: "text", value: "Hi " },
+      { type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" },
+      { type: "text", value: " " },
+      { type: "hashtag", value: "growth" },
+      { type: "text", value: " " },
+      { type: "hashtag", value: "b2b" },
+    ]);
+  });
+
+  it("matches the same mention more than once", () => {
+    const segs = buildCommentarySegments("@Acme Corp and @Acme Corp again", [acme]);
+    expect(segs?.filter((s) => s.type === "mention")).toHaveLength(2);
+  });
+
+  it("prefers the longer name when one is a prefix of another", () => {
+    const mentions: ResolvedMention[] = [
+      { name: "Acme", urn: "urn:li:organization:1" },
+      { name: "Acme Corp", urn: "urn:li:organization:2" },
+    ];
+    expect(buildCommentarySegments("ping @Acme Corp", mentions)).toEqual([
+      { type: "text", value: "ping " },
+      { type: "mention", urn: "urn:li:organization:2", name: "Acme Corp" },
+    ]);
+  });
+
+  it("does not match a mention glued to a preceding word char (email@Acme Corp)", () => {
+    expect(buildCommentarySegments("mail to bob@Acme Corp", [acme])).toBeNull();
+  });
+
+  it("does not match when the name is immediately followed by a word char", () => {
+    // "@Acme Corpx" — the trailing 'x' means it isn't exactly the org name
+    expect(buildCommentarySegments("hey @Acme Corpx", [acme])).toBeNull();
+  });
+
+  it("does not treat a mid-word # as a hashtag", () => {
+    const segs = buildCommentarySegments("c#sharp @Acme Corp", [acme]);
+    // the "c#sharp" stays text (no boundary before #), the mention still parses
+    expect(segs).toEqual([
+      { type: "text", value: "c#sharp " },
+      { type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" },
+    ]);
+  });
+
+  it("ignores blank-name mentions", () => {
+    expect(
+      buildCommentarySegments("@Acme Corp", [{ name: "  ", urn: "urn:li:organization:9" }, acme]),
+    ).toEqual([{ type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" }]);
+  });
+});

--- a/src/app/dashboard/content/linkedin/_components/commentary-segments.test.ts
+++ b/src/app/dashboard/content/linkedin/_components/commentary-segments.test.ts
@@ -78,4 +78,26 @@ describe("buildCommentarySegments", () => {
       buildCommentarySegments("@Acme Corp", [{ name: "  ", urn: "urn:li:organization:9" }, acme]),
     ).toEqual([{ type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" }]);
   });
+
+  it("matches a name containing regex-special characters as a literal token", () => {
+    const special: ResolvedMention = { name: "C++ (India)", urn: "urn:li:organization:7" };
+    expect(buildCommentarySegments("love @C++ (India) tools", [special])).toEqual([
+      { type: "text", value: "love " },
+      { type: "mention", urn: "urn:li:organization:7", name: "C++ (India)" },
+      { type: "text", value: " tools" },
+    ]);
+  });
+
+  it("does not match a single-word name glued to a longer word", () => {
+    const single: ResolvedMention = { name: "Acme", urn: "urn:li:organization:5" };
+    expect(buildCommentarySegments("see @Acmeworks", [single])).toBeNull();
+  });
+
+  it("serializes the matched mention and ignores an unmatched recorded one", () => {
+    const ghost: ResolvedMention = { name: "Ghost Inc", urn: "urn:li:organization:99" };
+    expect(buildCommentarySegments("hi @Acme Corp", [acme, ghost])).toEqual([
+      { type: "text", value: "hi " },
+      { type: "mention", urn: "urn:li:organization:123", name: "Acme Corp" },
+    ]);
+  });
 });

--- a/src/app/dashboard/content/linkedin/_components/commentary-segments.ts
+++ b/src/app/dashboard/content/linkedin/_components/commentary-segments.ts
@@ -1,0 +1,95 @@
+import type { LinkedInCommentarySegment } from "@/lib/api/linkedin-content";
+
+/** An org mention the user inserted via the @-typeahead. `name` is the org's
+ *  display name (the visible token, which LinkedIn requires to match exactly);
+ *  `urn` is its `urn:li:organization:{id}`. */
+export interface ResolvedMention {
+  name: string;
+  urn: string;
+}
+
+// LinkedIn hashtag chars: letters, digits, underscore (no spaces).
+const HASHTAG_RE = /^[A-Za-z0-9_]+/;
+
+function isWordChar(ch: string | undefined): boolean {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+
+/**
+ * Convert composer text + the org mentions the user inserted into LinkedIn
+ * "little"-format commentary segments (CMA D4). Returns `null` when no recorded
+ * mention actually appears in the text — the caller should then send the raw
+ * `commentary` string instead (which lets LinkedIn auto-link plain #hashtags,
+ * and avoids needlessly escaping a post that has no mentions).
+ *
+ * Matching rules:
+ *   - A mention is the literal token `@<name>` at a left boundary (start or a
+ *     non-word char before the `@`) and a right boundary (end or a non-word
+ *     char after the name) — so `email@Acme` and `@Acme` inside `@Acmexyz`
+ *     don't match. Longer names are matched first so `@Acme Corp` wins over
+ *     `@Acme`.
+ *   - A hashtag is `#<word>` at a left boundary → a hashtag segment, so it
+ *     survives the little-format escaping the server applies to text segments.
+ *   - Everything else accumulates into text segments.
+ */
+export function buildCommentarySegments(
+  text: string,
+  mentions: ResolvedMention[],
+): LinkedInCommentarySegment[] | null {
+  // Longest token first so a longer name isn't shadowed by a shorter prefix.
+  const tokens = mentions
+    .map((m) => ({ token: `@${m.name}`, name: m.name, urn: m.urn }))
+    .filter((t) => t.name.trim().length > 0)
+    .sort((a, b) => b.token.length - a.token.length);
+
+  const segments: LinkedInCommentarySegment[] = [];
+  let buf = "";
+  let matchedAnyMention = false;
+  const flush = () => {
+    if (buf) {
+      segments.push({ type: "text", value: buf });
+      buf = "";
+    }
+  };
+
+  let i = 0;
+  while (i < text.length) {
+    const prev = i > 0 ? text[i - 1] : undefined;
+    const atBoundary = !isWordChar(prev);
+
+    // Mention?
+    if (text[i] === "@" && atBoundary) {
+      let matched = false;
+      for (const t of tokens) {
+        if (text.startsWith(t.token, i) && !isWordChar(text[i + t.token.length])) {
+          flush();
+          segments.push({ type: "mention", urn: t.urn, name: t.name });
+          i += t.token.length;
+          matched = true;
+          matchedAnyMention = true;
+          break;
+        }
+      }
+      if (matched) continue;
+    }
+
+    // Hashtag?
+    if (text[i] === "#" && atBoundary) {
+      const m = HASHTAG_RE.exec(text.slice(i + 1));
+      if (m) {
+        flush();
+        segments.push({ type: "hashtag", value: m[0] });
+        i += 1 + m[0].length;
+        continue;
+      }
+    }
+
+    buf += text[i];
+    i++;
+  }
+  flush();
+
+  // No mention actually landed → let the caller use the raw-commentary path.
+  if (!matchedAnyMention) return null;
+  return segments;
+}

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -160,8 +160,10 @@ export function PostComposer({ identity, seedText }: Props) {
       setText(seedText);
       // A seeded draft is a NEW composition — drop any prior draft id so
       // the next auto-save creates a fresh cnt_drafts row rather than
-      // overwriting the one the user just navigated away from.
+      // overwriting the one the user just navigated away from. Also clear
+      // recorded mentions so a stale URN can't ride along on the new text.
       setDraftId(null);
+      setMentions([]);
     }
   }, [seedText]);
   const [visibility, setVisibility] = useState<LinkedInVisibility>("PUBLIC");
@@ -484,11 +486,14 @@ export function PostComposer({ identity, seedText }: Props) {
   }, []);
 
   // ── AI compose toolbar handler ──────────────────────────────────
-  // Drop recorded mentions whose `@<name>` token no longer appears in the text
-  // (e.g. after an AI redraft / variant-apply replaced the body). Keeps the
-  // chips honest — without this they'd advertise mentions that won't link.
+  // Drop recorded mentions whose `@<name>` token no longer resolves in the text
+  // (e.g. after an AI redraft / variant-apply replaced the body). Uses the same
+  // boundary-aware serializer as publish, so a name that's merely a prefix of
+  // another retained mention isn't kept by a naive substring check.
   const pruneMentions = useCallback((nextText: string) => {
-    setMentions((prev) => prev.filter((m) => nextText.includes(`@${m.name}`)));
+    setMentions((prev) =>
+      prev.filter((m) => buildCommentarySegments(nextText, [m]) !== null),
+    );
   }, []);
 
   const handleAiAction = useCallback(

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -32,6 +32,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import {
+  AtSign,
   CalendarClock,
   ChevronDown,
   GalleryHorizontalEnd,
@@ -63,6 +64,7 @@ import {
 } from "@/lib/api/linkedin-content";
 import { CarouselPreviewDialog } from "./carousel-preview-dialog";
 import { PollEditor, emptyPoll, isPollValid, type PollState } from "./poll-editor";
+import { buildCommentarySegments, type ResolvedMention } from "./commentary-segments";
 import { ApiError } from "@/lib/api";
 import { rewriteContent, createDraft, updateDraft, type ComposerDraftRef } from "@/lib/api/content";
 import { insertAtCaret } from "@/lib/composer/caret";
@@ -73,11 +75,13 @@ import {
   DraftSaver,
   EmojiPickerTrigger,
   HashtagSuggest,
+  MentionTypeahead,
   PlatformCharCounter,
   useDraftSaver,
   type AiActionContext,
   type ComposerCommand,
   type HashtagCandidate,
+  type MentionCandidate,
   type RewriteOp,
   type VoiceCardSummary,
 } from "@/components/composer";
@@ -168,6 +172,10 @@ export function PostComposer({ identity, seedText }: Props) {
   // turning it on clears the link, and carousel/schedule are disabled while it
   // is active (the carousel + scheduler paths don't carry a poll).
   const [poll, setPoll] = useState<PollState | null>(null);
+  // Org @mentions (CMA D4) the user inserted via the typeahead, deduped by URN.
+  // The inserted `@<name>` text alone can't carry the URN, so we record it here
+  // and serialize text → commentarySegments on publish.
+  const [mentions, setMentions] = useState<ResolvedMention[]>([]);
   const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
 
   // Author picker — discriminated union string keys for the Select.
@@ -351,6 +359,7 @@ export function PostComposer({ identity, seedText }: Props) {
     setLinkTitle("");
     setShowLink(false);
     setPoll(null);
+    setMentions([]);
     setVariants(null);
     setDraftId(null);
     setMode("compose");
@@ -396,9 +405,19 @@ export function PostComposer({ identity, seedText }: Props) {
 
     const body: PublishLinkedInPostInput = {
       author,
-      commentary: text.trim(),
       visibility: effectiveVisibility,
     };
+
+    // Structured commentary (CMA D4): when the user inserted org @mentions that
+    // still appear in the text, send segments so the URNs link. Otherwise send
+    // the raw string (which also lets LinkedIn auto-link plain #hashtags). Poll
+    // posts use the raw path — a poll's intro text isn't segmented here.
+    const segments = poll ? null : buildCommentarySegments(text.trim(), mentions);
+    if (segments) {
+      body.commentarySegments = segments;
+    } else {
+      body.commentary = text.trim();
+    }
 
     if (poll) {
       // A poll is exclusive — never combine it with a link. Trim the question
@@ -502,6 +521,37 @@ export function PostComposer({ identity, seedText }: Props) {
     [],
   );
 
+  // Org @mention typeahead (CMA D4). org-lookup is an EXACT vanity-handle
+  // resolver (people search is closed), so a match surfaces once the user has
+  // typed the full handle. The candidate's `handle` is the org's display name —
+  // that's the text inserted as `@<name>` AND the text LinkedIn must match to
+  // render the mention. `id` carries the org URN for the mention segment.
+  const searchMentions = useCallback(
+    async (query: string, signal: AbortSignal): Promise<MentionCandidate[]> => {
+      try {
+        const { organizations } = await linkedInContentApi.orgLookup(query);
+        if (signal.aborted) return [];
+        return organizations.map((o) => ({
+          id: o.urn,
+          handle: o.name,
+          displayName: o.name,
+        }));
+      } catch {
+        // 403 / not-connected / network — surface no matches, never an error.
+        return [];
+      }
+    },
+    [],
+  );
+
+  // Record a picked org so publish can resolve its `@<name>` token → a mention
+  // segment with the URN. Dedupe by URN (the same org may be mentioned twice).
+  const handlePickMention = useCallback((c: MentionCandidate) => {
+    setMentions((prev) =>
+      prev.some((m) => m.urn === c.id) ? prev : [...prev, { name: c.handle, urn: c.id }],
+    );
+  }, []);
+
   function updateCaret(e: { currentTarget: HTMLTextAreaElement }) {
     setCaret(e.currentTarget.selectionStart ?? 0);
   }
@@ -526,6 +576,11 @@ export function PostComposer({ identity, seedText }: Props) {
     // scheduler's linkedin publisher adapter reads (authorUrn /
     // visibility / link) so a scheduled post fires with the SAME author
     // + visibility + link the user picked here.
+    // NOTE: the scheduler adapter publishes the raw text only — it does not
+    // carry commentary SEGMENTS, so org @mentions in a SCHEDULED post post as
+    // plain `@Name` text (not linked). Immediate publish links them. Threading
+    // segments through the scheduler is a follow-up; surfaced via the mention
+    // hint below so the user isn't surprised.
     const channelOptions: Record<string, unknown> = {
       authorUrn: isOrgAuthor
         ? `urn:li:organization:${authorKey.slice("org:".length)}`
@@ -844,6 +899,44 @@ export function PostComposer({ identity, seedText }: Props) {
         onSearch={searchHashtags}
         minQueryLength={2}
       />
+      <MentionTypeahead
+        containerRef={composerWrapRef}
+        targetRef={textareaRef}
+        text={text}
+        caret={caret}
+        onChange={setText}
+        onSearch={searchMentions}
+        onPick={handlePickMention}
+        minQueryLength={2}
+      />
+
+      {mentions.length > 0 && (
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Mentions</span>
+            {mentions.map((m) => (
+              <span
+                key={m.urn}
+                className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
+              >
+                <AtSign className="size-3 text-muted-foreground" />
+                {m.name}
+                <button
+                  type="button"
+                  onClick={() => setMentions((prev) => prev.filter((x) => x.urn !== m.urn))}
+                  className="text-muted-foreground hover:text-foreground"
+                  aria-label={`Unlink mention ${m.name}`}
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Mentions link when you publish now. Scheduled posts send them as plain text.
+          </p>
+        </div>
+      )}
 
       <div className="flex items-center gap-2">
         <EmojiPickerTrigger onInsert={insertSnippet} />

--- a/src/app/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/dashboard/content/linkedin/_components/post-composer.tsx
@@ -265,7 +265,9 @@ export function PostComposer({ identity, seedText }: Props) {
     // Replace the hook with the picked variant, preserving any body
     // below the first blank-line boundary.
     const [, ...rest] = text.split(/\n\s*\n/);
-    setText(rest.length > 0 ? `${v.hook}\n\n${rest.join("\n\n")}` : v.hook);
+    const next = rest.length > 0 ? `${v.hook}\n\n${rest.join("\n\n")}` : v.hook;
+    setText(next);
+    pruneMentions(next);
     setVariants(null);
   }
 
@@ -482,6 +484,13 @@ export function PostComposer({ identity, seedText }: Props) {
   }, []);
 
   // ── AI compose toolbar handler ──────────────────────────────────
+  // Drop recorded mentions whose `@<name>` token no longer appears in the text
+  // (e.g. after an AI redraft / variant-apply replaced the body). Keeps the
+  // chips honest — without this they'd advertise mentions that won't link.
+  const pruneMentions = useCallback((nextText: string) => {
+    setMentions((prev) => prev.filter((m) => nextText.includes(`@${m.name}`)));
+  }, []);
+
   const handleAiAction = useCallback(
     async (ctx: AiActionContext): Promise<string> => {
       const res = await rewriteContent({
@@ -501,12 +510,13 @@ export function PostComposer({ identity, seedText }: Props) {
       } else {
         newText = res.text;
         setText(newText);
+        pruneMentions(newText); // a full-body replace can drop @mention tokens
         setVariants(null); // stale once the body changed
       }
       toast.success(aiOpToastMessage(ctx.op));
       return newText;
     },
-    [insertSnippet],
+    [insertSnippet, pruneMentions],
   );
 
   // No-op hashtag search — LinkedIn has no hashtag-history endpoint yet,

--- a/src/components/composer/mention-typeahead.tsx
+++ b/src/components/composer/mention-typeahead.tsx
@@ -101,6 +101,11 @@ export interface MentionTypeaheadProps {
    *  function reference is stashed in a ref so passing an inline
    *  lambda from the host won't re-fire the debounce. */
   onSearch: (query: string, signal: AbortSignal) => Promise<MentionCandidate[]>;
+  /** Optional: called with the picked candidate when the user selects one.
+   *  The host uses this to record the candidate's id/URN (the inserted text
+   *  alone can't carry it) — e.g. to build a LinkedIn mention segment. Fires
+   *  alongside the `onChange` that inserts `@<handle>` into the text. */
+  onPick?: (candidate: MentionCandidate) => void;
   /** Minimum query length before firing onSearch. Default 1 (most
    *  platforms accept single-char prefixes — bump to 2 for noisier
    *  datasets). */
@@ -134,6 +139,7 @@ export function MentionTypeahead({
   caret,
   onChange,
   onSearch,
+  onPick,
   minQueryLength = 1,
 }: MentionTypeaheadProps) {
   const detected = useMemo(() => detectMention(text, caret), [text, caret]);
@@ -220,6 +226,9 @@ export function MentionTypeahead({
       const insert = `@${c.handle} `;
       const next = before + insert + after;
       onChange(next);
+      // Let the host record the picked candidate's id/URN — the inserted
+      // `@<handle>` text alone can't carry it.
+      onPick?.(c);
       const newCaret = liveDetected.start + insert.length;
       requestAnimationFrame(() => {
         const elNow = targetRef.current;
@@ -228,7 +237,7 @@ export function MentionTypeahead({
         elNow.setSelectionRange(newCaret, newCaret);
       });
     },
-    [text, caret, onChange, targetRef],
+    [text, caret, onChange, onPick, targetRef],
   );
 
   // Window-level keyboard handler — only active when popover is open.

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -17,9 +17,22 @@ export interface LinkedInPollInput {
   duration: LinkedInPollDuration;
 }
 
+/** A structured commentary segment (CMA D4). The composer emits these to
+ *  embed org @mentions / #hashtags; the server assembles them into LinkedIn's
+ *  "little" format. Mention URNs are organization-only (member data is closed). */
+export type LinkedInCommentarySegment =
+  | { type: "text"; value: string }
+  | { type: "mention"; urn: string; name: string }
+  | { type: "hashtag"; value: string };
+
 export interface PublishLinkedInPostInput {
   author: LinkedInAuthor;
-  commentary: string;
+  /** Raw post text. Provide EITHER this OR `commentarySegments` (the server
+   *  requires exactly one). The composer sends this for plain/poll posts. */
+  commentary?: string;
+  /** Structured commentary with org @mentions / #hashtags (CMA D4). Mutually
+   *  exclusive with `commentary`. */
+  commentarySegments?: LinkedInCommentarySegment[];
   visibility?: LinkedInVisibility;
   link?: { url: string; title?: string; description?: string };
   imageUrns?: string[];
@@ -30,6 +43,17 @@ export interface PublishLinkedInPostInput {
    *  audit pipeline so retrieved-source citations + claim extraction
    *  fire when this LinkedIn post ships. Omit for ad-hoc posts. */
   ideaId?: string;
+}
+
+/** A resolved organization from the org-lookup typeahead (CMA E5). */
+export interface LinkedInOrgLookupResult {
+  /** `urn:li:organization:{id}` — pass as a mention segment's urn. */
+  urn: string;
+  id: string;
+  /** Locale-resolved display name — the mention's visible text must match it. */
+  name: string;
+  vanityName?: string;
+  primaryOrganizationType?: string;
 }
 
 export interface LinkedInOrgPage {
@@ -293,6 +317,15 @@ export const linkedInContentApi = {
       `/v1/linkedin/content/engagers${q ? `?${q}` : ""}`,
     );
   },
+
+  /** Resolve organization(s) by EXACT vanity handle (CMA E5) for the @mention
+   *  typeahead. Returns 0+ matches; the composer maps each to a mention
+   *  candidate (name → visible text, urn → segment urn). People search is
+   *  unavailable (member data closed), so this is org-only. */
+  orgLookup: (vanityName: string) =>
+    api.get<{ organizations: LinkedInOrgLookupResult[] }>(
+      `/v1/linkedin/content/org-lookup?vanityName=${encodeURIComponent(vanityName)}`,
+    ),
 
   /** Generate N initial LinkedIn post drafts grounded in the active
    *  business's profile + voice card + cohort archetype. Persists each


### PR DESCRIPTION
## What

Wires inline org **@mentions** into the LinkedIn composer (api **#514**, org-lookup **#513**). Type `@<handle>`, pick the org, and it publishes as a linked mention.

org-lookup is an **exact vanity-handle** resolver (people search is closed), so this is **org-only** — matching the D4 plan.

## How

- `MentionTypeahead` gains an optional **`onPick(candidate)`** callback — the inserted `@<name>` text alone can't carry the URN. Backward-compatible (no existing consumers).
- New pure **`buildCommentarySegments(text, mentions)`** tokenizes the composer text into the server's segments (`text` / `mention` / `hashtag`), matching `@<org name>` at word boundaries and converting `#hashtags` so they survive the server's little-format escaping. Returns `null` when no recorded mention is present → composer sends the **raw-commentary** path (so plain posts are byte-unchanged and LinkedIn still auto-links bare #tags).
- Composer: `searchMentions` → `orgLookup`; `onPick` records `{name, urn}` (deduped by URN); removable **mention chips**; `onSubmit` sends `commentarySegments` when mentions resolve, else `commentary` (exactly one, per the server). Mentions are pruned when an AI redraft replaces the body.
- Mentions link on **immediate publish**; a hint notes **scheduled** posts send them as plain text (the scheduler adapter doesn't carry segments — a follow-up).

## Tests

14 unit tests for the pure serializer (ordering, boundaries, longest-first, hashtag-in-segment-mode, regex-special names, unmatched-mention fallback). `tsc` + `eslint` clean.

## Review

Two full rounds (manual + general-purpose subagent each). Round 1 confirmed the exactly-one-of invariant + dual-typeahead (`@`/`#`) non-conflict, and added stale-chip pruning on AI redraft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)