### PR TITLE
feat(website): nav pages, container padding, homepage cleanup

### DIFF
--- a/components.json
+++ b/components.json
@@ -20,12 +20,7 @@
     "hooks": "@/hooks"
   },
   "registries": {
-    "@shadcnblocks": {
-      "url": "https://shadcnblocks.com/r/{name}",
-      "headers": {
-        "Authorization": "Bearer ${SHADCNBLOCKS_API_KEY}"
-      }
-    },
+    "@shadcnblocks": "https://shadcnblocks.com/r/{name}?token=${SHADCNBLOCKS_API_KEY}",
     "@diceui": "https://diceui.com/r/{name}.json"
   }
 }

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -1,0 +1,179 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Zap, Globe2, Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "About — Peakhour",
+  description:
+    "Peakhour is building AI that helps merchants sell more — starting with WhatsApp for Shopify. Learn who we are and why we're building this.",
+};
+
+const VALUES = [
+  {
+    icon: Zap,
+    title: "Merchants first",
+    description:
+      "Every feature we ship has a direct, measurable impact for the merchant. No vanity metrics, no feature theatre — just more revenue and less manual work.",
+  },
+  {
+    icon: Globe2,
+    title: "Built for emerging markets",
+    description:
+      "WhatsApp is how billions of people shop. We're building for the merchants who serve them — not after the fact, but as the primary use case.",
+  },
+  {
+    icon: Users,
+    title: "Small team, big surface area",
+    description:
+      "We're a focused founding team that moves fast. Founding partners get direct access to us — not a support queue, not a chatbot.",
+  },
+] as const;
+
+export default function AboutPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="flex-1">
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.12) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute right-0 top-0 -z-10 h-[500px] w-[600px] translate-x-1/3 -translate-y-1/4 rounded-full bg-primary/10 blur-3xl"
+            aria-hidden
+          />
+          <div className="container">
+            <div className="mx-auto max-w-3xl">
+              <Badge variant="outline" className="mb-5 gap-1.5 px-3 py-1 text-xs">
+                Our story
+              </Badge>
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.25rem] lg:leading-[1.1]">
+                Every hour is{" "}
+                <span className="text-primary">Peakhour</span>
+              </h1>
+              <p className="mt-6 text-lg leading-relaxed text-muted-foreground">
+                We started Peakhour because we watched smart merchants lose sales
+                to slow replies. A shopper asks about a product at 11 PM, gets no
+                answer until morning, and buys elsewhere. That gap is the
+                problem we&apos;re solving.
+              </p>
+              <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
+                We&apos;re building AI commerce infrastructure — starting with the
+                channel where most of the world already shops: WhatsApp. Every
+                hour your store is live on WhatsApp is a potential peak hour.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Values ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                How we work
+              </p>
+              <h2 className="mb-12 text-3xl font-bold tracking-tight">
+                What we stand for
+              </h2>
+              <div className="grid gap-6 md:grid-cols-3">
+                {VALUES.map((v) => {
+                  const Icon = v.icon;
+                  return (
+                    <div
+                      key={v.title}
+                      className="group rounded-2xl border bg-background p-6 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/20 transition-colors group-hover:bg-primary/15">
+                        <Icon className="size-5 text-primary" strokeWidth={1.5} />
+                      </div>
+                      <h3 className="mb-2 font-semibold">{v.title}</h3>
+                      <p className="text-sm leading-relaxed text-muted-foreground">
+                        {v.description}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── What we're building ── */}
+        <section className="border-t bg-muted/30 py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                The bigger picture
+              </p>
+              <h2 className="mb-6 text-3xl font-bold tracking-tight">
+                Three pillars, one platform
+              </h2>
+              <div className="space-y-4 text-muted-foreground">
+                <p className="leading-relaxed">
+                  We&apos;re building Peakhour in three acts. <strong className="text-foreground">Commerce</strong> comes
+                  first — catalog-aware AI on WhatsApp for Shopify merchants.
+                  Once that&apos;s proven, we add <strong className="text-foreground">Content</strong> — AI writers,
+                  news desk, and multi-format publishing so merchants can feed
+                  every channel with brand-consistent content, automatically.
+                </p>
+                <p className="leading-relaxed">
+                  The third act is <strong className="text-foreground">Growth</strong> — ads intelligence, audience
+                  analytics, and performance benchmarks that close the loop
+                  between what you publish, what you sell, and what you should
+                  do next.
+                </p>
+                <p className="leading-relaxed">
+                  We&apos;re not building three separate products. We&apos;re building one
+                  intelligence layer that compounds across commerce, content, and
+                  growth — each pillar making the others smarter.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="py-20">
+          <div className="container">
+            <div className="mx-auto max-w-2xl text-center">
+              <h2 className="text-2xl font-bold tracking-tight lg:text-3xl">
+                Shape the product from day one
+              </h2>
+              <p className="mt-3 text-muted-foreground">
+                We&apos;re accepting a small founding cohort of Shopify merchants who
+                want to be part of building this. You&apos;ll get direct access to the
+                team, locked-in pricing, and first say on what we build.
+              </p>
+              <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See Peakhour Commerce</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -51,7 +51,7 @@ export default function AboutPage() {
             }}
           />
           <div
-            className="pointer-events-none absolute right-0 top-0 -z-10 h-[500px] w-[600px] translate-x-1/3 -translate-y-1/4 rounded-full bg-primary/10 blur-3xl"
+            className="pointer-events-none absolute right-0 top-0 -z-10 h-125 w-150 translate-x-1/3 -translate-y-1/4 rounded-full bg-primary/10 blur-3xl"
             aria-hidden
           />
           <div className="container">

--- a/src/app/(site)/commerce/autopilot/page.tsx
+++ b/src/app/(site)/commerce/autopilot/page.tsx
@@ -1,0 +1,480 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  Gauge,
+  Zap,
+  Shield,
+  BarChart2,
+  RefreshCw,
+  MessageCircle,
+  FileText,
+  Undo2,
+  ChevronLeft,
+  Check,
+  Bot,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Shopify Autopilot Commerce — Peakhour",
+  description:
+    "Set your guardrails once. Peakhour runs your Shopify merchandising operation autonomously — scoring, recommending, executing, and reporting. You only hear from it when something needs you.",
+};
+
+const FEATURES = [
+  {
+    icon: Gauge,
+    title: "Merchant-defined guardrails",
+    description:
+      "Set your rules once: max discount %, margin floor, excluded collections, new arrivals protection, campaign duration limit, revenue threshold for auto-execute. Peakhour never crosses them.",
+  },
+  {
+    icon: Zap,
+    title: "Autonomous campaign execution",
+    description:
+      "When a recommendation passes all guardrails, Peakhour executes without waiting for approval — discount created in Shopify, Smart Rail updated, campaign tracked. Zero clicks.",
+  },
+  {
+    icon: Shield,
+    title: "Stop-loss rules",
+    description:
+      "If a campaign scores more than 100 impressions with fewer than 5 clicks after 24 hours, Peakhour sends a WhatsApp alert and waits for your instruction before continuing.",
+  },
+  {
+    icon: Undo2,
+    title: "Rollback in one tap",
+    description:
+      "If you want to stop a running campaign, one tap in Shopify Admin or a WhatsApp reply deactivates the discount and Smart Rail immediately — no lag, no support ticket.",
+  },
+  {
+    icon: FileText,
+    title: "Full audit log (append-only)",
+    description:
+      "Every autopilot decision is logged: what triggered it, which guardrails it passed, what it executed, and what the outcome was. Append-only — no decision can be quietly deleted.",
+  },
+  {
+    icon: BarChart2,
+    title: "Peaks ROI dashboard",
+    description:
+      "See the ROI of every AI decision in Shopify Admin. This week: 14 AI decisions, 620 Peaks spent, ₹61,400 recovered. Every credit has a measurable return.",
+  },
+  {
+    icon: RefreshCw,
+    title: "Nightly learning loop",
+    description:
+      "Every night, Peakhour updates the voice card and recommendation bias based on what worked and what didn't. Autopilot gets smarter with every cycle — without configuration.",
+  },
+  {
+    icon: MessageCircle,
+    title: "WhatsApp alerts for exceptions only",
+    description:
+      "When autopilot is running well, you hear nothing. You only get a WhatsApp message when something needs a decision — a stop-loss trigger, a guardrail edge case, or a high-value opportunity.",
+  },
+];
+
+const GUARDRAILS = [
+  { label: "Max discount %", example: "e.g. Never offer more than 25% off" },
+  { label: "Margin floor", example: "e.g. Never go below 40% margin per unit" },
+  { label: "Excluded collections", example: "e.g. Never touch New Arrivals or Premium Line" },
+  { label: "New arrivals protection", example: "e.g. Products < 30 days old are off-limits" },
+  { label: "Campaign duration limit", example: "e.g. No campaign longer than 72 hours" },
+  { label: "Revenue threshold", example: "e.g. Only auto-execute if expected recovery > ₹20,000" },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Merchant sets guardrails: max discount, excluded products, revenue threshold",
+    description:
+      "One-time setup in Shopify Admin. Six guardrails that define the boundary within which Peakhour can operate autonomously. These are your rules — Peakhour enforces them on every recommendation it considers executing.",
+  },
+  {
+    step: "02",
+    title: "Daily recommendation generated from intelligence data",
+    description:
+      "Every morning, Peakhour's intelligence layer runs: dead-stock scores updated, velocity trends recalculated, voice card reviewed. The best recovery opportunity is identified and a campaign recommendation is drafted.",
+  },
+  {
+    step: "03",
+    title: "Autopilot checks every guardrail — if passed, campaign executes automatically",
+    description:
+      "The recommendation is evaluated against all six guardrails. Discount within limit? Margin floor protected? Not in an excluded collection? Not a new arrival? Revenue threshold met? If every check passes, the campaign executes — discount live in Shopify, Smart Rail updated, campaign running.",
+  },
+  {
+    step: "04",
+    title: "Stop-loss monitors live campaigns; underperformers get a WhatsApp alert",
+    description:
+      "Every active campaign is monitored in real time. If a campaign accumulates over 100 impressions with fewer than 5 clicks within 24 hours, autopilot triggers stop-loss: a WhatsApp alert arrives with the performance data and options to stop the campaign or continue.",
+  },
+  {
+    step: "05",
+    title: "Nightly learning loop updates the voice card and recommendation bias",
+    description:
+      "After every campaign — approved manually or executed by autopilot — the outcome feeds the learning model. What discount level performed well at what margin? Which product clusters responded? The recommendation engine adjusts. Autopilot gets more precise over time.",
+  },
+];
+
+export default function AutopilotPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full blur-3xl"
+            aria-hidden
+            style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+          />
+
+          <div className="container">
+            <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
+              <Link
+                href="/commerce"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronLeft className="size-3" />
+                Back to Commerce
+              </Link>
+
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
+                  <Bot className="size-3" />
+                  Fully autonomous
+                </Badge>
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  Autopilot
+                </Badge>
+              </div>
+
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                Set your guardrails once.{" "}
+                <span className="text-primary">Peakhour runs the operation.</span>
+              </h1>
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                When autopilot is enabled, Peakhour evaluates recommendations
+                against merchant-defined guardrails and, if they pass, executes
+                campaigns without waiting for approval. Every decision is logged.
+                Stop-loss rules protect against underperforming campaigns. You
+                only hear from Peakhour when something needs you.
+              </p>
+
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See all features</Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "Merchant-defined guardrails",
+                  "Stop-loss rules protect every campaign",
+                  "Full audit log — append-only",
+                  "WhatsApp alerts for exceptions only",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Guardrails visual ── */}
+        <section className="border-y bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="grid gap-10 md:grid-cols-2 md:items-start">
+                <div>
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    Six guardrails
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight lg:text-3xl">
+                    Your rules. Peakhour never crosses them.
+                  </h2>
+                  <p className="mt-3 text-muted-foreground">
+                    Set your business boundaries once — max discount, margin
+                    floor, protected collections, new arrivals protection,
+                    campaign duration, and minimum revenue threshold. Autopilot
+                    evaluates every recommendation against all six before
+                    executing a single action.
+                  </p>
+                  <div className="mt-6 space-y-2.5">
+                    {GUARDRAILS.map((g) => (
+                      <div key={g.label} className="flex items-start gap-3 rounded-xl border bg-background px-4 py-3">
+                        <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                          <Check className="size-3 text-primary" strokeWidth={3} />
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold">{g.label}</p>
+                          <p className="text-xs text-muted-foreground">{g.example}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="rounded-2xl border bg-background p-5">
+                    <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-primary">
+                      Example: autopilot decision log
+                    </p>
+                    <div className="space-y-2.5">
+                      {[
+                        { time: "07:14", action: "Recommendation generated", detail: "Linen Kurtis · 14 SKUs · score 78" },
+                        { time: "07:14", action: "Guardrail: discount check", detail: "Suggested 20% · limit 25% ✓" },
+                        { time: "07:14", action: "Guardrail: margin floor", detail: "Margin at 42% · floor 40% ✓" },
+                        { time: "07:14", action: "Guardrail: collection exclusion", detail: "Not in New Arrivals ✓" },
+                        { time: "07:14", action: "Guardrail: revenue threshold", detail: "Expected ₹48k · threshold ₹20k ✓" },
+                        { time: "07:15", action: "Campaign executed", detail: "Discount live · Smart Rail updated" },
+                      ].map((entry) => (
+                        <div key={entry.action} className="flex items-start gap-3">
+                          <span className="mt-0.5 shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                            {entry.time}
+                          </span>
+                          <div>
+                            <p className="text-xs font-semibold">{entry.action}</p>
+                            <p className="text-[11px] text-muted-foreground">{entry.detail}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-primary/20 bg-primary/5 px-5 py-4">
+                    <p className="text-xs font-semibold text-primary">This week&apos;s autopilot summary</p>
+                    <div className="mt-3 grid grid-cols-3 gap-3">
+                      {[
+                        { value: "14", label: "AI decisions" },
+                        { value: "620", label: "Peaks spent" },
+                        { value: "₹61,400", label: "Recovered" },
+                      ].map((stat) => (
+                        <div key={stat.label} className="text-center">
+                          <p className="text-lg font-bold text-primary">{stat.value}</p>
+                          <p className="text-[10px] text-muted-foreground">{stat.label}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  How it works
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  From guardrails to autonomous execution
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Five steps. You configure it once. Peakhour runs it every day —
+                  and only interrupts you when something genuinely needs your
+                  decision.
+                </p>
+              </div>
+
+              <div className="space-y-0">
+                {STEPS.map((s, idx) => (
+                  <div key={s.step} className="relative flex gap-6 pb-10 last:pb-0">
+                    {idx < STEPS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div
+                      className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl text-xs font-bold text-primary-foreground shadow-lg"
+                      style={{ background: "oklch(0.60 0.20 68)" }}
+                    >
+                      {s.step}
+                    </div>
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Feature grid ── */}
+        <section className="border-t bg-muted/20 py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full feature set
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  The merchandising operation that runs itself
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Eight capabilities — from guardrail enforcement through
+                  stop-loss protection to nightly learning. Autonomous, but never
+                  a black box.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div
+                        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                        aria-hidden
+                        style={{
+                          background:
+                            "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                        }}
+                      />
+                      <div className="relative">
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                          <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                        </div>
+                        <p className="mb-1 text-sm font-semibold leading-snug">{f.title}</p>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {f.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Main callout ── */}
+        <section className="border-t py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative max-w-2xl">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    The promise
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                    &ldquo;The merchandising operation runs itself. You only hear from Peakhour when something needs you.&rdquo;
+                  </h2>
+                  <p className="mt-4 leading-relaxed text-muted-foreground">
+                    The Peakhour autopilot is not an AI that asks you questions
+                    and waits for instructions. It&apos;s a system that evaluates,
+                    decides, executes, and learns — within boundaries you set
+                    once. You&apos;re not in the loop on routine decisions.
+                  </p>
+                  <p className="mt-3 leading-relaxed text-muted-foreground">
+                    You&apos;re in the loop when a campaign underperforms beyond
+                    the stop-loss threshold. When a new product category appears
+                    that wasn&apos;t in your original guardrails. When the recommended
+                    discount would push a product below your margin floor. Those
+                    are the moments Peakhour sends a WhatsApp message. Not routine
+                    execution — only genuine exceptions.
+                  </p>
+                  <div className="mt-6 rounded-xl border bg-muted/40 px-5 py-4">
+                    <p className="text-xs font-semibold text-muted-foreground">Example Peaks ROI summary</p>
+                    <p className="mt-2 text-sm">
+                      This week: <strong>14 AI decisions</strong> ·{" "}
+                      <strong>620 Peaks spent</strong> ·{" "}
+                      <strong className="text-primary">₹61,400 recovered</strong>
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      You were involved in 0 of those 14 decisions. 2 stop-loss alerts were triggered; both resolved automatically.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                Get started
+              </p>
+              <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                Your merchandising operation. Autonomous.
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                Apply as a launch partner and get early access to autopilot —
+                with full guardrail configuration, stop-loss rules, and Peaks ROI
+                tracking — before public launch.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">
+                    <ChevronLeft className="size-4" />
+                    Back to Commerce
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/commerce/brand-voice/page.tsx
+++ b/src/app/(site)/commerce/brand-voice/page.tsx
@@ -1,0 +1,437 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  Sparkles,
+  Brain,
+  Gauge,
+  Languages,
+  BookOpen,
+  RefreshCw,
+  Pencil,
+  ThumbsUp,
+  ChevronLeft,
+  Check,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Shopify AI Recommendations with Your Brand Voice — Peakhour",
+  description:
+    "AI recommendations that sound like your brand wrote them. Auto-synthesised from your Shopify catalog. Commerce Voice Cards learn from every approval and rejection — gets better with every campaign.",
+};
+
+const FEATURES = [
+  {
+    icon: Sparkles,
+    title: "Auto-synthesised on first connect",
+    description:
+      "No forms to fill. On your first catalog sync, Peakhour analyzes your product titles, tags, and descriptions to build your initial voice card automatically.",
+  },
+  {
+    icon: BookOpen,
+    title: "Brand register detection",
+    description:
+      "Peakhour infers your brand register: editorial or casual? Premium or accessible? Aspirational or practical? The voice card reflects how your catalog actually speaks.",
+  },
+  {
+    icon: Languages,
+    title: "Cultural vocabulary (India / GCC / SEA)",
+    description:
+      "A fashion brand targeting India uses different vocabulary than one targeting the GCC. Peakhour's voice synthesis is culturally aware — not just linguistically translated.",
+  },
+  {
+    icon: BookOpen,
+    title: "Category-specific terms",
+    description:
+      "Different product categories in the same store can have different voice profiles. Footwear copy is different from home decor copy — Peakhour tracks both separately.",
+  },
+  {
+    icon: ThumbsUp,
+    title: "Learning loop from approvals",
+    description:
+      "Every campaign approval, title edit, or rejection teaches the voice card. After 20 campaigns, Peakhour generates titles you wouldn't change. After 50, they sound like your copy team.",
+  },
+  {
+    icon: Pencil,
+    title: "Rail title generation",
+    description:
+      "Every Smart Rail gets an AI-generated title in your voice — not a generic category label. 'The Linen Edit — Last 12 Pieces' instead of 'Dead Stock Clearance'.",
+  },
+  {
+    icon: Sparkles,
+    title: "Campaign copy in your voice",
+    description:
+      "WhatsApp campaign messages, push notifications, and email subject lines — all generated in your brand voice, from your actual product data and intelligence scores.",
+  },
+  {
+    icon: RefreshCw,
+    title: "Rejection signals refine the model",
+    description:
+      "If you change 'Sale' to 'End of Season Edit', Peakhour learns that 'Sale' is not in your vocabulary. Negative signals are as valuable as positive ones for voice refinement.",
+  },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "First catalog sync: Peakhour analyzes product titles, tags, and descriptions",
+    description:
+      "When your Shopify catalog syncs for the first time, Peakhour's voice synthesis engine reads every product title, tag, and description. It's looking for vocabulary patterns, formality register, cultural markers, and the words you use most vs. the words generic SaaS systems use.",
+  },
+  {
+    step: "02",
+    title: "Voice card auto-synthesised: brand register, preferred vocabulary, cultural context",
+    description:
+      "A Commerce Voice Card is created automatically. It captures: your brand's formality register, preferred category vocabulary, cultural context (India/GCC/SEA), and a 'never use' list inferred from what's absent in your copy. No forms. No setup calls.",
+  },
+  {
+    step: "03",
+    title: "AI recommendations generated daily — titles in your voice, discount and duration suggested",
+    description:
+      "Daily recommendations arrive with rail titles and campaign copy already in your brand voice. A fashion brand sees 'The Linen Edit — Last 12 Pieces'. A kitchenware brand sees 'The Summer Cookware Clear-Out — 48 Hours Only'. Same product type. Different voice.",
+  },
+  {
+    step: "04",
+    title: "Every approval/rejection teaches the voice card — gets smarter automatically",
+    description:
+      "When you approve a title unchanged, Peakhour marks it as good. When you edit it (changing 'clearance' to 'curated edit'), it learns the substitution. When you reject, it learns the pattern to avoid. After 20–50 campaigns, the voice card is precise enough that you rarely need to edit.",
+  },
+];
+
+export default function BrandVoicePage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full blur-3xl"
+            aria-hidden
+            style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+          />
+
+          <div className="container">
+            <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
+              <Link
+                href="/commerce"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronLeft className="size-3" />
+                Back to Commerce
+              </Link>
+
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
+                  <Sparkles className="size-3" />
+                  Commerce Voice Cards
+                </Badge>
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  AI Recommendations & Brand Voice
+                </Badge>
+              </div>
+
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                AI recommendations that sound like{" "}
+                <span className="text-primary">your brand wrote them</span>
+              </h1>
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                Commerce Voice Cards are auto-synthesised from your catalog on
+                first connect. Peakhour infers your brand register, preferred
+                vocabulary, and cultural context — no forms, no setup. Gets
+                smarter with every campaign you approve or reject.
+              </p>
+
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See all features</Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "Auto-synthesised — no setup forms",
+                  "Learns from every approval and rejection",
+                  "India / GCC / SEA cultural vocabulary",
+                  "Gets smarter after every campaign",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Voice example callout ── */}
+        <div className="border-y bg-muted/30">
+          <div className="container">
+            <div className="mx-auto max-w-5xl py-12">
+              <div className="mb-8 text-center">
+                <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+                  The difference
+                </p>
+                <h2 className="mt-2 text-2xl font-bold">Same product. Different voice.</h2>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border bg-background px-6 py-5">
+                  <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                    Generic SaaS output
+                  </p>
+                  <div className="space-y-2">
+                    {[
+                      "Dead Stock Clearance",
+                      "Sale — Up to 40% Off",
+                      "Clearance Items",
+                      "Discounted Products",
+                    ].map((label) => (
+                      <div key={label} className="rounded-lg border bg-muted/40 px-3 py-2 text-sm text-muted-foreground line-through">
+                        {label}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-primary/20 bg-primary/5 px-6 py-5">
+                  <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-primary">
+                    Peakhour in your brand voice
+                  </p>
+                  <div className="space-y-2">
+                    {[
+                      "The Linen Edit — Last 12 Pieces",
+                      "Season's End · Limited Stock",
+                      "The Curated Clear-Out — 48 Hours",
+                      "New Season In. Time to Move These Out.",
+                    ].map((label) => (
+                      <div key={label} className="rounded-lg border border-primary/15 bg-background px-3 py-2 text-sm font-medium">
+                        {label}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <p className="mt-6 text-center text-sm text-muted-foreground">
+                Generated from your catalog. In your voice. Not a template — a learned synthesis.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  How it works
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  From catalog to voice card to campaign copy
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Four steps, fully automatic. You never fill a form. You never
+                  define a style guide. Peakhour reads your catalog and learns
+                  your voice from what&apos;s already there.
+                </p>
+              </div>
+
+              <div className="space-y-0">
+                {STEPS.map((s, idx) => (
+                  <div key={s.step} className="relative flex gap-6 pb-10 last:pb-0">
+                    {idx < STEPS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div
+                      className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl text-xs font-bold text-primary-foreground shadow-lg"
+                      style={{ background: "oklch(0.60 0.20 68)" }}
+                    >
+                      {s.step}
+                    </div>
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Feature grid ── */}
+        <section className="border-t bg-muted/20 py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full feature set
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  Everything Commerce Voice Cards includes
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Eight capabilities that turn generic AI output into
+                  brand-consistent commerce copy — synthesised from your catalog,
+                  refined by your behaviour.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div
+                        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                        aria-hidden
+                        style={{
+                          background:
+                            "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                        }}
+                      />
+                      <div className="relative">
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                          <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                        </div>
+                        <p className="mb-1 text-sm font-semibold leading-snug">{f.title}</p>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {f.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Learning loop callout ── */}
+        <section className="border-t py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative max-w-2xl">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    The moat
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                    &ldquo;The Linen Edit — Last 12 Pieces&rdquo; vs &ldquo;Dead Stock Clearance&rdquo;. That&apos;s the difference.
+                  </h2>
+                  <p className="mt-4 leading-relaxed text-muted-foreground">
+                    Generic commerce AI generates generic commerce copy. When
+                    every app uses the same underlying model, every Shopify store
+                    gets the same vocabulary — &ldquo;sale&rdquo;, &ldquo;clearance&rdquo;, &ldquo;deal&rdquo;.
+                    Commerce Voice Cards are trained on your store specifically.
+                  </p>
+                  <p className="mt-3 leading-relaxed text-muted-foreground">
+                    A fashion brand in India that uses &ldquo;edit&rdquo; and &ldquo;pieces&rdquo; gets
+                    those words back in every recommendation title. A kitchenware
+                    brand that never uses &ldquo;limited time&rdquo; never sees it. The
+                    moat deepens with every campaign — your competitor can&apos;t
+                    copy a voice card they don&apos;t have.
+                  </p>
+                  <div className="mt-6 space-y-2">
+                    {[
+                      { milestone: "After 1st connect", outcome: "Initial voice card synthesised from catalog" },
+                      { milestone: "After 10 campaigns", outcome: "Vocabulary precision noticeably better" },
+                      { milestone: "After 20 campaigns", outcome: "Titles rarely need editing" },
+                      { milestone: "After 50 campaigns", outcome: "Sounds like your copy team wrote it" },
+                    ].map((m) => (
+                      <div key={m.milestone} className="flex items-center gap-3 rounded-lg border bg-muted/40 px-4 py-2.5">
+                        <span className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                          {m.milestone}
+                        </span>
+                        <span className="text-sm text-muted-foreground">{m.outcome}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                Get started
+              </p>
+              <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                Recommendations in your voice. Starting today.
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                Apply as a launch partner. Voice card synthesises automatically
+                on first catalog sync. No setup, no forms, no style guide to
+                write — just a better AI from day one.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">
+                    <ChevronLeft className="size-4" />
+                    Back to Commerce
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/commerce/campaign-approval/page.tsx
+++ b/src/app/(site)/commerce/campaign-approval/page.tsx
@@ -1,0 +1,469 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  MessageCircle,
+  Check,
+  Clock,
+  Shield,
+  Zap,
+  BarChart2,
+  CircleDollarSign,
+  History,
+  StopCircle,
+  ChevronLeft,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Shopify Campaign Approval via WhatsApp — Peakhour",
+  description:
+    "Approve Shopify discount campaigns with a single WhatsApp reply. Peakhour creates the discount, activates the Smart Rail, tracks the campaign, and sends a results summary when it ends.",
+};
+
+const FEATURES = [
+  {
+    icon: MessageCircle,
+    title: "WhatsApp-first approval (reply 1/2/3)",
+    description:
+      "Peakhour sends a structured WhatsApp message with all campaign details. Reply 1 to approve, 2 to change the discount, 3 to see the product list. No app to open.",
+  },
+  {
+    icon: Zap,
+    title: "Natural language edits via chat",
+    description:
+      "Free-text instructions work too. 'Change to 10% and skip the blue ones' is a valid instruction — Peakhour parses it and adjusts the campaign before creating the discount.",
+  },
+  {
+    icon: Shield,
+    title: "Shopify discount via Billing API",
+    description:
+      "Every discount is created through Shopify's own Billing and Discounts APIs — not workarounds. Clean, auditable, and uninstall-safe. The discount lives in Shopify Admin.",
+  },
+  {
+    icon: BarChart2,
+    title: "Campaign lifecycle tracking",
+    description:
+      "Pending → Approved → Running → Completed. The full campaign state is tracked in real time. Impressions, clicks, add-to-carts, and conversions all logged as the campaign runs.",
+  },
+  {
+    icon: Clock,
+    title: "Post-campaign WhatsApp summary",
+    description:
+      "One hour after every campaign ends, a WhatsApp summary arrives: revenue recovered, top-performing product, attribution vs. organic, and the next recommendation.",
+  },
+  {
+    icon: History,
+    title: "Campaign history in Shopify Admin",
+    description:
+      "Full campaign history viewable inside Shopify Admin. Every approval, every outcome, every WhatsApp exchange — logged and searchable. No separate dashboard to maintain.",
+  },
+  {
+    icon: StopCircle,
+    title: "Stop campaign from Admin",
+    description:
+      "If something looks off mid-campaign, you can stop it from Shopify Admin with one click. Peakhour deactivates the discount and the Smart Rail immediately.",
+  },
+  {
+    icon: CircleDollarSign,
+    title: "Zero markup on WhatsApp",
+    description:
+      "Campaign approval messages and post-campaign summaries are sent via WhatsApp. Like all Peakhour WhatsApp usage, fees go directly from your Meta account to Meta — no Peakhour cut.",
+  },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Dead-stock intelligence identifies a recovery opportunity",
+    description:
+      "Peakhour's daily scoring identifies a cluster of products above the critical threshold. Risk score, velocity trend, and days-in-stock converge into a recovery recommendation — products, suggested discount %, and recommended duration.",
+  },
+  {
+    step: "02",
+    title: "Peakhour sends a WhatsApp message: products, discount, duration, expected ₹ recovery",
+    description:
+      "You receive a structured WhatsApp message: product group name, count, risk score, suggested discount, campaign duration, and expected revenue recovery range in your local currency. All from your real data.",
+  },
+  {
+    step: "03",
+    title: "Reply 1 to approve — Peakhour creates the discount in Shopify via the Billing API",
+    description:
+      "A single reply creates the Shopify discount code, sets the applicable product list, and activates it — all via Shopify's official Billing and Discounts API. Takes under 10 seconds from reply to live discount.",
+  },
+  {
+    step: "04",
+    title: "Smart Rail activates with the discounted products; campaign is tracked in real time",
+    description:
+      "The Smart Rail on your storefront updates immediately to show the discounted products with urgency labels. Every impression, click, and add-to-cart is tracked against the campaign. You can see live performance in Shopify Admin.",
+  },
+  {
+    step: "05",
+    title: "1 hour after campaign ends: WhatsApp summary arrives",
+    description:
+      "The campaign summary comes to you — no dashboard to open. Revenue recovered, top-performing product, attribution vs. organic baseline, and a suggested next action if stock remains. Close the loop without leaving WhatsApp.",
+  },
+];
+
+const REPLY_OPTIONS = [
+  { key: "1", action: "Approve", detail: "Campaign creates and goes live immediately" },
+  { key: "2 [x%]", action: "Change discount", detail: "e.g. '2 10' changes the discount to 10%" },
+  { key: "3", action: "Show product list", detail: "Peakhour sends the full product list for review" },
+  { key: "4 [time]", action: "Schedule later", detail: "e.g. '4 Saturday 10am' — schedules the campaign" },
+  { key: "5", action: "Reject", detail: "Campaign dismissed; Peakhour won't re-suggest for 7 days" },
+];
+
+export default function CampaignApprovalPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full blur-3xl"
+            aria-hidden
+            style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+          />
+
+          <div className="container">
+            <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
+              <Link
+                href="/commerce"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronLeft className="size-3" />
+                Back to Commerce
+              </Link>
+
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
+                  <MessageCircle className="size-3" />
+                  WhatsApp-first
+                </Badge>
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  Campaign Approval
+                </Badge>
+              </div>
+
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                Approve campaigns with a WhatsApp reply.{" "}
+                <span className="text-primary">Peakhour executes everything.</span>
+              </h1>
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                Peakhour sends you a WhatsApp message with the campaign details —
+                products, discount, duration, expected recovery. Reply 1 to
+                approve. Discount created in Shopify, Smart Rail live, campaign
+                tracked, post-campaign summary delivered. All in under 10 seconds.
+              </p>
+
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See all features</Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "Reply 1 to approve — that's it",
+                  "Discount via Shopify Billing API",
+                  "Post-campaign summary on WhatsApp",
+                  "Zero markup on WhatsApp charges",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Reply options visual ── */}
+        <section className="border-y bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="grid gap-10 md:grid-cols-2 md:items-start">
+                <div>
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    Reply options
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight lg:text-3xl">
+                    Five reply options. Natural language also works.
+                  </h2>
+                  <p className="mt-3 text-muted-foreground">
+                    Structured replies for speed, free text for nuance.
+                    &ldquo;Change to 10% and skip the blue ones&rdquo; is a valid instruction
+                    — Peakhour parses it before creating the discount.
+                  </p>
+                  <div className="mt-6 space-y-2.5">
+                    {REPLY_OPTIONS.map((opt) => (
+                      <div key={opt.key} className="flex items-start gap-3 rounded-xl border bg-background px-4 py-3">
+                        <span className="mt-0.5 inline-flex h-7 min-w-[3rem] shrink-0 items-center justify-center rounded-lg bg-primary/10 px-2 text-[11px] font-bold text-primary">
+                          {opt.key}
+                        </span>
+                        <div>
+                          <p className="text-sm font-semibold">{opt.action}</p>
+                          <p className="text-xs text-muted-foreground">{opt.detail}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    Example message
+                  </p>
+                  <div className="rounded-2xl border bg-background p-5 shadow-sm">
+                    <div className="mb-3 flex items-center gap-2">
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                        <MessageCircle className="size-4 text-primary" />
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold">Peakhour Commerce</p>
+                        <p className="text-[10px] text-muted-foreground">WhatsApp Business</p>
+                      </div>
+                    </div>
+                    <div className="rounded-xl bg-muted/50 px-4 py-4 text-sm leading-relaxed">
+                      <p className="font-semibold">📦 Campaign Recommendation</p>
+                      <p className="mt-2 text-muted-foreground">
+                        <strong>Products:</strong> Linen Kurtis — Grey & Beige (14 SKUs)<br />
+                        <strong>Risk score:</strong> 74–82 · Slow-moving to Critical<br />
+                        <strong>Suggested discount:</strong> 20% off for 72 hours<br />
+                        <strong>Expected recovery:</strong> ₹38,000 – ₹52,000<br />
+                        <strong>Smart Rail:</strong> &ldquo;The Linen Edit — Last 14 Pieces&rdquo;
+                      </p>
+                      <div className="mt-3 border-t pt-3 text-xs text-muted-foreground">
+                        Reply <strong>1</strong> Approve · <strong>2 [x%]</strong> Change discount ·{" "}
+                        <strong>3</strong> Show list · <strong>4 [time]</strong> Schedule · <strong>5</strong> Reject
+                      </div>
+                    </div>
+                    <div className="mt-3 flex justify-end">
+                      <div className="rounded-xl bg-primary/10 px-4 py-2.5 text-sm font-medium text-primary">
+                        1
+                      </div>
+                    </div>
+                    <div className="mt-2 rounded-xl bg-muted/50 px-4 py-3 text-xs text-muted-foreground">
+                      ✅ <strong>Approved.</strong> Discount created in Shopify. Smart Rail live. Campaign running. I&apos;ll send a summary when it ends.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  How it works
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  From recommendation to live campaign in under 10 seconds
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Five steps. You&apos;re involved in one of them. Peakhour does the rest.
+                </p>
+              </div>
+
+              <div className="space-y-0">
+                {STEPS.map((s, idx) => (
+                  <div key={s.step} className="relative flex gap-6 pb-10 last:pb-0">
+                    {idx < STEPS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div
+                      className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl text-xs font-bold text-primary-foreground shadow-lg"
+                      style={{ background: "oklch(0.60 0.20 68)" }}
+                    >
+                      {s.step}
+                    </div>
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Feature grid ── */}
+        <section className="border-t bg-muted/20 py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full feature set
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  From recommendation to live campaign in under 10 seconds
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Eight capabilities — from WhatsApp approval through campaign
+                  tracking to post-campaign summary. You never need to leave
+                  WhatsApp to run a full campaign.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div
+                        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                        aria-hidden
+                        style={{
+                          background:
+                            "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                        }}
+                      />
+                      <div className="relative">
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                          <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                        </div>
+                        <p className="mb-1 text-sm font-semibold leading-snug">{f.title}</p>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {f.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Speed callout ── */}
+        <section className="border-t py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative max-w-2xl">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    The speed advantage
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                    &ldquo;From recommendation to live campaign in under 10 seconds.&rdquo;
+                  </h2>
+                  <p className="mt-4 leading-relaxed text-muted-foreground">
+                    The old process: log into Shopify Admin, find the products,
+                    create a discount code manually, set the conditions, pick the
+                    applicable products, activate it, update your storefront
+                    collection, set a reminder to deactivate it. 20–30 minutes
+                    per campaign, minimum.
+                  </p>
+                  <p className="mt-3 leading-relaxed text-muted-foreground">
+                    With Peakhour: read the WhatsApp message. Reply 1. Done.
+                    The discount is live in Shopify, the Smart Rail is updated,
+                    the campaign is being tracked, and you&apos;ll get a summary
+                    when it ends — without opening a single dashboard.
+                  </p>
+                  <div className="mt-6 grid grid-cols-2 gap-3">
+                    {[
+                      { label: "Time to approve", before: "20–30 min", after: "< 10 seconds" },
+                      { label: "Steps required", before: "8–12 manual steps", after: "1 reply" },
+                      { label: "Storefront update", before: "Manual collection edit", after: "Automatic" },
+                      { label: "Campaign debrief", before: "Dashboard check required", after: "WhatsApp summary" },
+                    ].map((row) => (
+                      <div key={row.label} className="rounded-xl border bg-muted/40 px-4 py-3">
+                        <p className="text-xs font-semibold text-muted-foreground">{row.label}</p>
+                        <p className="mt-1 text-[11px] text-muted-foreground line-through">{row.before}</p>
+                        <p className="text-sm font-bold text-primary">{row.after}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                Get started
+              </p>
+              <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                Campaigns live in under 10 seconds
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                Apply as a launch partner and get full campaign approval — from
+                WhatsApp recommendation to live Shopify discount — before the
+                public launch.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">
+                    <ChevronLeft className="size-4" />
+                    Back to Commerce
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/commerce/inventory-intelligence/page.tsx
+++ b/src/app/(site)/commerce/inventory-intelligence/page.tsx
@@ -1,0 +1,451 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  TrendingDown,
+  Brain,
+  BarChart2,
+  RefreshCw,
+  Clock,
+  Target,
+  AlertTriangle,
+  ChevronLeft,
+  Check,
+  Activity,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Shopify Dead-Stock Intelligence — Peakhour",
+  description:
+    "AI that scores every product in your Shopify store daily. Know which products are at risk before they cost you margin. Five risk bands, plain-language diagnosis, actionable next steps.",
+};
+
+const FEATURES = [
+  {
+    icon: Activity,
+    title: "Daily automated scoring",
+    description:
+      "Every product scored every day, without you doing anything. The algorithm runs on the latest sales, stock, and traffic data from your Shopify store.",
+  },
+  {
+    icon: AlertTriangle,
+    title: "5 risk score bands",
+    description:
+      "Healthy (0–30), Watchlist (31–50), Slow-moving (51–70), Dead-stock risk (71–85), Critical (86–100). Know exactly where every product sits on the risk curve.",
+  },
+  {
+    icon: Brain,
+    title: "AI diagnosis per product group",
+    description:
+      "Products with the same score can have different root causes. Peakhour groups them and explains: 'High views, low add-to-cart — pricing problem' vs 'No views — discovery gap'.",
+  },
+  {
+    icon: Clock,
+    title: "Inventory age tracking",
+    description:
+      "How long has each unit been sitting in your warehouse? Age-weighted scoring means a product that's been unsold for 90 days gets flagged before it becomes a write-off.",
+  },
+  {
+    icon: Target,
+    title: "Actionable next steps",
+    description:
+      "Every diagnosis comes with a recommended action: 'Run a 15% discount this weekend', 'Move to a bundle', 'Increase storefront visibility'. Not just a number — a direction.",
+  },
+  {
+    icon: BarChart2,
+    title: "Insights Network benchmarks",
+    description:
+      "Your dead-stock rate compared to anonymised cohorts of merchants in your category. Know if you're above or below average — and by how much.",
+  },
+  {
+    icon: RefreshCw,
+    title: "Continuous catalog sync",
+    description:
+      "Products, variants, prices, and inventory levels pull automatically from Shopify. Every score is grounded in the current state of your store — never a stale snapshot.",
+  },
+  {
+    icon: TrendingDown,
+    title: "Score history & trend lines",
+    description:
+      "Track how a product's score has changed over the last 30 days. A score moving from 40 to 70 in two weeks is a different signal than a product that's been at 70 for three months.",
+  },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Catalog sync pulls every product, variant, and inventory level from Shopify",
+    description:
+      "Peakhour connects to your Shopify store and syncs your full catalog: every product, every variant, every SKU, and current inventory levels. Sync is continuous — new products appear automatically.",
+  },
+  {
+    step: "02",
+    title: "Order history gives Peakhour sales velocity and purchase patterns",
+    description:
+      "Historical orders show which products are selling, at what rate, and in what pattern. A product with seasonal velocity is scored differently from one with a flat, declining curve.",
+  },
+  {
+    step: "03",
+    title: "Daily scoring job runs on every product, assigning a 0–100 score",
+    description:
+      "The scoring algorithm runs every night. Days since last sale (40%), stock age (20%), sales velocity (20%), views-to-purchase ratio (20%). Every product gets a fresh score each morning.",
+  },
+  {
+    step: "04",
+    title: "AI groups products by score band and root cause, generates a plain-language diagnosis",
+    description:
+      "Products aren't just scored — they're grouped by what's actually wrong. One morning you might see: 'Kurtis in Grey & Beige — 14 products, score 71–85 — High views, low add-to-cart. Likely a pricing or imagery problem.' That's a diagnosis, not just a number.",
+  },
+];
+
+const SCORE_BANDS = [
+  { range: "0 – 30", label: "Healthy", color: "text-emerald-600", bg: "bg-emerald-50 border-emerald-200", description: "Selling well, stock turning over as expected." },
+  { range: "31 – 50", label: "Watchlist", color: "text-yellow-600", bg: "bg-yellow-50 border-yellow-200", description: "Slowing down. Worth monitoring this week." },
+  { range: "51 – 70", label: "Slow-moving", color: "text-orange-600", bg: "bg-orange-50 border-orange-200", description: "Velocity has dropped. Consider a promotion or price test." },
+  { range: "71 – 85", label: "Dead-stock risk", color: "text-red-600", bg: "bg-red-50 border-red-200", description: "High risk. Intervention recommended within 14 days." },
+  { range: "86 – 100", label: "Critical", color: "text-red-800", bg: "bg-red-100 border-red-300", description: "Urgent. Recovery window is closing — act this week." },
+];
+
+export default function InventoryIntelligencePage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full blur-3xl"
+            aria-hidden
+            style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+          />
+
+          <div className="container">
+            <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
+              <Link
+                href="/commerce"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronLeft className="size-3" />
+                Back to Commerce
+              </Link>
+
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
+                  <TrendingDown className="size-3" />
+                  Dead-stock prevention
+                </Badge>
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  Inventory Intelligence
+                </Badge>
+              </div>
+
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                Know which Shopify products are at risk{" "}
+                <span className="text-primary">before they cost you margin</span>
+              </h1>
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                Daily dead-stock scoring for every product using a weighted
+                algorithm. Five risk bands. AI diagnosis per product group.
+                Plain-language explanation of what&apos;s wrong — and what to do
+                about it.
+              </p>
+
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See all features</Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "Runs every night on every product",
+                  "Plain-language diagnosis",
+                  "5 risk score bands",
+                  "Actionable next steps",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Score bands visual ── */}
+        <section className="border-y bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-10 text-center">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  The scoring system
+                </p>
+                <h2 className="text-2xl font-bold tracking-tight lg:text-3xl">
+                  Five risk bands — instantly actionable
+                </h2>
+                <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+                  A 0–100 score built from four weighted signals: days since last
+                  sale (40%), stock age (20%), sales velocity (20%), and
+                  views-to-purchase ratio (20%).
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                {SCORE_BANDS.map((band) => (
+                  <div
+                    key={band.label}
+                    className={`rounded-xl border px-4 py-4 ${band.bg}`}
+                  >
+                    <div className={`text-lg font-bold ${band.color}`}>{band.range}</div>
+                    <div className={`mt-0.5 text-sm font-semibold ${band.color}`}>{band.label}</div>
+                    <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                      {band.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  How it works
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  From Shopify data to a morning diagnosis
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Four steps, fully automated. You wake up to a prioritised view
+                  of your inventory risk — no spreadsheets, no manual analysis.
+                </p>
+              </div>
+
+              <div className="space-y-0">
+                {STEPS.map((s, idx) => (
+                  <div key={s.step} className="relative flex gap-6 pb-10 last:pb-0">
+                    {idx < STEPS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div
+                      className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl text-xs font-bold text-primary-foreground shadow-lg"
+                      style={{ background: "oklch(0.60 0.20 68)" }}
+                    >
+                      {s.step}
+                    </div>
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Feature grid ── */}
+        <section className="border-t bg-muted/20 py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full feature set
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  Know your dead-stock risk before it&apos;s unrecoverable
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Eight capabilities that give you complete visibility into every
+                  product&apos;s performance trajectory — before margin erosion
+                  becomes unavoidable.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div
+                        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                        aria-hidden
+                        style={{
+                          background:
+                            "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                        }}
+                      />
+                      <div className="relative">
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                          <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                        </div>
+                        <p className="mb-1 text-sm font-semibold leading-snug">{f.title}</p>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {f.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Diagnosis example callout ── */}
+        <section className="border-t py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative grid gap-10 md:grid-cols-2 md:items-center">
+                  <div>
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                      Example diagnosis
+                    </p>
+                    <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                      Not just a score. A reason. A direction.
+                    </h2>
+                    <p className="mt-4 leading-relaxed text-muted-foreground">
+                      Two products can have the same score (say, 74) for completely
+                      different reasons. One has high storefront traffic but nobody
+                      adds to cart — a pricing or presentation problem. The other
+                      has zero views — a discovery gap.
+                    </p>
+                    <p className="mt-3 leading-relaxed text-muted-foreground">
+                      Peakhour separates them into different diagnosis groups and
+                      gives you the right intervention for each. Not a single
+                      "your inventory is risky" headline — a specific, root-cause
+                      explanation for every cluster of products.
+                    </p>
+                  </div>
+                  <div className="space-y-3">
+                    {[
+                      {
+                        score: "74",
+                        group: "High views, low add-to-cart",
+                        diagnosis: "Pricing or imagery problem. Shoppers are finding it — they're not convinced.",
+                        action: "A/B price test or refresh product images",
+                      },
+                      {
+                        score: "74",
+                        group: "High stock, near-zero views",
+                        diagnosis: "Discovery gap. The product isn't being seen, not rejected.",
+                        action: "Surface in Smart Rail or run a search ad",
+                      },
+                      {
+                        score: "82",
+                        group: "Was selling — stopped 30 days ago",
+                        diagnosis: "Trend shift or seasonal end. Stock is accumulating fast.",
+                        action: "Run a time-boxed discount campaign this week",
+                      },
+                    ].map((row) => (
+                      <div key={row.group} className="rounded-xl border bg-muted/40 px-4 py-3">
+                        <div className="flex items-start gap-3">
+                          <span className="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-[11px] font-bold text-primary">
+                            {row.score}
+                          </span>
+                          <div>
+                            <p className="text-sm font-semibold">{row.group}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {row.diagnosis}
+                            </p>
+                            <p className="mt-1 text-[11px] font-medium text-primary">
+                              → {row.action}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                Get started
+              </p>
+              <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                Know your dead-stock risk before it&apos;s unrecoverable
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                Apply as a launch partner and get full inventory intelligence —
+                daily scoring, AI diagnosis, and campaign recommendations —
+                before public launch.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">
+                    <ChevronLeft className="size-4" />
+                    Back to Commerce
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/commerce/page.tsx
+++ b/src/app/(site)/commerce/page.tsx
@@ -12,66 +12,260 @@ import {
   Zap,
   ShoppingBag,
   Users,
+  TrendingDown,
+  Sparkles,
+  Brain,
+  Layers,
+  Shield,
+  LineChart,
+  MonitorSmartphone,
+  BadgeCheck,
+  MessageSquarePlus,
+  CircleDollarSign,
+  Gauge,
+  Clock,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 import { PricingGrid } from "@/components/marketing/pricing-grid";
 import { getPricing } from "@/lib/pricing";
 
 export const metadata: Metadata = {
-  title: "Shopify Commerce Assistant — Peakhour",
+  title: "Peakhour Commerce — AI Commerce Platform for Shopify",
   description:
-    "AI that answers your Shopify shoppers on WhatsApp in real time. Catalog sync, multilingual replies, and actionable insights — starting free.",
+    "The most powerful AI commerce platform built for Shopify. WhatsApp assistant, dead-stock intelligence, Smart Rails, brand-voice AI recommendations, and autopilot campaigns. Zero markup on WhatsApp charges.",
 };
 
-const FEATURES = [
+const CAPABILITY_GROUPS = [
   {
-    icon: RefreshCw,
-    title: "Automatic catalog sync",
+    label: "AI Commerce Assistant",
     description:
-      "Products, prices, and stock levels sync continuously from your Shopify store. Your AI always answers from live data — never stale.",
+      "Your catalog, available on every channel — 24/7, in any language.",
+    features: [
+      {
+        icon: MessageCircle,
+        title: "WhatsApp assistant for shoppers",
+        description:
+          "Answers every shopper question on your WhatsApp Business number in real time. Live stock, live prices, multilingual — no agent required.",
+      },
+      {
+        icon: BotMessageSquare,
+        title: "In-app assistant for merchants",
+        description:
+          "Ask your catalog anything right inside Shopify Admin. What's low on stock? What's trending this week? What needs a price review?",
+      },
+      {
+        icon: Languages,
+        title: "Multilingual replies",
+        description:
+          "Replies in the shopper's language — Hinglish, Hindi, Arabic, Tamil. Designed for markets where English is the second language, not the first.",
+      },
+      {
+        icon: MonitorSmartphone,
+        title: "On-store chat widget",
+        description:
+          "Catalog-grounded chat on your storefront. Anonymous shoppers get a taste; a seamless sign-in nudge turns them into known customers.",
+      },
+    ],
   },
   {
-    icon: MessageCircle,
-    title: "WhatsApp assistant",
+    label: "Inventory Intelligence",
     description:
-      "Answers shoppers on your WhatsApp Business number around the clock. Natural conversation, accurate answers, zero agent time.",
+      "Know which products are turning dead before they cost you margin.",
+    features: [
+      {
+        icon: TrendingDown,
+        title: "Dead-stock scoring",
+        description:
+          "A weighted daily score for every product: days since last sale, stock age, views-to-purchase ratio, and sales velocity — combined into a single risk signal.",
+      },
+      {
+        icon: Brain,
+        title: "AI diagnosis per product group",
+        description:
+          "Not just a score — a plain-language diagnosis. 'High views, low add-to-cart — pricing problem' vs 'high stock, no views — discovery gap'. Actionable, not abstract.",
+      },
+      {
+        icon: BarChart2,
+        title: "Insights Network",
+        description:
+          "See how your store performs against anonymised cohort benchmarks. Know if your dead-stock rate is above or below merchants like you.",
+      },
+      {
+        icon: RefreshCw,
+        title: "Continuous catalog sync",
+        description:
+          "Products, variants, prices, and inventory pull automatically from Shopify. Every AI decision is grounded in live data — never stale.",
+      },
+    ],
   },
   {
-    icon: BotMessageSquare,
-    title: "In-app assistant",
+    label: "Smart Rail — Storefront Merchandising",
     description:
-      "Chat with your catalog right inside Shopify admin. Ask what's low on stock, what's trending, what needs a price update — instantly.",
+      "Set your storefront once. Peakhour manages what it shows forever.",
+    features: [
+      {
+        icon: Layers,
+        title: "10 intelligent rail types",
+        description:
+          "Dead Stock Clearance · Trending Now · New Arrivals · Price Drops · Bestsellers · Back in Stock · Low Inventory · Complete the Look · Frequently Bought Together · Auto (AI decides).",
+      },
+      {
+        icon: Zap,
+        title: "Merchant sets it once",
+        description:
+          "Place the Smart Rail block via Shopify's theme editor. No code. Peakhour manages what products appear, in what order, with what title — autonomously.",
+      },
+      {
+        icon: LineChart,
+        title: "Event tracking",
+        description:
+          "Every impression, click, and add-to-cart feeds back into dead-stock scoring and recommendation accuracy. The storefront becomes a data collection layer.",
+      },
+      {
+        icon: MessageSquarePlus,
+        title: "WhatsApp handoff",
+        description:
+          "On-store chat widget offers 'Continue on WhatsApp' — bridges anonymous web sessions into your owned WhatsApp channel. Web to owned channel, one tap.",
+      },
+    ],
   },
   {
-    icon: Languages,
-    title: "Multilingual replies",
+    label: "AI Recommendations & Brand Voice",
     description:
-      "Replies in the shopper's own language — including Hinglish. Reach every customer in the language they're most comfortable with.",
+      "Recommendations that sound like your brand wrote them — not a generic SaaS.",
+    features: [
+      {
+        icon: Sparkles,
+        title: "Commerce voice cards",
+        description:
+          "Auto-synthesised from your catalog on first connect. Peakhour learns your brand register, preferred vocabulary, and words to avoid — without a single form to fill.",
+      },
+      {
+        icon: Brain,
+        title: "Brand-personalised titles",
+        description:
+          "Rail titles and campaign copy generated in your voice. 'The Linen Edit — Last 12 Pieces' instead of 'Dead Stock Clearance'. Your copy, not ours.",
+      },
+      {
+        icon: Sparkles,
+        title: "AI recommendations",
+        description:
+          "One recommendation per day, generated from your intelligence data. Products to surface, discount to suggest, expected recovery range — with a plain-language reason.",
+      },
+      {
+        icon: Gauge,
+        title: "Learning loop",
+        description:
+          "Every approval, edit, or rejection teaches the voice card. After 20 campaigns, Peakhour generates titles you wouldn't change. After 50, it sounds like your copy team wrote them.",
+      },
+    ],
   },
   {
-    icon: BarChart2,
-    title: "Insights Network",
+    label: "WhatsApp Campaign Approval",
     description:
-      "See how your store performs against anonymised cohort benchmarks. Founding members get priority access and shape the data model.",
+      "Approve campaigns in seconds. Peakhour executes everything.",
+    features: [
+      {
+        icon: MessageCircle,
+        title: "Approve with a single reply",
+        description:
+          "Peakhour sends you a WhatsApp message: products, discount, duration, expected recovery. Reply 1 to approve. That's it — discount created, rail live, campaign running.",
+      },
+      {
+        icon: Check,
+        title: "Full control from chat",
+        description:
+          "Change the discount, exclude products, schedule for later — all via WhatsApp replies. 'Change to 10% and skip the blue ones' is a valid instruction.",
+      },
+      {
+        icon: Clock,
+        title: "Post-campaign summary",
+        description:
+          "One hour after every campaign ends, you get a WhatsApp summary: revenue recovered, top performer, next recommendation. Close the loop without opening a dashboard.",
+      },
+      {
+        icon: Shield,
+        title: "Discount via Shopify Billing API",
+        description:
+          "Every discount is created through Shopify's own Billing and Discounts APIs — not workarounds. Clean, auditable, uninstall-safe.",
+      },
+    ],
   },
   {
-    icon: Zap,
-    title: "AI Commerce Assistant",
+    label: "Autopilot — Set It Once",
     description:
-      "The core engine: natural language, catalog-grounded, always accurate. Understands nuanced queries, suggests upsells, handles returns policy.",
+      "Your merchandising operation, running autonomously within your guardrails.",
+    features: [
+      {
+        icon: Gauge,
+        title: "Merchant guardrails",
+        description:
+          "Set your rules once: max discount %, margin floor, excluded collections, new arrivals protection, revenue threshold for auto-execute. Peakhour never crosses them.",
+      },
+      {
+        icon: Zap,
+        title: "Autonomous campaign execution",
+        description:
+          "When a recommendation passes all guardrails, Peakhour executes without waiting for approval. Rail active, discount live, campaign tracked — zero clicks.",
+      },
+      {
+        icon: Shield,
+        title: "Stop-loss rules",
+        description:
+          "If a campaign underperforms within 24 hours, Peakhour sends a WhatsApp alert and deactivates. You're never locked into a poor campaign.",
+      },
+      {
+        icon: BarChart2,
+        title: "Full audit log",
+        description:
+          "Every autopilot decision is logged: what triggered it, which guardrails applied, what the outcome was. Total transparency, zero black box.",
+      },
+    ],
+  },
+] as const;
+
+const HOW_IT_WORKS = [
+  {
+    step: "01",
+    title: "Install from the Shopify App Store",
+    description:
+      "Add Peakhour to your store. Catalog sync starts automatically — products, variants, prices, and stock, all pulled in.",
+  },
+  {
+    step: "02",
+    title: "Connect your WhatsApp Business number",
+    description:
+      "One-click connection via Meta Embedded Signup. Your shoppers can now ask questions on your WhatsApp number and get instant, accurate answers.",
+  },
+  {
+    step: "03",
+    title: "AI watches your catalog",
+    description:
+      "Peakhour scores every product daily. Dead-stock risks are diagnosed with plain-language explanations before they cost you margin.",
+  },
+  {
+    step: "04",
+    title: "Receive your first recommendation",
+    description:
+      "A WhatsApp message: products to surface, discount to run, duration, expected recovery. All in your brand voice, all from your real data.",
+  },
+  {
+    step: "05",
+    title: "Reply 1 to approve. Peakhour does the rest.",
+    description:
+      "Discount created in Shopify. Smart Rail updated on your storefront. Campaign tracked. Post-campaign summary arrives when it's done.",
   },
 ] as const;
 
 const LAUNCH_BENEFITS = [
-  "Early access before the public launch",
+  "Early access before public launch",
   "Direct line to the founding team",
-  "Shape the product with your feedback",
-  "Founding-partner pricing locked in forever",
-  "Priority onboarding and setup support",
+  "Shape the product roadmap with your feedback",
+  "Founding-partner pricing — locked in forever",
+  "Priority onboarding and dedicated setup support",
 ] as const;
 
 export default async function CommercePage() {
@@ -93,145 +287,442 @@ export default async function CommercePage() {
       <Header />
 
       <main>
-        {/* Hero */}
-        <section className="relative overflow-hidden border-b py-24 sm:py-32">
-          <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center overflow-hidden" aria-hidden>
-            <div className="h-[600px] w-[1000px] rounded-full bg-primary/10 blur-3xl opacity-70" />
-          </div>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full bg-primary/10 blur-3xl"
+            aria-hidden
+          />
+
           <div className="container">
             <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
-              <div className="flex items-center gap-2">
-                <Badge variant="outline" className="gap-1.5 px-3 py-1">
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
                   <ShoppingBag className="size-3" />
-                  Shopify Commerce
+                  Built for Shopify
                 </Badge>
-                {!isLive && (
-                  <Badge className="gap-1 bg-primary/10 text-primary hover:bg-primary/10 px-3 py-1 text-xs font-medium border-primary/20">
-                    Early Access
-                  </Badge>
-                )}
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  Founding Partner Program · Limited spots
+                </Badge>
               </div>
 
-              <h1 className="text-4xl font-bold tracking-tight text-pretty sm:text-5xl lg:text-6xl">
-                Your catalog, always-on{" "}
-                <span className="text-primary">WhatsApp</span>
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                The AI commerce platform{" "}
+                <span className="text-primary">built for your Shopify store</span>
               </h1>
-              <p className="max-w-2xl text-lg text-muted-foreground lg:text-xl">
-                AI that knows every product in your Shopify store and answers shoppers
-                on WhatsApp in real time — in their own language, with live prices and stock.
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                WhatsApp assistant, dead-stock intelligence, AI-powered Smart
+                Rails, brand-voice campaign recommendations, and autonomous
+                execution — all inside Shopify Admin. From first install to
+                fully autonomous operation.
               </p>
 
               <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
                 {isLive ? (
                   <>
-                    <Button asChild size="lg" className="gap-2">
+                    <Button asChild size="lg" className="gap-2 px-8">
                       <Link href="#plans">
                         See plans
                         <ArrowRight className="size-4" />
                       </Link>
                     </Button>
                     <Button asChild variant="outline" size="lg">
-                      <Link href="#features">Learn more</Link>
+                      <Link href="#features">Explore features</Link>
                     </Button>
                   </>
                 ) : (
                   <>
-                    <Button asChild size="lg" className="gap-2">
+                    <Button asChild size="lg" className="gap-2 px-8">
                       <Link href="/launch-partner">
-                        Join as a launch partner
+                        Apply as a launch partner
                         <ArrowRight className="size-4" />
                       </Link>
                     </Button>
                     <Button asChild variant="outline" size="lg">
-                      <Link href="#features">See what&apos;s coming</Link>
+                      <Link href="#features">Explore all features</Link>
                     </Button>
                   </>
                 )}
               </div>
 
-              {/* Shopify trust mark */}
-              <p className="text-xs text-muted-foreground">
-                Built for Shopify · Billed through your Shopify account · Available in the Shopify App Store
-              </p>
+              {/* Trust strip */}
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "Zero markup on WhatsApp charges",
+                  "Billed through Shopify",
+                  "No credit card to start",
+                  "Built for Shopify badge track",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
         </section>
 
-        {/* Features */}
-        <section id="features" className="bg-muted/40 py-20">
+        {/* ── Three trust callouts ── */}
+        <div className="border-y bg-muted/30">
           <div className="container">
-            <div className="mx-auto max-w-5xl">
-              <div className="mb-12 text-center">
-                <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">
-                  Everything your store needs to sell smarter
+            <div className="grid divide-y md:grid-cols-3 md:divide-x md:divide-y-0">
+              {[
+                {
+                  icon: CircleDollarSign,
+                  stat: "0% markup",
+                  label: "on WhatsApp charges",
+                  detail:
+                    "WhatsApp messaging fees go directly from your Meta account to Meta. Peakhour takes zero cut. Fully transparent.",
+                },
+                {
+                  icon: BadgeCheck,
+                  stat: "Native",
+                  label: "inside Shopify Admin",
+                  detail:
+                    "Polaris design system throughout. Session-token auth. No external logins, no iframe hacks. Built the way Shopify intended.",
+                },
+                {
+                  icon: Gauge,
+                  stat: "Per-action",
+                  label: "Peaks billing model",
+                  detail:
+                    "Every AI action earns you a measurable outcome. See exactly what each campaign, diagnosis, and recommendation costs in Peaks — and what it recovered.",
+                },
+              ].map((item) => {
+                const Icon = item.icon;
+                return (
+                  <div
+                    key={item.stat}
+                    className="flex flex-col gap-2 px-6 py-6 md:px-8"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+                        <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                      </div>
+                      <div>
+                        <span className="text-base font-bold text-foreground">{item.stat}</span>
+                        <span className="ml-1 text-sm text-muted-foreground">{item.label}</span>
+                      </div>
+                    </div>
+                    <p className="text-xs leading-relaxed text-muted-foreground">
+                      {item.detail}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* ── Full feature grid ── */}
+        <section id="features" className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-16 max-w-2xl">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full platform
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  Everything a Shopify merchant needs to sell more
                 </h2>
-                <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
-                  Six capabilities that turn your Shopify catalog into an always-on
-                  sales and support assistant.
+                <p className="mt-3 text-muted-foreground">
+                  Six capability layers, one platform. Each layer makes the
+                  others more intelligent over time.
                 </p>
               </div>
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {FEATURES.map((f) => {
-                  const FeatureIcon = f.icon;
-                  return (
-                    <Card key={f.title} className="card-lift">
-                      <CardHeader className="pb-2">
-                        <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-                          <FeatureIcon className="size-5 text-primary" strokeWidth={1.5} />
-                        </div>
-                        <CardTitle className="text-base">{f.title}</CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <p className="text-sm text-muted-foreground leading-relaxed">
-                          {f.description}
+
+              <div className="space-y-16">
+                {CAPABILITY_GROUPS.map((group) => (
+                  <div key={group.label}>
+                    <div className="mb-6 flex items-start gap-3">
+                      <div>
+                        <h3 className="text-xl font-bold">{group.label}</h3>
+                        <p className="mt-0.5 text-sm text-muted-foreground">
+                          {group.description}
                         </p>
-                      </CardContent>
-                    </Card>
-                  );
-                })}
+                      </div>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                      {group.features.map((f) => {
+                        const Icon = f.icon;
+                        return (
+                          <div
+                            key={f.title}
+                            className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                          >
+                            <div
+                              className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                              aria-hidden
+                              style={{
+                                background:
+                                  "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                              }}
+                            />
+                            <div className="relative">
+                              <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                                <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                              </div>
+                              <p className="mb-1 text-sm font-semibold leading-snug">
+                                {f.title}
+                              </p>
+                              <p className="text-xs leading-relaxed text-muted-foreground">
+                                {f.description}
+                              </p>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
         </section>
 
-        {/* How it works */}
-        <section className="py-20">
+        {/* ── WhatsApp transparency callout ── */}
+        <section className="border-t border-b bg-muted/30 py-16">
           <div className="container">
             <div className="mx-auto max-w-5xl">
-              <h2 className="text-center text-3xl font-semibold text-pretty lg:text-4xl">
-                Live in minutes
-              </h2>
-              <div className="mt-14 grid gap-10 md:grid-cols-3">
-                {[
-                  {
-                    step: "1",
-                    title: "Install from Shopify App Store",
-                    description:
-                      "Add the Peakhour app to your store. Catalog sync starts automatically — no CSV exports, no manual setup.",
-                  },
-                  {
-                    step: "2",
-                    title: "Connect WhatsApp Business",
-                    description:
-                      "Link your WhatsApp Business number. Shoppers can now ask product questions and get instant, accurate answers.",
-                  },
-                  {
-                    step: "3",
-                    title: "Grow with insights",
-                    description:
-                      "Track conversations, see what shoppers ask most, spot gaps in your catalog, and benchmark against your cohort.",
-                  },
-                ].map((s) => (
-                  <div key={s.step} className="relative text-center">
-                    <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary text-2xl font-bold text-primary-foreground shadow-lg">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 shadow-sm lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative grid gap-8 md:grid-cols-2 md:gap-16 md:items-center">
+                  <div>
+                    <Badge className="mb-4 gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                      On billing transparency
+                    </Badge>
+                    <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                      We charge zero markup on WhatsApp
+                    </h2>
+                    <p className="mt-3 leading-relaxed text-muted-foreground">
+                      WhatsApp messaging fees are charged directly from your
+                      Meta account to Meta. Peakhour takes no cut, no margin,
+                      no markup — ever. We believe you should know exactly what
+                      you&apos;re paying and who you&apos;re paying it to.
+                    </p>
+                    <p className="mt-3 leading-relaxed text-muted-foreground">
+                      Peakhour&apos;s own billing is through Shopify — on your existing Shopify bill,
+                      no new payment method required. AI actions are tracked in Peaks — a transparent,
+                      per-action credit that shows you exactly what each decision cost and what it recovered.
+                    </p>
+                  </div>
+                  <div className="space-y-4">
+                    {[
+                      {
+                        label: "WhatsApp charges",
+                        who: "Paid directly to Meta",
+                        markup: "0% Peakhour markup",
+                      },
+                      {
+                        label: "App subscription",
+                        who: "Billed through Shopify",
+                        markup: "On your existing Shopify bill",
+                      },
+                      {
+                        label: "AI actions (Peaks)",
+                        who: "Per-action, pay-as-you-go",
+                        markup: "See exact ROI for every credit spent",
+                      },
+                    ].map((row) => (
+                      <div
+                        key={row.label}
+                        className="rounded-xl border bg-muted/40 px-4 py-3"
+                      >
+                        <div className="flex items-start justify-between gap-4">
+                          <div>
+                            <p className="text-sm font-medium">{row.label}</p>
+                            <p className="text-xs text-muted-foreground">{row.who}</p>
+                          </div>
+                          <span className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                            {row.markup}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14 text-center">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  From install to autopilot
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  How it works
+                </h2>
+              </div>
+
+              <div className="space-y-0">
+                {HOW_IT_WORKS.map((s, idx) => (
+                  <div
+                    key={s.step}
+                    className="relative flex gap-6 pb-10 last:pb-0"
+                  >
+                    {/* Connector line */}
+                    {idx < HOW_IT_WORKS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-primary shadow-lg shadow-primary/25 text-xs font-bold text-primary-foreground">
                       {s.step}
                     </div>
-                    {s.step !== "3" && (
-                      <div className="absolute top-7 left-[calc(50%+2rem)] hidden h-px w-[calc(100%-4rem)] bg-border md:block" />
-                    )}
-                    <h3 className="mt-5 text-lg font-semibold">{s.title}</h3>
-                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                      {s.description}
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Peaks ROI callout ── */}
+        <section className="border-t bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-4xl">
+              <div className="grid gap-8 md:grid-cols-2 md:items-center">
+                <div>
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    Peaks — AI credits
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                    Every Peaks credit has a measurable return
+                  </h2>
+                  <p className="mt-3 text-muted-foreground leading-relaxed">
+                    Unlike opaque AI subscriptions, Peaks are per-action.
+                    You see exactly what each AI decision costs and what it
+                    recovered — inside Shopify Admin. No surprises on your bill.
+                  </p>
+                  <div className="mt-6 rounded-xl border bg-background px-5 py-4 text-sm font-medium">
+                    <span className="text-muted-foreground">Example outcome:&nbsp;</span>
+                    620 Peaks spent &rarr;{" "}
+                    <span className="text-primary font-bold">₹61,400 recovered</span>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  {[
+                    { action: "Dead-stock analysis (full store, daily)", peaks: "50 Peaks" },
+                    { action: "AI diagnosis per product group", peaks: "10 Peaks" },
+                    { action: "Campaign recommendation generated", peaks: "30 Peaks" },
+                    { action: "Rail title in your brand voice", peaks: "10 Peaks" },
+                    { action: "Campaign summary sent via WhatsApp", peaks: "10 Peaks" },
+                    { action: "Autopilot execution (per campaign)", peaks: "15 Peaks" },
+                  ].map((row) => (
+                    <div
+                      key={row.action}
+                      className="flex items-center justify-between gap-4 rounded-lg border bg-background px-4 py-2.5"
+                    >
+                      <span className="text-xs text-muted-foreground">{row.action}</span>
+                      <span className="shrink-0 text-xs font-semibold text-primary">{row.peaks}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Competitive position ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-10 text-center">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Why Peakhour
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight">
+                  No other Shopify app does all seven
+                </h2>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {[
+                  {
+                    phase: "Foundation",
+                    capability:
+                      "Catalog sync + AI assistant grounded in live product data",
+                  },
+                  {
+                    phase: "Intelligence",
+                    capability:
+                      "Know which products are at risk before they become a problem",
+                  },
+                  {
+                    phase: "Storefront",
+                    capability:
+                      "AI manages your rails and on-site chat without touching the theme",
+                  },
+                  {
+                    phase: "Brand voice",
+                    capability:
+                      "Recommendations that sound like your brand, not a generic SaaS",
+                  },
+                  {
+                    phase: "Approval",
+                    capability:
+                      "Approve campaigns on WhatsApp in seconds — Peakhour executes",
+                  },
+                  {
+                    phase: "Autopilot",
+                    capability:
+                      "Set your guardrails once — Peakhour runs the operation autonomously",
+                  },
+                  {
+                    phase: "Transparency",
+                    capability:
+                      "Zero markup on WhatsApp · per-action Peaks · billed through Shopify",
+                  },
+                  {
+                    phase: "India / GCC first",
+                    capability:
+                      "WhatsApp-first for SMB merchants, multilingual, built for emerging markets",
+                  },
+                ].map((row) => (
+                  <div
+                    key={row.phase}
+                    className="rounded-2xl border bg-background p-4"
+                  >
+                    <span className="mb-2 block text-[10px] font-bold uppercase tracking-widest text-primary">
+                      {row.phase}
+                    </span>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      {row.capability}
                     </p>
                   </div>
                 ))}
@@ -240,51 +731,80 @@ export default async function CommercePage() {
           </div>
         </section>
 
-        {/* Plans (dev only) OR Launch partner CTA (prod) */}
+        {/* ── Plans (dev only) OR Launch partner CTA (prod) ── */}
         {isLive ? (
-          <section id="plans" className="border-t bg-muted/40 py-20">
+          <section id="plans" className="border-t py-20">
             <div className="container">
-              <div className="mx-auto max-w-3xl">
-                <PricingGrid plans={[]} products={pricing?.products ?? []} showHeader={false} />
+              <div className="mx-auto max-w-6xl">
+                <PricingGrid plans={[]} products={pricing?.products ?? []} showHeader />
               </div>
             </div>
           </section>
         ) : (
-          <section className="border-t bg-muted/40 py-20">
+          <section className="border-t py-20">
             <div className="container">
               <div className="mx-auto max-w-3xl">
-                <div className="rounded-2xl border bg-background p-8 shadow-sm lg:p-12">
-                  <div className="flex items-center gap-3 mb-6">
-                    <span className="flex size-10 items-center justify-center rounded-full bg-primary/10">
-                      <Users className="size-5 text-primary" />
-                    </span>
-                    <div>
-                      <h2 className="text-2xl font-bold">Be a founding partner</h2>
-                      <p className="text-sm text-muted-foreground">Limited spots · Shopify merchants only</p>
+                <div className="relative overflow-hidden rounded-3xl border bg-background px-8 py-10 shadow-sm lg:px-14 lg:py-14">
+                  <div
+                    className="pointer-events-none absolute inset-0"
+                    aria-hidden
+                    style={{
+                      backgroundImage:
+                        "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.12) 1.5px, transparent 1.5px)",
+                      backgroundSize: "28px 28px",
+                      maskImage:
+                        "radial-gradient(ellipse 60% 60% at 100% 0%, black 0%, transparent 70%)",
+                      WebkitMaskImage:
+                        "radial-gradient(ellipse 60% 60% at 100% 0%, black 0%, transparent 70%)",
+                    }}
+                  />
+                  <div
+                    className="pointer-events-none absolute -top-24 -right-24 h-64 w-64 rounded-full blur-3xl"
+                    style={{ background: "oklch(0.60 0.20 68 / 0.12)" }}
+                    aria-hidden
+                  />
+                  <div className="relative">
+                    <div className="mb-5 flex items-center gap-3">
+                      <span className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+                        <Users className="size-5 text-primary" />
+                      </span>
+                      <div>
+                        <h2 className="text-2xl font-bold">Be a founding partner</h2>
+                        <p className="text-sm text-muted-foreground">
+                          Limited spots · Shopify merchants only
+                        </p>
+                      </div>
+                    </div>
+                    <p className="text-muted-foreground">
+                      We&apos;re opening early access to a small cohort of Shopify
+                      merchants who will help shape the full Commerce Platform
+                      before public launch. Founding partners get every
+                      capability — WhatsApp assistant, dead-stock intelligence,
+                      Smart Rail, AI recommendations, autopilot — plus locked-in
+                      pricing and direct access to the team.
+                    </p>
+                    <ul className="mt-6 grid gap-2.5 sm:grid-cols-2">
+                      {LAUNCH_BENEFITS.map((b) => (
+                        <li key={b} className="flex items-start gap-2.5 text-sm">
+                          <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full bg-primary/15">
+                            <Check className="size-2.5 text-primary" strokeWidth={3} />
+                          </span>
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                    <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+                      <Button asChild size="lg" className="gap-2 px-8">
+                        <Link href="/launch-partner">
+                          Apply as a launch partner
+                          <ArrowRight className="size-4" />
+                        </Link>
+                      </Button>
+                      <p className="text-xs text-muted-foreground">
+                        No credit card required · We&apos;ll reach out to confirm your spot
+                      </p>
                     </div>
                   </div>
-                  <p className="text-muted-foreground mb-8">
-                    We&apos;re opening early access to a small cohort of Shopify merchants who will
-                    help shape the Commerce Assistant before public launch. Founding partners get
-                    locked-in pricing, direct access to the team, and first say on what we build next.
-                  </p>
-                  <ul className="mb-8 space-y-3">
-                    {LAUNCH_BENEFITS.map((b) => (
-                      <li key={b} className="flex items-center gap-3 text-sm">
-                        <Check className="size-4 shrink-0 text-primary" />
-                        {b}
-                      </li>
-                    ))}
-                  </ul>
-                  <Button asChild size="lg" className="gap-2">
-                    <Link href="/launch-partner">
-                      Apply as a launch partner
-                      <ArrowRight className="size-4" />
-                    </Link>
-                  </Button>
-                  <p className="mt-4 text-xs text-muted-foreground">
-                    No credit card required. We&apos;ll reach out to confirm your spot.
-                  </p>
                 </div>
               </div>
             </div>

--- a/src/app/(site)/commerce/page.tsx
+++ b/src/app/(site)/commerce/page.tsx
@@ -41,6 +41,7 @@ export const metadata: Metadata = {
 const CAPABILITY_GROUPS = [
   {
     label: "AI Commerce Assistant",
+    href: "/commerce/whatsapp-assistant",
     description:
       "Your catalog, available on every channel — 24/7, in any language.",
     features: [
@@ -72,6 +73,7 @@ const CAPABILITY_GROUPS = [
   },
   {
     label: "Inventory Intelligence",
+    href: "/commerce/inventory-intelligence",
     description:
       "Know which products are turning dead before they cost you margin.",
     features: [
@@ -103,6 +105,7 @@ const CAPABILITY_GROUPS = [
   },
   {
     label: "Smart Rail — Storefront Merchandising",
+    href: "/commerce/smart-rail",
     description:
       "Set your storefront once. Peakhour manages what it shows forever.",
     features: [
@@ -134,6 +137,7 @@ const CAPABILITY_GROUPS = [
   },
   {
     label: "AI Recommendations & Brand Voice",
+    href: "/commerce/brand-voice",
     description:
       "Recommendations that sound like your brand wrote them — not a generic SaaS.",
     features: [
@@ -165,6 +169,7 @@ const CAPABILITY_GROUPS = [
   },
   {
     label: "WhatsApp Campaign Approval",
+    href: "/commerce/campaign-approval",
     description:
       "Approve campaigns in seconds. Peakhour executes everything.",
     features: [
@@ -196,6 +201,7 @@ const CAPABILITY_GROUPS = [
   },
   {
     label: "Autopilot — Set It Once",
+    href: "/commerce/autopilot",
     description:
       "Your merchandising operation, running autonomously within your guardrails.",
     features: [
@@ -225,7 +231,7 @@ const CAPABILITY_GROUPS = [
       },
     ],
   },
-] as const;
+];
 
 const HOW_IT_WORKS = [
   {
@@ -445,13 +451,27 @@ export default async function CommercePage() {
               <div className="space-y-16">
                 {CAPABILITY_GROUPS.map((group) => (
                   <div key={group.label}>
-                    <div className="mb-6 flex items-start gap-3">
+                    <div className="mb-6 flex items-start justify-between gap-3">
                       <div>
-                        <h3 className="text-xl font-bold">{group.label}</h3>
+                        <Link
+                          href={group.href}
+                          className="group/heading inline-flex items-center gap-2"
+                        >
+                          <h3 className="text-xl font-bold transition-colors group-hover/heading:text-primary">
+                            {group.label}
+                          </h3>
+                          <ArrowRight className="size-4 text-muted-foreground opacity-0 transition-all duration-200 group-hover/heading:translate-x-0.5 group-hover/heading:text-primary group-hover/heading:opacity-100" />
+                        </Link>
                         <p className="mt-0.5 text-sm text-muted-foreground">
                           {group.description}
                         </p>
                       </div>
+                      <Link
+                        href={group.href}
+                        className="hidden shrink-0 text-xs font-medium text-primary underline-offset-2 hover:underline sm:block"
+                      >
+                        Learn more →
+                      </Link>
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
                       {group.features.map((f) => {
@@ -459,7 +479,7 @@ export default async function CommercePage() {
                         return (
                           <div
                             key={f.title}
-                            className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                            className="group relative flex flex-col rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
                           >
                             <div
                               className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
@@ -469,16 +489,23 @@ export default async function CommercePage() {
                                   "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
                               }}
                             />
-                            <div className="relative">
+                            <div className="relative flex flex-1 flex-col">
                               <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
                                 <Icon className="size-4 text-primary" strokeWidth={1.5} />
                               </div>
                               <p className="mb-1 text-sm font-semibold leading-snug">
                                 {f.title}
                               </p>
-                              <p className="text-xs leading-relaxed text-muted-foreground">
+                              <p className="flex-1 text-xs leading-relaxed text-muted-foreground">
                                 {f.description}
                               </p>
+                              <Link
+                                href={group.href}
+                                className="mt-3 inline-flex items-center gap-1 text-[11px] font-medium text-primary opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+                              >
+                                Learn more
+                                <ArrowRight className="size-3" />
+                              </Link>
                             </div>
                           </div>
                         );

--- a/src/app/(site)/commerce/smart-rail/page.tsx
+++ b/src/app/(site)/commerce/smart-rail/page.tsx
@@ -1,0 +1,452 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  Layers,
+  Zap,
+  LineChart,
+  MessageSquarePlus,
+  MousePointerClick,
+  Tag,
+  ShoppingCart,
+  Repeat,
+  ChevronLeft,
+  Check,
+  Store,
+  Bot,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Shopify Smart Rail — AI Storefront Merchandising by Peakhour",
+  description:
+    "AI-powered product rails that update themselves. Merchant places the block once in Shopify's theme editor. Peakhour manages what it shows forever — products, order, title, and urgency labels.",
+};
+
+const RAIL_TYPES = [
+  { name: "Dead Stock Clearance", description: "Surfaces your highest-risk products first. AI chooses from the current dead-stock scoring data." },
+  { name: "Trending Now", description: "Products with accelerating sales velocity this week — not last month's bestsellers." },
+  { name: "New Arrivals", description: "Products added in the last 14 days, prioritised by early engagement signals." },
+  { name: "Price Drops", description: "Products with active discounts or recent price reductions — auto-populated from Shopify." },
+  { name: "Bestsellers", description: "Top performers by revenue over the last 30 days, updated nightly." },
+  { name: "Back in Stock", description: "Products that were out of stock and have been restocked — high-intent signal for returning shoppers." },
+  { name: "Low Inventory Selling Fast", description: "Urgency rail: products with fewer than 10 units remaining and positive velocity." },
+  { name: "Complete the Look", description: "Category-based cross-sell: products that complete an outfit, kit, or set." },
+  { name: "Frequently Bought Together", description: "Order-graph recommendations: products other shoppers bought in the same session." },
+  { name: "Auto (AI decides)", description: "Peakhour picks the best rail type for the current moment — balancing clearance pressure, trending velocity, and inventory health." },
+];
+
+const FEATURES = [
+  {
+    icon: Layers,
+    title: "10 intelligent rail types",
+    description:
+      "From Dead Stock Clearance to Frequently Bought Together — each rail type is driven by live intelligence data, not a static product collection.",
+  },
+  {
+    icon: Zap,
+    title: "Zero-code merchant setup",
+    description:
+      "Place the Smart Rail block in Shopify's theme editor via drag and drop. One block, one decision. Peakhour manages everything inside it from that point forward.",
+  },
+  {
+    icon: Bot,
+    title: "AI chooses products from scoring data",
+    description:
+      "The products that appear on your rail aren't manually selected — they're chosen from your live intelligence data. Dead-stock scores, velocity, and inventory levels all feed the selection.",
+  },
+  {
+    icon: MousePointerClick,
+    title: "Event tracking",
+    description:
+      "Every impression, click, and add-to-cart is captured. This data feeds back into dead-stock scoring and recommendation accuracy — the storefront becomes a live data collection layer.",
+  },
+  {
+    icon: Tag,
+    title: "Discount badge & urgency labels",
+    description:
+      "AI adds context labels where appropriate: 'Only 3 left', 'Price dropped', '40% off this weekend'. Generated from your actual inventory and discount data — not scripted.",
+  },
+  {
+    icon: MessageSquarePlus,
+    title: "On-store chat widget",
+    description:
+      "Catalog-grounded chat for storefront visitors. Anonymous shoppers get instant answers; a seamless sign-in nudge converts them into known customers before the session ends.",
+  },
+  {
+    icon: ShoppingCart,
+    title: "WhatsApp handoff button",
+    description:
+      "'Continue on WhatsApp' bridges the anonymous web session into your owned WhatsApp channel. One tap — the conversation context carries over, the shopper becomes known.",
+  },
+  {
+    icon: Store,
+    title: "Works with Dawn, Craft, Sense, and more",
+    description:
+      "Built as a native Shopify Theme App Extension. Compatible with all major Shopify themes — no custom theme required, no developer needed for installation.",
+  },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Install the Smart Rail block in Shopify's theme editor",
+    description:
+      "Open your Shopify theme editor, find the Smart Rail block in the app extensions list, and drag it to any section of your homepage, collection page, or product page. No code, no developer.",
+  },
+  {
+    step: "02",
+    title: "Choose a rail type or set to Auto — Peakhour handles the rest",
+    description:
+      "Select from 10 rail types or leave it on Auto. When set to Auto, Peakhour evaluates your current inventory health, trending velocity, and clearance pressure to decide what the rail should show in real time.",
+  },
+  {
+    step: "03",
+    title: "Dead-stock intelligence feeds which products appear",
+    description:
+      "The products in your rail aren't guesses — they come from your daily dead-stock scoring data. Products with the highest clearance need and the lowest recent visibility get surfaced first.",
+  },
+  {
+    step: "04",
+    title: "Every click and add-to-cart feeds back into scoring",
+    description:
+      "Shopper interactions on the rail are captured as events. A product that's in the rail but getting zero clicks has a different problem than one getting clicks but no purchases. Both signals update the scoring model.",
+  },
+];
+
+export default function SmartRailPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full blur-3xl"
+            aria-hidden
+            style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+          />
+
+          <div className="container">
+            <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
+              <Link
+                href="/commerce"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronLeft className="size-3" />
+                Back to Commerce
+              </Link>
+
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
+                  <Layers className="size-3" />
+                  Shopify Theme App Extension
+                </Badge>
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  Smart Rail
+                </Badge>
+              </div>
+
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                Place the block once.{" "}
+                <span className="text-primary">Peakhour manages your storefront forever.</span>
+              </h1>
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                A Shopify Theme App Extension block that merchants place once via
+                the theme editor. Peakhour controls what products appear, in what
+                order, with what AI-generated title — autonomously, in real time,
+                without the merchant ever touching the theme again.
+              </p>
+
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See all features</Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "10 intelligent rail types",
+                  "Zero code required",
+                  "Works with all major Shopify themes",
+                  "On-store chat + WhatsApp handoff",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Rail types grid ── */}
+        <section className="border-y bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-10 text-center">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  10 rail types
+                </p>
+                <h2 className="text-2xl font-bold tracking-tight lg:text-3xl">
+                  Every rail type is intelligence-driven, not manually curated
+                </h2>
+                <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+                  Choose the right rail for the moment — or set to Auto and let
+                  Peakhour decide what your storefront needs right now.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                {RAIL_TYPES.map((rail) => (
+                  <div
+                    key={rail.name}
+                    className="rounded-xl border bg-background p-4 transition-colors hover:border-primary/30"
+                  >
+                    <p className="text-sm font-semibold">{rail.name}</p>
+                    <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+                      {rail.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  How it works
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  Set it once. Peakhour manages it forever.
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  The merchant makes one decision — where to put the block. From
+                  there, every product selection, ordering, and merchandising
+                  decision is made by Peakhour.
+                </p>
+              </div>
+
+              <div className="space-y-0">
+                {STEPS.map((s, idx) => (
+                  <div key={s.step} className="relative flex gap-6 pb-10 last:pb-0">
+                    {idx < STEPS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div
+                      className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl text-xs font-bold text-primary-foreground shadow-lg"
+                      style={{ background: "oklch(0.60 0.20 68)" }}
+                    >
+                      {s.step}
+                    </div>
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Feature grid ── */}
+        <section className="border-t bg-muted/20 py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full feature set
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  The storefront that manages itself
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  Eight capabilities that turn your product rail from a static
+                  block you maintain manually into a live, intelligent, self-managing
+                  storefront layer.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div
+                        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                        aria-hidden
+                        style={{
+                          background:
+                            "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                        }}
+                      />
+                      <div className="relative">
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                          <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                        </div>
+                        <p className="mb-1 text-sm font-semibold leading-snug">{f.title}</p>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {f.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Callout ── */}
+        <section className="border-t py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative grid gap-10 md:grid-cols-2 md:items-center">
+                  <div>
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                      Why it matters
+                    </p>
+                    <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                      "Set it once. Peakhour manages it forever."
+                    </h2>
+                    <p className="mt-4 leading-relaxed text-muted-foreground">
+                      Manual product curation is invisible work. Every weekend
+                      someone has to log in, drag products around, update
+                      featured collections, remove out-of-stock items, and add new
+                      arrivals. It takes hours and it&apos;s never perfectly current.
+                    </p>
+                    <p className="mt-3 leading-relaxed text-muted-foreground">
+                      Smart Rail eliminates that entirely. The block you place
+                      once becomes a live intelligence surface — pulling from your
+                      dead-stock scores, your trending velocity, your inventory
+                      levels. What shoppers see tonight is different from what
+                      they saw this morning, without you touching a thing.
+                    </p>
+                  </div>
+                  <div className="space-y-3">
+                    <div className="rounded-xl border bg-muted/40 px-5 py-4">
+                      <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Without Smart Rail</p>
+                      <ul className="mt-3 space-y-2">
+                        {[
+                          "Manually update featured products weekly",
+                          "Out-of-stock items showing to shoppers",
+                          "Dead stock buried in unpromoted collections",
+                          "No data on which rail products convert",
+                        ].map((item) => (
+                          <li key={item} className="flex items-start gap-2 text-sm text-muted-foreground">
+                            <span className="mt-1 shrink-0 size-1.5 rounded-full bg-muted-foreground/40" />
+                            {item}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="rounded-xl border border-primary/20 bg-primary/5 px-5 py-4">
+                      <p className="text-xs font-semibold uppercase tracking-widest text-primary">With Smart Rail</p>
+                      <ul className="mt-3 space-y-2">
+                        {[
+                          "Rail updates itself from live intelligence data",
+                          "Dead stock surfaced with urgency labels automatically",
+                          "Every click + add-to-cart feeds back into scoring",
+                          "WhatsApp handoff converts anonymous web sessions",
+                        ].map((item) => (
+                          <li key={item} className="flex items-start gap-2 text-sm">
+                            <Check className="mt-0.5 size-3.5 shrink-0 text-primary" strokeWidth={2.5} />
+                            {item}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                Get started
+              </p>
+              <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                Your storefront, managed autonomously
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                Apply as a launch partner and get Smart Rail — plus every other
+                Commerce capability — before the public Shopify App Store launch.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">
+                    <ChevronLeft className="size-4" />
+                    Back to Commerce
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/commerce/smart-rail/page.tsx
+++ b/src/app/(site)/commerce/smart-rail/page.tsx
@@ -9,7 +9,6 @@ import {
   MousePointerClick,
   Tag,
   ShoppingCart,
-  Repeat,
   ChevronLeft,
   Check,
   Store,

--- a/src/app/(site)/commerce/whatsapp-assistant/page.tsx
+++ b/src/app/(site)/commerce/whatsapp-assistant/page.tsx
@@ -1,0 +1,405 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  MessageCircle,
+  Languages,
+  Clock,
+  Database,
+  BotMessageSquare,
+  MonitorSmartphone,
+  History,
+  ShieldCheck,
+  Zap,
+  Check,
+  ChevronLeft,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Shopify WhatsApp Assistant — Peakhour",
+  description:
+    "AI that knows your entire Shopify catalog. Answers shoppers on WhatsApp 24/7 in their language — stock, pricing, variants, delivery, returns. Zero agent time.",
+};
+
+const FEATURES = [
+  {
+    icon: Database,
+    title: "Catalog-grounded accuracy",
+    description:
+      "Every answer is pulled from your live Shopify catalog — products, variants, stock levels, prices. No hallucinations, no outdated information, no wrong prices.",
+  },
+  {
+    icon: Languages,
+    title: "Multilingual by default",
+    description:
+      "Replies in the shopper's language: Hinglish, Hindi, Arabic, Tamil, and more. Built for markets where the customer switches languages mid-conversation.",
+  },
+  {
+    icon: Clock,
+    title: "24/7 availability",
+    description:
+      "Your catalog never sleeps. Shoppers ask at 2am on a Sunday — they get an instant, accurate answer. No agent shift, no support queue, no wait time.",
+  },
+  {
+    icon: BotMessageSquare,
+    title: "In-app assistant for merchants",
+    description:
+      "Ask your catalog anything from inside Shopify Admin. What's low on stock? What's trending this week? What needs a price review? Your data, answered instantly.",
+  },
+  {
+    icon: Zap,
+    title: "Live stock & pricing",
+    description:
+      "Catalog sync keeps the assistant grounded in real-time data. Variant-level stock, current prices, sale prices — the assistant always answers from the latest state.",
+  },
+  {
+    icon: MonitorSmartphone,
+    title: "On-store chat widget",
+    description:
+      "Catalog-grounded chat on your storefront for anonymous shoppers. One seamless sign-in nudge converts them into known customers before WhatsApp handoff.",
+  },
+  {
+    icon: History,
+    title: "Conversation history",
+    description:
+      "Full conversation history in Shopify Admin. See what shoppers asked, what the assistant answered, and which conversations converted to an order.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Zero markup on WhatsApp charges",
+    description:
+      "WhatsApp messaging fees go directly from your Meta account to Meta. Peakhour takes zero cut — ever. No hidden margin on your message costs.",
+  },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Shopper sends a message to your WhatsApp Business number",
+    description:
+      "Any question — 'Do you have this in size M?', 'When will my order arrive?', 'What's the price in USD?' — arrives on your connected WhatsApp Business number.",
+  },
+  {
+    step: "02",
+    title: "Peakhour pulls live data from your Shopify catalog",
+    description:
+      "The assistant queries your catalog in real time: product details, variant-level stock, current prices, and any active discounts. No caching, no stale data.",
+  },
+  {
+    step: "03",
+    title: "AI generates a grounded reply in the shopper's language",
+    description:
+      "The reply is generated from your actual product data — not a general LLM guess. Hinglish, Hindi, Arabic, Tamil: the assistant matches the shopper's language naturally.",
+  },
+  {
+    step: "04",
+    title: "Optional: handoff to on-store chat or human agent",
+    description:
+      "Complex queries or purchase-ready shoppers can be handed off to your on-store chat widget or a human agent — with full conversation context carried over.",
+  },
+];
+
+export default function WhatsAppAssistantPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main>
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28 lg:py-32">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-175 w-225 -translate-x-1/2 -translate-y-1/3 rounded-full blur-3xl"
+            aria-hidden
+            style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+          />
+
+          <div className="container">
+            <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
+              <Link
+                href="/commerce"
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ChevronLeft className="size-3" />
+                Back to Commerce
+              </Link>
+
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Badge variant="outline" className="gap-1.5 px-3 py-1 text-xs">
+                  <MessageCircle className="size-3" />
+                  WhatsApp-first
+                </Badge>
+                <Badge className="gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                  AI Commerce Assistant
+                </Badge>
+              </div>
+
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+                Your Shopify catalog,{" "}
+                <span className="text-primary">answering shoppers on WhatsApp 24/7</span>
+              </h1>
+
+              <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                AI grounded in your live catalog answers every shopper question
+                on your WhatsApp Business number — stock, pricing, variants,
+                delivery, returns — in real time, in their language. Zero agent
+                required.
+              </p>
+
+              <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See all features</Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                {[
+                  "Zero markup on WhatsApp charges",
+                  "Live catalog sync — no stale data",
+                  "Hinglish · Hindi · Arabic · Tamil",
+                  "No agent required",
+                ].map((t) => (
+                  <span key={t} className="flex items-center gap-1.5">
+                    <Check className="size-3 text-primary" strokeWidth={2.5} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Callout stat ── */}
+        <div className="border-y bg-muted/30">
+          <div className="container">
+            <div className="mx-auto max-w-5xl py-10">
+              <div className="grid gap-6 md:grid-cols-3">
+                {[
+                  {
+                    stat: "0%",
+                    label: "markup on WhatsApp charges",
+                    detail: "Paid directly from your Meta account to Meta. Peakhour takes nothing.",
+                  },
+                  {
+                    stat: "Real-time",
+                    label: "catalog grounding",
+                    detail: "Every reply pulls live variant stock and current prices — not a cached snapshot.",
+                  },
+                  {
+                    stat: "6+",
+                    label: "languages supported",
+                    detail: "Hinglish, Hindi, Arabic, Tamil, English, and expanding. Natural, not translated.",
+                  },
+                ].map((item) => (
+                  <div key={item.stat} className="flex flex-col gap-1.5 px-2 py-4 md:px-4">
+                    <div className="text-2xl font-bold text-primary">{item.stat}</div>
+                    <div className="text-sm font-semibold">{item.label}</div>
+                    <div className="text-xs leading-relaxed text-muted-foreground">{item.detail}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── How it works ── */}
+        <section className="py-24">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  How it works
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight lg:text-4xl">
+                  From shopper question to accurate reply in seconds
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  No agent routing, no knowledge-base maintenance, no scripted flows.
+                  The assistant reads your live catalog and answers directly.
+                </p>
+              </div>
+
+              <div className="space-y-0">
+                {STEPS.map((s, idx) => (
+                  <div key={s.step} className="relative flex gap-6 pb-10 last:pb-0">
+                    {idx < STEPS.length - 1 && (
+                      <div className="absolute left-6 top-14 h-full w-px border-l border-dashed border-border" />
+                    )}
+                    <div
+                      className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl text-xs font-bold text-primary-foreground shadow-lg"
+                      style={{ background: "oklch(0.60 0.20 68)" }}
+                    >
+                      {s.step}
+                    </div>
+                    <div className="pt-2.5">
+                      <p className="font-semibold">{s.title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Feature cards ── */}
+        <section className="border-t bg-muted/20 py-24">
+          <div className="container">
+            <div className="mx-auto max-w-6xl">
+              <div className="mb-14">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  Full feature set
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  Everything the WhatsApp assistant includes
+                </h2>
+                <p className="mt-3 max-w-2xl text-muted-foreground">
+                  No stale data. No wrong prices. No agent time. Every capability
+                  is live from the moment you connect your WhatsApp Business number.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group relative rounded-2xl border bg-background p-5 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div
+                        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                        aria-hidden
+                        style={{
+                          background:
+                            "radial-gradient(ellipse at top left, oklch(0.60 0.20 68 / 0.03) 0%, transparent 70%)",
+                        }}
+                      />
+                      <div className="relative">
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15 transition-colors group-hover:bg-primary/15">
+                          <Icon className="size-4 text-primary" strokeWidth={1.5} />
+                        </div>
+                        <p className="mb-1 text-sm font-semibold leading-snug">{f.title}</p>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {f.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Trust callout ── */}
+        <section className="border-t py-16">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <div className="relative overflow-hidden rounded-3xl border border-primary/20 bg-background px-8 py-10 lg:px-14 lg:py-12">
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-3xl"
+                  aria-hidden
+                  style={{
+                    backgroundImage:
+                      "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.08) 1.5px, transparent 1.5px)",
+                    backgroundSize: "28px 28px",
+                    maskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                    WebkitMaskImage:
+                      "radial-gradient(ellipse 80% 100% at 100% 50%, black 0%, transparent 70%)",
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute -right-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full blur-3xl"
+                  style={{ background: "oklch(0.60 0.20 68 / 0.10)" }}
+                  aria-hidden
+                />
+                <div className="relative max-w-2xl">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                    The difference
+                  </p>
+                  <h2 className="text-2xl font-bold tracking-tight text-balance lg:text-3xl">
+                    "No stale data. No wrong prices. No agent time."
+                  </h2>
+                  <p className="mt-4 leading-relaxed text-muted-foreground">
+                    Most WhatsApp chatbots are scripted flows built on a static
+                    knowledge base that someone has to maintain. When you change
+                    a price or a product goes out of stock, the bot still gives
+                    the old answer.
+                  </p>
+                  <p className="mt-3 leading-relaxed text-muted-foreground">
+                    Peakhour&apos;s assistant is grounded in your live Shopify
+                    catalog. Every answer is generated from what your store
+                    actually shows right now — variant-level stock, current
+                    prices, active discounts. It can&apos;t give a wrong price
+                    because it doesn&apos;t have a stored price to be wrong about.
+                  </p>
+                  <div className="mt-6 inline-flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/5 px-4 py-2 text-sm font-medium text-primary">
+                    <ShieldCheck className="size-4" />
+                    Zero markup on WhatsApp charges — paid directly to Meta
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── CTA ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                Get started
+              </p>
+              <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                Your WhatsApp number. Your catalog. 24/7.
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                Apply as a launch partner and get early access to the WhatsApp
+                assistant before public launch — with founding-partner pricing
+                locked in forever.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Apply as a launch partner
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">
+                    <ChevronLeft className="size-4" />
+                    Back to Commerce
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/content/page.tsx
+++ b/src/app/(site)/content/page.tsx
@@ -57,7 +57,7 @@ export default function ContentPage() {
             }}
           />
           <div
-            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-[500px] w-[700px] -translate-x-1/2 -translate-y-1/3 rounded-full bg-primary/8 blur-3xl"
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-125 w-175 -translate-x-1/2 -translate-y-1/3 rounded-full bg-primary/10 blur-3xl"
             aria-hidden
           />
           <div className="container">

--- a/src/app/(site)/content/page.tsx
+++ b/src/app/(site)/content/page.tsx
@@ -1,0 +1,144 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, PenLine, Rss, LayoutGrid, Clock } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Content — Peakhour",
+  description:
+    "AI writers, news desk, and multi-format publishing — coming soon on Peakhour. Get early access.",
+};
+
+const FEATURES = [
+  {
+    icon: PenLine,
+    title: "AI writers that know your brand",
+    description:
+      "Newsletters, articles, product announcements, and social posts — generated from your voice cards, not a generic prompt. Brand-consistent on every channel.",
+  },
+  {
+    icon: Rss,
+    title: "News desk for publishers",
+    description:
+      "Fact-first idea generation grounded in live trends and verified sources. Every idea cites what it's based on. No invented news.",
+  },
+  {
+    icon: LayoutGrid,
+    title: "Multi-format publishing",
+    description:
+      "Write once, publish everywhere. The same story repurposed for Beehiiv, LinkedIn, WhatsApp, and your blog — each format optimised for its channel.",
+  },
+  {
+    icon: Clock,
+    title: "Scheduling and autopilot",
+    description:
+      "Queue content weeks in advance or let the AI propose a publishing calendar based on your audience and goals. You approve; it ships.",
+  },
+] as const;
+
+export default function ContentPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="flex-1">
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.10) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 -z-10 h-[500px] w-[700px] -translate-x-1/2 -translate-y-1/3 rounded-full bg-primary/8 blur-3xl"
+            aria-hidden
+          />
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <Badge className="mb-5 gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                Coming soon · Content pillar
+              </Badge>
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.25rem] lg:leading-[1.1]">
+                Content that works as hard{" "}
+                <span className="text-primary">as you do</span>
+              </h1>
+              <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                AI writers trained on your brand voice. A news desk grounded in
+                real sources. Publishing tools that reach every channel without
+                extra effort. Peakhour Content is in development — and founding
+                partners get first access.
+              </p>
+              <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Join the waitlist
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See Peakhour Commerce →</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Features ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                What&apos;s coming
+              </p>
+              <h2 className="mb-12 text-3xl font-bold tracking-tight">
+                Every format. Every channel. On brand.
+              </h2>
+              <div className="grid gap-6 md:grid-cols-2">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group rounded-2xl border bg-background p-6 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/20 transition-colors group-hover:bg-primary/15">
+                        <Icon className="size-5 text-primary" strokeWidth={1.5} />
+                      </div>
+                      <h3 className="mb-2 font-semibold">{f.title}</h3>
+                      <p className="text-sm leading-relaxed text-muted-foreground">
+                        {f.description}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Commerce first CTA ── */}
+        <section className="border-t bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="text-sm font-medium text-muted-foreground">
+                Peakhour Content launches after Commerce.{" "}
+                <Link href="/commerce" className="text-primary underline-offset-4 hover:underline">
+                  See what&apos;s live now →
+                </Link>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/growth/page.tsx
+++ b/src/app/(site)/growth/page.tsx
@@ -1,0 +1,144 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, TrendingUp, Target, BarChart2, Lightbulb } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+
+export const metadata: Metadata = {
+  title: "Growth — Peakhour",
+  description:
+    "Ads intelligence, audience analytics, and growth benchmarks — coming soon on Peakhour. Get early access.",
+};
+
+const FEATURES = [
+  {
+    icon: Target,
+    title: "Ads intelligence",
+    description:
+      "See what creatives and copy are working across Meta, X, and Google — not just for you, but against your cohort. Stop guessing; start scaling what works.",
+  },
+  {
+    icon: BarChart2,
+    title: "Audience analytics",
+    description:
+      "Understand who your best customers are, what they respond to, and where they drop off. Slice by channel, campaign, and cohort.",
+  },
+  {
+    icon: TrendingUp,
+    title: "Growth benchmarks",
+    description:
+      "Compare your acquisition costs, conversion rates, and content performance against merchants like you. Know where you stand and what to fix first.",
+  },
+  {
+    icon: Lightbulb,
+    title: "AI-driven recommendations",
+    description:
+      "Close the loop between content, commerce, and ads. Peakhour identifies the patterns that drive revenue and surfaces the next best action.",
+  },
+] as const;
+
+export default function GrowthPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <main className="flex-1">
+        {/* ── Hero ── */}
+        <section className="relative overflow-hidden py-20 sm:py-28">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10"
+            aria-hidden
+            style={{
+              backgroundImage:
+                "radial-gradient(oklch(from var(--primary) calc(l * 0.7) calc(c * 1.8) h / 0.10) 1.5px, transparent 1.5px)",
+              backgroundSize: "28px 28px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute -right-32 top-0 -z-10 h-[500px] w-[600px] translate-x-1/4 -translate-y-1/4 rounded-full bg-primary/8 blur-3xl"
+            aria-hidden
+          />
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <Badge className="mb-5 gap-1 border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/10">
+                Coming soon · Growth pillar
+              </Badge>
+              <h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-[3.25rem] lg:leading-[1.1]">
+                Know what&apos;s working.{" "}
+                <span className="text-primary">Scale it faster.</span>
+              </h1>
+              <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                Ads intelligence, audience analytics, and performance benchmarks
+                that close the loop between what you publish, what you sell, and
+                what you should do next. Peakhour Growth is in development —
+                and founding partners get first access.
+              </p>
+              <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                <Button asChild size="lg" className="gap-2 px-8">
+                  <Link href="/launch-partner">
+                    Join the waitlist
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link href="/commerce">See Peakhour Commerce →</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Features ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-5xl">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                What&apos;s coming
+              </p>
+              <h2 className="mb-12 text-3xl font-bold tracking-tight">
+                Intelligence that compounds over time
+              </h2>
+              <div className="grid gap-6 md:grid-cols-2">
+                {FEATURES.map((f) => {
+                  const Icon = f.icon;
+                  return (
+                    <div
+                      key={f.title}
+                      className="group rounded-2xl border bg-background p-6 transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+                    >
+                      <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/20 transition-colors group-hover:bg-primary/15">
+                        <Icon className="size-5 text-primary" strokeWidth={1.5} />
+                      </div>
+                      <h3 className="mb-2 font-semibold">{f.title}</h3>
+                      <p className="text-sm leading-relaxed text-muted-foreground">
+                        {f.description}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Commerce first CTA ── */}
+        <section className="border-t bg-muted/30 py-16">
+          <div className="container">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="text-sm font-medium text-muted-foreground">
+                Peakhour Growth launches after Commerce and Content.{" "}
+                <Link href="/commerce" className="text-primary underline-offset-4 hover:underline">
+                  See what&apos;s live now →
+                </Link>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/growth/page.tsx
+++ b/src/app/(site)/growth/page.tsx
@@ -57,7 +57,7 @@ export default function GrowthPage() {
             }}
           />
           <div
-            className="pointer-events-none absolute -right-32 top-0 -z-10 h-[500px] w-[600px] translate-x-1/4 -translate-y-1/4 rounded-full bg-primary/8 blur-3xl"
+            className="pointer-events-none absolute -right-32 top-0 -z-10 h-125 w-150 translate-x-1/4 -translate-y-1/4 rounded-full bg-primary/10 blur-3xl"
             aria-hidden
           />
           <div className="container">

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { headers } from "next/headers";
 import type { Metadata } from "next";
 import {
   ArrowRight,
@@ -18,8 +17,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
-import { PricingGrid } from "@/components/marketing/pricing-grid";
-import { getPricing } from "@/lib/pricing";
 import { getPublicCatalog } from "@/lib/catalog";
 
 export const metadata: Metadata = {
@@ -81,11 +78,11 @@ function WhatsAppMockup() {
       </div>
       {/* WhatsApp header */}
       <div className="flex items-center gap-3 px-3 py-2.5" style={{ background: "#075E54" }}>
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-bold text-primary-foreground">
-          P
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-700 text-sm font-bold text-white">
+          MK
         </div>
         <div className="min-w-0">
-          <p className="truncate text-xs font-semibold text-white">Peakhour Assistant</p>
+          <p className="truncate text-xs font-semibold text-white">Mumbai Kicks</p>
           <p className="text-[10px] text-white/70">Online</p>
         </div>
       </div>
@@ -147,17 +144,7 @@ function WhatsAppMockup() {
 }
 
 export default async function Home() {
-  const h = await headers();
-  const vercelCountry = h.get("x-vercel-ip-country");
-  const country =
-    vercelCountry && /^[A-Za-z]{2}$/.test(vercelCountry)
-      ? vercelCountry.toUpperCase()
-      : "DEFAULT";
-
-  const [pricing, catalog] = await Promise.all([
-    getPricing(country),
-    getPublicCatalog(),
-  ]);
+  const catalog = await getPublicCatalog();
   const platform = catalog?.platform;
 
   return (
@@ -488,16 +475,6 @@ export default async function Home() {
           </div>
         </section>
 
-        {/* ── Pricing — dev only ── */}
-        {pricing && pricing.products.length > 0 && (
-          <section id="pricing" className="border-t py-24">
-            <div className="container">
-              <div className="mx-auto max-w-6xl">
-                <PricingGrid plans={pricing.plans} products={pricing.products} />
-              </div>
-            </div>
-          </section>
-        )}
       </main>
 
       <Footer />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,6 +146,23 @@
   }
 }
 
+/* Global container padding — Tailwind v4 container has no padding by default */
+@layer base {
+  .container {
+    padding-inline: 1rem;
+  }
+  @media (min-width: 640px) {
+    .container {
+      padding-inline: 1.5rem;
+    }
+  }
+  @media (min-width: 1024px) {
+    .container {
+      padding-inline: 2rem;
+    }
+  }
+}
+
 /* Card hover lift utilities */
 @layer utilities {
   .card-lift {

--- a/src/components/shared/header.tsx
+++ b/src/components/shared/header.tsx
@@ -8,7 +8,12 @@ import { useAuth } from "@/providers/auth-provider";
 import { PeakhourLogo } from "@/components/shared/peakhour-logo";
 
 const NAV_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/commerce", label: "Commerce" },
+  { href: "/content", label: "Content" },
+  { href: "/growth", label: "Growth" },
   { href: "/pricing", label: "Pricing" },
+  { href: "/about", label: "About" },
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

- **Nav**: Full nav added — Home, Commerce, Content, Growth, Pricing, About (header + mobile menu)
- **Container padding**: Fixed globally via `@layer base` in `globals.css` — content was sticking to viewport edges on all pages
- **Homepage**: Removed the pricing section; fixed WhatsApp mockup header from "Peakhour Assistant" to "Mumbai Kicks" (fictitious merchant store, which is what the product actually does)
- **shadcnblocks**: Fixed `components.json` to use `?token=` format (MCP + CLI compatible)
- **New pages**:
  - `/about` — story, values (merchants first, emerging markets, small team), 3-pillar overview, CTA
  - `/content` — coming soon page with AI writers / news desk / multi-format publishing feature previews
  - `/growth` — coming soon page with ads intelligence / audience analytics / benchmarks feature previews

## Test plan

- [ ] Homepage: no pricing section, WhatsApp mockup shows "Mumbai Kicks" store name, content has left/right padding
- [ ] Nav: all 6 links present on desktop and mobile menu
- [ ] `/about` loads with full page content
- [ ] `/content` loads with coming soon treatment and waitlist CTA
- [ ] `/growth` loads with coming soon treatment and waitlist CTA
- [ ] `/commerce` — container padding applies (inherited from globals.css fix)
- [ ] Dark mode — all new pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
