### PR TITLE
fix(shopify): session-token hang + unlinked-store reconnect funnel

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_lib/session.ts
+++ b/src/app/(commerce)/shopify/embedded/_lib/session.ts
@@ -21,7 +21,20 @@ export async function getSessionToken(timeoutMs = 6000): Promise<string | null> 
   while (Date.now() < deadline) {
     if (window.shopify?.idToken) {
       try {
-        return await window.shopify.idToken();
+        // RACE the idToken call against the remaining deadline: when the page
+        // is loaded OUTSIDE the admin iframe (e.g. embedded=false app config,
+        // or a direct browser visit), App Bridge attaches window.shopify but
+        // idToken() never resolves — an un-raced await here hung every page
+        // in its loading skeleton forever (field bug, 2026-06-12).
+        const remaining = Math.max(250, deadline - Date.now());
+        const token = await Promise.race<string | null>([
+          window.shopify.idToken(),
+          new Promise<null>((r) => setTimeout(() => r(null), remaining)),
+        ]);
+        if (token) return token;
+        // Timed out or empty — fall through to the deadline check (which
+        // will now fail) so callers get the clean "reopen from your Shopify
+        // admin" error instead of an infinite skeleton.
       } catch {
         // Token fetch failed (bridge not ready or transient error) — keep polling
         // rather than returning null immediately; only give up at deadline.

--- a/src/app/(commerce)/shopify/embedded/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/page.tsx
@@ -384,7 +384,7 @@ export default function ShopifyEmbeddedHome() {
   if (!state.ctx.connected) {
     const shop = state.ctx.shop;
     const connectUrl = shop
-      ? `/shopify/connect?shop=${encodeURIComponent(shop)}`
+      ? `/shopify/connect?shop=${encodeURIComponent(shop)}&reconnect=1`
       : "/shopify/connect";
     return (
       <Page title="Peakhour Commerce">

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -247,7 +247,7 @@ export default function SettingsPage() {
       }
       // Back into the connect flow — top-level navigation escapes the admin
       // iframe (a relative redirect would only move the iframe itself).
-      const connectUrl = `/shopify/connect?shop=${encodeURIComponent(state.ctx.shop)}`;
+      const connectUrl = `/shopify/connect?shop=${encodeURIComponent(state.ctx.shop)}&reconnect=1`;
       (window.top ?? window).location.href = connectUrl;
     } catch {
       setDisconnectError("Network error disconnecting.");
@@ -273,7 +273,7 @@ export default function SettingsPage() {
 
   if (!ctx.connected) {
     const connectUrl = ctx.shop
-      ? `/shopify/connect?shop=${encodeURIComponent(ctx.shop)}`
+      ? `/shopify/connect?shop=${encodeURIComponent(ctx.shop)}&reconnect=1`
       : "/shopify/connect";
     return (
       <Page title="Settings">


### PR DESCRIPTION
Two field bugs from the first live install test: (1) idToken() raced against the deadline so non-embedded loads error cleanly instead of skeleton-forever; (2) not-connected EmptyStates + post-disconnect redirect now use reconnect=1 so installed-but-unlinked stores can link without reinstalling. Recovered from a branch collision with a concurrent session; contains ONLY the 3 shopify files.