### PR TITLE
feat(commerce): embedded Subscribe CTA + billing return page (SB-2d)

### DIFF
--- a/src/app/shopify/embedded/billing/return/page.tsx
+++ b/src/app/shopify/embedded/billing/return/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Shopify Billing return page (SB-2d). After the merchant approves the charge
+ * on Shopify's hosted page, Shopify redirects here (the app's returnUrl). We
+ * get a fresh App Bridge session token and call billing/confirm, which
+ * reconciles + grants the commerce.assistant entitlement.
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+declare global {
+  interface Window {
+    shopify?: { idToken: () => Promise<string> };
+  }
+}
+
+async function getSessionToken(timeoutMs = 6000): Promise<string | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (typeof window !== "undefined" && window.shopify?.idToken) {
+      try {
+        return await window.shopify.idToken();
+      } catch {
+        return null;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return null;
+}
+
+type State =
+  | { status: "confirming" }
+  | { status: "active" }
+  | { status: "inactive" }
+  | { status: "error"; message: string };
+
+export default function ShopifyBillingReturn() {
+  const [state, setState] = useState<State>({ status: "confirming" });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const token = await getSessionToken();
+      if (cancelled) return;
+      if (!token) {
+        setState({ status: "error", message: "Couldn't confirm — please reopen from your Shopify admin." });
+        return;
+      }
+      try {
+        const res = await fetch(`${API_URL}/v1/shopify/embedded/billing/confirm`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({ status: "error", message: "Couldn't confirm your subscription. Please try again." });
+          return;
+        }
+        const data = (await res.json()) as { active?: boolean };
+        setState({ status: data.active ? "active" : "inactive" });
+      } catch {
+        if (!cancelled) setState({ status: "error", message: "Network error confirming your subscription." });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <h1 className="text-2xl font-semibold">Peakhour Commerce</h1>
+      <div className="mt-8 rounded-xl border border-neutral-200 p-6">
+        {state.status === "confirming" && (
+          <p className="text-sm text-neutral-500">Confirming your subscription…</p>
+        )}
+        {state.status === "active" && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <span className="inline-block h-2 w-2 rounded-full bg-green-500" aria-hidden />
+              <span className="font-medium">Your assistant is active 🎉</span>
+            </div>
+            <p className="text-sm text-neutral-600">
+              The catalog-grounded WhatsApp assistant is switched on for your store. You can
+              configure and preview it from your Peakhour dashboard.
+            </p>
+            <a href="/shopify/embedded" className="inline-block pt-1 text-sm text-[#075E54] underline">
+              Back to Peakhour Commerce
+            </a>
+          </div>
+        )}
+        {state.status === "inactive" && (
+          <p className="text-sm text-neutral-600">
+            We couldn&apos;t find an active subscription yet. If you just approved it, give it a
+            moment and refresh.
+          </p>
+        )}
+        {state.status === "error" && <p className="text-sm text-red-600">{state.message}</p>}
+      </div>
+    </main>
+  );
+}

--- a/src/app/shopify/embedded/page.tsx
+++ b/src/app/shopify/embedded/page.tsx
@@ -25,6 +25,13 @@ interface EmbeddedContext {
   currency?: string | null;
   productsSyncedAt?: string | null;
   connectionStatus?: string | null;
+  assistantActive?: boolean;
+  pricing?: {
+    displayName: string;
+    amount: string;
+    currency: string;
+    interval: "monthly" | "annual";
+  } | null;
 }
 
 /** App Bridge attaches `window.shopify` asynchronously after its CDN script
@@ -51,6 +58,38 @@ type State =
 
 export default function ShopifyEmbeddedHome() {
   const [state, setState] = useState<State>({ status: "loading" });
+  const [subscribing, setSubscribing] = useState(false);
+  const [subErr, setSubErr] = useState<string | null>(null);
+
+  /** Start the Shopify Billing checkout: mint a charge, then break out of the
+   *  admin iframe to Shopify's hosted approve-and-pay page. */
+  async function handleSubscribe() {
+    setSubscribing(true);
+    setSubErr(null);
+    const token = await getSessionToken();
+    if (!token) {
+      setSubErr("Couldn't get a Shopify session. Please reopen from your admin.");
+      setSubscribing(false);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/v1/shopify/embedded/billing/subscribe`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json().catch(() => ({}))) as { confirmationUrl?: string };
+      if (!res.ok || !data.confirmationUrl) {
+        setSubErr("Could not start checkout. Please try again.");
+        setSubscribing(false);
+        return;
+      }
+      // confirmationUrl is a Shopify-hosted page — navigate the TOP frame.
+      (window.top ?? window).location.href = data.confirmationUrl;
+    } catch {
+      setSubErr("Network error starting checkout.");
+      setSubscribing(false);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -129,11 +168,32 @@ export default function ShopifyEmbeddedHome() {
                   : "Syncing…"}
               </dd>
             </dl>
-            <p className="pt-2 text-sm text-neutral-500">
-              Your product catalog is syncing to Peakhour. The WhatsApp assistant answers
-              shopper questions grounded in these products. Set up and preview it from your
-              Peakhour dashboard.
-            </p>
+            {state.ctx.assistantActive ? (
+              <div className="mt-2 rounded-lg bg-green-50 px-4 py-3 text-sm text-green-800">
+                ✓ Your WhatsApp catalog assistant is active. Manage and preview it from your
+                Peakhour dashboard.
+              </div>
+            ) : (
+              <div className="mt-2 space-y-2 rounded-lg border border-neutral-200 p-4">
+                <p className="text-sm text-neutral-600">
+                  Switch on the catalog-grounded WhatsApp assistant — it answers shopper
+                  questions using your real products, in their own language.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleSubscribe}
+                  disabled={subscribing}
+                  className="rounded-lg bg-[#075E54] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                >
+                  {subscribing
+                    ? "Starting checkout…"
+                    : state.ctx.pricing
+                      ? `Subscribe — ${state.ctx.pricing.currency === "USD" ? "$" : state.ctx.pricing.currency + " "}${state.ctx.pricing.amount}/mo`
+                      : "Subscribe"}
+                </button>
+                {subErr && <p className="text-sm text-red-600">{subErr}</p>}
+              </div>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
Closes the purchase loop in the embedded surface (pairs with api #536 + the SB-2b charge flow).

- Embedded home: when connected + not entitled, a **Subscribe** CTA at the CMS price → `billing/subscribe` → breaks out of the admin iframe to Shopify's hosted approve-and-pay page; when active, an 'assistant active' badge.
- `billing/return` page: after approval, gets a session token → `billing/confirm` (reconciles + grants `commerce.assistant`) → success/pending.

typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)