### PR TITLE
fix(shopify): force-dynamic on the commerce tree - CSP nonce blocked all embedded hydration

### DIFF
--- a/src/app/(commerce)/layout.tsx
+++ b/src/app/(commerce)/layout.tsx
@@ -22,6 +22,21 @@ import type { ReactNode } from "react";
 
 const SHOPIFY_API_KEY = process.env.NEXT_PUBLIC_SHOPIFY_API_KEY ?? "";
 
+/**
+ * Force per-request rendering for the whole /shopify/** tree.
+ *
+ * The middleware serves a nonce-based CSP (`script-src 'self' 'nonce-…'
+ * https://cdn.shopify.com`), and Next.js can only stamp that nonce onto its
+ * inline bootstrap scripts when the page renders DYNAMICALLY. These routes
+ * are pure client components with no cookie/header reads, so they were
+ * statically prerendered at build time — nonce-less inline scripts that the
+ * per-request CSP then blocked, freezing every embedded page on its loading
+ * skeleton inside the Shopify admin (zero hydration, zero API calls; field
+ * bug 2026-06-12). The (site) tree never hit this because its auth-cookie
+ * reads already force dynamic rendering.
+ */
+export const dynamic = "force-dynamic";
+
 export default function CommerceRootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">

--- a/src/app/(commerce)/layout.tsx
+++ b/src/app/(commerce)/layout.tsx
@@ -27,13 +27,16 @@ const SHOPIFY_API_KEY = process.env.NEXT_PUBLIC_SHOPIFY_API_KEY ?? "";
  *
  * The middleware serves a nonce-based CSP (`script-src 'self' 'nonce-…'
  * https://cdn.shopify.com`), and Next.js can only stamp that nonce onto its
- * inline bootstrap scripts when the page renders DYNAMICALLY. These routes
- * are pure client components with no cookie/header reads, so they were
- * statically prerendered at build time — nonce-less inline scripts that the
- * per-request CSP then blocked, freezing every embedded page on its loading
- * skeleton inside the Shopify admin (zero hydration, zero API calls; field
- * bug 2026-06-12). The (site) tree never hit this because its auth-cookie
- * reads already force dynamic rendering.
+ * inline bootstrap scripts when the page renders DYNAMICALLY. The
+ * embedded/** pages are pure client components with no dynamic-API reads
+ * (/shopify/connect was already dynamic via awaited searchParams), so they
+ * were statically prerendered at build time — nonce-less inline scripts
+ * that the per-request CSP then blocked, freezing every embedded page on
+ * its loading skeleton inside the Shopify admin (zero hydration, zero API
+ * calls; field bug 2026-06-12). The (site) tree avoids this with an
+ * explicit `await connection()` in its own root layout, deliberately
+ * scoped there so this surface manages its dynamic behaviour
+ * independently — this is that management.
  */
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## Root cause (field bug, diagnosed live with Prashant)

Every embedded page froze on its skeleton inside Shopify admin with **zero** API calls. Console showed the smoking gun: `Executing inline script violates ... script-src 'self' 'nonce-...' https://cdn.shopify.com` ×3.

The middleware issues a **per-request nonce CSP**, but the `/shopify/**` routes (pure client components, no cookie/header reads) were **statically prerendered** — their inline Next bootstrap scripts are baked at build time with no nonce. CSP blocks them → no hydration → frozen skeleton. The `(site)` tree never hit this because auth-cookie reads force dynamic rendering there; the embedded tree was the app's only static + nonce-CSP'd surface.

## Fix

`export const dynamic = "force-dynamic"` on the `(commerce)` root layout. Build verified: all 6 `/shopify` routes flipped ○ static → ƒ dynamic, so the middleware nonce gets stamped per-request.

Trade-off: no static caching for the embedded surface — per-merchant, low-traffic, data-driven pages; acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)