### PR TITLE
feat(site): global positioning -- Plus Jakarta Sans, larger logo, US-first copy

### DIFF
--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -21,9 +21,9 @@ const VALUES = [
   },
   {
     icon: Globe2,
-    title: "Built for emerging markets",
+    title: "Built for merchants everywhere",
     description:
-      "WhatsApp is how billions of people shop. We're building for the merchants who serve them — not after the fact, but as the primary use case.",
+      "WhatsApp is the fastest-growing commerce channel in the world. We're building for the merchants who serve their customers there — from New York to London to São Paulo.",
   },
   {
     icon: Users,

--- a/src/app/(site)/commerce/autopilot/page.tsx
+++ b/src/app/(site)/commerce/autopilot/page.tsx
@@ -257,7 +257,7 @@ export default function AutopilotPage() {
                     </p>
                     <div className="space-y-2.5">
                       {[
-                        { time: "07:14", action: "Recommendation generated", detail: "Linen Kurtis · 14 SKUs · score 78" },
+                        { time: "07:14", action: "Recommendation generated", detail: "Linen Trousers · 14 SKUs · score 78" },
                         { time: "07:14", action: "Guardrail: discount check", detail: "Suggested 20% · limit 25% ✓" },
                         { time: "07:14", action: "Guardrail: margin floor", detail: "Margin at 42% · floor 40% ✓" },
                         { time: "07:14", action: "Guardrail: collection exclusion", detail: "Not in New Arrivals ✓" },

--- a/src/app/(site)/commerce/autopilot/page.tsx
+++ b/src/app/(site)/commerce/autopilot/page.tsx
@@ -60,7 +60,7 @@ const FEATURES = [
     icon: BarChart2,
     title: "Peaks ROI dashboard",
     description:
-      "See the ROI of every AI decision in Shopify Admin. This week: 14 AI decisions, 620 Peaks spent, ₹61,400 recovered. Every credit has a measurable return.",
+      "See the ROI of every AI decision in Shopify Admin. This week: 14 AI decisions, 620 Peaks spent, $4,800 recovered. Every credit has a measurable return.",
   },
   {
     icon: RefreshCw,
@@ -82,7 +82,7 @@ const GUARDRAILS = [
   { label: "Excluded collections", example: "e.g. Never touch New Arrivals or Premium Line" },
   { label: "New arrivals protection", example: "e.g. Products < 30 days old are off-limits" },
   { label: "Campaign duration limit", example: "e.g. No campaign longer than 72 hours" },
-  { label: "Revenue threshold", example: "e.g. Only auto-execute if expected recovery > ₹20,000" },
+  { label: "Revenue threshold", example: "e.g. Only auto-execute if expected recovery > $1,500" },
 ];
 
 const STEPS = [
@@ -181,7 +181,7 @@ export default function AutopilotPage() {
                 </p>
                 <p className="text-muted-foreground">
                   14 AI decisions, 620 Peaks spent,{" "}
-                  <span className="font-bold text-primary">₹61,400 of inventory recovered</span>.
+                  <span className="font-bold text-primary">$4,800 of inventory recovered</span>.
                   Total transparency — you can judge for yourself whether your
                   AI teammate is earning its keep.
                 </p>
@@ -261,7 +261,7 @@ export default function AutopilotPage() {
                         { time: "07:14", action: "Guardrail: discount check", detail: "Suggested 20% · limit 25% ✓" },
                         { time: "07:14", action: "Guardrail: margin floor", detail: "Margin at 42% · floor 40% ✓" },
                         { time: "07:14", action: "Guardrail: collection exclusion", detail: "Not in New Arrivals ✓" },
-                        { time: "07:14", action: "Guardrail: revenue threshold", detail: "Expected ₹48k · threshold ₹20k ✓" },
+                        { time: "07:14", action: "Guardrail: revenue threshold", detail: "Expected $3.6k · threshold $1.5k ✓" },
                         { time: "07:15", action: "Campaign executed", detail: "Discount live · Smart Rail updated" },
                       ].map((entry) => (
                         <div key={entry.action} className="flex items-start gap-3">
@@ -283,7 +283,7 @@ export default function AutopilotPage() {
                       {[
                         { value: "14", label: "AI decisions" },
                         { value: "620", label: "Peaks spent" },
-                        { value: "₹61,400", label: "Recovered" },
+                        { value: "$4,800", label: "Recovered" },
                       ].map((stat) => (
                         <div key={stat.label} className="text-center">
                           <p className="text-lg font-bold text-primary">{stat.value}</p>
@@ -441,7 +441,7 @@ export default function AutopilotPage() {
                     <p className="mt-2 text-sm">
                       This week: <strong>14 AI decisions</strong> ·{" "}
                       <strong>620 Peaks spent</strong> ·{" "}
-                      <strong className="text-primary">₹61,400 recovered</strong>
+                      <strong className="text-primary">$4,800 recovered</strong>
                     </p>
                     <p className="mt-1 text-xs text-muted-foreground">
                       You were involved in 0 of those 14 decisions. 2 stop-loss alerts were triggered; both resolved automatically.

--- a/src/app/(site)/commerce/brand-voice/page.tsx
+++ b/src/app/(site)/commerce/brand-voice/page.tsx
@@ -39,9 +39,9 @@ const FEATURES = [
   },
   {
     icon: Languages,
-    title: "Cultural vocabulary (India / GCC / SEA)",
+    title: "Market-specific vocabulary",
     description:
-      "A fashion brand targeting India uses different vocabulary than one targeting the GCC. Peakhour's voice synthesis is culturally aware — not just linguistically translated.",
+      "A fashion brand in New York uses different vocabulary than one in London or Sydney. Peakhour's voice synthesis is culturally aware — not just linguistically translated.",
   },
   {
     icon: BookOpen,
@@ -86,7 +86,7 @@ const STEPS = [
     step: "02",
     title: "Voice card auto-synthesised: brand register, preferred vocabulary, cultural context",
     description:
-      "A Commerce Voice Card is created automatically. It captures: your brand's formality register, preferred category vocabulary, cultural context (India/GCC/SEA), and a 'never use' list inferred from what's absent in your copy. No forms. No setup calls.",
+      "A Commerce Voice Card is created automatically. It captures: your brand's formality register, preferred category vocabulary, regional context, and a 'never use' list inferred from what's absent in your copy. No forms. No setup calls.",
   },
   {
     step: "03",
@@ -173,7 +173,7 @@ export default function BrandVoicePage() {
                 {[
                   "Auto-synthesised — no setup forms",
                   "Learns from every approval and rejection",
-                  "India / GCC / SEA cultural vocabulary",
+                  "Market-specific cultural vocabulary",
                   "Gets smarter after every campaign",
                 ].map((t) => (
                   <span key={t} className="flex items-center gap-1.5">
@@ -370,7 +370,7 @@ export default function BrandVoicePage() {
                     Commerce Voice Cards are trained on your store specifically.
                   </p>
                   <p className="mt-3 leading-relaxed text-muted-foreground">
-                    A fashion brand in India that uses &ldquo;edit&rdquo; and &ldquo;pieces&rdquo; gets
+                    A fashion brand in New York that uses &ldquo;edit&rdquo; and &ldquo;pieces&rdquo; gets
                     those words back in every recommendation title. A kitchenware
                     brand that never uses &ldquo;limited time&rdquo; never sees it. The
                     moat deepens with every campaign — your competitor can&apos;t

--- a/src/app/(site)/commerce/campaign-approval/page.tsx
+++ b/src/app/(site)/commerce/campaign-approval/page.tsx
@@ -84,7 +84,7 @@ const STEPS = [
   },
   {
     step: "02",
-    title: "Peakhour sends a WhatsApp message: products, discount, duration, expected ₹ recovery",
+    title: "Peakhour sends a WhatsApp message: products, discount, duration, expected $ recovery",
     description:
       "You receive a structured WhatsApp message: product group name, count, risk score, suggested discount, campaign duration, and expected revenue recovery range in your local currency. All from your real data.",
   },
@@ -178,7 +178,7 @@ export default function CampaignApprovalPage() {
                   Example message from Peakhour
                 </p>
                 <p className="text-muted-foreground">
-                  Found ₹84,000 of slow-moving stock. Suggested: The Season-End
+                  Found $8,400 of slow-moving stock. Suggested: The Season-End
                   Edit — 14 products, 15% off, 72 hours.{" "}
                   <span className="font-medium text-foreground">Reply 1</span> to
                   approve.{" "}
@@ -269,7 +269,7 @@ export default function CampaignApprovalPage() {
                         <strong>Products:</strong> Linen Kurtis — Grey & Beige (14 SKUs)<br />
                         <strong>Risk score:</strong> 74–82 · Slow-moving to Critical<br />
                         <strong>Suggested discount:</strong> 20% off for 72 hours<br />
-                        <strong>Expected recovery:</strong> ₹38,000 – ₹52,000<br />
+                        <strong>Expected recovery:</strong> $3,200 – $4,400<br />
                         <strong>Smart Rail:</strong> &ldquo;The Linen Edit — Last 14 Pieces&rdquo;
                       </p>
                       <div className="mt-3 border-t pt-3 text-xs text-muted-foreground">

--- a/src/app/(site)/commerce/campaign-approval/page.tsx
+++ b/src/app/(site)/commerce/campaign-approval/page.tsx
@@ -266,7 +266,7 @@ export default function CampaignApprovalPage() {
                     <div className="rounded-xl bg-muted/50 px-4 py-4 text-sm leading-relaxed">
                       <p className="font-semibold">📦 Campaign Recommendation</p>
                       <p className="mt-2 text-muted-foreground">
-                        <strong>Products:</strong> Linen Kurtis — Grey & Beige (14 SKUs)<br />
+                        <strong>Products:</strong> Linen Trousers — Khaki & Navy (14 SKUs)<br />
                         <strong>Risk score:</strong> 74–82 · Slow-moving to Critical<br />
                         <strong>Suggested discount:</strong> 20% off for 72 hours<br />
                         <strong>Expected recovery:</strong> $3,200 – $4,400<br />

--- a/src/app/(site)/commerce/page.tsx
+++ b/src/app/(site)/commerce/page.tsx
@@ -61,7 +61,7 @@ const CAPABILITY_GROUPS = [
         icon: Languages,
         title: "Multilingual replies",
         description:
-          "Replies in the shopper's language — Hinglish, Hindi, Arabic, Tamil. Designed for markets where English is the second language, not the first.",
+          "Replies in the shopper's language — Spanish, French, Dutch, Portuguese, and more. Your assistant speaks every language your customers do.",
       },
       {
         icon: MonitorSmartphone,
@@ -659,7 +659,7 @@ export default async function CommercePage() {
                   </h2>
                   <p className="mt-3 text-muted-foreground leading-relaxed">
                     Think of Peaks like prepaid talk-time for your AI teammate.
-                    One Peak is worth one US cent ($0.01) — about ₹1. Every
+                    One Peak is worth one US cent ($0.01). Every
                     plan includes a monthly allowance, and every AI action uses
                     a few. You see exactly what each decision costs and what it
                     recovered — inside Shopify Admin. No surprises on your bill.
@@ -682,7 +682,7 @@ export default async function CommercePage() {
                   <div className="mt-4 rounded-xl border bg-background px-5 py-4 text-sm font-medium">
                     <span className="text-muted-foreground">Example outcome:&nbsp;</span>
                     14 AI decisions, 620 Peaks spent &rarr;{" "}
-                    <span className="text-primary font-bold">₹61,400 recovered</span>
+                    <span className="text-primary font-bold">$4,800 recovered</span>
                   </div>
                 </div>
                 <div className="space-y-3">
@@ -758,9 +758,9 @@ export default async function CommercePage() {
                       "Zero markup on WhatsApp · per-action Peaks · billed through Shopify",
                   },
                   {
-                    phase: "India / GCC first",
+                    phase: "WhatsApp-first globally",
                     capability:
-                      "WhatsApp-first for SMB merchants, multilingual, built for emerging markets",
+                      "WhatsApp as the primary commerce channel — designed for merchants in the US, UK, Australia, Brazil, and beyond",
                   },
                 ].map((row) => (
                   <div
@@ -800,7 +800,7 @@ export default async function CommercePage() {
                   },
                   {
                     q: "What languages does the assistant speak?",
-                    a: "Your shopper's language. It replies in whatever language the customer writes in — including Hinglish and other mixed everyday language.",
+                    a: "Your shopper's language. It replies in whatever language the customer writes in — Spanish, French, Dutch, Portuguese, and more.",
                   },
                   {
                     q: "What does WhatsApp messaging cost me?",
@@ -812,7 +812,7 @@ export default async function CommercePage() {
                   },
                   {
                     q: "Can I cancel anytime?",
-                    a: "Yes — anytime, right inside the app, in a couple of clicks. The 14-day trial means you can also try everything before paying a rupee.",
+                    a: "Yes — anytime, right inside the app, in a couple of clicks. The 14-day trial means you can try everything before paying a cent.",
                   },
                 ].map((item) => (
                   <div key={item.q} className="py-5">

--- a/src/app/(site)/commerce/whatsapp-assistant/page.tsx
+++ b/src/app/(site)/commerce/whatsapp-assistant/page.tsx
@@ -36,7 +36,7 @@ const FEATURES = [
     icon: Languages,
     title: "Multilingual by default",
     description:
-      "Replies in the shopper's language: Hinglish, Hindi, Arabic, Tamil, and more. Built for markets where the customer switches languages mid-conversation.",
+      "Replies in the shopper's language: Spanish, French, Dutch, Portuguese, German, and more. Built for the reality that your customers shop in their own language.",
   },
   {
     icon: Clock,
@@ -93,7 +93,7 @@ const STEPS = [
     step: "03",
     title: "AI generates a grounded reply in the shopper's language",
     description:
-      "The reply is generated from your actual product data — not a general LLM guess. Hinglish, Hindi, Arabic, Tamil: the assistant matches the shopper's language naturally.",
+      "The reply is generated from your actual product data — not a general LLM guess. Spanish, French, Dutch, Portuguese: the assistant matches the shopper's language naturally.",
   },
   {
     step: "04",
@@ -176,7 +176,7 @@ export default function WhatsAppAssistantPage() {
                 {[
                   "Zero markup on WhatsApp charges",
                   "Live catalog sync — no stale data",
-                  "Hinglish · Hindi · Arabic · Tamil",
+                  "Spanish · French · Dutch · Portuguese · German",
                   "No agent required",
                 ].map((t) => (
                   <span key={t} className="flex items-center gap-1.5">
@@ -208,7 +208,7 @@ export default function WhatsAppAssistantPage() {
                   {
                     stat: "6+",
                     label: "languages supported",
-                    detail: "Hinglish, Hindi, Arabic, Tamil, English, and expanding. Natural, not translated.",
+                    detail: "Spanish, French, Dutch, Portuguese, German, English, and expanding. Natural, not translated.",
                   },
                 ].map((item) => (
                   <div key={item.stat} className="flex flex-col gap-1.5 px-2 py-4 md:px-4">
@@ -236,7 +236,7 @@ export default function WhatsAppAssistantPage() {
                 <p className="mt-3 max-w-2xl text-muted-foreground">
                   No agent routing, no knowledge-base maintenance, no scripted flows.
                   The assistant reads your live catalog and answers directly.
-                  You&apos;ll be running before your chai gets cold — and you never
+                  You&apos;ll be live before your first coffee is cold — and you never
                   have to &ldquo;update the bot&rdquo;.
                 </p>
               </div>

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, Geist_Mono } from "next/font/google";
 import { connection } from "next/server";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { QueryProvider } from "@/providers/query-provider";
@@ -8,9 +8,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
 import "../globals.css";
 
-const geistSans = Geist({
+const plusJakartaSans = Plus_Jakarta_Sans({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
 });
 
 const geistMono = Geist_Mono({
@@ -45,7 +46,7 @@ export default async function SiteLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${plusJakartaSans.variable} ${geistMono.variable} font-sans antialiased`}
       >
         <ThemeProvider>
           <QueryProvider>

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -82,7 +82,7 @@ function WhatsAppMockup() {
           MK
         </div>
         <div className="min-w-0">
-          <p className="truncate text-xs font-semibold text-white">Mumbai Kicks</p>
+          <p className="truncate text-xs font-semibold text-white">Brooklyn Kicks</p>
           <p className="text-[10px] text-white/70">Online</p>
         </div>
       </div>
@@ -103,7 +103,7 @@ function WhatsAppMockup() {
             <p className="text-[11px] font-semibold text-gray-800">Nike Air Max 270</p>
             <div className="mt-1.5 space-y-0.5 text-[10px] text-gray-600">
               <p>✓ &nbsp;Size 10 — In stock (3 left)</p>
-              <p>₹8,995 &nbsp;· &nbsp;Free delivery</p>
+              <p>$189 · Free delivery</p>
             </div>
             <p className="mt-1.5 text-[10px]" style={{ color: "#075E54" }}>
               Want me to help you order? 😊

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -189,7 +189,7 @@ export default async function Home() {
           />
           {/* Amber glow — keeps the warm depth under the copy */}
           <div
-            className="pointer-events-none absolute -z-10 h-[650px] w-[800px] -translate-x-1/3 -translate-y-1/4 rounded-full bg-primary/15 blur-3xl"
+            className="pointer-events-none absolute -z-10 h-160 w-200 -translate-x-1/3 -translate-y-1/4 rounded-full bg-primary/15 blur-3xl"
             aria-hidden
           />
 
@@ -227,7 +227,7 @@ export default async function Home() {
 
                 <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 text-xs text-muted-foreground">
                   {["Built for Shopify", "WhatsApp Business", "No credit card required", "Limited spots"].map(
-                    (t, i, arr) => (
+                    (t) => (
                       <span key={t} className="flex items-center gap-2">
                         <span className="inline-flex size-1 rounded-full bg-primary/60" />
                         {t}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,6 +125,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-size: 1.0625rem; /* 17px — slightly larger than the 16px default */
   }
 }
 

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -65,7 +65,7 @@ export function Footer() {
         <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3 sm:items-start">
             <Link href="/" aria-label="Peakhour home">
-              <PeakhourLogo className="h-6 w-auto opacity-80 transition-opacity hover:opacity-100" />
+              <PeakhourLogo className="h-8 w-auto opacity-80 transition-opacity hover:opacity-100" />
             </Link>
             <a
               href="mailto:hello@peakhour.ai"

--- a/src/components/shared/header.tsx
+++ b/src/components/shared/header.tsx
@@ -39,7 +39,7 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
     <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
         <Link href="/" className="flex items-center" aria-label="Peakhour home">
-          <PeakhourLogo className="h-7 w-auto" />
+          <PeakhourLogo className="h-9 w-auto" />
         </Link>
 
         {!minimal && !isAuthPage && (


### PR DESCRIPTION
## Summary

- **Font upgrade**: Geist Sans to Plus Jakarta Sans (rounder, more premium feel); body font bumped 16px to 17px
- **Logo sizes**: header h-7 to h-9 (28px to 36px); footer h-6 to h-8 (24px to 32px)
- **Global positioning**: removed all India/GCC/SMB/SME/emerging-market framing across 7 pages; replaced with US-primary, Top 10 Shopify market examples (US, UK, AU, CA, DE, FR, NL, BR, IN, ES)
- **Currency**: all INR amounts replaced with USD equivalents throughout commerce sub-pages
- **Language examples**: Hinglish/Hindi/Arabic/Tamil replaced with Spanish/French/Dutch/Portuguese/German
- **Merchant examples**: "Mumbai Kicks" replaced with "Brooklyn Kicks" ($189); fashion brand India example replaced with New York/London/Sydney
- **Messaging**: "India/GCC first" replaced with "WhatsApp-first globally"; "Built for emerging markets" replaced with "Built for merchants everywhere"; "chai gets cold" replaced with "first coffee is cold"; "paying a rupee" replaced with "paying a cent"

## Files changed (11)

- `src/app/(site)/layout.tsx` — Plus Jakarta Sans font
- `src/app/globals.css` — 17px body font
- `src/components/shared/header.tsx` — h-9 logo
- `src/components/shared/footer.tsx` — h-8 logo
- `src/app/(site)/page.tsx` — Brooklyn Kicks + USD price in WhatsApp mockup
- `src/app/(site)/about/page.tsx` — global value proposition
- `src/app/(site)/commerce/page.tsx` — languages, currency, competitive grid, FAQ
- `src/app/(site)/commerce/whatsapp-assistant/page.tsx` — language strip, feature cards, coffee line
- `src/app/(site)/commerce/brand-voice/page.tsx` — cultural vocab, merchant example
- `src/app/(site)/commerce/campaign-approval/page.tsx` — INR to USD in example message
- `src/app/(site)/commerce/autopilot/page.tsx` — all INR amounts to USD

## Test plan

- [ ] Font renders as Plus Jakarta Sans at 17px body
- [ ] Header logo visibly larger; footer logo visibly larger
- [ ] Homepage WhatsApp mockup shows "Brooklyn Kicks" and "$189 Free delivery"
- [ ] /commerce FAQ says "Spanish, French, Dutch" not "Hinglish, Hindi"
- [ ] /commerce/campaign-approval example shows $8,400 and $3,200-$4,400
- [ ] /commerce/autopilot stats show $4,800 recovered
- [ ] /about says "Built for merchants everywhere"
- [ ] No INR symbols anywhere in public-facing copy
- [ ] TypeScript build passes

Generated with Claude Code
