### PR TITLE
fix(whatsapp): align Embedded Signup with Meta v4 reference (sessionInfoVersion + popup-close)

### DIFF
--- a/src/components/integrations/whatsapp-embedded-signup.tsx
+++ b/src/components/integrations/whatsapp-embedded-signup.tsx
@@ -135,15 +135,30 @@ export function WhatsAppEmbeddedSignup({
   const flowRef = useRef<ConnectFlow>("coexistence");
   const completingRef = useRef(false);
   const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The popup window FB.login opens, and a poll that watches it for a manual
+  // close. Meta does NOT reliably emit a CANCEL message when the user X-closes
+  // the ES window, so without this the flow would hang on the watchdog (up to
+  // 5 min for coexistence) before the Connect button frees. Mirrors Meta's
+  // reference Tech Provider sample (Fbl4bLauncher.tsx).
+  const popupRef = useRef<Window | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Set once the user starts a connect/disconnect — so a slow status-on-mount
   // fetch can't resolve late and clobber a user-initiated transition.
   const interactedRef = useRef(false);
 
+  // Stop both popup-resolution timers. The watchdog and the close-poll share a
+  // lifetime — both exist only while we're waiting on the ES popup — so every
+  // existing clearWatchdog() call site also tears the poll down.
   const clearWatchdog = () => {
     if (watchdogRef.current) {
       clearTimeout(watchdogRef.current);
       watchdogRef.current = null;
     }
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    popupRef.current = null;
   };
 
   const resetPieces = () => {
@@ -322,12 +337,25 @@ export function WhatsAppEmbeddedSignup({
     watchdogRef.current = setTimeout(
       () => {
         if (completingRef.current) return; // POST already started
+        clearWatchdog(); // also stops the close-poll — we've given up waiting
         resetPieces();
         setPhase("idle");
         setError("We didn’t hear back from WhatsApp. Please try connecting again.");
       },
       flow === "coexistence" ? COEX_WATCHDOG_MS : WATCHDOG_MS,
     );
+
+    // FB.login opens its popup synchronously via window.open during the call
+    // below (popups must open on the user gesture). Briefly wrap window.open to
+    // capture that handle, then restore it. We then poll the handle so a manual
+    // window close unwinds immediately instead of waiting out the watchdog.
+    const originalOpen = window.open;
+    window.open = function (...args: Parameters<typeof window.open>) {
+      const popup = originalOpen.apply(window, args);
+      if (popup) popupRef.current = popup;
+      window.open = originalOpen; // restore on first open
+      return popup;
+    };
 
     window.FB.login(
       (response: FacebookLoginResponse) => {
@@ -365,10 +393,18 @@ export function WhatsAppEmbeddedSignup({
         extras: {
           // v4 reference invocation sends an (empty) setup object
           // (.../embedded-signup/implementation/). v4-ONLY by decision
-          // (2026-06-11): no onboarded customers exist, so no v2/v3
-          // sessionInfoVersion tolerance — NEXT_PUBLIC_META_ES_CONFIG_ID
-          // must be a v4 configuration id.
+          // (2026-06-11): NEXT_PUBLIC_META_ES_CONFIG_ID must be a v4
+          // configuration id.
           setup: {},
+          // Pin the session-info message format. Meta's implementation doc and
+          // the reference Tech Provider sample (ClientDashboard.tsx
+          // computeEsConfig) both send sessionInfoVersion "3" — including for
+          // v4 — and the WA_EMBEDDED_SIGNUP payload that carries waba_id/
+          // phone_number_id is shaped by it. Omitting it lets Meta fall back to
+          // a legacy shape, which can break the FINISH-id parse and strand the
+          // flow on the watchdog. (Our findSignupIds parse stays
+          // shape-tolerant; this just stops the format from drifting.)
+          sessionInfoVersion: "3",
           // Coexistence (C5): launches the "connect your existing WhatsApp
           // Business app account" variant — the merchant keeps their app
           // and pairs the same number to Cloud API in-flow. The deprecated
@@ -380,6 +416,22 @@ export function WhatsAppEmbeddedSignup({
         },
       },
     );
+
+    // Belt-and-suspenders: restore window.open even if FB.login never opened a
+    // popup (e.g. it redirected), so we never leave the global patched.
+    window.open = originalOpen;
+
+    // Poll the captured popup. A manual close with no CANCEL message unwinds to
+    // idle straight away. Guard on completingRef so a normal post-FINISH close
+    // (Meta auto-closes the window on success) doesn't trip a false reset.
+    pollRef.current = setInterval(() => {
+      if (completingRef.current) return; // the POST owns the outcome now
+      if (popupRef.current && popupRef.current.closed) {
+        clearWatchdog(); // stops this poll + the watchdog
+        resetPieces();
+        setPhase("idle");
+      }
+    }, 500);
   }, [sdkState, complete, flow]);
 
   const disconnect = useCallback(async () => {


### PR DESCRIPTION
Diffs our WhatsApp Embedded Signup launcher against Meta's official Tech Provider sample ([fbsamples/business-messaging-sample-tech-provider-app](https://github.com/fbsamples/business-messaging-sample-tech-provider-app)) and closes the two meaningful gaps. **SDK Graph version stays at v25.0** (newer than the sample's v24.0).

## 1. Pin `extras.sessionInfoVersion: "3"`
The sample's `computeEsConfig` ([ClientDashboard.tsx](https://github.com/fbsamples/business-messaging-sample-tech-provider-app/blob/main/app/components/ClientDashboard.tsx#L675)) and Meta's implementation doc both send this — **including for v4**. It shapes the `WA_EMBEDDED_SIGNUP` message that carries `waba_id`/`phone_number_id`. We had dropped it (conflating "remove parse tolerance" with "remove the request param"); without it Meta can fall back to a legacy payload shape that breaks the FINISH-id parse and strands the flow on the watchdog. Our `findSignupIds` parse stays shape-tolerant — this just stops the format from drifting.

## 2. Detect a manual popup close
Like the sample's `Fbl4bLauncher`, briefly wrap `window.open` around `FB.login` to capture the popup handle, then poll `popup.closed` every 500ms. Meta doesn't reliably emit a CANCEL message when the user X-closes the ES window, so previously the flow hung on the watchdog (**up to 5 min for coexistence**) before the Connect button freed. `clearWatchdog()` now also tears down the poll, so every existing exit path (CANCEL, code-less callback, watchdog fire, `complete()`, unmount) stops it.

## Kept (we're already correct / ahead of the sample)
- `config_id`, `response_type:'code'`, `override_default_response_type:true`, coexistence `featureType` — already matched.
- `setup: {}` — canonical per Meta's doc.
- Stricter postMessage origin check (exact host match vs the sample's `endsWith('facebook.com')`, which also accepts `notfacebook.com`).

## Testing
- [x] `tsc --noEmit` clean; ESLint clean
- [x] Independent review of the popup-poll race / window.open restore / timer teardown / stale-closure — passed (poll stopped before POST; window.open always restored; pollRef cleared on every exit incl. unmount; poll reads only refs)
- [ ] Manual once the Meta-dashboard issue is cleared: X-close the popup → returns to idle immediately (no 90s/5min hang); complete a connect → FINISH still parses.

> Does **not** fix the dashboard-side *"Sorry, something went wrong"* — that's Meta App Dashboard config (domain allowlist / config / app mode). This makes the in-popup flow match Meta's reference once the dialog loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
