### PR TITLE
feat(coming-soon): waitlist launch-partner funnel + invite-only sign-in

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { Clock, Sparkles, ArrowRight } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { sendMagicLink } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
@@ -40,6 +41,10 @@ type Status =
       resendError?: string;
     }
   | { kind: "resending"; email: string; cooldownEndsAt: number }
+  // Pre-launch invite-only outcomes (no link sent). `waitlisted` = applied
+  // but not yet approved; `notEligible` = not on the launch list at all.
+  | { kind: "waitlisted"; email: string }
+  | { kind: "notEligible"; email: string }
   | { kind: "error"; message: string };
 
 // peakhour-api enforces a hard 60s rate limit between magic-link
@@ -168,7 +173,19 @@ function AuthPageInner() {
         : Date.now() + RESEND_COOLDOWN_SECONDS * 1000;
 
     try {
-      await sendMagicLink(targetEmail);
+      const res = await sendMagicLink(targetEmail);
+      // Pre-launch invite gate: the endpoint may return without sending a
+      // link. Branch to the matching card instead of the "check your email"
+      // cooldown. `sent` (or a legacy response with no `outcome`) falls
+      // through to the normal cooldown card.
+      if (res.outcome === "waitlisted") {
+        setStatus({ kind: "waitlisted", email: targetEmail });
+        return;
+      }
+      if (res.outcome === "not_found") {
+        setStatus({ kind: "notEligible", email: targetEmail });
+        return;
+      }
       setStatus({
         kind: "sent",
         email: targetEmail,
@@ -286,7 +303,61 @@ function AuthPageInner() {
       {/* Right panel — auth form */}
       <div className="flex flex-1 flex-col">
         <div className="flex flex-1 items-center justify-center px-4 py-12">
-          {isCoolingDown ? (
+          {status.kind === "waitlisted" ? (
+            <Card className="w-full max-w-md">
+              <CardHeader className="text-center">
+                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950">
+                  <Sparkles className="h-7 w-7 text-amber-600 dark:text-amber-400" aria-hidden />
+                </div>
+                <CardTitle className="text-2xl font-bold">You&apos;re on the watchlist</CardTitle>
+                <CardDescription>
+                  We found <strong>{status.email}</strong> on the list.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Sign-in is invite-only while we onboard launch partners.
+                  We&apos;ll email your sign-in link the moment your invite is
+                  ready — it&apos;ll be worth the wait.
+                </p>
+              </CardContent>
+              <CardFooter>
+                <Button variant="outline" className="w-full" onClick={handleReset}>
+                  Use a different email
+                </Button>
+              </CardFooter>
+            </Card>
+          ) : status.kind === "notEligible" ? (
+            <Card className="w-full max-w-md">
+              <CardHeader className="text-center">
+                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+                  <Clock className="h-7 w-7 text-primary" aria-hidden />
+                </div>
+                <CardTitle className="text-2xl font-bold">You&apos;re not on the list yet</CardTitle>
+                <CardDescription>
+                  <strong>{status.email}</strong> isn&apos;t on our launch list.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="text-center">
+                <p className="text-sm text-muted-foreground">
+                  {SITE.name} is invite-only right now. Apply to become a launch
+                  partner and we&apos;ll add you to the waitlist — the wait will
+                  be worth it.
+                </p>
+              </CardContent>
+              <CardFooter className="flex flex-col gap-2">
+                <Button asChild className="w-full">
+                  <Link href="/launch-partner">
+                    Become a launch partner
+                    <ArrowRight className="ml-1 size-4" aria-hidden />
+                  </Link>
+                </Button>
+                <Button variant="outline" className="w-full" onClick={handleReset}>
+                  Use a different email
+                </Button>
+              </CardFooter>
+            </Card>
+          ) : isCoolingDown ? (
             <Card className="w-full max-w-md">
               <CardHeader className="text-center">
                 <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -5,7 +5,7 @@ import { SITE } from "@/lib/utils";
 export const metadata: Metadata = {
   title: "Peakhour — Autonomous Customer Engagement",
   description:
-    "Peakhour helps businesses stay responsive, uncover growth opportunities, and automate customer engagement across WhatsApp, web, voice and more — without needing a dedicated marketing team. Two solutions, one platform: Peakhour Commerce and Peakhour Marketing. Launching soon.",
+    "Peakhour helps businesses build visibility, engage customers, and unlock growth opportunities across every channel — without a full-scale marketing team. Two solutions, one platform: Peakhour Commerce and Peakhour Marketing. Launching soon.",
 };
 
 /**
@@ -29,6 +29,18 @@ export default function ComingSoonPage() {
         className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-1/2 bg-linear-to-b from-primary/5 to-transparent"
       />
 
+      {/* Sign in — for approved launch partners (e.g. quests.travel). Plain
+          <a> so it resolves straight through the coming-soon gate, which
+          allowlists /auth (see middleware.ts). The magic-link endpoint only
+          sends a real link to ops-approved emails; everyone else is routed to
+          the waitlist from the sign-in page itself. */}
+      <a
+        href="/auth"
+        className="absolute right-6 top-6 z-10 inline-flex items-center rounded-full border bg-background/80 px-4 py-2 text-sm font-medium text-foreground backdrop-blur transition-colors hover:bg-muted/60"
+      >
+        Sign in
+      </a>
+
       {/* ── Hero ─────────────────────────────────────────────── */}
       <section className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
         <div className="mx-auto flex max-w-2xl flex-col items-center gap-7">
@@ -45,10 +57,9 @@ export default function ComingSoonPage() {
           </h1>
 
           <p className="max-w-xl text-balance text-lg text-muted-foreground">
-            {SITE.name} helps businesses stay responsive, uncover growth
-            opportunities, and automate customer engagement across WhatsApp,
-            web, voice and more &mdash; without needing a dedicated marketing
-            team.
+            {SITE.name} helps businesses build visibility, engage customers,
+            and unlock growth opportunities across every channel&mdash;without
+            a full-scale marketing team.
           </p>
 
           <div className="mt-2 flex flex-col items-center gap-3 sm:flex-row">

--- a/src/app/launch-partner/launch-partner-form.tsx
+++ b/src/app/launch-partner/launch-partner-form.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  ShoppingBag,
+  Megaphone,
+  Loader2,
+  Check,
+  Sparkles,
+  Share2,
+  ArrowRight,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * Launch-partner apply form. Replaces the old mailto capture — applying now
+ * lands a waitlist_signups row (POST /v1/waitlist/signup) tagged with the
+ * product cohort(s) the applicant picked. Ops approves in the CMS, which is
+ * what unlocks magic-link sign-in. No email address is shown anywhere.
+ *
+ * Mirrors the waitlist signup + success card from UpgradeDrawer (referral
+ * code, founding-member badge, position) so the two surfaces feel identical;
+ * the launch-partner-specific bit is the Commerce/Marketing product picker.
+ */
+type ProductInterest = "commerce" | "marketing";
+
+const PRODUCTS: {
+  key: ProductInterest;
+  label: string;
+  blurb: string;
+  Icon: typeof ShoppingBag;
+}[] = [
+  {
+    key: "commerce",
+    label: "Peakhour Commerce",
+    blurb: "Shopify / WooCommerce / D2C — recover carts, re-engage, grow revenue.",
+    Icon: ShoppingBag,
+  },
+  {
+    key: "marketing",
+    label: "Peakhour Marketing",
+    blurb: "Publishers & brands — create, optimize and automate campaigns.",
+    Icon: Megaphone,
+  },
+];
+
+export function LaunchPartnerForm() {
+  const [email, setEmail] = useState("");
+  const [products, setProducts] = useState<ProductInterest[]>([]);
+  const [businessContext, setBusinessContext] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<{
+    referralCode: string;
+    foundingMember: boolean;
+    position: number | null;
+  } | null>(null);
+
+  function toggleProduct(key: ProductInterest) {
+    setProducts((prev) =>
+      prev.includes(key) ? prev.filter((p) => p !== key) : [...prev, key],
+    );
+  }
+
+  async function submit() {
+    if (!email || !email.includes("@")) {
+      toast.error("Please enter a valid email");
+      return;
+    }
+    if (products.length === 0) {
+      toast.error("Pick at least one — Commerce or Marketing");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = {
+        email,
+        intent: "general",
+        productInterest: products,
+        // Direct landing-page application (not an in-app feature gate).
+        channel: "direct",
+      };
+      if (businessContext) body.businessContext = businessContext;
+
+      const r = await api.post<{
+        referralCode: string;
+        foundingMember: boolean;
+        position: number | null;
+        idempotent?: boolean;
+      }>("/v1/waitlist/signup", body);
+
+      setSuccess({
+        referralCode: r.referralCode,
+        foundingMember: r.foundingMember,
+        position: r.position,
+      });
+      toast.success(r.idempotent ? "You're already on the list" : "You're in");
+    } catch (err) {
+      toast.error((err as Error)?.message || "Could not submit — please retry");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function shareReferral() {
+    if (!success) return;
+    const base = typeof window !== "undefined" ? window.location.origin : "";
+    // Random suffix defeats exact-URL caching on shares; non-security.
+    const nonce = Math.random().toString(36).slice(2, 6);
+    const url = `${base}/?ref=${success.referralCode}&n=${nonce}`;
+    if (navigator.share) {
+      navigator
+        .share({
+          title: "Peakhour — launch partner",
+          text: "I just applied to the Peakhour launch program. Skip the line:",
+          url,
+        })
+        .catch(() => {
+          /* user dismissed */
+        });
+    } else {
+      navigator.clipboard
+        .writeText(url)
+        .then(() => toast.success("Referral link copied"))
+        .catch(() => toast.error("Could not copy — copy it manually below"));
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="w-full space-y-4 text-left">
+        <div className="flex items-start gap-3 rounded-lg border bg-card p-4">
+          <div className="mt-0.5 rounded-full bg-green-100 p-2 dark:bg-green-950">
+            <Check className="size-4 text-green-700 dark:text-green-400" />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-medium">You&apos;re on the launch list</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {success.position
+                ? `Position #${success.position.toLocaleString()}`
+                : "Position will update on your next visit"}
+            </p>
+            {success.foundingMember ? (
+              <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+                <Sparkles className="size-3" />
+                Founding Member — early-access perks locked in
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-4">
+          <p className="text-sm">
+            When we approve your spot, you&apos;ll sign in with{" "}
+            <strong>{email}</strong> — we&apos;ll email your link. No password
+            needed.
+          </p>
+        </div>
+
+        <div className="space-y-2 rounded-lg border p-4">
+          <p className="text-sm font-medium">Skip 5 spots</p>
+          <p className="text-xs text-muted-foreground">
+            Invite a friend with your code; both of you move up the line.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 rounded bg-muted px-3 py-1.5 font-mono text-xs">
+              {success.referralCode}
+            </code>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={shareReferral}
+              aria-label="Share referral link"
+            >
+              <Share2 className="mr-1.5 size-3.5" />
+              Share
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!submitting) submit();
+      }}
+      className="w-full space-y-5 text-left"
+    >
+      <div className="space-y-2">
+        <Label>What are you most interested in?</Label>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {PRODUCTS.map(({ key, label, blurb, Icon }) => {
+            const selected = products.includes(key);
+            return (
+              <button
+                type="button"
+                key={key}
+                onClick={() => toggleProduct(key)}
+                aria-pressed={selected}
+                className={`flex flex-col items-start gap-2 rounded-xl border p-4 text-left transition-colors ${
+                  selected
+                    ? "border-primary bg-primary/5 ring-1 ring-primary"
+                    : "hover:border-foreground/20 hover:bg-muted/40"
+                }`}
+              >
+                <span className="inline-flex size-9 items-center justify-center rounded-lg border bg-muted/40 text-foreground">
+                  <Icon className="size-4" aria-hidden />
+                </span>
+                <span className="text-sm font-semibold">{label}</span>
+                <span className="text-xs text-muted-foreground">{blurb}</span>
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Pick one or both — you can change your mind later.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="lp-email">Work email</Label>
+        <Input
+          id="lp-email"
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          placeholder="you@company.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="h-11"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="lp-context">
+          Tell us about your business
+          <span className="ml-1 text-xs font-normal text-muted-foreground">
+            (optional — helps us prioritize)
+          </span>
+        </Label>
+        <Textarea
+          id="lp-context"
+          value={businessContext}
+          onChange={(e) => setBusinessContext(e.target.value)}
+          placeholder="e.g. Shopify store doing ~$40k/mo; we want to recover carts and re-engage customers on WhatsApp."
+          maxLength={2048}
+          rows={4}
+        />
+      </div>
+
+      <Button type="submit" className="h-11 w-full text-base" disabled={submitting}>
+        {submitting ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Submitting…
+          </>
+        ) : (
+          <>
+            Apply to join
+            <ArrowRight className="ml-1 size-4" aria-hidden />
+          </>
+        )}
+      </Button>
+      <p className="text-center text-xs text-muted-foreground">
+        Applying adds you to the waitlist. We&apos;ll email your sign-in link
+        when your spot is approved.
+      </p>
+    </form>
+  );
+}

--- a/src/app/launch-partner/page.tsx
+++ b/src/app/launch-partner/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
-import { ArrowLeft, Mail } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { SITE } from "@/lib/utils";
+import { LaunchPartnerForm } from "./launch-partner-form";
 
 export const metadata: Metadata = {
   title: "Become a Launch Partner — Peakhour",
@@ -8,32 +9,27 @@ export const metadata: Metadata = {
     "Join the Peakhour launch partner program. Work directly with our team to shape Peakhour Commerce and Peakhour Marketing, and get early access ahead of public launch.",
 };
 
-const PARTNER_EMAIL = SITE.contactGeneral;
-const MAILTO = `mailto:${PARTNER_EMAIL}?subject=${encodeURIComponent(
-  "Peakhour Launch Partner",
-)}&body=${encodeURIComponent(
-  "Hi Peakhour team,\n\nWe'd like to join as a launch partner.\n\nBusiness name:\nWebsite:\nWhat we sell / publish:\nPlatform (Shopify / WooCommerce / other):\nWhat we'd love help with:\n\nThanks!",
-)}`;
-
 /**
  * Pre-launch "Become a Launch Partner" capture. Self-contained (no Header/
  * Footer that link into the gated app), same monochrome aesthetic as the
  * coming-soon teaser. Reachable through the coming-soon gate because
  * /launch-partner is allowlisted in middleware (alongside the legal routes).
  *
- * V1 is intentionally a mailto capture (no backend / no new collection) —
- * pre-launch volume is low and a thread with the team is the right first
- * touch. Swap for a real form + API when volume warrants it.
+ * Applying = joining the waitlist (waitlist_signups). Ops approves applicants
+ * in the CMS (/admin/waitlist → Invite); approval is what unlocks the
+ * magic-link sign-in. No email address is exposed — the funnel is
+ * apply -> approve -> sign in. The interactive form lives in a client
+ * component so this page stays a server component for metadata.
  */
 export default function LaunchPartnerPage() {
   return (
-    <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 text-center">
+    <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 py-16 text-center">
       <div
         aria-hidden
         className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-1/2 bg-linear-to-b from-primary/5 to-transparent"
       />
 
-      <div className="mx-auto flex max-w-xl flex-col items-center gap-7">
+      <div className="mx-auto flex w-full max-w-xl flex-col items-center gap-7">
         <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
           Launch Partner Program
         </span>
@@ -49,23 +45,7 @@ export default function LaunchPartnerPage() {
           hands-on setup.
         </p>
 
-        <a
-          href={MAILTO}
-          className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
-        >
-          <Mail className="size-4" aria-hidden />
-          Email us to apply
-        </a>
-
-        <p className="text-xs text-muted-foreground">
-          Or write to{" "}
-          <a
-            href={`mailto:${PARTNER_EMAIL}`}
-            className="font-medium text-foreground underline-offset-4 hover:underline"
-          >
-            {PARTNER_EMAIL}
-          </a>
-        </p>
+        <LaunchPartnerForm />
 
         <a
           href="/coming-soon"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -116,10 +116,24 @@ export interface VerifyMagicResponse {
 
 // ── Magic Link ──────────────────────────────────────────────────
 
+/**
+ * Pre-launch sign-in is invite-only. The magic-link endpoint returns an
+ * `outcome` discriminator so the sign-in page can show the right card:
+ *   sent       — eligible (active member or ops-approved partner); link sent.
+ *   waitlisted — applied but not yet approved; tell them they're in line.
+ *   not_found  — no waitlist row; point them at the launch-partner apply form.
+ * `outcome` is optional for forward/backward-compat — absent is treated as
+ * "sent" (the legacy always-send behavior). Restored to always-"sent" at GA.
+ */
+export type MagicLinkOutcome = "sent" | "waitlisted" | "not_found";
+
 export async function sendMagicLink(
   email: string
-): Promise<{ message: string }> {
-  return api.post<{ message: string }>("/v1/auth/magic-link", { email });
+): Promise<{ outcome?: MagicLinkOutcome; message: string }> {
+  return api.post<{ outcome?: MagicLinkOutcome; message: string }>(
+    "/v1/auth/magic-link",
+    { email }
+  );
 }
 
 export async function verifyMagicLink(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -92,10 +92,14 @@ export function middleware(req: NextRequest) {
     !!previewSecret &&
     req.cookies.get(PREVIEW_COOKIE)?.value === previewSecret;
   // Pages that stay PUBLICLY reachable even while the coming-soon gate is on.
-  // Two reasons: (1) legal/compliance pages — Meta, Google, X, LinkedIn etc.
+  // Three reasons: (1) legal/compliance pages — Meta, Google, X, LinkedIn etc.
   // fetch these URLs to validate app/developer onboarding, and they must
   // resolve to the real document (not the teaser) before launch; (2) the
-  // pre-launch /launch-partner capture, linked from the coming-soon CTAs.
+  // pre-launch /launch-partner capture, linked from the coming-soon CTAs;
+  // (3) /auth (and /auth/verify) — the invite-only sign-in entry for approved
+  // launch partners (e.g. quests.travel). The page itself reveals nothing
+  // sensitive; the magic-link endpoint only sends a real link to ops-approved
+  // emails (see peakhour-api auth/magic-link.ts), so exposing the form is safe.
   // This is a plain allowlist entry on the already-running middleware — it
   // adds NO new edge function (the middleware runs on every request for the
   // CSP nonce regardless).
@@ -105,14 +109,28 @@ export function middleware(req: NextRequest) {
     "/cookie-policy",
     "/data-deletion",
     "/launch-partner",
+    "/auth",
   ];
   const isPublicPath = PUBLIC_PATHS.some(
     (p) => pathname === p || pathname.startsWith(`${p}/`),
   );
+  // Authenticated-session bypass. The b2c access/refresh cookies are scoped to
+  // the root domain (.peakhour.ai) and so are visible here. An approved launch
+  // partner who has signed in carries `refresh_token` (30d) — let them reach
+  // the real app instead of the teaser, otherwise the sign-in button is a dead
+  // end while the gate is on. This is a SOFT gate: presence ≠ validity. A
+  // crafted/garbage cookie bypasses the teaser but the app's own auth guard
+  // (AuthProvider → /v1/auth/me) immediately bounces an invalid session back to
+  // /auth, so no gated data leaks. Acceptable pre-launch; the real access
+  // control is the magic-link approval gate, not this teaser.
+  const hasSession =
+    !!req.cookies.get("access_token")?.value ||
+    !!req.cookies.get("refresh_token")?.value;
   const gated =
     comingSoon &&
     pathname !== "/coming-soon" &&
     !isPublicPath &&
+    !hasSession &&
     !grantPreview &&
     !hasPreviewCookie;
 


### PR DESCRIPTION
## What
Turns the pre-launch landing into a real **apply → CMS-approve → sign in** funnel, and kills the launch-partner mailto.

### Launch partner ([launch-partner](src/app/launch-partner/))
- New client **apply form**: email + **Commerce / Marketing** product picker (≥1) + optional business context → `POST /v1/waitlist/signup` with `productInterest`.
- **Removes the `hello@peakhour.ai` mailto** entirely. Applying = joining the waitlist.
- Success card: position, founding-member badge, referral share, and "we'll email your sign-in link when approved."

### Coming soon ([coming-soon](src/app/coming-soon/page.tsx))
- Adds a **Sign in** button (top-right) for approved partners (e.g. quests.travel).
- Hero copy refresh: visibility / engagement / growth, no channel laundry-list, fixes the "Peakhourhelps" run-together — in both H1 and meta description.

### Auth ([auth](src/app/auth/page.tsx))
- Branches on the magic-link `outcome`:
  - `waitlisted` → "**You're on the watchlist** — the wait will be worth it."
  - `not_found` → "You're not on the list yet" → **Become a launch partner** CTA.
  - `sent` → existing "check your email" cooldown card (unchanged).

### Middleware ([middleware.ts](src/middleware.ts))
- Allowlists `/auth` through the coming-soon gate (so the Sign-in button isn't a dead end).
- **Session-aware bypass**: a request carrying a b2c `access_token`/`refresh_token` (scoped to `.peakhour.ai`) skips the teaser, so approved partners reach the app. Soft gate — presence ≠ validity; the app's own `AuthProvider → /v1/auth/me` re-validates and bounces invalid sessions back to `/auth`, so no gated data leaks. Acceptable pre-launch; real access control is the magic-link approval gate.

## Why
No email shown to anyone; beta = whoever ops approves in the CMS. The sign-in page tells an approved partner ("check email") apart from an applicant-in-waiting ("watchlist") apart from a stranger ("apply").

## Checks
- `tsc --noEmit` ✅ · `eslint` (changed files) ✅

## Part of
Launch-partner waitlist funnel (PR 3/4): mongodb#200 → api#522 → **b2c** → cms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)