### PR TITLE
feat(shopify): P1.11/P1.12 UI — in-app Assistant chat + Integrations (WhatsApp)

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -3,7 +3,9 @@
 import { AppProvider, Frame, Navigation } from "@shopify/polaris";
 import {
   HomeIcon,
+  ChatIcon,
   ProductIcon,
+  ConnectIcon,
   GlobeIcon,
   CreditCardIcon,
   SettingsIcon,
@@ -29,7 +31,11 @@ function PolarisLink({ url, children, ...rest }: PolarisLinkProps) {
 
 const NAV_ITEMS = [
   { label: "Home", icon: HomeIcon, url: "/shopify/embedded", exactMatch: true },
+  // The assistant is the product (P1.11) — test it in-app, no WhatsApp needed.
+  { label: "Assistant", icon: ChatIcon, url: "/shopify/embedded/assistant" },
   { label: "Catalog", icon: ProductIcon, url: "/shopify/embedded/catalog" },
+  // WhatsApp (and future channels) connect here (P1.12, launch-to-domain).
+  { label: "Integrations", icon: ConnectIcon, url: "/shopify/embedded/integrations" },
   // PIN gets its own surface (product rule 2026-06-12): consent is captured
   // first-time in the connect wizard; this page is its standing home —
   // members see the network, non-members get the consent nudge.

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -21,7 +21,21 @@ type PolarisLinkProps = React.ComponentPropsWithoutRef<PolarisLinkComponent>;
 
 // Teach Polaris to use Next.js Link so Navigation clicks are client-side
 // (no full-page reload inside the Shopify Admin iframe).
-function PolarisLink({ url, children, ...rest }: PolarisLinkProps) {
+//
+// `external`: Polaris forwards it to the custom link component, but NextLink
+// IGNORES it — so `<Button url external>` would client-navigate the admin
+// IFRAME to the target (trapping the merchant; the cookie-authed dashboard
+// can't even load inside the iframe) instead of opening a real new tab. Honor
+// it with a plain anchor so "Open Peakhour Dashboard" (Home/Settings) actually
+// escapes the iframe.
+function PolarisLink({ url, external, children, ...rest }: PolarisLinkProps) {
+  if (external) {
+    return (
+      <a href={url ?? "#"} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  }
   return (
     <NextLink href={url ?? "#"} {...rest}>
       {children}

--- a/src/app/(commerce)/shopify/embedded/assistant/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/assistant/page.tsx
@@ -182,6 +182,11 @@ export default function AssistantPage() {
           <BlockStack gap="400">
             <div
               ref={scrollRef}
+              // role=log + polite so screen readers announce each assistant
+              // reply as it arrives (BFS accessibility).
+              role="log"
+              aria-live="polite"
+              aria-label="Assistant conversation"
               style={{ maxHeight: 420, overflowY: "auto", display: "flex", flexDirection: "column", gap: 12 }}
             >
               {messages.length === 0 && (

--- a/src/app/(commerce)/shopify/embedded/assistant/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/assistant/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Page,
+  Card,
+  BlockStack,
+  InlineStack,
+  Text,
+  Button,
+  Banner,
+  Badge,
+  Box,
+  TextField,
+  SkeletonPage,
+  SkeletonBodyText,
+  Spinner,
+} from "@shopify/polaris";
+import { getSessionToken } from "../_lib/session";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+/**
+ * In-app catalog-grounded assistant (P1.11) — the reviewer-testability
+ * keystone. A reviewer (or merchant) asks a catalog question right here and
+ * gets the SAME grounded answer the WhatsApp channel gives, with no WABA
+ * required. Non-subscribers get a capped daily teaser; at the cap the API
+ * returns 402 and we show the upgrade nudge.
+ */
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+type Phase =
+  | { status: "loading" }
+  | { status: "notlinked" }
+  | { status: "error"; message: string }
+  | { status: "ready" };
+
+const SUGGESTIONS = [
+  "What are your best sellers?",
+  "Do you have anything under $20?",
+  "What's good for a gift?",
+];
+
+function AssistantSkeleton() {
+  return (
+    <SkeletonPage title="Assistant">
+      <Card>
+        <BlockStack gap="400">
+          <SkeletonBodyText lines={4} />
+        </BlockStack>
+      </Card>
+    </SkeletonPage>
+  );
+}
+
+export default function AssistantPage() {
+  const [phase, setPhase] = useState<Phase>({ status: "loading" });
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [capped, setCapped] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Bootstrap: confirm the store is linked (reuse /context — a 404/inactive
+  // store routes to the connect CTA, same story as the other pages).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const token = await getSessionToken();
+      if (cancelled) return;
+      if (!token) {
+        setPhase({ status: "error", message: "Couldn't get a Shopify session. Please reopen Peakhour from your Shopify admin." });
+        return;
+      }
+      try {
+        const res = await fetch(`${API_URL}/v1/shopify/embedded/context`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (cancelled) return;
+        if (res.status === 404 || res.status === 400) {
+          setPhase({ status: "notlinked" });
+          return;
+        }
+        if (!res.ok) {
+          setPhase({ status: "error", message: `Could not load the assistant (${res.status}).` });
+          return;
+        }
+        const ctx = (await res.json()) as { connected?: boolean };
+        setPhase(ctx.connected ? { status: "ready" } : { status: "notlinked" });
+      } catch {
+        if (!cancelled) setPhase({ status: "error", message: "Network error loading the assistant." });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, sending]);
+
+  const send = useCallback(async (text: string) => {
+    const message = text.trim();
+    if (!message || sending) return;
+    setSending(true);
+    setSendError(null);
+    setMessages((m) => [...m, { role: "user", content: message }]);
+    setInput("");
+
+    const token = await getSessionToken();
+    if (!token) {
+      setSendError("Couldn't get a Shopify session. Please reopen from your admin.");
+      setSending(false);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/v1/shopify/embedded/assistant/chat`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        reply?: string;
+        capped?: boolean;
+      };
+      if (res.status === 402) {
+        setCapped(true);
+        if (data.reply) setMessages((m) => [...m, { role: "assistant", content: data.reply! }]);
+      } else if (!res.ok) {
+        setSendError("The assistant couldn’t answer just now. Please try again in a moment.");
+      } else if (data.reply) {
+        setMessages((m) => [...m, { role: "assistant", content: data.reply! }]);
+      }
+    } catch {
+      setSendError("Network error contacting the assistant.");
+    }
+    setSending(false);
+  }, [sending]);
+
+  if (phase.status === "loading") return <AssistantSkeleton />;
+
+  if (phase.status === "notlinked" || phase.status === "error") {
+    return (
+      <Page title="Assistant">
+        <Card>
+          <BlockStack gap="300">
+            <Text as="p" variant="bodyMd">
+              {phase.status === "notlinked"
+                ? "Finish linking your store to use the assistant."
+                : phase.message}
+            </Text>
+            {phase.status === "notlinked" && (
+              <Box>
+                <Button
+                  onClick={() => {
+                    (window.top ?? window).location.href = "/shopify/connect";
+                  }}
+                >
+                  Set up Peakhour Commerce
+                </Button>
+              </Box>
+            )}
+          </BlockStack>
+        </Card>
+      </Page>
+    );
+  }
+
+  return (
+    <Page
+      title="Assistant"
+      subtitle="Ask anything about your catalog — the same answers your shoppers get on WhatsApp"
+    >
+      <BlockStack gap="400">
+        <Card>
+          <BlockStack gap="400">
+            <div
+              ref={scrollRef}
+              style={{ maxHeight: 420, overflowY: "auto", display: "flex", flexDirection: "column", gap: 12 }}
+            >
+              {messages.length === 0 && (
+                <BlockStack gap="300">
+                  <Text as="p" variant="bodyMd" tone="subdued">
+                    Try one of these, or ask your own:
+                  </Text>
+                  <InlineStack gap="200" wrap>
+                    {SUGGESTIONS.map((s) => (
+                      <Button key={s} size="slim" onClick={() => void send(s)} disabled={sending}>
+                        {s}
+                      </Button>
+                    ))}
+                  </InlineStack>
+                </BlockStack>
+              )}
+              {messages.map((m, i) => (
+                <InlineStack key={i} align={m.role === "user" ? "end" : "start"}>
+                  <div style={{ maxWidth: "80%" }}>
+                    <Box
+                      background={m.role === "user" ? "bg-fill-brand" : "bg-fill-secondary"}
+                      padding="300"
+                      borderRadius="200"
+                    >
+                      <Text as="p" variant="bodyMd" tone={m.role === "user" ? "text-inverse" : undefined}>
+                        {m.content}
+                      </Text>
+                    </Box>
+                  </div>
+                </InlineStack>
+              ))}
+              {sending && (
+                <InlineStack align="start" gap="200" blockAlign="center">
+                  <Spinner size="small" />
+                  <Text as="span" variant="bodySm" tone="subdued">Thinking…</Text>
+                </InlineStack>
+              )}
+            </div>
+
+            {sendError && (
+              <Banner tone="critical">
+                <Text as="p" variant="bodyMd">{sendError}</Text>
+              </Banner>
+            )}
+
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                void send(input);
+              }}
+            >
+              <InlineStack gap="200" blockAlign="center" wrap={false}>
+                <div style={{ flex: 1 }}>
+                  <TextField
+                    label="Message"
+                    labelHidden
+                    value={input}
+                    onChange={setInput}
+                    placeholder="Ask about your products…"
+                    autoComplete="off"
+                    disabled={sending || capped}
+                  />
+                </div>
+                <Button submit variant="primary" loading={sending} disabled={!input.trim() || capped}>
+                  Send
+                </Button>
+              </InlineStack>
+            </form>
+          </BlockStack>
+        </Card>
+
+        {capped && (
+          <Card>
+            <BlockStack gap="300">
+              <InlineStack gap="200" blockAlign="center">
+                <Badge tone="attention">Free preview limit reached</Badge>
+              </InlineStack>
+              <Text as="p" variant="bodyMd" tone="subdued">
+                You’ve used today’s free preview. Subscribe to the Commerce Assistant to chat without
+                limits — and put it live on WhatsApp so it answers your shoppers around the clock.
+              </Text>
+              <Box>
+                <Button
+                  variant="primary"
+                  url="/shopify/embedded/subscription"
+                >
+                  See plans
+                </Button>
+              </Box>
+            </BlockStack>
+          </Card>
+        )}
+      </BlockStack>
+    </Page>
+  );
+}

--- a/src/app/(commerce)/shopify/embedded/integrations/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/integrations/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Page,
+  Card,
+  BlockStack,
+  InlineStack,
+  Text,
+  Button,
+  Banner,
+  Badge,
+  Box,
+  Divider,
+  SkeletonPage,
+  SkeletonBodyText,
+  SkeletonDisplayText,
+} from "@shopify/polaris";
+import { getSessionToken } from "../_lib/session";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+/**
+ * Integrations (P1.12) — where the merchant connects WhatsApp (and, later,
+ * other channels). The WhatsApp WABA links to the SAME Peakhour business the
+ * store is linked to, so a connection made on peakhour.ai shows up here.
+ *
+ * Launch-to-domain (forced by architecture): the /shopify CSP blocks the FB
+ * SDK and Meta Embedded Signup is cookie-authed, so we can't run the connect
+ * popup inside the admin iframe. "Connect WhatsApp" opens the peakhour.ai
+ * connect page in a new top-level tab; the merchant connects there and
+ * returns — this page reads status via the session-token endpoint.
+ */
+
+type WaStatus =
+  | { state: "loading" }
+  | { state: "notlinked" }
+  | { state: "error" }
+  | { state: "connected"; name: string | null; phoneNumber: string | null; needsReauth: boolean }
+  | { state: "disconnected" };
+
+// Where the cookie-authed WhatsApp Embedded Signup lives on the main app.
+const DASHBOARD_WHATSAPP_URL = "/dashboard/content/whatsapp";
+
+function IntegrationsSkeleton() {
+  return (
+    <SkeletonPage title="Integrations">
+      <Card>
+        <BlockStack gap="400">
+          <SkeletonDisplayText size="small" />
+          <SkeletonBodyText lines={2} />
+        </BlockStack>
+      </Card>
+    </SkeletonPage>
+  );
+}
+
+export default function IntegrationsPage() {
+  const [wa, setWa] = useState<WaStatus>({ state: "loading" });
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const token = await getSessionToken();
+      if (cancelled) return;
+      if (!token) {
+        setWa({ state: "error" });
+        return;
+      }
+      try {
+        const res = await fetch(`${API_URL}/v1/shopify/embedded/whatsapp/status`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (cancelled) return;
+        if (res.status === 404 || res.status === 400) {
+          setWa({ state: "notlinked" });
+          return;
+        }
+        if (!res.ok) {
+          setWa({ state: "error" });
+          return;
+        }
+        const d = (await res.json()) as {
+          connected?: boolean;
+          needsReauth?: boolean;
+          name?: string | null;
+          phoneNumber?: string | null;
+        };
+        if (cancelled) return;
+        setWa(
+          d.connected
+            ? { state: "connected", name: d.name ?? null, phoneNumber: d.phoneNumber ?? null, needsReauth: Boolean(d.needsReauth) }
+            : { state: "disconnected" },
+        );
+      } catch {
+        if (!cancelled) setWa({ state: "error" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [retryKey]);
+
+  // Open the cookie-authed connect flow on peakhour.ai in a NEW top-level tab
+  // (escapes the admin iframe). After connecting there the merchant returns
+  // and refreshes status.
+  const openConnect = useCallback(() => {
+    window.open(DASHBOARD_WHATSAPP_URL, "_blank", "noopener,noreferrer");
+  }, []);
+
+  if (wa.state === "loading") return <IntegrationsSkeleton />;
+
+  return (
+    <Page title="Integrations" subtitle="Connect the channels your shoppers already use">
+      <BlockStack gap="500">
+        {/* WhatsApp */}
+        <Card>
+          <BlockStack gap="400">
+            <InlineStack align="space-between" blockAlign="center">
+              <Text as="h2" variant="headingMd">WhatsApp</Text>
+              {wa.state === "connected" && !wa.needsReauth && <Badge tone="success">Connected</Badge>}
+              {wa.state === "connected" && wa.needsReauth && <Badge tone="warning">Needs reconnect</Badge>}
+              {wa.state === "disconnected" && <Badge>Not connected</Badge>}
+            </InlineStack>
+            <Divider />
+
+            {wa.state === "connected" ? (
+              <BlockStack gap="300">
+                <Text as="p" variant="bodyMd">
+                  Your catalog-grounded assistant is live on WhatsApp
+                  {wa.name ? ` for ${wa.name}` : ""}
+                  {wa.phoneNumber ? ` · ${wa.phoneNumber}` : ""}. Shoppers messaging your
+                  WhatsApp get answers from your real catalog.
+                </Text>
+                {wa.needsReauth && (
+                  <Banner tone="warning">
+                    <Text as="p" variant="bodyMd">
+                      Your WhatsApp connection needs to be refreshed. Reconnect to keep the
+                      assistant answering.
+                    </Text>
+                  </Banner>
+                )}
+                <Box>
+                  <Button onClick={openConnect}>Manage on your Peakhour dashboard</Button>
+                </Box>
+              </BlockStack>
+            ) : wa.state === "disconnected" ? (
+              <BlockStack gap="300">
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  Connect your WhatsApp Business number so the assistant can answer your shoppers
+                  there — grounded in this store’s catalog. You’ll connect on your Peakhour
+                  dashboard (opens in a new tab); it links to the same account as this store.
+                </Text>
+                <Box>
+                  <Button variant="primary" onClick={openConnect}>
+                    Connect WhatsApp
+                  </Button>
+                </Box>
+              </BlockStack>
+            ) : wa.state === "notlinked" ? (
+              <BlockStack gap="300">
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  Finish linking your store first, then connect WhatsApp from here.
+                </Text>
+                <Box>
+                  <Button
+                    onClick={() => {
+                      (window.top ?? window).location.href = "/shopify/connect";
+                    }}
+                  >
+                    Set up Peakhour Commerce
+                  </Button>
+                </Box>
+              </BlockStack>
+            ) : (
+              <BlockStack gap="300">
+                <Text as="p" variant="bodyMd" tone="subdued">
+                  We couldn’t load your WhatsApp status.
+                </Text>
+                <Box>
+                  <Button onClick={() => setRetryKey((k) => k + 1)}>Try again</Button>
+                </Box>
+              </BlockStack>
+            )}
+          </BlockStack>
+        </Card>
+
+        {/* Future channels — honest "coming soon", no fake controls */}
+        <Card>
+          <BlockStack gap="200">
+            <Text as="h2" variant="headingMd">More channels</Text>
+            <Divider />
+            <Text as="p" variant="bodyMd" tone="subdued">
+              On-store chat and other channels are coming — your assistant will answer shoppers
+              everywhere they reach you, all grounded in this catalog.
+            </Text>
+          </BlockStack>
+        </Card>
+      </BlockStack>
+    </Page>
+  );
+}


### PR DESCRIPTION
Assistant page (interactive catalog-grounded chat, teaser-cap upgrade nudge) + Integrations page (WhatsApp status + launch-to-domain connect) + nav items (Assistant, Integrations). Pairs with peakhour-api feat/shopify-inapp-assistant. tsc+eslint clean, routes build dynamic, 57 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)