### PR TITLE
feat(shopify): PIN gets its own nav surface - dedicated Insights Network page

### DIFF
--- a/src/app/(commerce)/shopify/connect/_components/connect-wizard.tsx
+++ b/src/app/(commerce)/shopify/connect/_components/connect-wizard.tsx
@@ -177,8 +177,9 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
   }, [token]);
 
   // PIN opt-in from the wizard. Consent is never a gate on onboarding — a
-  // failed call advances anyway (the merchant can join later from Settings),
-  // but the success screen says so instead of implying enrollment.
+  // failed call advances anyway (the merchant can join later from the
+  // Insights Network page in the app nav), but the success screen says so
+  // instead of implying enrollment.
   const joinNetwork = useCallback(async () => {
     setJoining(true);
     try {
@@ -395,7 +396,8 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
                 </BlockStack>
 
                 <Text as="p" variant="bodySm" tone="subdued" alignment="center">
-                  You can join or leave anytime from Settings.
+                  You can join or leave anytime from the Insights Network page
+                  in the app.
                 </Text>
               </BlockStack>
             )}
@@ -420,7 +422,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
                   <Banner tone="warning">
                     <Text as="p" variant="bodyMd">
                       We couldn&apos;t enroll you in the Insights Network just now — you can
-                      join anytime from Settings.
+                      join anytime from the Insights Network page in the app.
                     </Text>
                   </Banner>
                 )}

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -4,6 +4,7 @@ import { AppProvider, Frame, Navigation } from "@shopify/polaris";
 import {
   HomeIcon,
   ProductIcon,
+  GlobeIcon,
   CreditCardIcon,
   SettingsIcon,
 } from "@shopify/polaris-icons";
@@ -29,6 +30,10 @@ function PolarisLink({ url, children, ...rest }: PolarisLinkProps) {
 const NAV_ITEMS = [
   { label: "Home", icon: HomeIcon, url: "/shopify/embedded", exactMatch: true },
   { label: "Catalog", icon: ProductIcon, url: "/shopify/embedded/catalog" },
+  // PIN gets its own surface (product rule 2026-06-12): consent is captured
+  // first-time in the connect wizard; this page is its standing home —
+  // members see the network, non-members get the consent nudge.
+  { label: "Insights Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
   { label: "Subscription", icon: CreditCardIcon, url: "/shopify/embedded/subscription" },
   { label: "Settings", icon: SettingsIcon, url: "/shopify/embedded/settings" },
 ];

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -12,6 +12,7 @@ import {
   Badge,
   Box,
   Divider,
+  EmptyState,
   List,
   SkeletonPage,
   SkeletonBodyText,
@@ -54,7 +55,7 @@ const COMING_INSIGHTS = [
   "Seasonal demand signals across the network, ahead of your own data showing them",
 ];
 
-type Membership = "loading" | "member" | "nonmember" | "unknown";
+type Membership = "loading" | "member" | "nonmember" | "unknown" | "notlinked";
 
 function PinSkeleton() {
   return (
@@ -83,7 +84,7 @@ export default function PinPage() {
   const [error, setError] = useState<string | null>(null);
   // Bumped by the retry button — re-runs the status load (sibling-page
   // pattern: inline IIFE + cancellation flag keeps the react-compiler
-  // lint happy and aborts cleanly on unmount).
+  // lint happy and discards late results after unmount).
   const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
@@ -102,7 +103,11 @@ export default function PinPage() {
         });
         if (cancelled) return;
         if (!res.ok) {
-          setMembership("unknown");
+          // 404 = store not linked to a Peakhour account; 400 = store row
+          // inactive — retrying can't fix either, so route to the connect
+          // story instead of a dead-end retry loop. Other failures (401,
+          // 5xx, blips) keep the retry CTA.
+          setMembership(res.status === 404 || res.status === 400 ? "notlinked" : "unknown");
           return;
         }
         const data = (await res.json()) as { pin?: PinState | null };
@@ -241,6 +246,28 @@ export default function PinPage() {
                 </Text>
               </InlineStack>
             </BlockStack>
+          </Card>
+        )}
+
+        {membership === "notlinked" && (
+          <Card>
+            <EmptyState
+              heading="Link your Peakhour account"
+              action={{
+                content: "Set up Peakhour Commerce",
+                // Navigate the top-level window — relative URLs inside an
+                // admin iframe would only navigate the iframe itself.
+                onAction: () => {
+                  (window.top ?? window).location.href = "/shopify/connect";
+                },
+              }}
+              image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
+            >
+              <Text as="p" variant="bodyMd">
+                This store isn&apos;t linked to a Peakhour account yet. Finish setup
+                first — then join the Insights Network from here.
+              </Text>
+            </EmptyState>
           </Card>
         )}
 

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -78,10 +78,24 @@ function PinSkeleton() {
   );
 }
 
+/** Shop domain from the App Bridge session token's `dest` claim
+ *  (`https://{shop}.myshopify.com`). Display/navigation use only — never
+ *  trusted server-side (the api verifies the token signature itself). */
+function shopFromSessionToken(token: string): string | null {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1] ?? "")) as { dest?: string };
+    const host = payload.dest ? new URL(payload.dest).hostname : "";
+    return /^[a-z0-9][a-z0-9-]*\.myshopify\.com$/.test(host) ? host : null;
+  } catch {
+    return null;
+  }
+}
+
 export default function PinPage() {
   const [membership, setMembership] = useState<Membership>("loading");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [shop, setShop] = useState<string | null>(null);
   // Bumped by the retry button — re-runs the status load (sibling-page
   // pattern: inline IIFE + cancellation flag keeps the react-compiler
   // lint happy and discards late results after unmount).
@@ -97,6 +111,7 @@ export default function PinPage() {
         setError("Couldn't get a Shopify session. Please reopen Peakhour from your Shopify admin.");
         return;
       }
+      setShop(shopFromSessionToken(token));
       try {
         const res = await fetch(`${API_URL}/v1/shopify/embedded/pin/status`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -250,25 +265,29 @@ export default function PinPage() {
         )}
 
         {membership === "notlinked" && (
-          <Card>
-            <EmptyState
-              heading="Link your Peakhour account"
-              action={{
-                content: "Set up Peakhour Commerce",
-                // Navigate the top-level window — relative URLs inside an
-                // admin iframe would only navigate the iframe itself.
-                onAction: () => {
-                  (window.top ?? window).location.href = "/shopify/connect";
-                },
-              }}
-              image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
-            >
-              <Text as="p" variant="bodyMd">
-                This store isn&apos;t linked to a Peakhour account yet. Finish setup
-                first — then join the Insights Network from here.
-              </Text>
-            </EmptyState>
-          </Card>
+          <EmptyState
+            heading="Link your Peakhour account"
+            action={{
+              content: "Set up Peakhour Commerce",
+              // Navigate the top-level window — relative URLs inside an
+              // admin iframe would only navigate the iframe itself. Carry
+              // shop + reconnect like Home/Settings do: the bare wizard URL
+              // hard-errors ("please reinstall") without a shop param.
+              onAction: () => {
+                const url = shop
+                  ? `/shopify/connect?shop=${encodeURIComponent(shop)}&reconnect=1`
+                  : "/shopify/connect";
+                (window.top ?? window).location.href = url;
+              },
+            }}
+            image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
+          >
+            <Text as="p" variant="bodyMd">
+              {shop ? `${shop} isn't` : "This store isn't"} linked to a Peakhour
+              account yet. Finish setup first — then join the Insights Network
+              from here.
+            </Text>
+          </EmptyState>
         )}
 
         {membership === "unknown" && (

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Page,
+  Card,
+  BlockStack,
+  InlineStack,
+  Text,
+  Button,
+  Banner,
+  Badge,
+  Box,
+  Divider,
+  List,
+  SkeletonPage,
+  SkeletonBodyText,
+  SkeletonDisplayText,
+} from "@shopify/polaris";
+import { getSessionToken } from "../_lib/session";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+/**
+ * Peakhour Insights Network (PIN) — dedicated nav surface.
+ *
+ * Product rule (Prashant, 2026-06-12): consent is CAPTURED first-time in
+ * onboarding (the connect wizard's "Insights Network" step); this page is
+ * the standing home for it afterwards — members see the network, everyone
+ * else gets the consent ask with a proper nudge. Settings no longer hosts
+ * the membership card.
+ *
+ * Consent posture: affirmative-only (no pre-ticked anything), withdraw is
+ * always available to members — App Review-friendly.
+ */
+
+interface PinState {
+  consentStatus?: { pin_contribution?: "opted_in" | "revoked" };
+}
+
+// Truthful-today framing (matches the wizard): benchmarks ship to members
+// FIRST as they roll out — never claimed as visible now.
+const PIN_BENEFITS = [
+  "Early access: benchmarks for stores like yours reach members first",
+  "Help shape sharper AI recommendations as the network learns",
+  "Only anonymized cohort signals are shared — never products, customers, or revenue",
+];
+
+/** What members will see appear on this page as the network rolls out —
+ *  honest placeholders, never fake data. */
+const COMING_INSIGHTS = [
+  "How your catalog size and pricing spread compare with stores in your country and sector",
+  "What shoppers ask assistants in your category — the questions your store should answer",
+  "Seasonal demand signals across the network, ahead of your own data showing them",
+];
+
+type Membership = "loading" | "member" | "nonmember" | "unknown";
+
+function PinSkeleton() {
+  return (
+    <SkeletonPage title="Insights Network">
+      <BlockStack gap="500">
+        <Card>
+          <BlockStack gap="400">
+            <SkeletonDisplayText size="small" />
+            <SkeletonBodyText lines={3} />
+          </BlockStack>
+        </Card>
+        <Card>
+          <BlockStack gap="400">
+            <SkeletonDisplayText size="small" />
+            <SkeletonBodyText lines={2} />
+          </BlockStack>
+        </Card>
+      </BlockStack>
+    </SkeletonPage>
+  );
+}
+
+export default function PinPage() {
+  const [membership, setMembership] = useState<Membership>("loading");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped by the retry button — re-runs the status load (sibling-page
+  // pattern: inline IIFE + cancellation flag keeps the react-compiler
+  // lint happy and aborts cleanly on unmount).
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const token = await getSessionToken();
+      if (cancelled) return;
+      if (!token) {
+        setMembership("unknown");
+        setError("Couldn't get a Shopify session. Please reopen Peakhour from your Shopify admin.");
+        return;
+      }
+      try {
+        const res = await fetch(`${API_URL}/v1/shopify/embedded/pin/status`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setMembership("unknown");
+          return;
+        }
+        const data = (await res.json()) as { pin?: PinState | null };
+        if (cancelled) return;
+        setMembership(
+          data.pin?.consentStatus?.pin_contribution === "opted_in" ? "member" : "nonmember",
+        );
+      } catch {
+        if (!cancelled) setMembership("unknown");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [retryKey]);
+
+  const toggle = useCallback(async (join: boolean) => {
+    setBusy(true);
+    setError(null);
+    const token = await getSessionToken();
+    if (!token) {
+      setError("Couldn't get a Shopify session. Please reopen from your admin.");
+      setBusy(false);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/v1/shopify/embedded/pin/consent`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ action: join ? "opt_in" : "withdraw" }),
+      });
+      if (!res.ok) {
+        setError("Could not update your Insights Network membership. Please try again.");
+      } else {
+        setMembership(join ? "member" : "nonmember");
+      }
+    } catch {
+      setError("Network error updating membership.");
+    }
+    setBusy(false);
+  }, []);
+
+  if (membership === "loading") return <PinSkeleton />;
+
+  return (
+    <Page
+      title="Insights Network"
+      subtitle="Anonymous, cohort-level intelligence from stores like yours"
+    >
+      <BlockStack gap="500">
+        {error && (
+          <Banner tone="critical">
+            <Text as="p" variant="bodyMd">{error}</Text>
+          </Banner>
+        )}
+
+        {membership === "member" && (
+          <>
+            <Card>
+              <BlockStack gap="400">
+                <InlineStack align="space-between" blockAlign="center">
+                  <Text as="h2" variant="headingMd">Your membership</Text>
+                  <Badge tone="success">Member</Badge>
+                </InlineStack>
+                <Divider />
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  Your store contributes anonymized cohort signals — and members get
+                  benchmarks and network insights first as they roll out. Only country,
+                  industry, size, and platform-level aggregates are shared — never
+                  products, customers, or revenue.
+                </Text>
+              </BlockStack>
+            </Card>
+
+            <Card>
+              <BlockStack gap="400">
+                <InlineStack align="space-between" blockAlign="center">
+                  <Text as="h2" variant="headingMd">Network insights</Text>
+                  <Badge tone="attention">Rolling out</Badge>
+                </InlineStack>
+                <Divider />
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  Insights appear here as the network reaches critical mass — members
+                  see them first. Coming up:
+                </Text>
+                <List type="bullet">
+                  {COMING_INSIGHTS.map((b) => (
+                    <List.Item key={b}>
+                      <Text as="span" variant="bodyMd">{b}</Text>
+                    </List.Item>
+                  ))}
+                </List>
+              </BlockStack>
+            </Card>
+
+            <Card>
+              <BlockStack gap="300">
+                <Text as="h2" variant="headingMd">Leave the network</Text>
+                <Divider />
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  You can withdraw at any time — your store stops contributing
+                  signals immediately and loses member-first access to insights.
+                </Text>
+                <Box>
+                  <Button onClick={() => toggle(false)} loading={busy} variant="plain" tone="critical">
+                    Leave the network
+                  </Button>
+                </Box>
+              </BlockStack>
+            </Card>
+          </>
+        )}
+
+        {membership === "nonmember" && (
+          <Card>
+            <BlockStack gap="400">
+              <Text as="h2" variant="headingMd">Join the Peakhour Insights Network</Text>
+              <Divider />
+              <Text as="p" variant="bodyMd" tone="subdued">
+                Get member-first access to benchmarks and network-powered insights as
+                they roll out — included free on your current plan.
+              </Text>
+              <List type="bullet">
+                {PIN_BENEFITS.map((b) => (
+                  <List.Item key={b}>
+                    <Text as="span" variant="bodyMd">{b}</Text>
+                  </List.Item>
+                ))}
+              </List>
+              <InlineStack gap="300" blockAlign="center">
+                <Button onClick={() => toggle(true)} loading={busy} variant="primary">
+                  Count me in
+                </Button>
+                <Text as="span" variant="bodySm" tone="subdued">
+                  Opt-in only — you can leave at any time.
+                </Text>
+              </InlineStack>
+            </BlockStack>
+          </Card>
+        )}
+
+        {membership === "unknown" && (
+          <Card>
+            <BlockStack gap="300">
+              <Text as="h2" variant="headingMd">Peakhour Insights Network</Text>
+              <Divider />
+              <Text as="p" variant="bodyMd" tone="subdued">
+                We couldn&apos;t load your membership status.
+              </Text>
+              <Box>
+                <Button
+                  onClick={() => {
+                    setMembership("loading");
+                    setError(null);
+                    setRetryKey((k) => k + 1);
+                  }}
+                >
+                  Try again
+                </Button>
+              </Box>
+            </BlockStack>
+          </Card>
+        )}
+      </BlockStack>
+    </Page>
+  );
+}

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -13,7 +13,6 @@ import {
   Badge,
   Box,
   Divider,
-  List,
   Modal,
   EmptyState,
   SkeletonPage,
@@ -36,17 +35,9 @@ interface ContextData {
   productsCount?: number;
 }
 
-interface PinState {
-  consentStatus?: { pin_contribution?: "opted_in" | "revoked" };
-}
-
-// Truthful-today framing (matches the wizard): benchmarks ship to members
-// FIRST as they roll out — never claimed as visible now.
-const PIN_BENEFITS = [
-  "Early access: benchmarks for stores like yours reach members first",
-  "Help shape sharper AI recommendations as the network learns",
-  "Only anonymized cohort signals are shared — never products, customers, or revenue",
-];
+// PIN (Insights Network) membership moved to its own nav surface —
+// /shopify/embedded/pin — per the 2026-06-12 product rule: onboarding
+// captures consent first-time, the dedicated page owns it afterwards.
 
 type PageState =
   | { status: "loading" }
@@ -103,12 +94,6 @@ export default function SettingsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
-  // Tri-state + unknown: a member whose status fetch failed must NOT be shown
-  // a "Join" button (withdraw has to stay as discoverable as join), so the
-  // action is hidden until membership is actually known.
-  const [pinMembership, setPinMembership] = useState<"loading" | "member" | "nonmember" | "unknown">("loading");
-  const [pinBusy, setPinBusy] = useState(false);
-  const [pinError, setPinError] = useState<string | null>(null);
   const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -132,62 +117,12 @@ export default function SettingsPage() {
         }
         const ctx = (await res.json()) as ContextData;
         setState({ status: "ready", ctx });
-
-        // PIN membership is secondary content — fetch after the page is ready.
-        // On failure the membership is "unknown" and the card hides its action
-        // (never show "Join" to someone who may already be a member).
-        if (ctx.connected) {
-          try {
-            const pinRes = await fetch(`${API_URL}/v1/shopify/embedded/pin/status`, {
-              headers: { Authorization: `Bearer ${token}` },
-              signal: ctrl.signal,
-            });
-            if (ctrl.signal.aborted) return;
-            if (pinRes.ok) {
-              const data = (await pinRes.json()) as { pin?: PinState | null };
-              setPinMembership(
-                data.pin?.consentStatus?.pin_contribution === "opted_in" ? "member" : "nonmember",
-              );
-            } else {
-              setPinMembership("unknown");
-            }
-          } catch (err) {
-            if ((err as { name?: string }).name === "AbortError") return;
-            setPinMembership("unknown");
-          }
-        }
       } catch (err) {
         if ((err as { name?: string }).name === "AbortError") return;
         setState({ status: "error", message: "Network error loading settings." });
       }
     })();
     return () => ctrl.abort();
-  }, []);
-
-  const togglePin = useCallback(async (join: boolean) => {
-    setPinBusy(true);
-    setPinError(null);
-    const token = await getSessionToken();
-    if (!token) {
-      setPinError("Couldn't get a Shopify session. Please reopen from your admin.");
-      setPinBusy(false);
-      return;
-    }
-    try {
-      const res = await fetch(`${API_URL}/v1/shopify/embedded/pin/consent`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ action: join ? "opt_in" : "withdraw" }),
-      });
-      if (!res.ok) {
-        setPinError("Could not update your Insights Network membership. Please try again.");
-      } else {
-        setPinMembership(join ? "member" : "nonmember");
-      }
-    } catch {
-      setPinError("Network error updating membership.");
-    }
-    setPinBusy(false);
   }, []);
 
   // Clear the pending sync-feedback timer on unmount (no setState after unmount).
@@ -372,65 +307,7 @@ export default function SettingsPage() {
           </BlockStack>
         </Card>
 
-        {/* ── Card 3 — Insights Network (PIN consent) ─────────────────── */}
-        <Card>
-          <BlockStack gap="400">
-            <InlineStack align="space-between" blockAlign="center">
-              <Text as="h2" variant="headingMd">Peakhour Insights Network</Text>
-              {pinMembership === "member" && <Badge tone="success">Member</Badge>}
-            </InlineStack>
-            <Divider />
-            {pinMembership === "member" ? (
-              <Text as="p" variant="bodyMd" tone="subdued">
-                Your store contributes anonymized cohort signals — and members get
-                benchmarks and network insights first as they roll out. Only country,
-                industry, size, and platform-level aggregates are shared — never
-                products, customers, or revenue.
-              </Text>
-            ) : (
-              <BlockStack gap="300">
-                <Text as="p" variant="bodyMd" tone="subdued">
-                  Join the network to get member-first access to benchmarks and
-                  network-powered insights as they roll out — included free on the
-                  Lens plan.
-                </Text>
-                <List type="bullet">
-                  {PIN_BENEFITS.map((b) => (
-                    <List.Item key={b}>
-                      <Text as="span" variant="bodyMd">{b}</Text>
-                    </List.Item>
-                  ))}
-                </List>
-              </BlockStack>
-            )}
-            {pinError && (
-              <Banner tone="critical">
-                <Text as="p" variant="bodyMd">{pinError}</Text>
-              </Banner>
-            )}
-            {pinMembership === "member" && (
-              <Box>
-                <Button onClick={() => togglePin(false)} loading={pinBusy} variant="plain" tone="critical">
-                  Leave the network
-                </Button>
-              </Box>
-            )}
-            {pinMembership === "nonmember" && (
-              <Box>
-                <Button onClick={() => togglePin(true)} loading={pinBusy} variant="primary">
-                  Join the network
-                </Button>
-              </Box>
-            )}
-            {pinMembership === "unknown" && (
-              <Text as="p" variant="bodySm" tone="subdued">
-                Membership status is unavailable right now — refresh the page to manage it.
-              </Text>
-            )}
-          </BlockStack>
-        </Card>
-
-        {/* ── Card 4 — Danger zone ────────────────────────────────────── */}
+        {/* ── Card 3 — Danger zone ────────────────────────────────────── */}
         <Card>
           <BlockStack gap="400">
             <Text as="h2" variant="headingMd">Danger zone</Text>


### PR DESCRIPTION
## What (product rule, Prashant 2026-06-12)

1. **Consent is captured first-time in onboarding** — already true: the connect wizard has 'Insights Network' as dedicated step 3 of 4 (Count me in / Maybe later, never a gate). Verified, unchanged.
2. **PIN becomes its own nav item** — 'Insights Network' (GlobeIcon) added to the embedded nav between Catalog and Subscription.
3. **State-aware PIN page** at /shopify/embedded/pin:
   - **Member** → membership card (Member badge, what's shared/not shared) + 'Network insights — Rolling out' section listing what members will see first (honest placeholders, never fake data) + leave-the-network
   - **Non-member** → the consent nudge: benefits, privacy line, primary 'Count me in', 'opt-in only' note
   - **Unknown** → retry button (improves on the old hide-the-action behavior)
4. **Settings drops the PIN card** + all its state/logic.

Same App-Bridge-authed endpoints as before (/embedded/pin/status, /embedded/pin/consent {action: opt_in|withdraw}); affirmative-only posture preserved (App Review-friendly).

## Verification

eslint clean (incl. react-compiler effect rule), build green — /shopify/embedded/pin renders dynamic like the rest of the tree (CSP nonce), 57 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)