### PR TITLE
feat(auth): read session cookies via AUTH_COOKIE_NS namespace

### DIFF
--- a/src/lib/auth-cookies.test.ts
+++ b/src/lib/auth-cookies.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { b2cAccessCookieName, b2cRefreshCookieName } from "./auth-cookies";
+
+/**
+ * Must stay byte-identical to peakhour-api's resolution: unset → bare
+ * names (production), AUTH_COOKIE_NS="dev" → dev_ prefix. If these drift
+ * from the API, the coming-soon middleware's soft-session bypass reads a
+ * cookie the API never wrote.
+ */
+describe("b2c auth cookie names", () => {
+  const prev = process.env.AUTH_COOKIE_NS;
+  beforeEach(() => {
+    delete process.env.AUTH_COOKIE_NS;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.AUTH_COOKIE_NS;
+    else process.env.AUTH_COOKIE_NS = prev;
+  });
+
+  it("UNSET → bare names", () => {
+    expect(b2cAccessCookieName()).toBe("access_token");
+    expect(b2cRefreshCookieName()).toBe("refresh_token");
+  });
+
+  it("empty / whitespace → bare names (no leading underscore)", () => {
+    process.env.AUTH_COOKIE_NS = "";
+    expect(b2cAccessCookieName()).toBe("access_token");
+    process.env.AUTH_COOKIE_NS = "   ";
+    expect(b2cAccessCookieName()).toBe("access_token");
+  });
+
+  it('"dev" → dev_-prefixed names', () => {
+    process.env.AUTH_COOKIE_NS = "dev";
+    expect(b2cAccessCookieName()).toBe("dev_access_token");
+    expect(b2cRefreshCookieName()).toBe("dev_refresh_token");
+  });
+});

--- a/src/lib/auth-cookies.ts
+++ b/src/lib/auth-cookies.ts
@@ -1,0 +1,32 @@
+/**
+ * Auth-cookie name namespacing — mirrors peakhour-api's `jwt.ts` cookieNs().
+ *
+ * dev and prod both store the b2c session cookies on the shared
+ * `.peakhour.ai` parent domain, so without a namespace they share one
+ * cookie slot and collide in a browser that has visited both. The API
+ * stamps an optional `AUTH_COOKIE_NS` prefix onto the names; the
+ * coming-soon middleware's soft-session check must derive the SAME name.
+ * The value MUST match peakhour-api (and peakhour-cms) for the
+ * environment — unset/empty everywhere → bare names (production).
+ *
+ * Pure (process.env + string ops), so it is safe to import into the Edge
+ * middleware, which already reads other process.env values at runtime.
+ */
+function cookieNs(): string {
+  return (process.env.AUTH_COOKIE_NS || "").trim();
+}
+
+function nsCookie(base: string): string {
+  const ns = cookieNs();
+  return ns ? `${ns}_${base}` : base;
+}
+
+/** Resolved b2c access-token cookie name (ns-aware). */
+export function b2cAccessCookieName(): string {
+  return nsCookie("access_token");
+}
+
+/** Resolved b2c refresh-token cookie name (ns-aware). */
+export function b2cRefreshCookieName(): string {
+  return nsCookie("refresh_token");
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { b2cAccessCookieName, b2cRefreshCookieName } from "@/lib/auth-cookies";
 
 const isDev = process.env.NODE_ENV !== "production";
 
@@ -130,8 +131,8 @@ export function middleware(req: NextRequest) {
     (p) => pathname === p || pathname.startsWith(`${p}/`),
   );
   const hasSession =
-    !!req.cookies.get("access_token")?.value ||
-    !!req.cookies.get("refresh_token")?.value;
+    !!req.cookies.get(b2cAccessCookieName())?.value ||
+    !!req.cookies.get(b2cRefreshCookieName())?.value;
   const sessionBypass = hasSession && isAppRoute;
   const gated =
     comingSoon &&


### PR DESCRIPTION
## Why
Reader-side half of env-namespaced auth cookies (peakhour-api#524) for b2c. dev + prod b2c session cookies share the `.peakhour.ai` parent domain and the same name → collide in a browser that's visited both.

## What
- New `src/lib/auth-cookies.ts` mirrors the API's `cookieNs()`: `b2cAccessCookieName()` / `b2cRefreshCookieName()` apply the optional `AUTH_COOKIE_NS` prefix.
- `middleware.ts` coming-soon soft-session bypass resolves `access_token` / `refresh_token` through it (was hardcoded). This is the **only** runtime cookie-name read in b2c — `api.ts` reads `csrf_token` from the response **body**, not a cookie.
- Helper is pure (process.env + strings) → Edge-safe for the middleware.

## Invariant
`AUTH_COOKIE_NS` unset → **bare names = no-op in prod**. Must equal peakhour-api's value per environment.

## Tests
New `auth-cookies.test.ts` (unset=bare, empty/whitespace=bare, dev prefix). `eslint` + `tsc` clean.

## Rollout
Merge alongside api#524 + cms#96. Activate by setting `AUTH_COOKIE_NS=dev` in the dev/Preview scope of all three projects; leave unset in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)