### PR TITLE
fix(csp): allow Facebook SDK hosts in connect-src for WhatsApp Embedded Signup

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -57,6 +57,17 @@ function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
     "https://*.vercel-insights.com",
     "https://vitals.vercel-insights.com",
     "https://*.vercel-analytics.com",
+    // WhatsApp Embedded Signup: the Facebook JS SDK (connect.facebook.net,
+    // loaded via 'strict-dynamic') makes runtime fetch/XHR calls to
+    // www.facebook.com (impression/funnel logging) and graph.facebook.com.
+    // Without these, the SDK is blocked by CSP and FB.login dies with Meta's
+    // generic "Sorry, something went wrong" page. The ES popup can launch from
+    // /dashboard/content/whatsapp and the /dashboard/integrations modal, so the
+    // allowance is global (like the Vercel hosts above). frame-src/img-src
+    // already permit `https:`, covering the SDK's xd_arbiter iframe + pixels.
+    "https://www.facebook.com",
+    "https://graph.facebook.com",
+    "https://connect.facebook.net",
     isDev ? "ws: wss: http://localhost:* ws://localhost:*" : "",
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Root cause (from DevTools)
The WhatsApp Embedded Signup popup showed Meta's generic *"Sorry, something went wrong"*. DevTools revealed the real reason — our **CSP** blocked the Facebook SDK:

```
Fetch API cannot load https://www.facebook.com/platform/impression.php/…
Refused to connect because it violates the document's Content Security Policy.
```

The SDK script itself loads (via `'strict-dynamic'`), but at runtime it `fetch`es `www.facebook.com` / `graph.facebook.com`, and our `connect-src` only allowed `'self'` + the API + Vercel hosts. With those calls refused, `FB.login` never completes → the generic error page.

## Fix
Add the Facebook SDK hosts to `connect-src` in `src/middleware.ts`:
- `https://www.facebook.com`
- `https://graph.facebook.com`
- `https://connect.facebook.net`

`script-src` (strict-dynamic) and `frame-src`/`img-src` (`https:`) already cover the SDK script, the `xd_arbiter` iframe, and pixels — `connect-src` was the only gap. The allowance is global because the ES popup launches from both `/dashboard/content/whatsapp` and the `/dashboard/integrations` modal.

## Testing
- [x] `tsc --noEmit` clean; ESLint clean
- [ ] Manual on dev.peakhour.ai: open WhatsApp Connect → the `impression.php` CSP error is gone and the ES dialog renders instead of "Sorry, something went wrong".

This unblocks the end-to-end verification of the merged WhatsApp work (b2c #318/#319, api #560).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
