### PR TITLE
feat(shopify): embedded admin surface shell (SE-2)

### DIFF
--- a/src/app/shopify/embedded/layout.tsx
+++ b/src/app/shopify/embedded/layout.tsx
@@ -1,0 +1,32 @@
+import Script from "next/script";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+/**
+ * Embedded Shopify admin surface (shopify-app-submission-plan.md §SE).
+ *
+ * Loaded inside an iframe by admin.shopify.com (the middleware grants these
+ * routes a `frame-ancestors https://admin.shopify.com` CSP and exempts them
+ * from the coming-soon gate). App Bridge v4 is loaded from Shopify's CDN and
+ * reads the app's client id (API key) from the `shopify-api-key` meta tag,
+ * then exposes `window.shopify` (incl. `idToken()` for per-request auth).
+ *
+ * Set NEXT_PUBLIC_SHOPIFY_API_KEY to the app's client id (public — it travels
+ * in every authorize URL; it is the same value as shopify.app.toml client_id).
+ */
+
+const SHOPIFY_API_KEY = process.env.NEXT_PUBLIC_SHOPIFY_API_KEY ?? "";
+
+export const metadata: Metadata = {
+  // Placed in <head> by Next's metadata API — App Bridge reads this at load.
+  other: SHOPIFY_API_KEY ? { "shopify-api-key": SHOPIFY_API_KEY } : {},
+};
+
+export default function ShopifyEmbeddedLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Script src="https://cdn.shopify.com/shopifycloud/app-bridge.js" />
+      <div className="min-h-screen bg-white text-neutral-900">{children}</div>
+    </>
+  );
+}

--- a/src/app/shopify/embedded/page.tsx
+++ b/src/app/shopify/embedded/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Embedded surface home — the primary workflow entry inside Shopify admin.
+ * Authenticates via the App Bridge session token (no cookie — iframes block
+ * third-party cookies), calls the api `/v1/shopify/embedded/context`, and
+ * renders the connected store's status (or a link-account prompt when the
+ * shop isn't yet tied to a Peakhour account → onboarding lands in S3).
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+declare global {
+  interface Window {
+    shopify?: { idToken: () => Promise<string> };
+  }
+}
+
+interface EmbeddedContext {
+  connected: boolean;
+  shop?: string;
+  storeName?: string | null;
+  currency?: string | null;
+  productsSyncedAt?: string | null;
+  connectionStatus?: string | null;
+}
+
+/** App Bridge attaches `window.shopify` asynchronously after its CDN script
+ *  loads; poll briefly for it, then fetch a fresh session token. */
+async function getSessionToken(timeoutMs = 6000): Promise<string | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (typeof window !== "undefined" && window.shopify?.idToken) {
+      try {
+        return await window.shopify.idToken();
+      } catch {
+        return null;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return null;
+}
+
+type State =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; ctx: EmbeddedContext };
+
+export default function ShopifyEmbeddedHome() {
+  const [state, setState] = useState<State>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const token = await getSessionToken();
+      if (cancelled) return;
+      if (!token) {
+        setState({
+          status: "error",
+          message:
+            "Couldn't get a Shopify session. Please open Peakhour from your Shopify admin.",
+        });
+        return;
+      }
+      try {
+        const res = await fetch(`${API_URL}/v1/shopify/embedded/context`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({ status: "error", message: `Could not load your store (${res.status}).` });
+          return;
+        }
+        const ctx = (await res.json()) as EmbeddedContext;
+        if (!cancelled) setState({ status: "ready", ctx });
+      } catch {
+        if (!cancelled) setState({ status: "error", message: "Network error contacting Peakhour." });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <h1 className="text-2xl font-semibold">Peakhour Commerce</h1>
+      <p className="mt-1 text-sm text-neutral-500">
+        Your catalog-grounded WhatsApp assistant, connected to your Shopify store.
+      </p>
+
+      <div className="mt-8 rounded-xl border border-neutral-200 p-6">
+        {state.status === "loading" && (
+          <p className="text-sm text-neutral-500">Connecting to your store…</p>
+        )}
+
+        {state.status === "error" && (
+          <p className="text-sm text-red-600">{state.message}</p>
+        )}
+
+        {state.status === "ready" && state.ctx.connected && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <span className="inline-block h-2 w-2 rounded-full bg-green-500" aria-hidden />
+              <span className="font-medium">
+                {state.ctx.storeName || state.ctx.shop} is connected
+              </span>
+            </div>
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-neutral-600">
+              {state.ctx.shop && (
+                <>
+                  <dt className="text-neutral-400">Store</dt>
+                  <dd>{state.ctx.shop}</dd>
+                </>
+              )}
+              {state.ctx.currency && (
+                <>
+                  <dt className="text-neutral-400">Currency</dt>
+                  <dd>{state.ctx.currency}</dd>
+                </>
+              )}
+              <dt className="text-neutral-400">Catalog last synced</dt>
+              <dd>
+                {state.ctx.productsSyncedAt
+                  ? new Date(state.ctx.productsSyncedAt).toLocaleString()
+                  : "Syncing…"}
+              </dd>
+            </dl>
+            <p className="pt-2 text-sm text-neutral-500">
+              Your product catalog is syncing to Peakhour. The WhatsApp assistant answers
+              shopper questions grounded in these products. Set up and preview it from your
+              Peakhour dashboard.
+            </p>
+          </div>
+        )}
+
+        {state.status === "ready" && !state.ctx.connected && (
+          <div className="space-y-3">
+            <p className="font-medium">Link your Peakhour account</p>
+            <p className="text-sm text-neutral-600">
+              {state.ctx.shop ? `${state.ctx.shop} ` : "This store "}
+              isn&apos;t linked to a Peakhour account yet. Finish setup to connect your
+              catalog and switch on the assistant.
+            </p>
+            <p className="text-xs text-neutral-400">
+              Guided onboarding is coming to this screen shortly.
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,16 +17,31 @@ const apiOrigin = (() => {
  * Only needed for full-document requests — prefetch/rsc/server-action requests
  * deliberately get no nonce/CSP (it can break RSC streaming).
  */
+/** The embedded Shopify surface must be iframeable by Shopify admin and load
+ *  App Bridge from Shopify's CDN — so those routes get a distinct CSP. Every
+ *  other route keeps `frame-ancestors 'none'`. */
+function isShopifyEmbeddedPath(pathname: string): boolean {
+  return pathname === "/shopify/embedded" || pathname.startsWith("/shopify/embedded/");
+}
+
 function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
   const nonce = btoa(
     String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
   );
+  const embedded = isShopifyEmbeddedPath(req.nextUrl.pathname);
+
+  // Embedded routes: allow Shopify to frame us + App Bridge from cdn.shopify.com.
+  // We DON'T use 'strict-dynamic' here (it fights App Bridge's dynamic loads);
+  // the explicit cdn.shopify.com host allowance + nonce cover our scripts.
   const scriptSrc = isDev
-    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.shopify.com"
+    : embedded
+      ? `script-src 'self' 'nonce-${nonce}' https://cdn.shopify.com`
+      : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
   const connectSrc = [
     "connect-src 'self'",
     apiOrigin,
+    embedded ? "https://cdn.shopify.com" : "",
     "https://*.vercel-insights.com",
     "https://vitals.vercel-insights.com",
     "https://*.vercel-analytics.com",
@@ -34,6 +49,9 @@ function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
   ]
     .filter(Boolean)
     .join(" ");
+  const frameAncestors = embedded
+    ? "frame-ancestors https://admin.shopify.com https://*.myshopify.com"
+    : "frame-ancestors 'none'";
   const csp = [
     "default-src 'self'",
     scriptSrc,
@@ -43,10 +61,10 @@ function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
     // Allow framing https subresources — the LinkedIn carousel preview renders
     // a PDF served from the R2 media origin in an <iframe>. Consistent with the
     // img-src `https:` allowance; `frame-ancestors 'none'` still blocks anyone
-    // from framing US.
+    // from framing US (except the embedded Shopify surface, above).
     "frame-src 'self' https:",
     connectSrc,
-    "frame-ancestors 'none'",
+    frameAncestors,
     "base-uri 'self'",
     "form-action 'self'",
     "object-src 'none'",
@@ -134,10 +152,15 @@ export function middleware(req: NextRequest) {
     !!req.cookies.get(b2cAccessCookieName())?.value ||
     !!req.cookies.get(b2cRefreshCookieName())?.value;
   const sessionBypass = hasSession && isAppRoute;
+  // The embedded Shopify surface is loaded by Shopify admin (iframe) and
+  // authenticates via the App Bridge session token, not our cookie — so it
+  // must stay reachable even while the coming-soon gate is on.
+  const isShopifyEmbedded = isShopifyEmbeddedPath(pathname);
   const gated =
     comingSoon &&
     pathname !== "/coming-soon" &&
     !isPublicPath &&
+    !isShopifyEmbedded &&
     !sessionBypass &&
     !grantPreview &&
     !hasPreviewCookie;


### PR DESCRIPTION
## What

Sprint **SE-2** — the App-Store-required **embedded admin surface**, built as a route group inside `peakhour-b2c` (the locked decision: host it here, not a separate repo). Pairs with api **#530** (session-token auth).

## Changes

- **`middleware.ts`** — a **scoped** Shopify CSP for `/shopify/embedded/*` only:
  - `frame-ancestors https://admin.shopify.com https://*.myshopify.com` so Shopify can iframe it. **Every other route keeps `frame-ancestors 'none'`** (verified: the `embedded` flag is path-gated).
  - allows App Bridge from `https://cdn.shopify.com` in `script-src`/`connect-src`; drops `strict-dynamic` on these routes only (it fights App Bridge's dynamic script loads).
  - exempts the embedded routes from the **coming-soon gate** (Shopify must reach them pre-launch; they self-auth via the session token, not our cookie).
- **`app/shopify/embedded/layout.tsx`** — loads **App Bridge v4** from `cdn.shopify.com` + the `shopify-api-key` meta (`NEXT_PUBLIC_SHOPIFY_API_KEY`).
- **`app/shopify/embedded/page.tsx`** — gets the App Bridge **session token** and calls `/v1/shopify/embedded/context`, rendering the connected store's status (name/currency/last-sync) or a **link-account** prompt when the shop isn't tied to a Peakhour account yet (guided onboarding = S3).

## Validation
- `tsc --noEmit` clean; `eslint` clean on the changed files.
- Non-embedded routes' CSP is unchanged (framing still blocked) — the relaxation is strictly path-scoped to `/shopify/embedded/*`.

## Activation (S6 deploy step — intentionally NOT in this PR)
This builds the surface; turning the app "embedded" is a coordinated deploy step, deferred to avoid disturbing the live connector mid-flight:
1. set **`NEXT_PUBLIC_SHOPIFY_API_KEY`** (= the app client id) in b2c env,
2. move `shopify.app.toml` → b2c root, set `embedded = true` + `application_url` → the b2c embedded surface,
3. Partner Dashboard: flip embedded + app URL,
4. `shopify app deploy`.

## Follow-up
- **S3**: token exchange (managed install on first embedded load) + the fresh-install onboarding/account-link UX that this page currently stubs.
- Polish: swap the plain-Tailwind shell for shadcn/AI-Elements components alongside the **S5** preview widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
