### PR TITLE
feat(shopify): show linked Peakhour account email on embedded Settings

### DIFF
--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -29,6 +29,7 @@ interface ContextData {
   connected: boolean;
   shop: string;
   storeName?: string | null;
+  accountEmail?: string | null;
   currency?: string | null;
   productsSyncedAt?: string | null;
   connectionStatus?: string | null;
@@ -247,6 +248,12 @@ export default function SettingsPage() {
               <BlockStack gap="100">
                 <Text as="p" variant="bodySm" tone="subdued">Shop domain</Text>
                 <Text as="p" variant="bodyMd" fontWeight="semibold">{ctx.shop}</Text>
+              </BlockStack>
+              <BlockStack gap="100">
+                <Text as="p" variant="bodySm" tone="subdued">Peakhour account</Text>
+                <Text as="p" variant="bodyMd" fontWeight="semibold">
+                  {ctx.accountEmail || "—"}
+                </Text>
               </BlockStack>
               {ctx.currency && (
                 <BlockStack gap="100">


### PR DESCRIPTION
## Summary
Surfaces the new `accountEmail` from `GET /v1/shopify/embedded/context` in the embedded Settings → Store information card, so a merchant can confirm which Peakhour account their store is linked to. Falls back to an em-dash when not resolvable.

Companion to peakhour-api #565 (which adds `accountEmail` to the context response and fixes the in-app assistant 503).

## Test plan
- `tsc --noEmit` clean.
- Renders the new "Peakhour account" field; null/undefined → "—".

🤖 Generated with [Claude Code](https://claude.com/claude-code)