### PR TITLE
feat(website): merchant-voice content upgrade — real copy across all commerce pages

### DIFF
--- a/src/app/(site)/commerce/autopilot/page.tsx
+++ b/src/app/(site)/commerce/autopilot/page.tsx
@@ -167,12 +167,25 @@ export default function AutopilotPage() {
               </h1>
 
               <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                The store works while you sleep, but you&apos;re always the boss.
                 When autopilot is enabled, Peakhour evaluates recommendations
                 against merchant-defined guardrails and, if they pass, executes
                 campaigns without waiting for approval. Every decision is logged.
                 Stop-loss rules protect against underperforming campaigns. You
                 only hear from Peakhour when something needs you.
               </p>
+
+              <div className="w-full max-w-lg rounded-2xl border bg-muted/40 px-5 py-4 text-left text-sm leading-relaxed">
+                <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-2">
+                  This week&apos;s autopilot summary
+                </p>
+                <p className="text-muted-foreground">
+                  14 AI decisions, 620 Peaks spent,{" "}
+                  <span className="font-bold text-primary">₹61,400 of inventory recovered</span>.
+                  Total transparency — you can judge for yourself whether your
+                  AI teammate is earning its keep.
+                </p>
+              </div>
 
               <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
                 <Button asChild size="lg" className="gap-2 px-8">

--- a/src/app/(site)/commerce/brand-voice/page.tsx
+++ b/src/app/(site)/commerce/brand-voice/page.tsx
@@ -53,7 +53,7 @@ const FEATURES = [
     icon: ThumbsUp,
     title: "Learning loop from approvals",
     description:
-      "Every campaign approval, title edit, or rejection teaches the voice card. After 20 campaigns, Peakhour generates titles you wouldn't change. After 50, they sound like your copy team.",
+      "Every campaign approval, title edit, or rejection teaches the voice card. After 20 campaigns, Peakhour generates titles you wouldn't change. After 50, they sound like your copy team. It becomes your copywriter — one that gets better every week and never leaves.",
   },
   {
     icon: Pencil,

--- a/src/app/(site)/commerce/campaign-approval/page.tsx
+++ b/src/app/(site)/commerce/campaign-approval/page.tsx
@@ -165,11 +165,29 @@ export default function CampaignApprovalPage() {
               </h1>
 
               <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
-                Peakhour sends you a WhatsApp message with the campaign details —
-                products, discount, duration, expected recovery. Reply 1 to
-                approve. Discount created in Shopify, Smart Rail live, campaign
-                tracked, post-campaign summary delivered. All in under 10 seconds.
+                You approve a revenue-recovery campaign from the school pickup
+                line, in five seconds. Peakhour sends you a WhatsApp message —
+                products, discount, duration, expected recovery — and you reply
+                1 to approve. Discount created in Shopify, Smart Rail live,
+                campaign tracked, post-campaign summary delivered. All in under
+                10 seconds.
               </p>
+
+              <div className="w-full max-w-lg rounded-2xl border bg-muted/40 px-5 py-4 text-left text-sm leading-relaxed">
+                <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-2">
+                  Example message from Peakhour
+                </p>
+                <p className="text-muted-foreground">
+                  Found ₹84,000 of slow-moving stock. Suggested: The Season-End
+                  Edit — 14 products, 15% off, 72 hours.{" "}
+                  <span className="font-medium text-foreground">Reply 1</span> to
+                  approve.{" "}
+                  <span className="font-medium text-foreground">Reply 2 10</span>{" "}
+                  to change the discount to 10%.{" "}
+                  <span className="font-medium text-foreground">Reply 3</span> to
+                  see the products.
+                </p>
+              </div>
 
               <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
                 <Button asChild size="lg" className="gap-2 px-8">

--- a/src/app/(site)/commerce/inventory-intelligence/page.tsx
+++ b/src/app/(site)/commerce/inventory-intelligence/page.tsx
@@ -41,7 +41,7 @@ const FEATURES = [
     icon: Brain,
     title: "AI diagnosis per product group",
     description:
-      "Products with the same score can have different root causes. Peakhour groups them and explains: 'High views, low add-to-cart — pricing problem' vs 'No views — discovery gap'.",
+      “Not just a score — a sentence you can act on: “These 12 jackets get lots of views but few add-to-carts — this looks like a pricing problem, not a visibility problem.” You find out a product is dying weeks before it becomes dead money on a shelf.”,
   },
   {
     icon: Clock,

--- a/src/app/(site)/commerce/page.tsx
+++ b/src/app/(site)/commerce/page.tsx
@@ -327,10 +327,15 @@ export default async function CommercePage() {
               </h1>
 
               <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
-                WhatsApp assistant, dead-stock intelligence, AI-powered Smart
-                Rails, brand-voice campaign recommendations, and autonomous
-                execution — all inside Shopify Admin. From first install to
-                fully autonomous operation.
+                Peakhour Commerce gives your Shopify store an AI teammate. It
+                learns your real catalog — your actual products, prices, and
+                stock — and then puts that knowledge to work everywhere:
+                answering shoppers on WhatsApp and on your website in their own
+                language, watching your inventory for products that are quietly
+                going stale, dressing your storefront with fresh product
+                showcases, and suggesting campaigns to recover slow stock. And
+                it always asks your permission before acting — until the day you
+                trust it enough to set a few limits and let it run on its own.
               </p>
 
               <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
@@ -653,13 +658,30 @@ export default async function CommercePage() {
                     Every Peaks credit has a measurable return
                   </h2>
                   <p className="mt-3 text-muted-foreground leading-relaxed">
-                    Unlike opaque AI subscriptions, Peaks are per-action.
-                    You see exactly what each AI decision costs and what it
+                    Think of Peaks like prepaid talk-time for your AI teammate.
+                    One Peak is worth one US cent ($0.01) — about ₹1. Every
+                    plan includes a monthly allowance, and every AI action uses
+                    a few. You see exactly what each decision costs and what it
                     recovered — inside Shopify Admin. No surprises on your bill.
                   </p>
-                  <div className="mt-6 rounded-xl border bg-background px-5 py-4 text-sm font-medium">
+                  <div className="mt-4 space-y-2">
+                    {[
+                      { name: "Boost", peaks: "+500 Peaks", price: "$5" },
+                      { name: "Value", peaks: "+2,000 Peaks", price: "$18" },
+                      { name: "Pro", peaks: "+10,000 Peaks", price: "$80" },
+                    ].map((pack) => (
+                      <div key={pack.name} className="flex items-center justify-between rounded-lg border bg-background px-4 py-2.5">
+                        <div>
+                          <span className="text-sm font-semibold">{pack.name}</span>
+                          <span className="ml-2 text-xs text-muted-foreground">{pack.peaks}</span>
+                        </div>
+                        <span className="text-sm font-bold text-primary">{pack.price}</span>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 rounded-xl border bg-background px-5 py-4 text-sm font-medium">
                     <span className="text-muted-foreground">Example outcome:&nbsp;</span>
-                    620 Peaks spent &rarr;{" "}
+                    14 AI decisions, 620 Peaks spent &rarr;{" "}
                     <span className="text-primary font-bold">₹61,400 recovered</span>
                   </div>
                 </div>
@@ -750,6 +772,53 @@ export default async function CommercePage() {
                     </span>
                     <p className="text-sm leading-relaxed text-muted-foreground">
                       {row.capability}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── FAQ ── */}
+        <section className="border-t py-20">
+          <div className="container">
+            <div className="mx-auto max-w-3xl">
+              <div className="mb-10">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-primary">
+                  FAQ
+                </p>
+                <h2 className="text-3xl font-bold tracking-tight text-balance lg:text-4xl">
+                  Honest questions, honest answers
+                </h2>
+              </div>
+              <div className="divide-y">
+                {[
+                  {
+                    q: "Do I need to know how to code?",
+                    a: "No. Installing takes a few clicks, the catalog syncs itself, and even storefront rails are placed through Shopify's own theme editor — never in code.",
+                  },
+                  {
+                    q: "What languages does the assistant speak?",
+                    a: "Your shopper's language. It replies in whatever language the customer writes in — including Hinglish and other mixed everyday language.",
+                  },
+                  {
+                    q: "What does WhatsApp messaging cost me?",
+                    a: "Peakhour adds zero markup on WhatsApp — ever. Any messaging fees are billed directly by Meta (WhatsApp's owner) to your WhatsApp Business Account at Meta's own rates; we never touch that money. Replies to chats your shoppers start are currently free under Meta's pricing — it's mainly outbound campaign messages Meta charges for.",
+                  },
+                  {
+                    q: "Will the AI ever make up a product or a price?",
+                    a: "No. Every answer is grounded in your synced catalog. If something isn't in your store, the assistant says so instead of guessing.",
+                  },
+                  {
+                    q: "Can I cancel anytime?",
+                    a: "Yes — anytime, right inside the app, in a couple of clicks. The 14-day trial means you can also try everything before paying a rupee.",
+                  },
+                ].map((item) => (
+                  <div key={item.q} className="py-5">
+                    <p className="font-semibold">{item.q}</p>
+                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                      {item.a}
                     </p>
                   </div>
                 ))}

--- a/src/app/(site)/commerce/whatsapp-assistant/page.tsx
+++ b/src/app/(site)/commerce/whatsapp-assistant/page.tsx
@@ -154,8 +154,10 @@ export default function WhatsAppAssistantPage() {
               <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">
                 AI grounded in your live catalog answers every shopper question
                 on your WhatsApp Business number — stock, pricing, variants,
-                delivery, returns — in real time, in their language. Zero agent
-                required.
+                delivery, returns — in real time, in their language. You stop
+                losing the 11pm &ldquo;do you have this in medium?&rdquo; customer. It
+                never invents products: every answer comes from your real,
+                synced catalog. Zero agent required.
               </p>
 
               <div className="flex w-full flex-col items-center justify-center gap-3 sm:flex-row">
@@ -234,6 +236,8 @@ export default function WhatsAppAssistantPage() {
                 <p className="mt-3 max-w-2xl text-muted-foreground">
                   No agent routing, no knowledge-base maintenance, no scripted flows.
                   The assistant reads your live catalog and answers directly.
+                  You&apos;ll be running before your chai gets cold — and you never
+                  have to &ldquo;update the bot&rdquo;.
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary

Content upgrade across all commerce pages using the merchant features guide (`docs/shopify-listing/merchant-features-guide.md`) as the source of truth for copy. Replaces generic feature descriptions with specific, relatable merchant moments.

**Key copy changes:**
- `/commerce` hero → "AI teammate" short-version paragraph (much stronger than the feature list)
- `/commerce` → new "Honest questions, honest answers" FAQ section (5 Q&As: no code needed, multilingual, zero WhatsApp markup, grounding guarantee, cancel anytime)
- `/commerce` Peaks section → "prepaid talk-time" analogy + $0.01 = ₹1 + Boost/Value/Pro top-up packs
- `/commerce/whatsapp-assistant` → "11pm do you have this in medium" moment + "chai gets cold" setup line
- `/commerce/inventory-intelligence` → "12 jackets / pricing problem not visibility problem" specific diagnosis quote
- `/commerce/brand-voice` → "becomes your copywriter — gets better every week and never leaves"
- `/commerce/campaign-approval` → "school pickup line, five seconds" hero + styled ₹84,000 example WhatsApp message
- `/commerce/autopilot` → "store works while you sleep, you're always the boss" + "14 decisions, 620 Peaks, ₹61,400 recovered"

## Test plan

- [ ] `/commerce` hero copy reads as the guide's "short version" paragraph
- [ ] `/commerce` FAQ section renders with 5 Q&As, divider lines, correct typography
- [ ] `/commerce` Peaks section has prepaid talk-time analogy + top-up pack table
- [ ] `/commerce/whatsapp-assistant` mentions the 11pm customer moment
- [ ] `/commerce/inventory-intelligence` has the "12 jackets / pricing problem" quote
- [ ] `/commerce/brand-voice` has the "copywriter" framing in learning loop card
- [ ] `/commerce/campaign-approval` has school pickup line + styled WhatsApp example
- [ ] `/commerce/autopilot` has "store works while you sleep" + Peaks ROI callout
- [ ] All pages build without TypeScript errors (server components only)
- [ ] Dark mode — all new copy sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
