### PR TITLE
feat(linkedin): engage back with top engagers — reply + react (CMA B3 UI)

### DIFF
--- a/src/app/dashboard/content/linkedin/_components/audience-panel.test.ts
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.test.ts
@@ -15,6 +15,12 @@ describe("engageErrorMessage", () => {
     );
   });
 
+  it("nudges reconnect on NOT_CONNECTED (expired token on the write path)", () => {
+    expect(engageErrorMessage(new ApiError("NOT_CONNECTED", "raw", 400))).toMatch(
+      /reconnect linkedin/i,
+    );
+  });
+
   it("surfaces a rate-limit message on 429", () => {
     expect(engageErrorMessage(new ApiError("RATE_LIMITED", "raw", 429))).toMatch(
       /rate-limit/i,

--- a/src/app/dashboard/content/linkedin/_components/audience-panel.test.ts
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "@/lib/api";
+import { engageErrorMessage } from "./audience-panel";
+
+describe("engageErrorMessage", () => {
+  it("nudges reconnect on RECONNECT_REQUIRED", () => {
+    expect(engageErrorMessage(new ApiError("RECONNECT_REQUIRED", "raw", 403))).toMatch(
+      /reconnect linkedin/i,
+    );
+  });
+
+  it("nudges reconnect on any 403", () => {
+    expect(engageErrorMessage(new ApiError("FORBIDDEN", "raw transport", 403))).toMatch(
+      /reconnect linkedin/i,
+    );
+  });
+
+  it("surfaces a rate-limit message on 429", () => {
+    expect(engageErrorMessage(new ApiError("RATE_LIMITED", "raw", 429))).toMatch(
+      /rate-limit/i,
+    );
+  });
+
+  it("never leaks the raw error string", () => {
+    const msg = engageErrorMessage(new ApiError("PUBLISH_FAILED", "LinkedIn 500: secret-internal", 500));
+    expect(msg).not.toContain("secret-internal");
+    expect(msg).toMatch(/couldn't reach linkedin/i);
+  });
+
+  it("handles a non-ApiError throwable", () => {
+    expect(engageErrorMessage(new Error("boom"))).toMatch(/couldn't reach linkedin/i);
+    expect(engageErrorMessage("string error")).toMatch(/couldn't reach linkedin/i);
+  });
+});

--- a/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -23,7 +23,7 @@ const COMMENT_MAX = 1250; // LinkedIn comment cap (mirrors the api route)
  *  Exported for unit testing. */
 export function engageErrorMessage(err: unknown): string {
   if (err instanceof ApiError) {
-    if (err.code === "RECONNECT_REQUIRED" || err.status === 403) {
+    if (err.code === "RECONNECT_REQUIRED" || err.code === "NOT_CONNECTED" || err.status === 403) {
       return "Reconnect LinkedIn to reply and react (it needs the latest permissions).";
     }
     if (err.status === 429) return "LinkedIn is rate-limiting — try again in a moment.";

--- a/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -1,16 +1,35 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Building2, Users } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { Building2, Loader2, MessageSquare, ThumbsUp, Users, X } from "lucide-react";
 import {
   linkedInContentApi,
   type EngagerScore,
 } from "@/lib/api/linkedin-content";
 import { RetentionFootnote } from "./retention-footnote";
+
+const COMMENT_MAX = 1250; // LinkedIn comment cap (mirrors the api route)
+
+/** Map an engagement-write failure to friendly toast copy — never leak the raw
+ *  LinkedIn/transport string. 403 RECONNECT_REQUIRED nudges the reconnect.
+ *  Exported for unit testing. */
+export function engageErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === "RECONNECT_REQUIRED" || err.status === 403) {
+      return "Reconnect LinkedIn to reply and react (it needs the latest permissions).";
+    }
+    if (err.status === 429) return "LinkedIn is rate-limiting — try again in a moment.";
+  }
+  return "Couldn't reach LinkedIn. Please try again.";
+}
 
 /**
  * AudiencePanel — surfaces the AQS Tier C ranking of recent LinkedIn
@@ -175,6 +194,50 @@ function EngagerRow({ engager, rank }: { engager: EngagerScore; rank: number }) 
 
   const recencyLabel = formatRecency(engager.signals.daysSinceLastComment);
 
+  // Engage-back affordances (CMA B3). Acting as the connected MEMBER (person) —
+  // always valid on the held member scope; replying/reacting as the brand page
+  // is a follow-up (needs the post's author surfaced). Reacting needs only the
+  // comment URN; replying additionally needs the parent post URN.
+  const commentUrn = engager.signals.lastCommentUrn;
+  const parentPostUrn = engager.signals.lastParentPostUrn;
+  const canReact = commentUrn.length > 0;
+  const canReply = canReact && parentPostUrn.length > 0;
+
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [liked, setLiked] = useState(false);
+
+  const react = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createReaction(commentUrn, {
+        author: { type: "person" },
+        reactionType: "LIKE",
+      }),
+    onSuccess: () => {
+      setLiked(true);
+      toast.success("Liked their comment.");
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  const reply = useMutation({
+    mutationFn: (text: string) =>
+      linkedInContentApi.createComment(parentPostUrn, {
+        author: { type: "person" },
+        text,
+        parentCommentUrn: commentUrn,
+      }),
+    onSuccess: () => {
+      setReplyOpen(false);
+      setReplyText("");
+      toast.success("Reply posted.");
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  const trimmedReply = replyText.trim();
+  const replyDisabled = reply.isPending || trimmedReply.length === 0 || trimmedReply.length > COMMENT_MAX;
+
   return (
     <li className="flex items-start gap-3 py-3">
       <span className="w-6 shrink-0 pt-0.5 text-xs tabular-nums text-muted-foreground">
@@ -213,6 +276,85 @@ function EngagerRow({ engager, rank }: { engager: EngagerScore; rank: number }) 
           ) : null}
           <span>last · {recencyLabel}</span>
         </div>
+
+        {/* Engage-back actions — only when we have the comment URN to act on. */}
+        {canReact ? (
+          <div className="flex items-center gap-1 pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              onClick={() => react.mutate()}
+              disabled={react.isPending || liked}
+              aria-pressed={liked}
+              title={liked ? "You liked this comment" : "Like this comment"}
+            >
+              {react.isPending ? (
+                <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+              ) : (
+                <ThumbsUp className="size-3.5" />
+              )}
+              {liked ? "Liked" : "Like"}
+            </Button>
+            {canReply ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setReplyOpen((o) => !o)}
+                aria-expanded={replyOpen}
+              >
+                <MessageSquare className="size-3.5" />
+                Reply
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {replyOpen && canReply ? (
+          <div className="space-y-1.5 pt-1">
+            <Textarea
+              value={replyText}
+              onChange={(e) => setReplyText(e.target.value)}
+              placeholder="Write a reply…"
+              rows={2}
+              maxLength={COMMENT_MAX}
+              className="resize-none text-sm"
+              aria-label="Reply to this comment"
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] tabular-nums text-muted-foreground">
+                {trimmedReply.length}/{COMMENT_MAX}
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => {
+                    setReplyOpen(false);
+                    setReplyText("");
+                  }}
+                >
+                  <X className="size-3.5 mr-1" /> Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => reply.mutate(trimmedReply)}
+                  disabled={replyDisabled}
+                  aria-busy={reply.isPending}
+                >
+                  {reply.isPending ? "Posting…" : "Reply"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : null}
       </div>
       <div className="shrink-0 text-right">
         <div

--- a/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -326,7 +326,7 @@ function EngagerRow({ engager, rank }: { engager: EngagerScore; rank: number }) 
             />
             <div className="flex items-center justify-between">
               <span className="text-[10px] tabular-nums text-muted-foreground">
-                {trimmedReply.length}/{COMMENT_MAX}
+                {replyText.length}/{COMMENT_MAX}
               </span>
               <div className="flex items-center gap-1">
                 <Button

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -215,6 +215,10 @@ export interface EngagerScore {
     firstCommentedAt: string;
     lastCommentText: string;
     lastParentPostUrn: string;
+    /** Composite URN of the engager's most recent comment — lets the panel
+     *  reply to it (createComment parentComment) or react to it
+     *  (createReaction). `""` for legacy rows synced before it was captured. */
+    lastCommentUrn: string;
   };
 }
 
@@ -387,6 +391,18 @@ export const linkedInContentApi = {
     ),
 
   /**
+   * React to a post OR a comment as the member or an org page. `entityUrn` is
+   * the target's full URN — a post (`urn:li:share:*` / `urn:li:ugcPost:*`) or a
+   * comment (`urn:li:comment:(...)`). Same `RECONNECT_REQUIRED` (403) contract
+   * as createComment when the `_feed` scope is missing.
+   */
+  createReaction: (entityUrn: string, body: CreateReactionInput) =>
+    api.post<{ reacted: boolean; reactionType: string }>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(entityUrn)}/reactions`,
+      body,
+    ),
+
+  /**
    * Repurpose a piece of long-form text into a LinkedIn document "carousel"
    * (PDF, one AI-rendered slide per section). LONG-RUNNING — the server
    * generates an image per slide, so a 5-slide carousel can take 30–60s; the
@@ -453,6 +469,20 @@ export interface CreateCommentInput {
   text: string;
   /** Composite parent comment URN — set to reply to a comment, not the post. */
   parentCommentUrn?: string;
+}
+
+/** LinkedIn reaction types the API accepts (MAYBE is deprecated → excluded). */
+export type LinkedInReactionType =
+  | "LIKE"
+  | "PRAISE"
+  | "EMPATHY"
+  | "INTEREST"
+  | "APPRECIATION"
+  | "ENTERTAINMENT";
+
+export interface CreateReactionInput {
+  author: LinkedInAuthor;
+  reactionType: LinkedInReactionType;
 }
 
 export interface CarouselResult {


### PR DESCRIPTION
## What

CMA **B3** (final piece) — turns the read-only **Audience** panel into **reply + react**, so users engage back with the people commenting on their posts. Consumes the engager comment URN surfaced in api #519; works once the connection has the `_feed` write scope (#517).

## How

- api client: `createReaction(entityUrn, {author, reactionType})` + `CreateReactionInput`/`LinkedInReactionType`; `lastCommentUrn` on `EngagerScore.signals`.
- Audience panel, per engager (when the comment URN is present):
  - **Like** → `createReaction(commentUrn, LIKE)` (one-shot, disables after).
  - **Reply** → inline composer → `createComment(parentPostUrn, {text, parentCommentUrn: commentUrn})`.
  - Acts as the connected **member** (`{type:"person"}`) — always valid on the held member scope; brand-page author is a follow-up (needs the post author surfaced).
  - 403 → friendly **Reconnect** toast via `engageErrorMessage` (never leaks raw transport strings); legacy rows (no comment URN) hide the actions.

## Tests

5 unit tests for the pure `engageErrorMessage` (reconnect on 403/RECONNECT_REQUIRED, rate-limit on 429, no raw-string leak, non-ApiError fallback). `tsc` + `eslint` clean.

## Review
Two rounds (manual + subagent). Round 1 verified rules-of-hooks (per-row state isolated), the reply/react argument order vs the server contract, and legacy-row gating; fixed the counter/maxLength mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)