### PR TITLE
fix(build): legacy-peer-deps for Vercel installs (Polaris 13 + React 19)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+﻿# Polaris 13 declares React 18 peer deps while the app runs React 19 -
+# npm's ERESOLVE kills fresh installs (Vercel default 'npm install').
+# Same flag used for all local installs since Polaris landed (P1.1).
+legacy-peer-deps=true


### PR DESCRIPTION
dev.peakhour.ai serves a pre-Phase-1 build: /shopify/connect 404s and /shopify/embedded has no App Bridge. Local npm install reproducibly ERESOLVEs on Polaris's React-18 peers without --legacy-peer-deps; Vercel's default install hits the same wall. .npmrc makes the resolution explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)