### PR TITLE
feat(peaks): balance chip, cap banners, and rate card page

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -37,6 +37,8 @@ import { BusinessSwitcher } from "@/components/dashboard/business-switcher";
 import { PlanBadge } from "@/components/dashboard/plan-badge";
 import { AttentionBell } from "@/components/dashboard/attention-bell";
 import { TrialExpiryBanner } from "@/components/dashboard/trial-expiry-banner";
+import { BalanceChip } from "@/components/dashboard/balance-chip";
+import { CreditCapBanner } from "@/components/dashboard/credits-cap-banner";
 import { CommandMenu } from "@/components/molecules/command-menu";
 import { SidebarStorageMeter } from "@/components/dashboard/sidebar-storage-meter";
 import { FeedbackWidget } from "@/components/molecules/feedback-widget";
@@ -52,6 +54,7 @@ import {
   ArrowLeftRight,
   ChevronRight,
   ListChecks,
+  Zap,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -125,6 +128,7 @@ const NAV_GROUPS: NavGroup[] = [
       },
       { href: "/dashboard/tasks", label: "Tasks", icon: ListChecks, badge: () => <RunningJobsBadge /> },
       { href: "/dashboard/integrations", label: "Integrations", icon: Plug },
+      { href: "/dashboard/peaks", label: "Peaks", icon: Zap },
       {
         href: "/dashboard/settings",
         label: "Settings",
@@ -414,6 +418,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
           <div className="ml-auto flex items-center gap-3">
+            <BalanceChip />
             <PlanBadge />
             <AttentionBell />
             <FeedbackWidget />
@@ -424,8 +429,9 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
               only when a trial is within the final 3 days. Component
               renders nothing in all other states (no trial, plenty of
               days left, dismissed). */}
-          <div className="mb-4">
+          <div className="mb-4 flex flex-col gap-2">
             <TrialExpiryBanner />
+            <CreditCapBanner />
           </div>
           {children}
         </div>

--- a/src/app/dashboard/peaks/loading.tsx
+++ b/src/app/dashboard/peaks/loading.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function PeaksLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="h-16 w-48 animate-pulse rounded-md bg-muted" />
+      <Card>
+        <CardHeader>
+          <div className="h-5 w-24 animate-pulse rounded bg-muted" />
+        </CardHeader>
+        <CardContent>
+          <div className="h-20 animate-pulse rounded-md bg-muted" />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <div className="h-5 w-24 animate-pulse rounded bg-muted" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="h-8 animate-pulse rounded-md bg-muted" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/peaks/page.tsx
+++ b/src/app/dashboard/peaks/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+import { Zap, History, ArrowUpRight, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import Link from "next/link";
+import { useCreditsBalance, useCreditsRateCard, useCreditsHistory } from "@/hooks/use-credits";
+
+// ── Formatting helpers ────────────────────────────────────────────────────
+
+function fmtPeaks(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function fmtResetDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: "long", day: "numeric" });
+}
+
+// ── Usage History Sheet ────────────────────────────────────────────────────
+
+function UsageHistorySheet({ open, onOpenChange }: { open: boolean; onOpenChange: (v: boolean) => void }) {
+  const { data, isLoading } = useCreditsHistory();
+
+  const days = data?.days ?? [];
+  const total = data?.total ?? 0;
+
+  // Find max for bar scaling
+  const maxPeaks = days.reduce((m, d) => Math.max(m, d.peaks), 1);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex flex-col sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <History className="size-4" />
+            Usage History
+          </SheetTitle>
+          <SheetDescription>Peaks consumed per day over the last 30 days.</SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4 flex-1 overflow-auto px-1">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : days.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-center">
+              <Zap className="size-8 text-muted-foreground/40" />
+              <p className="text-sm text-muted-foreground">No Peaks used in the last 30 days.</p>
+            </div>
+          ) : (
+            <>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Total:{" "}
+                <span className="font-semibold text-foreground">{fmtPeaks(total)} Peaks</span>
+              </p>
+              <div className="space-y-2">
+                {[...days].reverse().map((d) => (
+                  <div key={d.date} className="flex items-center gap-3">
+                    <span className="w-16 shrink-0 text-xs text-muted-foreground">
+                      {fmtDate(d.date)}
+                    </span>
+                    <div className="flex flex-1 items-center gap-2">
+                      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+                        <div
+                          className="h-full rounded-full bg-primary"
+                          style={{ width: `${Math.max(2, (d.peaks / maxPeaks) * 100)}%` }}
+                        />
+                      </div>
+                      <span className="w-16 text-right text-xs tabular-nums text-foreground">
+                        {fmtPeaks(d.peaks)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────
+
+export default function PeaksPage() {
+  const { data: balance, isLoading: balanceLoading } = useCreditsBalance();
+  const { data: rateCard, isLoading: rateLoading } = useCreditsRateCard();
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  const pct =
+    balance && !balance.unlimited && balance.hardCap > 0
+      ? Math.min(100, Math.round((balance.used / balance.hardCap) * 100))
+      : 0;
+
+  const capColor =
+    balance && !balance.unlimited
+      ? pct >= 100
+        ? "bg-red-500"
+        : pct >= 80
+          ? "bg-amber-500"
+          : "bg-primary"
+      : "bg-primary";
+
+  return (
+    <>
+      <UsageHistorySheet open={historyOpen} onOpenChange={setHistoryOpen} />
+
+      <div className="space-y-6">
+        {/* Page header */}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+              <Zap className="size-6" />
+              Peaks
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              AI credits that power every feature. Resets monthly on your billing date.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => setHistoryOpen(true)}
+          >
+            <History className="size-4" />
+            Usage history
+          </Button>
+        </div>
+
+        {/* ── Balance card ──────────────────────────────────────────── */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Your Balance</CardTitle>
+            {balance && !balance.unlimited && (
+              <CardDescription>
+                Resets on {fmtResetDate(balance.resetAt)}
+              </CardDescription>
+            )}
+          </CardHeader>
+          <CardContent>
+            {balanceLoading ? (
+              <div className="h-16 animate-pulse rounded-md bg-muted" />
+            ) : !balance ? (
+              <p className="text-sm text-muted-foreground">Could not load balance.</p>
+            ) : balance.unlimited ? (
+              <div className="flex items-center gap-3">
+                <span className="text-4xl font-bold tracking-tight">∞</span>
+                <span className="text-muted-foreground">Unlimited Peaks</span>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex items-end justify-between">
+                  <div>
+                    <span className="text-4xl font-bold tabular-nums tracking-tight">
+                      {fmtPeaks(balance.remaining)}
+                    </span>
+                    <span className="ml-2 text-muted-foreground">
+                      / {fmtPeaks(balance.hardCap)} remaining
+                    </span>
+                  </div>
+                  <span className="text-sm tabular-nums text-muted-foreground">
+                    {pct}% used
+                  </span>
+                </div>
+                {/* Styled progress bar — uses a raw div so we can color-code it */}
+                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className={`h-full rounded-full transition-all ${capColor}`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                {pct >= 80 && (
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm text-muted-foreground">
+                      {pct >= 100
+                        ? "AI features are paused until your Peaks reset."
+                        : "Getting close — AI features pause when you hit the limit."}
+                    </p>
+                    <Button size="sm" variant="outline" asChild className="gap-1">
+                      <Link href="/dashboard/settings/billing">
+                        Upgrade <ArrowUpRight className="size-3" />
+                      </Link>
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Rate card ─────────────────────────────────────────────── */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle className="text-base">Rate Card</CardTitle>
+                <CardDescription className="mt-1">
+                  How many Peaks each AI feature uses per activation.
+                  Actual usage varies by output length.
+                </CardDescription>
+              </div>
+              {rateLoading && (
+                <RefreshCw className="size-4 animate-spin text-muted-foreground" />
+              )}
+            </div>
+          </CardHeader>
+          <CardContent className="p-0">
+            {rateLoading ? (
+              <div className="space-y-2 p-6">
+                {[...Array(6)].map((_, i) => (
+                  <div key={i} className="h-8 animate-pulse rounded-md bg-muted" />
+                ))}
+              </div>
+            ) : !rateCard || rateCard.useCases.length === 0 ? (
+              <p className="p-6 text-sm text-muted-foreground">
+                Rate card not available. Contact support if this persists.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Feature</TableHead>
+                    <TableHead className="text-right">Min Peaks / call</TableHead>
+                    <TableHead className="text-right">Rate multiplier</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rateCard.useCases.map((u) => (
+                    <TableRow key={u.useCase}>
+                      <TableCell className="font-medium">{u.label}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {u.minCreditsPerCall > 0 ? u.minCreditsPerCall.toLocaleString() : "—"}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-muted-foreground">
+                        {u.creditMultiplier}×
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Explainer ─────────────────────────────────────────────── */}
+        <p className="text-xs text-muted-foreground">
+          1 Peak ≈ $0.001 in AI compute. Peaks are consumed when the AI runs — not when you write
+          or edit. Unused Peaks reset each month and do not roll over.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/balance-chip.tsx
+++ b/src/components/dashboard/balance-chip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { Zap } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useCreditsBalance, getCapStatus } from "@/hooks/use-credits";
+
+/**
+ * Compact Peaks balance chip for the dashboard top bar.
+ *
+ * Colour-codes by cap state:
+ *   - none  : muted (healthy)
+ *   - soft  : amber (≥80% of monthly cap — warning)
+ *   - hard  : red   (≥100% — AI features paused)
+ *   - unlimited: muted with "∞" glyph
+ *
+ * Clicking navigates to /dashboard/peaks for the full rate card + history.
+ * Renders nothing until the balance fetch resolves.
+ */
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+const CAP_CLASSES: Record<"none" | "soft" | "hard", string> = {
+  none: "text-muted-foreground hover:text-foreground",
+  soft: "text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300",
+  hard: "text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300",
+};
+
+export function BalanceChip() {
+  const { data: balance } = useCreditsBalance();
+
+  if (!balance) return null;
+
+  const capStatus = getCapStatus(balance);
+  const classes = CAP_CLASSES[capStatus];
+
+  const label = balance.unlimited
+    ? "∞ Peaks"
+    : `${fmt(balance.remaining)} Peaks`;
+
+  return (
+    <Link
+      href="/dashboard/peaks"
+      className={cn(
+        "hidden items-center gap-1 text-xs font-medium transition-colors sm:flex",
+        classes,
+      )}
+      title={
+        balance.unlimited
+          ? "Unlimited Peaks — click for rate card"
+          : `${balance.remaining.toLocaleString()} of ${balance.hardCap.toLocaleString()} Peaks remaining`
+      }
+    >
+      <Zap className="size-3.5" />
+      {label}
+    </Link>
+  );
+}

--- a/src/components/dashboard/credits-cap-banner.tsx
+++ b/src/components/dashboard/credits-cap-banner.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Zap, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useCreditsBalance, getCapStatus } from "@/hooks/use-credits";
+
+/**
+ * Dismissible banner that surfaces when an org approaches or hits its
+ * monthly Peaks limit.
+ *
+ *   - soft cap (used ≥ softCap): amber — "You've used 80%+ of your Peaks"
+ *   - hard cap (used ≥ hardCap): red   — "Peaks limit reached, AI paused"
+ *
+ * Dismissal is session-scoped (component state). Persisting it across
+ * reloads via localStorage is deliberately deferred — the hard-cap banner
+ * should reappear on every page load until the user acts.
+ *
+ * Renders nothing when: unlimited plan, below soft threshold, loading,
+ * or dismissed (for soft cap only — hard cap cannot be dismissed).
+ */
+export function CreditCapBanner() {
+  const { data: balance, isLoading } = useCreditsBalance();
+  const [softDismissed, setSoftDismissed] = useState(false);
+
+  if (isLoading || !balance || balance.unlimited) return null;
+
+  const capStatus = getCapStatus(balance);
+  if (capStatus === "none") return null;
+  if (capStatus === "soft" && softDismissed) return null;
+
+  const pct = balance.hardCap > 0 ? Math.round((balance.used / balance.hardCap) * 100) : 0;
+  const resetDate = new Date(balance.resetAt).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+
+  if (capStatus === "hard") {
+    return (
+      <div
+        className="flex flex-col gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-900 sm:flex-row sm:items-center sm:gap-3 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200"
+        role="alert"
+        aria-live="assertive"
+      >
+        <AlertTriangle className="size-4 shrink-0" />
+        <div className="flex-1 text-sm">
+          <span className="font-medium">Monthly Peaks limit reached.</span>{" "}
+          AI features are paused until {resetDate}. Upgrade to resume immediately.
+        </div>
+        <Button size="sm" variant="destructive" asChild>
+          <Link href="/dashboard/settings/billing">Upgrade plan</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  // soft cap
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 sm:flex-row sm:items-center sm:gap-3 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200"
+      role="status"
+      aria-live="polite"
+    >
+      <Zap className="size-4 shrink-0" />
+      <div className="flex-1 text-sm">
+        <span className="font-medium">You&apos;ve used {pct}% of your monthly Peaks.</span>{" "}
+        AI features will pause when the limit is reached. Resets on {resetDate}.
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="outline" asChild className="border-amber-300 dark:border-amber-700">
+          <Link href="/dashboard/settings/billing">Upgrade</Link>
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => setSoftDismissed(true)}
+          aria-label="Dismiss"
+        >
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-credits.ts
+++ b/src/hooks/use-credits.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+// ── Response types ─────────────────────────────────────────────────────────
+
+export type CreditsBalance =
+  | { unlimited: true; plan: string }
+  | {
+      unlimited: false;
+      plan: string;
+      metric: string;
+      hardCap: number;
+      softCap: number;
+      used: number;
+      remaining: number;
+      windowStartAt: string;
+      resetAt: string;
+      boostAddonKey: string | null;
+    };
+
+export interface RateCardUseCase {
+  useCase: string;
+  label: string;
+  creditMultiplier: number;
+  minCreditsPerCall: number;
+}
+
+export interface CreditsHistoryDay {
+  date: string;
+  peaks: number;
+}
+
+// ── Cap status helper ──────────────────────────────────────────────────────
+
+/** Returns "hard" | "soft" | "none". Unlimited plans always return "none". */
+export function getCapStatus(balance: CreditsBalance | undefined): "hard" | "soft" | "none" {
+  if (!balance || balance.unlimited) return "none";
+  if (balance.used >= balance.hardCap) return "hard";
+  if (balance.used >= balance.softCap) return "soft";
+  return "none";
+}
+
+// ── Cache keys ─────────────────────────────────────────────────────────────
+
+const CREDITS_KEY = "/v1/dashboard/credits";
+const RATE_CARD_KEY = "/v1/dashboard/credits/rate-card";
+const HISTORY_KEY = "/v1/dashboard/credits/history";
+
+// ── Hooks ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the org's Peaks balance summary from /v1/dashboard/credits.
+ * Powers the BalanceChip, the cap banners, and the Peaks page header.
+ * Refetches every 60s since the rollup cron runs every minute.
+ */
+export function useCreditsBalance() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<CreditsBalance>({
+    queryKey: [CREDITS_KEY, org?._id ?? null],
+    queryFn: () => api.get<CreditsBalance>("/v1/dashboard/credits"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+}
+
+/**
+ * Fetches the rate card (cfg_ai_models useCases with Peaks per call).
+ * Stale for 5 minutes — this data changes only when ops updates pricing.
+ */
+export function useCreditsRateCard() {
+  const { isAuthenticated } = useAuth();
+  return useQuery<{ useCases: RateCardUseCase[] }>({
+    // Rate card is a global catalog (no org-scoped data) — single shared cache entry
+    queryKey: [RATE_CARD_KEY],
+    queryFn: () => api.get<{ useCases: RateCardUseCase[] }>("/v1/dashboard/credits/rate-card"),
+    enabled: isAuthenticated,
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Fetches 30-day daily Peaks consumption from ts_usage_meters.
+ * Powers the usage history drawer on the Peaks page.
+ */
+export function useCreditsHistory() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<{ days: CreditsHistoryDay[]; total: number }>({
+    queryKey: [HISTORY_KEY, org?._id ?? null],
+    queryFn: () => api.get<{ days: CreditsHistoryDay[]; total: number }>("/v1/dashboard/credits/history"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 5 * 60_000,
+  });
+}


### PR DESCRIPTION
## Summary

- **`BalanceChip`** — compact `⚡ Peaks` chip in the dashboard top bar. Colour-codes by cap state: muted (healthy) → amber (soft cap) → red (hard cap). Links to `/dashboard/peaks`. Renders nothing until balance loads.
- **`CreditCapBanner`** — dismissible banner in the layout banner slot alongside `TrialExpiryBanner`. Soft cap (≥ softCap): amber + dismiss button. Hard cap (≥ hardCap): red + non-dismissible + `role=alert`.
- **`useCreditsBalance` / `useCreditsRateCard` / `useCreditsHistory`** hooks in `src/hooks/use-credits.ts`. Balance refetches every 60s (matches rollup cron cadence). Rate card is a global cache entry (no org-id key since the data is platform-wide).
- **`/dashboard/peaks` page** — Balance card with colour-coded progress bar + upgrade CTA at ≥80%, Rate Card table (feature name / min Peaks / multiplier), and a Usage History Sheet drawer showing 30-day daily bar chart.
- **Layout**: `BalanceChip` before `PlanBadge` in header; `CreditCapBanner` in banner slot; `Peaks` nav item between Integrations and Settings.

Depends on: peakhour-api #542 (rate-card + history endpoints)

## Test plan

- [ ] Balance chip shows in header for metered plans; shows "∞ Peaks" for unlimited
- [ ] Balance chip turns amber at ≥80% usage, red at ≥100%
- [ ] Soft-cap banner appears at ≥80%; dismissible within session
- [ ] Hard-cap banner appears at 100%; cannot be dismissed
- [ ] Both banners absent for unlimited plan
- [ ] `/dashboard/peaks` Balance card shows correct remaining/cap and reset date
- [ ] Progress bar colours: primary (healthy) → amber (soft) → red (hard)
- [ ] Rate Card table populates from `GET /credits/rate-card`
- [ ] Usage History drawer opens, shows 30-day chart or empty state
- [ ] Peaks nav item visible and navigates correctly
- [ ] No flash/error when org is loading (enabled guards in hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)