### PR TITLE
feat(pricing): P3 — product tier comparison on /pricing + Shopify subscription page

### DIFF
--- a/src/app/(commerce)/shopify/embedded/subscription/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/subscription/page.tsx
@@ -12,12 +12,13 @@ import {
   Banner,
   Badge,
   Divider,
-  List,
+  Icon,
   Modal,
   SkeletonPage,
   SkeletonBodyText,
   SkeletonDisplayText,
 } from "@shopify/polaris";
+import { CheckCircleIcon } from "@shopify/polaris-icons";
 import { getSessionToken } from "../_lib/session";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
@@ -39,16 +40,37 @@ interface ContextData {
   } | null;
 }
 
+interface PlanTier {
+  key: string;
+  name: string;
+  tagline?: string;
+  features: string[];
+  highlightAsRecommended: boolean;
+  pricing: {
+    monthly: number;
+    yearly: number;
+    trialDays: number;
+    displayPrefix?: string;
+  };
+}
+
 type PageState = "loading" | "error" | "ready";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-const FEATURES = [
-  "Catalog-grounded WhatsApp assistant — answers from your real products",
-  "Live Shopify catalog sync — accurate inventory and pricing",
-  "Multilingual — responds in the shopper's language",
-  "Always on — no human agent needed",
-];
+// Human-readable labels for cfg_feature keys.
+const FEATURE_LABELS: Record<string, string> = {
+  "commerce.assistant": "Live AI commerce assistant",
+  "commerce.catalog_sync": "Automatic catalog sync",
+  "commerce.whatsapp": "WhatsApp shopping channel",
+  "commerce.in_app_assistant": "In-app product assistant",
+  "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
+  "commerce.insights_network": "Insights Network access",
+};
+
+function featureLabel(key: string): string {
+  return FEATURE_LABELS[key] ?? key;
+}
 
 function priceLabel(pricing: ContextData["pricing"], interval: "monthly" | "annual"): string | null {
   if (!pricing) return null;
@@ -57,8 +79,6 @@ function priceLabel(pricing: ContextData["pricing"], interval: "monthly" | "annu
     return `${sym}${pricing.annual.amount}/yr`;
   }
   const sym = pricing.currency === "USD" ? "$" : `${pricing.currency} `;
-  // Period from the actual picked row — if the CMS ever has no monthly price,
-  // the fallback row may be annual and must not be labelled "/mo".
   return `${sym}${pricing.amount}/${pricing.interval === "annual" ? "yr" : "mo"}`;
 }
 
@@ -66,13 +86,21 @@ function priceLabel(pricing: ContextData["pricing"], interval: "monthly" | "annu
 
 function SubscriptionSkeleton() {
   return (
-    <SkeletonPage title="Subscription">
-      <Card>
-        <BlockStack gap="400">
-          <SkeletonDisplayText size="small" />
-          <SkeletonBodyText lines={5} />
-        </BlockStack>
-      </Card>
+    <SkeletonPage title="Plans">
+      <BlockStack gap="400">
+        <Card>
+          <BlockStack gap="400">
+            <SkeletonDisplayText size="small" />
+            <SkeletonBodyText lines={4} />
+          </BlockStack>
+        </Card>
+        <Card>
+          <BlockStack gap="400">
+            <SkeletonDisplayText size="small" />
+            <SkeletonBodyText lines={6} />
+          </BlockStack>
+        </Card>
+      </BlockStack>
     </SkeletonPage>
   );
 }
@@ -83,6 +111,7 @@ export default function SubscriptionPage() {
   const [pageState, setPageState] = useState<PageState>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
   const [ctx, setCtx] = useState<ContextData | null>(null);
+  const [tiers, setTiers] = useState<PlanTier[]>([]);
   const [subscribing, setSubscribing] = useState(false);
   const [subError, setSubError] = useState<string | null>(null);
   const [billingInterval, setBillingInterval] = useState<"monthly" | "annual">("monthly");
@@ -110,8 +139,6 @@ export default function SubscriptionPage() {
         setCancelling(false);
         return;
       }
-      // Reflect the new entitlement immediately — the org may still be active
-      // via another store's subscription.
       setCtx((prev) => (prev ? { ...prev, assistantActive: data.active === true } : prev));
       setCancelOpen(false);
       setCancelling(false);
@@ -131,25 +158,47 @@ export default function SubscriptionPage() {
         setPageState("error");
         return;
       }
-      try {
-        const res = await fetch(`${API_URL}/v1/shopify/embedded/context`, {
+
+      // Fetch context + plan tiers in parallel.
+      const [contextRes, pricingRes] = await Promise.all([
+        fetch(`${API_URL}/v1/shopify/embedded/context`, {
           headers: { Authorization: `Bearer ${token}` },
           signal: ctrl.signal,
-        });
-        if (ctrl.signal.aborted) return;
-        if (!res.ok) {
-          setLoadError(`Could not load subscription info (${res.status}).`);
-          setPageState("error");
-          return;
-        }
-        const data = (await res.json()) as ContextData;
-        setCtx(data);
-        setPageState("ready");
-      } catch (err) {
-        if ((err as { name?: string }).name === "AbortError") return;
-        setLoadError("Network error loading subscription info.");
+        }).catch(() => null),
+        fetch(`${API_URL}/v1/platform/pricing?country=DEFAULT`).catch(() => null),
+      ]);
+
+      if (ctrl.signal.aborted) return;
+
+      if (!contextRes || !contextRes.ok) {
+        setLoadError(`Could not load subscription info (${contextRes?.status ?? "network error"}).`);
         setPageState("error");
+        return;
       }
+
+      const data = (await contextRes.json()) as ContextData;
+      setCtx(data);
+
+      // Extract commerce_assistant tiers from the pricing response (best-effort).
+      if (pricingRes?.ok) {
+        try {
+          const pj = (await pricingRes.json()) as {
+            ok?: boolean;
+            data?: {
+              products?: Array<{
+                key: string;
+                tiers?: PlanTier[];
+              }>;
+            };
+          };
+          const commerceProduct = pj.data?.products?.find((p) => p.key === "commerce_assistant");
+          if (commerceProduct?.tiers) setTiers(commerceProduct.tiers);
+        } catch {
+          // Non-fatal — tiers stay empty, UI falls back gracefully.
+        }
+      }
+
+      setPageState("ready");
     })();
     return () => ctrl.abort();
   }, []);
@@ -189,7 +238,7 @@ export default function SubscriptionPage() {
 
   if (pageState === "error") {
     return (
-      <Page title="Subscription">
+      <Page title="Plans">
         <Banner tone="critical" title="Could not load subscription">
           <Text as="p" variant="bodyMd">{loadError}</Text>
         </Banner>
@@ -199,17 +248,18 @@ export default function SubscriptionPage() {
 
   const label = priceLabel(ctx?.pricing ?? null, billingInterval);
   const hasAnnual = !!ctx?.pricing?.annual;
+  const lensTier = tiers.find((t) => t.key === "commerce_assistant.lens");
+  const commerceTier = tiers.find((t) => t.key === "commerce_assistant.commerce");
 
   // ── Active ───────────────────────────────────────────────────────────────
 
   if (ctx?.assistantActive) {
-    // Link to Shopify admin billing — navigate the top frame out of the iframe.
     const manageBillingUrl = ctx.shop ? `https://${ctx.shop}/admin/settings/billing` : null;
 
     return (
-      <Page title="Subscription">
+      <Page title="Plans">
         <BlockStack gap="500">
-          <Banner tone="success" title="Commerce Assistant is active">
+          <Banner tone="success" title="Peakhour Commerce is active">
             <Text as="p" variant="bodyMd">
               Your catalog-grounded WhatsApp assistant is live and answering shopper questions
               around the clock.
@@ -223,7 +273,7 @@ export default function SubscriptionPage() {
               <InlineStack align="space-between" blockAlign="center">
                 <BlockStack gap="100">
                   <Text as="p" variant="bodyMd" fontWeight="semibold">
-                    {ctx.pricing?.displayName ?? "Commerce Assistant"}
+                    {ctx.pricing?.displayName ?? "Peakhour Commerce"}
                   </Text>
                   {label && (
                     <Text as="p" variant="bodySm" tone="subdued">{label}</Text>
@@ -231,6 +281,20 @@ export default function SubscriptionPage() {
                 </BlockStack>
                 <Badge tone="success">Active</Badge>
               </InlineStack>
+
+              {commerceTier && commerceTier.features.length > 0 && (
+                <>
+                  <Divider />
+                  <BlockStack gap="200">
+                    {commerceTier.features.map((f) => (
+                      <InlineStack key={f} gap="200" blockAlign="center">
+                        <Icon source={CheckCircleIcon} tone="success" />
+                        <Text as="span" variant="bodySm">{featureLabel(f)}</Text>
+                      </InlineStack>
+                    ))}
+                  </BlockStack>
+                </>
+              )}
 
               <Divider />
               {cancelError && (
@@ -287,79 +351,182 @@ export default function SubscriptionPage() {
     );
   }
 
-  // ── Inactive — show upgrade card ─────────────────────────────────────────
+  // ── Inactive — show tier comparison ──────────────────────────────────────
 
   return (
-    <Page title="Subscription">
-      <Card>
-        <BlockStack gap="500">
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingMd">Commerce Assistant</Text>
-            <Text as="p" variant="bodyMd" tone="subdued">
-              Unlock the catalog-grounded WhatsApp assistant — it answers shopper questions
-              using your real products, in their own language, 24/7.
-            </Text>
-          </BlockStack>
-
-          <Divider />
-
-          <List type="bullet">
-            {FEATURES.map((f) => (
-              <List.Item key={f}>
-                <Text as="span" variant="bodyMd">{f}</Text>
-              </List.Item>
-            ))}
-          </List>
-
-          {hasAnnual && (
-            <ButtonGroup variant="segmented">
-              <Button pressed={billingInterval === "monthly"} onClick={() => setBillingInterval("monthly")}>
-                Monthly
-              </Button>
-              <Button pressed={billingInterval === "annual"} onClick={() => setBillingInterval("annual")}>
-                Annual — 2 months free
-              </Button>
-            </ButtonGroup>
-          )}
-
-          {label && (
-            <BlockStack gap="100">
-              <Text as="p" variant="headingLg" fontWeight="bold">{label}</Text>
-              {(ctx?.pricing?.trialDays ?? 0) > 0 && (
-                <Text as="p" variant="bodyMd" tone="subdued">
-                  {ctx!.pricing!.trialDays}-day free trial — billing starts when the trial ends.
-                </Text>
-              )}
-            </BlockStack>
-          )}
-
-          <Divider />
-
-          {subError && (
-            <Banner tone="critical">
-              <Text as="p" variant="bodyMd">{subError}</Text>
-            </Banner>
-          )}
-
-          <Button
-            onClick={handleSubscribe}
-            loading={subscribing}
-            variant="primary"
-            size="large"
-          >
-            {(ctx?.pricing?.trialDays ?? 0) > 0
-              ? `Start ${ctx!.pricing!.trialDays}-day free trial`
-              : "Subscribe"}
-          </Button>
-
-          <Text as="p" variant="bodySm" tone="subdued">
-            Billed through your Shopify account. Cancel anytime right here on this page.
-            WhatsApp Business messaging fees, where applicable, are billed directly by
-            Meta to your WhatsApp Business Account — replies to shopper-initiated chats
-            are free under Meta&apos;s current service-conversation pricing.
+    <Page title="Plans">
+      <BlockStack gap="600">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingLg">Commerce Assistant plans</Text>
+          <Text as="p" variant="bodyMd" tone="subdued">
+            Connect your store and get started free. Upgrade to unlock the live WhatsApp
+            assistant.
           </Text>
         </BlockStack>
-      </Card>
+
+        {/* Tier comparison cards */}
+        {tiers.length > 0 ? (
+          <BlockStack gap="400">
+            {/* Lens — free, current */}
+            {lensTier && (
+              <Card>
+                <BlockStack gap="400">
+                  <InlineStack align="space-between" blockAlign="start">
+                    <BlockStack gap="100">
+                      <Text as="h3" variant="headingMd">{lensTier.name}</Text>
+                      {lensTier.tagline && (
+                        <Text as="p" variant="bodySm" tone="subdued">{lensTier.tagline}</Text>
+                      )}
+                    </BlockStack>
+                    <BlockStack gap="100" inlineAlign="end">
+                      <Text as="p" variant="headingLg" fontWeight="bold">Free</Text>
+                      <Badge>Included</Badge>
+                    </BlockStack>
+                  </InlineStack>
+                  {lensTier.features.length > 0 && (
+                    <BlockStack gap="200">
+                      {lensTier.features.map((f) => (
+                        <InlineStack key={f} gap="200" blockAlign="center">
+                          <Icon source={CheckCircleIcon} tone="base" />
+                          <Text as="span" variant="bodySm">{featureLabel(f)}</Text>
+                        </InlineStack>
+                      ))}
+                    </BlockStack>
+                  )}
+                </BlockStack>
+              </Card>
+            )}
+
+            {/* Peakhour Commerce — paid */}
+            {commerceTier && (
+              <Card>
+                <BlockStack gap="400">
+                  <InlineStack align="space-between" blockAlign="start">
+                    <BlockStack gap="100">
+                      <Text as="h3" variant="headingMd">{commerceTier.name}</Text>
+                      {commerceTier.tagline && (
+                        <Text as="p" variant="bodySm" tone="subdued">{commerceTier.tagline}</Text>
+                      )}
+                    </BlockStack>
+                    <BlockStack gap="100" inlineAlign="end">
+                      {label ? (
+                        <>
+                          <Text as="p" variant="headingLg" fontWeight="bold">{label}</Text>
+                          <Badge tone="info">Recommended</Badge>
+                        </>
+                      ) : (
+                        <Badge tone="info">Recommended</Badge>
+                      )}
+                    </BlockStack>
+                  </InlineStack>
+
+                  {commerceTier.features.length > 0 && (
+                    <BlockStack gap="200">
+                      {commerceTier.features.map((f) => (
+                        <InlineStack key={f} gap="200" blockAlign="center">
+                          <Icon source={CheckCircleIcon} tone="success" />
+                          <Text as="span" variant="bodySm">{featureLabel(f)}</Text>
+                        </InlineStack>
+                      ))}
+                    </BlockStack>
+                  )}
+
+                  <Divider />
+
+                  {hasAnnual && (
+                    <ButtonGroup variant="segmented">
+                      <Button pressed={billingInterval === "monthly"} onClick={() => setBillingInterval("monthly")}>
+                        Monthly
+                      </Button>
+                      <Button pressed={billingInterval === "annual"} onClick={() => setBillingInterval("annual")}>
+                        Annual — 2 months free
+                      </Button>
+                    </ButtonGroup>
+                  )}
+
+                  {(ctx?.pricing?.trialDays ?? 0) > 0 && (
+                    <Text as="p" variant="bodySm" tone="subdued">
+                      {ctx!.pricing!.trialDays}-day free trial — billing starts when the trial ends.
+                    </Text>
+                  )}
+
+                  {subError && (
+                    <Banner tone="critical">
+                      <Text as="p" variant="bodyMd">{subError}</Text>
+                    </Banner>
+                  )}
+
+                  <Button
+                    onClick={handleSubscribe}
+                    loading={subscribing}
+                    variant="primary"
+                    size="large"
+                  >
+                    {(ctx?.pricing?.trialDays ?? 0) > 0
+                      ? `Start ${ctx!.pricing!.trialDays}-day free trial`
+                      : "Subscribe to Peakhour Commerce"}
+                  </Button>
+                </BlockStack>
+              </Card>
+            )}
+          </BlockStack>
+        ) : (
+          /* Fallback when pricing endpoint returned no tiers (network issue) */
+          <Card>
+            <BlockStack gap="400">
+              <Text as="h2" variant="headingMd">Peakhour Commerce</Text>
+              <Text as="p" variant="bodyMd" tone="subdued">
+                Unlock the catalog-grounded WhatsApp assistant — it answers shopper questions
+                using your real products, in their own language, 24/7.
+              </Text>
+              <Divider />
+              {hasAnnual && (
+                <ButtonGroup variant="segmented">
+                  <Button pressed={billingInterval === "monthly"} onClick={() => setBillingInterval("monthly")}>
+                    Monthly
+                  </Button>
+                  <Button pressed={billingInterval === "annual"} onClick={() => setBillingInterval("annual")}>
+                    Annual — 2 months free
+                  </Button>
+                </ButtonGroup>
+              )}
+              {label && (
+                <BlockStack gap="100">
+                  <Text as="p" variant="headingLg" fontWeight="bold">{label}</Text>
+                  {(ctx?.pricing?.trialDays ?? 0) > 0 && (
+                    <Text as="p" variant="bodyMd" tone="subdued">
+                      {ctx!.pricing!.trialDays}-day free trial — billing starts when the trial ends.
+                    </Text>
+                  )}
+                </BlockStack>
+              )}
+              <Divider />
+              {subError && (
+                <Banner tone="critical">
+                  <Text as="p" variant="bodyMd">{subError}</Text>
+                </Banner>
+              )}
+              <Button
+                onClick={handleSubscribe}
+                loading={subscribing}
+                variant="primary"
+                size="large"
+              >
+                {(ctx?.pricing?.trialDays ?? 0) > 0
+                  ? `Start ${ctx!.pricing!.trialDays}-day free trial`
+                  : "Subscribe"}
+              </Button>
+            </BlockStack>
+          </Card>
+        )}
+
+        <Text as="p" variant="bodySm" tone="subdued">
+          Billed through your Shopify account. Cancel anytime right here on this page.
+          WhatsApp Business messaging fees, where applicable, are billed directly by
+          Meta to your WhatsApp Business Account — replies to shopper-initiated chats
+          are free under Meta&apos;s current service-conversation pricing.
+        </Text>
+      </BlockStack>
     </Page>
   );
 }

--- a/src/app/(commerce)/shopify/embedded/subscription/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/subscription/page.tsx
@@ -248,6 +248,8 @@ export default function SubscriptionPage() {
 
   const label = priceLabel(ctx?.pricing ?? null, billingInterval);
   const hasAnnual = !!ctx?.pricing?.annual;
+  // Extract once so ternary branches can reference it without non-null assertions.
+  const trialDays = ctx?.pricing?.trialDays ?? 0;
   const lensTier = tiers.find((t) => t.key === "commerce_assistant.lens");
   const commerceTier = tiers.find((t) => t.key === "commerce_assistant.commerce");
 
@@ -444,9 +446,9 @@ export default function SubscriptionPage() {
                     </ButtonGroup>
                   )}
 
-                  {(ctx?.pricing?.trialDays ?? 0) > 0 && (
+                  {trialDays > 0 && (
                     <Text as="p" variant="bodySm" tone="subdued">
-                      {ctx!.pricing!.trialDays}-day free trial — billing starts when the trial ends.
+                      {trialDays}-day free trial — billing starts when the trial ends.
                     </Text>
                   )}
 
@@ -462,8 +464,8 @@ export default function SubscriptionPage() {
                     variant="primary"
                     size="large"
                   >
-                    {(ctx?.pricing?.trialDays ?? 0) > 0
-                      ? `Start ${ctx!.pricing!.trialDays}-day free trial`
+                    {trialDays > 0
+                      ? `Start ${trialDays}-day free trial`
                       : "Subscribe to Peakhour Commerce"}
                   </Button>
                 </BlockStack>
@@ -493,9 +495,9 @@ export default function SubscriptionPage() {
               {label && (
                 <BlockStack gap="100">
                   <Text as="p" variant="headingLg" fontWeight="bold">{label}</Text>
-                  {(ctx?.pricing?.trialDays ?? 0) > 0 && (
+                  {trialDays > 0 && (
                     <Text as="p" variant="bodyMd" tone="subdued">
-                      {ctx!.pricing!.trialDays}-day free trial — billing starts when the trial ends.
+                      {trialDays}-day free trial — billing starts when the trial ends.
                     </Text>
                   )}
                 </BlockStack>
@@ -512,8 +514,8 @@ export default function SubscriptionPage() {
                 variant="primary"
                 size="large"
               >
-                {(ctx?.pricing?.trialDays ?? 0) > 0
-                  ? `Start ${ctx!.pricing!.trialDays}-day free trial`
+                {trialDays > 0
+                  ? `Start ${trialDays}-day free trial`
                   : "Subscribe"}
               </Button>
             </BlockStack>

--- a/src/app/(site)/pricing/page.tsx
+++ b/src/app/(site)/pricing/page.tsx
@@ -38,7 +38,7 @@ export default async function PricingPage() {
         <section className="py-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             {pricing && pricing.plans.length > 0 ? (
-              <PricingGrid plans={pricing.plans} />
+              <PricingGrid plans={pricing.plans} products={pricing.products} />
             ) : (
               <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-6 text-sm text-amber-700 dark:text-amber-400">
                 Pricing is temporarily unavailable. Please refresh in a

--- a/src/components/marketing/pricing-grid.tsx
+++ b/src/components/marketing/pricing-grid.tsx
@@ -12,9 +12,15 @@ import {
   formatMonthly,
   formatYearly,
   PLAN_BULLETS,
+  FEATURE_LABELS,
   type PlanKey,
   type ResolvedPlan,
+  type ResolvedProduct,
+  type ResolvedProductTier,
 } from "@/lib/pricing";
+
+const SHOPIFY_APP_STORE_URL =
+  process.env.NEXT_PUBLIC_SHOPIFY_APP_STORE_URL ?? "https://apps.shopify.com/";
 
 /**
  * Country-aware pricing grid — renders the API-resolved pricing
@@ -28,38 +34,52 @@ import {
  *
  * Enterprise renders below the comparison row as a contact-sales
  * banner instead of a fifth narrow column.
+ *
+ * When `products` is non-empty (env-gated: only shows in prod when the
+ * product status is coming_soon/live), a per-product section renders
+ * below the main SaaS grid showing pillar-branded tier cards.
  */
 export function PricingGrid({
   plans,
+  products = [],
   showHeader = true,
 }: {
   plans: ResolvedPlan[];
+  products?: ResolvedProduct[];
   showHeader?: boolean;
 }) {
   const comparisonPlans = plans.filter((p) => p.key !== "enterprise");
   const enterprise = plans.find((p) => p.key === "enterprise");
 
   return (
-    <div className="space-y-8">
-      {showHeader && (
-        <div className="text-center">
-          <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
-            Simple, transparent pricing
-          </h2>
-          <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
-            Start free. Upgrade when you&apos;re ready. Prices shown in your
-            local currency.
-          </p>
-        </div>
-      )}
+    <div className="space-y-16">
+      {/* ── Main SaaS plan grid ─────────────────────────────────────── */}
+      <div className="space-y-8">
+        {showHeader && (
+          <div className="text-center">
+            <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
+              Simple, transparent pricing
+            </h2>
+            <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+              Start free. Upgrade when you&apos;re ready. Prices shown in your
+              local currency.
+            </p>
+          </div>
+        )}
 
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {comparisonPlans.map((plan) => (
-          <PlanCard key={plan.key} plan={plan} />
-        ))}
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {comparisonPlans.map((plan) => (
+            <PlanCard key={plan.key} plan={plan} />
+          ))}
+        </div>
+
+        {enterprise ? <EnterpriseBanner plan={enterprise} /> : null}
       </div>
 
-      {enterprise ? <EnterpriseBanner plan={enterprise} /> : null}
+      {/* ── Product-scoped tier sections (env-gated) ────────────────── */}
+      {products.map((product) => (
+        <ProductSection key={product.key} product={product} />
+      ))}
     </div>
   );
 }
@@ -157,6 +177,111 @@ function EnterpriseBanner({ plan }: { plan: ResolvedPlan }) {
             {plan.pricing.tagline ?? "Contact sales"}
           </Link>
         </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Product-scoped tier section ────────────────────────────────────────────
+
+function ProductSection({ product }: { product: ResolvedProduct }) {
+  return (
+    <div className="space-y-8">
+      <div className="border-t pt-10">
+        <div className="text-center">
+          <span className="mb-3 inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary capitalize">
+            {product.pillar}
+          </span>
+          <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
+            {product.name}
+          </h2>
+          {product.tagline && (
+            <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+              {product.tagline}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:max-w-3xl lg:mx-auto">
+        {product.tiers.map((tier) => (
+          <ProductTierCard key={tier.key} tier={tier} />
+        ))}
+      </div>
+
+      <p className="text-center text-xs text-muted-foreground">
+        Billed through your Shopify account · available in the Shopify App
+        Store
+      </p>
+    </div>
+  );
+}
+
+function ProductTierCard({ tier }: { tier: ResolvedProductTier }) {
+  const isFree = tier.pricing.monthly === 0;
+  const featureLabels = tier.features.map(
+    (k) => FEATURE_LABELS[k] ?? k,
+  );
+
+  return (
+    <Card
+      className={`relative flex flex-col transition-shadow hover:shadow-md ${
+        tier.highlightAsRecommended
+          ? "border-primary shadow-lg ring-1 ring-primary/20"
+          : ""
+      }`}
+    >
+      {tier.highlightAsRecommended && (
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground">
+          Recommended
+        </div>
+      )}
+      <CardHeader>
+        <CardTitle className="text-lg">{tier.name}</CardTitle>
+        <div className="mt-2 flex items-baseline gap-1">
+          {isFree ? (
+            <span className="text-3xl font-bold">Free</span>
+          ) : (
+            <>
+              <span className="text-3xl font-bold">
+                {formatMonthly(tier.pricing)}
+              </span>
+              <span className="text-sm text-muted-foreground">/month</span>
+            </>
+          )}
+        </div>
+        {!isFree && tier.pricing.yearly > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {formatYearly(tier.pricing)} billed yearly · 2 months free
+          </p>
+        )}
+        {tier.tagline && (
+          <CardDescription className="mt-2">{tier.tagline}</CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        <ul className="flex-1 space-y-2.5 text-sm">
+          {featureLabels.map((label) => (
+            <li key={label} className="flex items-start gap-2.5">
+              <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+              {label}
+            </li>
+          ))}
+        </ul>
+        <Button
+          asChild
+          className="w-full"
+          variant={tier.highlightAsRecommended ? "default" : "outline"}
+        >
+          <Link href={SHOPIFY_APP_STORE_URL} target="_blank" rel="noopener noreferrer">
+            {isFree ? "Get started free" : `Get ${tier.name}`}
+          </Link>
+        </Button>
+        {!isFree && tier.pricing.trialDays > 0 && (
+          <p className="text-center text-[11px] text-muted-foreground">
+            {tier.pricing.trialDays}-day free trial · billed through Shopify
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -97,7 +97,7 @@ async function fetchPricing(country: string): Promise<PricingResponse | null> {
     const json = (await res.json()) as { ok?: boolean; data?: PricingResponse };
     if (!json.ok || !json.data) return null;
     // Normalise: API before this PR omits `products` — default to empty array.
-    return { products: [], ...json.data };
+    return { ...json.data, products: json.data.products ?? [] };
   } catch {
     return null;
   }

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -49,9 +49,35 @@ export interface ResolvedPlan {
   pricing: PricingEntry;
 }
 
+/** A single tier within a product (e.g. commerce_assistant.lens). */
+export interface ResolvedProductTier {
+  key: string;
+  name: string;
+  tagline?: string;
+  description?: string;
+  /** cfg_feature keys granted by this tier. */
+  features: string[];
+  limits: Record<string, number | undefined>;
+  highlightAsRecommended: boolean;
+  version: number;
+  pricing: PricingEntry;
+}
+
+/** A product with its resolved tiers (e.g. Commerce Assistant: [Lens, Commerce]). */
+export interface ResolvedProduct {
+  key: string;
+  name: string;
+  tagline?: string;
+  pillar: string;
+  status: string;
+  tiers: ResolvedProductTier[];
+}
+
 export interface PricingResponse {
   country: string;
   plans: ResolvedPlan[];
+  /** Product-scoped tiers (env-gated: empty in prod when product is in_development). */
+  products: ResolvedProduct[];
 }
 
 /**
@@ -70,7 +96,8 @@ async function fetchPricing(country: string): Promise<PricingResponse | null> {
     if (!res.ok) return null;
     const json = (await res.json()) as { ok?: boolean; data?: PricingResponse };
     if (!json.ok || !json.data) return null;
-    return json.data;
+    // Normalise: API before this PR omits `products` — default to empty array.
+    return { products: [], ...json.data };
   } catch {
     return null;
   }
@@ -145,4 +172,18 @@ export const PLAN_BULLETS: Record<PlanKey, string[]> = {
     "Dedicated success manager",
     "SSO + audit log",
   ],
+};
+
+/**
+ * Display labels for cfg_feature keys used in product tier comparison cards.
+ * Keyed by the feature key stored in cfg_features / cfg_plans.features[].
+ * Kept client-side so marketing can tune copy without a DB write.
+ */
+export const FEATURE_LABELS: Record<string, string> = {
+  "commerce.assistant": "Live AI commerce assistant",
+  "commerce.catalog_sync": "Automatic catalog sync",
+  "commerce.whatsapp": "WhatsApp shopping channel",
+  "commerce.in_app_assistant": "In-app product assistant",
+  "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
+  "commerce.insights_network": "Insights Network access",
 };


### PR DESCRIPTION
## Summary

- **`lib/pricing.ts`** — New types (`ResolvedProductTier`, `ResolvedProduct`), `PricingResponse.products[]` (normalized to `[]` when absent for API backward compat), `FEATURE_LABELS` map for cfg_feature keys → display strings
- **`pricing-grid.tsx`** — `PricingGrid` renders a `ProductSection` per product below the SaaS plan grid (env-gated: Commerce Assistant is `in_development` so this is empty in prod today, visible in dev); `ProductTierCard` uses API feature lists + Shopify App Store CTA
- **`(site)/pricing/page.tsx`** — Passes `pricing.products` to `PricingGrid`
- **`(commerce)/shopify/embedded/subscription/page.tsx`** — Parallel fetch of context + public pricing; shows Lens (free, "Included") vs Peakhour Commerce (paid, "Recommended") tier comparison with feature lists; falls back to the old single-card layout on network failure; active state shows Peakhour Commerce features

**Requires:** peakhour-api #558 (merged ✅) — the API now returns `products[]`

## Test plan

- [ ] `tsc --noEmit` passes (confirmed in worktree)
- [ ] `/pricing` in dev: SaaS grid (free/starter/growth/agency) renders + "Commerce" pillar section shows below with "Lens | Peakhour Commerce" cards
- [ ] Shopify embedded `/subscription`: Lens + Peakhour Commerce tier cards visible; subscribe button still works
- [ ] `/pricing` in prod (or `APP_ENV=vercel` locally): products section absent (Commerce Assistant is `in_development`)
- [ ] Legacy SaaS plan grid unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)