### PR TITLE
feat(commerce): WhatsApp-style assistant preview widget (S5)

### DIFF
--- a/src/app/dashboard/commerce/assistant/page.tsx
+++ b/src/app/dashboard/commerce/assistant/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { CommerceAssistantPreview } from "@/components/commerce/assistant-preview";
+
+export const metadata: Metadata = {
+  title: "Assistant preview · Commerce",
+};
+
+/**
+ * Commerce → Assistant preview (shopify-app-submission-plan.md §S5).
+ * Try the catalog-grounded WhatsApp assistant against your connected store's
+ * real catalog, right from the dashboard — no live WhatsApp number needed.
+ */
+export default function CommerceAssistantPreviewPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-xl font-semibold">Assistant preview</h1>
+        <p className="mt-1 text-sm text-neutral-500">
+          This is the same catalog-grounded assistant that answers your customers on WhatsApp,
+          running against your connected store. Ask it anything a shopper might — in any language.
+          It only states facts from your real product catalog.
+        </p>
+      </header>
+      <CommerceAssistantPreview />
+    </div>
+  );
+}

--- a/src/components/commerce/assistant-preview.tsx
+++ b/src/components/commerce/assistant-preview.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useCommercePreview } from "@/hooks/use-commerce-preview";
+
+/**
+ * Simulated-WhatsApp preview of the catalog-grounded assistant
+ * (shopify-app-submission-plan.md §S5). Lets a merchant try the assistant
+ * against their real catalog from the Peakhour dashboard, before/without a
+ * live WhatsApp number. Styled to read like a WhatsApp thread.
+ */
+
+const SUGGESTIONS = [
+  "What do you sell?",
+  "Show me something under 1000",
+  "Is this available in small?",
+];
+
+export function CommerceAssistantPreview() {
+  const { messages, isLoading, sendMessage } = useCommercePreview();
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, isLoading]);
+
+  const submit = (text: string) => {
+    if (!text.trim() || isLoading) return;
+    setInput("");
+    void sendMessage(text);
+  };
+
+  return (
+    <div className="mx-auto flex h-[560px] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-neutral-200 shadow-sm">
+      {/* WhatsApp-style header */}
+      <div className="flex items-center gap-3 bg-[#075E54] px-4 py-3 text-white">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/20 text-sm font-semibold">
+          P
+        </div>
+        <div className="leading-tight">
+          <div className="text-sm font-medium">Store Assistant</div>
+          <div className="text-xs text-white/70">preview · catalog-grounded</div>
+        </div>
+      </div>
+
+      {/* Thread */}
+      <div
+        ref={scrollRef}
+        className="flex-1 space-y-2 overflow-y-auto bg-[#ECE5DD] px-3 py-4"
+      >
+        {messages.length === 0 && (
+          <div className="mx-auto mt-6 max-w-xs rounded-lg bg-white/70 px-3 py-2 text-center text-xs text-neutral-500">
+            Ask about your products the way a customer would — in any language.
+          </div>
+        )}
+
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
+          >
+            <div
+              className={`max-w-[78%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm shadow-sm ${
+                m.role === "user"
+                  ? "rounded-br-none bg-[#DCF8C6] text-neutral-900"
+                  : "rounded-bl-none bg-white text-neutral-900"
+              }`}
+            >
+              {m.content}
+            </div>
+          </div>
+        ))}
+
+        {isLoading && (
+          <div className="flex justify-start">
+            <div className="rounded-lg rounded-bl-none bg-white px-3 py-2 text-sm text-neutral-400 shadow-sm">
+              typing…
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Suggestion chips (only before the first message) */}
+      {messages.length === 0 && (
+        <div className="flex flex-wrap gap-2 bg-[#ECE5DD] px-3 pb-2">
+          {SUGGESTIONS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => submit(s)}
+              className="rounded-full border border-neutral-300 bg-white px-3 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Composer */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit(input);
+        }}
+        className="flex items-center gap-2 border-t border-neutral-200 bg-white px-3 py-2"
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message…"
+          className="flex-1 rounded-full border border-neutral-200 px-4 py-2 text-sm outline-none focus:border-[#075E54]"
+          maxLength={2000}
+        />
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          className="rounded-full bg-[#075E54] px-4 py-2 text-sm font-medium text-white disabled:opacity-40"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/hooks/use-commerce-preview.ts
+++ b/src/hooks/use-commerce-preview.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { api } from "@/lib/api";
+
+export interface PreviewMessage {
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+}
+
+/**
+ * Drives the Commerce assistant preview (shopify-app-submission-plan.md §S5).
+ * Each send posts the message + recent history to the api, which runs the SAME
+ * catalog-grounded agent the WhatsApp path uses, against the merchant's real
+ * catalog. Non-streaming request/response (simple + good enough for a preview).
+ */
+export function useCommercePreview() {
+  const [messages, setMessages] = useState<PreviewMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+
+      const history = messages.slice(-6).map((m) => ({ role: m.role, content: m.content }));
+      const userMsg: PreviewMessage = {
+        role: "user",
+        content: trimmed,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+      setIsLoading(true);
+
+      try {
+        const res = await api.post<{ reply: string }>("/v1/commerce/assistant/preview", {
+          message: trimmed,
+          history,
+        });
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: res.reply, timestamp: new Date().toISOString() },
+        ]);
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content:
+              "Couldn't reach the assistant. Make sure a Shopify store is connected to this business, then try again.",
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [messages],
+  );
+
+  const reset = useCallback(() => setMessages([]), []);
+
+  return { messages, isLoading, sendMessage, reset };
+}


### PR DESCRIPTION
Dashboard preview of the catalog-grounded assistant (plan §S5) — try it against the real connected catalog, no live WhatsApp number needed. Pairs with peakhour-api preview endpoint.

- `use-commerce-preview` hook → `/v1/commerce/assistant/preview` (cookie-authed via api client).
- Simulated-WhatsApp widget (header/bubbles/suggestion chips/composer, plain Tailwind).
- Page at `/dashboard/commerce/assistant`.

Cookie-authed → lives in the dashboard (per §S5), distinct from the embedded iframe. typecheck + eslint clean. Follow-ups: top-level Commerce nav entry; optional Vercel AI Elements + streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)