### PR TITLE
feat(shopify): redesign embedded disconnect experience (frontend)

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Page, EmptyState, Text } from "@shopify/polaris";
+import { reconnectUrl } from "../_lib/context";
+
+/** Shared illustration for the Commerce setup / disconnected states. One asset
+ *  everywhere so the experience is consistent (Disconnect Redesign §12). */
+const SETUP_IMAGE = "https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg";
+
+interface CommerceDisconnectedProps {
+  shop?: string | null;
+  /** "Commerce Disconnected" (recovery) vs the default setup framing. */
+  heading?: string;
+  description?: string;
+  /** Wrap in a Polaris <Page> (standalone page use) or return bare (inside an
+   *  already-titled page / card). Defaults to standalone. */
+  withPage?: boolean;
+  pageTitle?: string;
+  /** Show the "Explore Growth Network" secondary CTA. Off on the Growth
+   *  Network page itself (would be self-referential). Defaults on. */
+  showGrowthNetworkLink?: boolean;
+}
+
+/**
+ * The single, consistent "no live Commerce connection" state — used for both a
+ * never-linked store and a disconnected one (Disconnect Redesign §1, §2, §10).
+ * Always gives the merchant a next action: Reconnect Shopify (primary, escapes
+ * the admin iframe to re-run OAuth) or Explore Growth Network (secondary, the
+ * free destination). No blank screens, no dead ends.
+ */
+export function CommerceDisconnected({
+  shop,
+  heading = "Set up Peakhour Commerce",
+  description = "Your Peakhour account is still active. Reconnect your Shopify store to sync your catalog, enable the AI Commerce Assistant, unlock product insights, and get AI-powered recommendations.",
+  withPage = true,
+  pageTitle = "Commerce",
+  showGrowthNetworkLink = true,
+}: CommerceDisconnectedProps) {
+  const content = (
+    <EmptyState
+      heading={heading}
+      action={{
+        content: "Reconnect Shopify",
+        // Top-level navigation escapes the admin iframe so OAuth can run; a
+        // relative redirect would only move the iframe itself.
+        onAction: () => {
+          (window.top ?? window).location.href = reconnectUrl(shop);
+        },
+      }}
+      secondaryAction={
+        showGrowthNetworkLink
+          ? {
+              content: "Explore Growth Network",
+              // In-iframe client nav (Polaris linkComponent = Next Link).
+              url: "/shopify/embedded/pin",
+            }
+          : undefined
+      }
+      image={SETUP_IMAGE}
+    >
+      <Text as="p" variant="bodyMd">
+        {description}
+      </Text>
+    </EmptyState>
+  );
+
+  if (!withPage) return content;
+  return <Page title={pageTitle}>{content}</Page>;
+}

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AppProvider, Frame, Navigation } from "@shopify/polaris";
+import { AppProvider, Frame, Navigation, Banner, Box, Text } from "@shopify/polaris";
 import {
   HomeIcon,
   ChatIcon,
@@ -15,6 +15,11 @@ import enTranslations from "@shopify/polaris/locales/en.json";
 import { usePathname } from "next/navigation";
 import NextLink from "next/link";
 import { useState, type ReactNode } from "react";
+import {
+  EmbeddedContextProvider,
+  useEmbeddedContext,
+  reconnectUrl,
+} from "../_lib/context";
 
 type PolarisLinkComponent = NonNullable<AppProviderProps["linkComponent"]>;
 type PolarisLinkProps = React.ComponentPropsWithoutRef<PolarisLinkComponent>;
@@ -50,13 +55,43 @@ const NAV_ITEMS = [
   { label: "Catalog", icon: ProductIcon, url: "/shopify/embedded/catalog" },
   // WhatsApp (and future channels) connect here (P1.12, launch-to-domain).
   { label: "Integrations", icon: ConnectIcon, url: "/shopify/embedded/integrations" },
-  // PIN gets its own surface (product rule 2026-06-12): consent is captured
-  // first-time in the connect wizard; this page is its standing home —
-  // members see the network, non-members get the consent nudge.
-  { label: "Insights Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
+  // The free Growth Network (formerly "Insights Network") — its own surface
+  // (product rule 2026-06-12): consent is captured first-time in the connect
+  // wizard; this page is its standing home — members see the network,
+  // non-members get the join nudge. Positioned as a valuable destination.
+  { label: "Growth Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
   { label: "Subscription", icon: CreditCardIcon, url: "/shopify/embedded/subscription" },
   { label: "Settings", icon: SettingsIcon, url: "/shopify/embedded/settings" },
 ];
+
+/**
+ * Persistent reconnect banner shown on EVERY embedded page while the store is
+ * disconnected (Disconnect Redesign §11). Keyed on the raw `status` so it only
+ * fires for a truly-disconnected store — never on a fresh, never-linked install
+ * (which also reports connected:false but has no `status`).
+ */
+function ReconnectBanner() {
+  const { ctx } = useEmbeddedContext();
+  if (ctx?.status !== "disconnected") return null;
+  return (
+    <Box padding="400" paddingBlockEnd="0">
+      <Banner
+        tone="warning"
+        title="Commerce is disconnected"
+        action={{
+          content: "Reconnect Shopify",
+          onAction: () => {
+            (window.top ?? window).location.href = reconnectUrl(ctx.shop);
+          },
+        }}
+      >
+        <Text as="p" variant="bodyMd">
+          Reconnect Shopify to activate your AI Commerce Assistant and Commerce Insights.
+        </Text>
+      </Banner>
+    </Box>
+  );
+}
 
 export function PolarisShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
@@ -70,13 +105,16 @@ export function PolarisShell({ children }: { children: ReactNode }) {
 
   return (
     <AppProvider i18n={enTranslations} linkComponent={PolarisLink}>
-      <Frame
-        navigation={navMarkup}
-        showMobileNavigation={mobileNavOpen}
-        onNavigationDismiss={() => setMobileNavOpen(false)}
-      >
-        {children}
-      </Frame>
+      <EmbeddedContextProvider>
+        <Frame
+          navigation={navMarkup}
+          showMobileNavigation={mobileNavOpen}
+          onNavigationDismiss={() => setMobileNavOpen(false)}
+        >
+          <ReconnectBanner />
+          {children}
+        </Frame>
+      </EmbeddedContextProvider>
     </AppProvider>
   );
 }

--- a/src/app/(commerce)/shopify/embedded/_lib/context.tsx
+++ b/src/app/(commerce)/shopify/embedded/_lib/context.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { getSessionToken } from "./session";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+/**
+ * Shape of GET /v1/shopify/embedded/context. Shared so the shell (persistent
+ * reconnect banner) and pages agree on one type. `status` is the raw merchant
+ * status — distinguishes a truly-disconnected store ("disconnected") from a
+ * never-linked one (no merchant row → connected:false, status absent), which
+ * the banner relies on so it never shows on a fresh install.
+ */
+export interface EmbeddedContextData {
+  connected: boolean;
+  status?: "active" | "disconnected" | string;
+  shop: string;
+  orgId?: string;
+  businessId?: string;
+  storeName?: string | null;
+  accountEmail?: string | null;
+  currency?: string | null;
+  productsSyncedAt?: string | null;
+  connectionStatus?: string | null;
+  assistantActive?: boolean;
+  productsCount?: number;
+  pricing?: {
+    displayName: string;
+    amount: string;
+    currency: string;
+    interval: "monthly" | "annual";
+    trialDays?: number;
+    annual?: { amount: string; currency: string } | null;
+  } | null;
+}
+
+interface EmbeddedContextValue {
+  ctx: EmbeddedContextData | null;
+  loading: boolean;
+  /** Re-fetch context — call after an action that changes connection/plan
+   *  state (disconnect, downgrade) so the UI updates in place without a reopen. */
+  refresh: () => Promise<void>;
+}
+
+const Ctx = createContext<EmbeddedContextValue | null>(null);
+
+/** Pure fetch of the embedded context — no React state, so it's safe to call
+ *  from both the mount effect (inline) and the exposed refresh() without
+ *  tripping react-hooks/set-state-in-effect. Returns null on no-session or error. */
+async function fetchEmbeddedContext(): Promise<EmbeddedContextData | null> {
+  const token = await getSessionToken();
+  if (!token) return null;
+  try {
+    const res = await fetch(`${API_URL}/v1/shopify/embedded/context`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) return (await res.json()) as EmbeddedContextData;
+  } catch {
+    // Non-fatal — the banner simply doesn't render; pages surface their own errors.
+  }
+  return null;
+}
+
+/**
+ * Fetches the embedded context once for the whole embedded surface and exposes
+ * it (plus a `refresh()`) via React context. Mounted in the Polaris shell so
+ * the persistent reconnect banner and any consumer share a single fetch.
+ * Pages may still fetch their own context independently — this provider does
+ * not force a migration; it powers the shell banner and in-place refreshes.
+ */
+export function EmbeddedContextProvider({ children }: { children: ReactNode }) {
+  const [ctx, setCtx] = useState<EmbeddedContextData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Exposed for event handlers (e.g. Settings disconnect/downgrade) — NOT
+  // called from the mount effect, so its setState calls don't trip the lint.
+  const refresh = useCallback(async () => {
+    const data = await fetchEmbeddedContext();
+    if (data) setCtx(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const data = await fetchEmbeddedContext();
+      if (cancelled) return;
+      if (data) setCtx(data);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return <Ctx.Provider value={{ ctx, loading, refresh }}>{children}</Ctx.Provider>;
+}
+
+export function useEmbeddedContext(): EmbeddedContextValue {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useEmbeddedContext must be used within EmbeddedContextProvider");
+  return v;
+}
+
+/** The top-level connect URL that re-runs OAuth. Used by every Reconnect CTA. */
+export function reconnectUrl(shop?: string | null): string {
+  return shop
+    ? `/shopify/connect?shop=${encodeURIComponent(shop)}&reconnect=1`
+    : "/shopify/connect";
+}

--- a/src/app/(commerce)/shopify/embedded/catalog/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/catalog/page.tsx
@@ -22,6 +22,8 @@ import {
 } from "@shopify/polaris";
 import { SearchIcon, ProductIcon } from "@shopify/polaris-icons";
 import { getSessionToken } from "../_lib/session";
+import { useEmbeddedContext } from "../_lib/context";
+import { CommerceDisconnected } from "../_components/commerce-disconnected";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 const PAGE_SIZE = 25;
@@ -48,6 +50,9 @@ interface CatalogResponse {
   page: number;
   limit: number;
   pages: number;
+  /** Set by the API when the store is disconnected — catalog is preserved
+   *  server-side but withheld from the UI. */
+  disconnected?: boolean;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -86,8 +91,10 @@ function CatalogSkeleton() {
 type PageState = "initializing" | "ready" | "error";
 
 export default function CatalogPage() {
+  const { ctx } = useEmbeddedContext();
   const [pageState, setPageState] = useState<PageState>("initializing");
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [disconnected, setDisconnected] = useState(false);
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
   const [pages, setPages] = useState(1);
@@ -131,6 +138,12 @@ export default function CatalogPage() {
         return;
       }
       const data = (await res.json()) as CatalogResponse;
+      if (data.disconnected) {
+        setDisconnected(true);
+        setPageState("ready");
+        setFetching(false);
+        return;
+      }
       setProducts(data.products);
       setTotal(data.total);
       setPages(data.pages);
@@ -197,6 +210,12 @@ export default function CatalogPage() {
 
   if (pageState === "initializing") return <CatalogSkeleton />;
 
+  if (disconnected) {
+    return (
+      <CommerceDisconnected shop={ctx?.shop} pageTitle="Catalog" heading="Commerce Disconnected" />
+    );
+  }
+
   if (pageState === "error") {
     return (
       <Page title="Catalog">
@@ -227,7 +246,7 @@ export default function CatalogPage() {
             image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
           >
             <Text as="p" variant="bodyMd">
-              Your Shopify catalog hasn't synced yet. Sync now to import your products and
+              Your Shopify catalog hasn&apos;t synced yet. Sync now to import your products and
               enable the catalog-grounded AI assistant.
             </Text>
           </EmptyState>

--- a/src/app/(commerce)/shopify/embedded/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/page.tsx
@@ -13,17 +13,18 @@ import {
   SkeletonPage,
   SkeletonBodyText,
   SkeletonDisplayText,
-  EmptyState,
   Divider,
   Box,
   InlineGrid,
 } from "@shopify/polaris";
 import { getSessionToken } from "./_lib/session";
+import { CommerceDisconnected } from "./_components/commerce-disconnected";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 interface EmbeddedContext {
   connected: boolean;
+  status?: string;
   shop: string;
   orgId?: string;
   businessId?: string;
@@ -382,28 +383,12 @@ export default function ShopifyEmbeddedHome() {
   }
 
   if (!state.ctx.connected) {
-    const shop = state.ctx.shop;
-    const connectUrl = shop
-      ? `/shopify/connect?shop=${encodeURIComponent(shop)}&reconnect=1`
-      : "/shopify/connect";
     return (
-      <Page title="Peakhour Commerce">
-        <EmptyState
-          heading="Link your Peakhour account"
-          action={{
-            content: "Set up Peakhour Commerce",
-            // Navigate the top-level window — relative URLs inside an admin
-            // iframe would only navigate the iframe itself.
-            onAction: () => { (window.top ?? window).location.href = connectUrl; },
-          }}
-          image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
-        >
-          <Text as="p" variant="bodyMd">
-            {shop ? `${shop} isn't` : "This store isn't"} linked to a Peakhour account yet.
-            Finish setup to connect your catalog and enable the AI commerce assistant.
-          </Text>
-        </EmptyState>
-      </Page>
+      <CommerceDisconnected
+        shop={state.ctx.shop}
+        pageTitle="Peakhour Commerce"
+        heading={state.ctx.status === "disconnected" ? "Commerce Disconnected" : "Set up Peakhour Commerce"}
+      />
     );
   }
 

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -12,13 +12,13 @@ import {
   Badge,
   Box,
   Divider,
-  EmptyState,
   List,
   SkeletonPage,
   SkeletonBodyText,
   SkeletonDisplayText,
 } from "@shopify/polaris";
 import { getSessionToken } from "../_lib/session";
+import { CommerceDisconnected } from "../_components/commerce-disconnected";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
@@ -40,10 +40,13 @@ interface PinState {
 }
 
 // Truthful-today framing (matches the wizard): benchmarks ship to members
-// FIRST as they roll out — never claimed as visible now.
-const PIN_BENEFITS = [
-  "Early access: benchmarks for stores like yours reach members first",
-  "Help shape sharper AI recommendations as the network learns",
+// FIRST as they roll out — never claimed as visible now. The Growth Network
+// is positioned as a valuable free destination, not a Commerce setup blocker.
+const GROWTH_BENEFITS = [
+  "Industry insights and growth trends for stores like yours",
+  "Community benchmarks — see how you compare, anonymously",
+  "AI-powered recommendations as the network learns",
+  "Early access to new features",
   "Only anonymized cohort signals are shared — never products, customers, or revenue",
 ];
 
@@ -59,7 +62,7 @@ type Membership = "loading" | "member" | "nonmember" | "unknown" | "notlinked";
 
 function PinSkeleton() {
   return (
-    <SkeletonPage title="Insights Network">
+    <SkeletonPage title="Growth Network">
       <BlockStack gap="500">
         <Card>
           <BlockStack gap="400">
@@ -155,7 +158,7 @@ export default function PinPage() {
         body: JSON.stringify({ action: join ? "opt_in" : "withdraw" }),
       });
       if (!res.ok) {
-        setError("Could not update your Insights Network membership. Please try again.");
+        setError("Could not update your Growth Network membership. Please try again.");
       } else {
         setMembership(join ? "member" : "nonmember");
       }
@@ -169,8 +172,8 @@ export default function PinPage() {
 
   return (
     <Page
-      title="Insights Network"
-      subtitle="Anonymous, cohort-level intelligence from stores like yours"
+      title="Growth Network"
+      subtitle="Smart insights. Zero personal tracking. Your identity stays yours."
     >
       <BlockStack gap="500">
         {error && (
@@ -239,14 +242,14 @@ export default function PinPage() {
         {membership === "nonmember" && (
           <Card>
             <BlockStack gap="400">
-              <Text as="h2" variant="headingMd">Join the Peakhour Insights Network</Text>
+              <Text as="h2" variant="headingMd">Join the Peakhour Growth Network</Text>
               <Divider />
               <Text as="p" variant="bodyMd" tone="subdued">
-                Get member-first access to benchmarks and network-powered insights as
-                they roll out — included free on your current plan.
+                A free community for founders and operators growing smarter with AI. Smart insights,
+                zero personal tracking — your identity stays yours.
               </Text>
               <List type="bullet">
-                {PIN_BENEFITS.map((b) => (
+                {GROWTH_BENEFITS.map((b) => (
                   <List.Item key={b}>
                     <Text as="span" variant="bodyMd">{b}</Text>
                   </List.Item>
@@ -254,46 +257,31 @@ export default function PinPage() {
               </List>
               <InlineStack gap="300" blockAlign="center">
                 <Button onClick={() => toggle(true)} loading={busy} variant="primary">
-                  Count me in
+                  Join Free Community Now
                 </Button>
-                <Text as="span" variant="bodySm" tone="subdued">
-                  Opt-in only — you can leave at any time.
-                </Text>
+                <Button url="/shopify/embedded/subscription" variant="tertiary">
+                  Connect Commerce Later
+                </Button>
               </InlineStack>
+              <Text as="span" variant="bodySm" tone="subdued">
+                Opt-in only — you can leave at any time.
+              </Text>
             </BlockStack>
           </Card>
         )}
 
         {membership === "notlinked" && (
-          <EmptyState
-            heading="Link your Peakhour account"
-            action={{
-              content: "Set up Peakhour Commerce",
-              // Navigate the top-level window — relative URLs inside an
-              // admin iframe would only navigate the iframe itself. Carry
-              // shop + reconnect like Home/Settings do: the bare wizard URL
-              // hard-errors ("please reinstall") without a shop param.
-              onAction: () => {
-                const url = shop
-                  ? `/shopify/connect?shop=${encodeURIComponent(shop)}&reconnect=1`
-                  : "/shopify/connect";
-                (window.top ?? window).location.href = url;
-              },
-            }}
-            image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
-          >
-            <Text as="p" variant="bodyMd">
-              {shop ? `${shop} isn't` : "This store isn't"} linked to a Peakhour
-              account yet. Finish setup first — then join the Insights Network
-              from here.
-            </Text>
-          </EmptyState>
+          <CommerceDisconnected
+            shop={shop}
+            withPage={false}
+            showGrowthNetworkLink={false}
+          />
         )}
 
         {membership === "unknown" && (
           <Card>
             <BlockStack gap="300">
-              <Text as="h2" variant="headingMd">Peakhour Insights Network</Text>
+              <Text as="h2" variant="headingMd">Peakhour Growth Network</Text>
               <Divider />
               <Text as="p" variant="bodyMd" tone="subdued">
                 We couldn&apos;t load your membership status.

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -181,7 +181,11 @@ export default function SettingsPage() {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (!res.ok) {
+      // 404 = "No active subscription found": the goal (no paid sub on this
+      // store) is already met — a store entitled via another store, a trial,
+      // or a manual grant. Treat it as success and land on the free welcome
+      // rather than dead-ending the retention path on a raw error.
+      if (!res.ok && res.status !== 404) {
         const data = (await res.json().catch(() => ({}))) as { error?: string };
         setActionError(data.error ?? "Could not update your plan. Please try again.");
         setBusy(false);

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   Page,
   Card,
@@ -14,36 +14,18 @@ import {
   Box,
   Divider,
   Modal,
-  EmptyState,
+  ChoiceList,
+  TextField,
+  List,
   SkeletonPage,
   SkeletonBodyText,
   SkeletonDisplayText,
 } from "@shopify/polaris";
 import { getSessionToken } from "../_lib/session";
+import { useEmbeddedContext } from "../_lib/context";
+import { CommerceDisconnected } from "../_components/commerce-disconnected";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
-
-// ── Types ──────────────────────────────────────────────────────────────────
-
-interface ContextData {
-  connected: boolean;
-  shop: string;
-  storeName?: string | null;
-  accountEmail?: string | null;
-  currency?: string | null;
-  productsSyncedAt?: string | null;
-  connectionStatus?: string | null;
-  productsCount?: number;
-}
-
-// PIN (Insights Network) membership moved to its own nav surface —
-// /shopify/embedded/pin — per the 2026-06-12 product rule: onboarding
-// captures consent first-time, the dedicated page owns it afterwards.
-
-type PageState =
-  | { status: "loading" }
-  | { status: "error"; message: string }
-  | { status: "ready"; ctx: ContextData };
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -67,7 +49,15 @@ function formatSyncTime(iso: string | null | undefined): string {
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-// ── Skeleton ───────────────────────────────────────────────────────────────
+/** Churn reasons — values MUST mirror the cmrc_disconnect_feedback enum. */
+const REASON_CHOICES = [
+  { label: "Just testing", value: "just_testing" },
+  { label: "Too expensive", value: "too_expensive" },
+  { label: "Missing features", value: "missing_features" },
+  { label: "Switching tools", value: "switching_tools" },
+  { label: "Store inactive", value: "store_inactive" },
+  { label: "Other", value: "other" },
+];
 
 function SettingsSkeleton() {
   return (
@@ -86,50 +76,62 @@ function SettingsSkeleton() {
   );
 }
 
-// ── Main component ─────────────────────────────────────────────────────────
+// ── Welcome to Growth Network (post-downgrade) ───────────────────────────────
+
+function GrowthNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <Page title="You're on the free plan">
+      <Card>
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingLg">
+            Welcome to the Peakhour Growth Network
+          </Text>
+          <Text as="p" variant="bodyMd" tone="subdued">
+            Your store stays connected and your catalog keeps syncing. You&rsquo;re now part of a
+            community of founders and operators using AI to grow smarter — at no cost.
+          </Text>
+          <List>
+            <List.Item>Industry insights &amp; growth trends</List.Item>
+            <List.Item>Community benchmarks for stores like yours</List.Item>
+            <List.Item>AI-powered recommendations</List.Item>
+            <List.Item>Early access to new features</List.Item>
+          </List>
+          <InlineStack gap="300">
+            <Button variant="primary" url="/shopify/embedded/pin">
+              Explore Growth Network
+            </Button>
+            <Button variant="tertiary" url="/shopify/embedded/subscription">
+              Back to Commerce
+            </Button>
+            <Button variant="plain" onClick={onDismiss}>
+              Back to settings
+            </Button>
+          </InlineStack>
+        </BlockStack>
+      </Card>
+    </Page>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
 
 export default function SettingsPage() {
-  const [state, setState] = useState<PageState>({ status: "loading" });
+  const { ctx, loading, refresh } = useEmbeddedContext();
+
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [disconnecting, setDisconnecting] = useState(false);
-  const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
-    const ctrl = new AbortController();
-    (async () => {
-      const token = await getSessionToken();
-      if (ctrl.signal.aborted) return;
-      if (!token) {
-        setState({ status: "error", message: "Couldn't get a Shopify session. Please reopen Peakhour from your Shopify admin." });
-        return;
-      }
-      try {
-        const res = await fetch(`${API_URL}/v1/shopify/embedded/context`, {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: ctrl.signal,
-        });
-        if (ctrl.signal.aborted) return;
-        if (!res.ok) {
-          setState({ status: "error", message: `Could not load settings (${res.status}).` });
-          return;
-        }
-        const ctx = (await res.json()) as ContextData;
-        setState({ status: "ready", ctx });
-      } catch (err) {
-        if ((err as { name?: string }).name === "AbortError") return;
-        setState({ status: "error", message: "Network error loading settings." });
-      }
-    })();
-    return () => ctrl.abort();
-  }, []);
+  // Disconnect modal: closed → confirm ("Before You Leave") → reason step.
+  const [modalStep, setModalStep] = useState<"closed" | "confirm" | "reason">("closed");
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [reason, setReason] = useState<string[]>([]);
+  const [details, setDetails] = useState("");
+  // One-time post-downgrade welcome screen (store stays connected).
+  const [flash, setFlash] = useState<null | "downgraded">(null);
 
-  // Clear the pending sync-feedback timer on unmount (no setState after unmount).
-  useEffect(() => () => {
-    if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
-  }, []);
+  const shop = ctx?.shop;
 
   const handleSync = useCallback(async () => {
     setSyncing(true);
@@ -150,8 +152,6 @@ export default function SettingsPage() {
         setSyncError(data.error ?? `Sync failed (${res.status}). Please try again.`);
         setSyncing(false);
       } else {
-        // Fire-and-forget queued — keep the "Sync started" banner for a few
-        // seconds of feedback, then clear (refresh shows updated counts).
         syncTimerRef.current = setTimeout(() => setSyncing(false), 5000);
       }
     } catch {
@@ -160,77 +160,112 @@ export default function SettingsPage() {
     }
   }, []);
 
-  const handleDisconnect = useCallback(async () => {
-    if (state.status !== "ready") return;
-    setDisconnecting(true);
-    setDisconnectError(null);
+  const closeModal = useCallback(() => {
+    if (busy) return;
+    setModalStep("closed");
+    setActionError(null);
+  }, [busy]);
+
+  // Primary retention path: keep the store connected, cancel only the paid sub.
+  const continueOnFree = useCallback(async () => {
+    setBusy(true);
+    setActionError(null);
     const token = await getSessionToken();
     if (!token) {
-      setDisconnectError("Couldn't get a Shopify session. Please reopen from your admin.");
-      setDisconnecting(false);
+      setActionError("Couldn't get a Shopify session. Please reopen from your admin.");
+      setBusy(false);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/v1/shopify/embedded/billing/cancel`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setActionError(data.error ?? "Could not update your plan. Please try again.");
+        setBusy(false);
+        return;
+      }
+      setModalStep("closed");
+      setBusy(false);
+      setFlash("downgraded");
+      void refresh();
+    } catch {
+      setActionError("Network error updating your plan.");
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  // Full disconnect — drop the token, mark disconnected, capture the reason.
+  const disconnectCompletely = useCallback(async () => {
+    setBusy(true);
+    setActionError(null);
+    const token = await getSessionToken();
+    if (!token) {
+      setActionError("Couldn't get a Shopify session. Please reopen from your admin.");
+      setBusy(false);
       return;
     }
     try {
       const res = await fetch(`${API_URL}/v1/shopify/embedded/disconnect`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...(reason[0] ? { reason: reason[0] } : {}),
+          ...(details.trim() ? { details: details.trim() } : {}),
+        }),
       });
       const data = (await res.json().catch(() => ({}))) as { disconnected?: boolean; error?: string };
       if (!res.ok || !data.disconnected) {
-        setDisconnectError(data.error ?? "Could not disconnect. Please try again.");
-        setDisconnecting(false);
+        setActionError(data.error ?? "Could not disconnect. Please try again.");
+        setBusy(false);
         return;
       }
-      // Back into the connect flow — top-level navigation escapes the admin
-      // iframe (a relative redirect would only move the iframe itself).
-      const connectUrl = `/shopify/connect?shop=${encodeURIComponent(state.ctx.shop)}&reconnect=1`;
-      (window.top ?? window).location.href = connectUrl;
+      // Stay in the app — refresh context so this page re-renders to the
+      // in-app Commerce Disconnected state. No redirect into OAuth.
+      setModalStep("closed");
+      setBusy(false);
+      void refresh();
     } catch {
-      setDisconnectError("Network error disconnecting.");
-      setDisconnecting(false);
+      setActionError("Network error disconnecting.");
+      setBusy(false);
     }
-  }, [state]);
+  }, [reason, details, refresh]);
 
-  // ── Render states ────────────────────────────────────────────────────────
+  // ── Render states ──────────────────────────────────────────────────────────
 
-  if (state.status === "loading") return <SettingsSkeleton />;
+  if (loading && !ctx) return <SettingsSkeleton />;
 
-  if (state.status === "error") {
+  if (!ctx) {
     return (
       <Page title="Settings">
         <Banner tone="critical" title="Could not load settings">
-          <Text as="p" variant="bodyMd">{state.message}</Text>
+          <Text as="p" variant="bodyMd">
+            Couldn&rsquo;t get a Shopify session. Please reopen Peakhour from your Shopify admin.
+          </Text>
         </Banner>
       </Page>
     );
   }
 
-  const { ctx } = state;
+  if (flash === "downgraded") {
+    return <GrowthNetworkWelcome onDismiss={() => setFlash(null)} />;
+  }
 
   if (!ctx.connected) {
-    const connectUrl = ctx.shop
-      ? `/shopify/connect?shop=${encodeURIComponent(ctx.shop)}&reconnect=1`
-      : "/shopify/connect";
+    // Disconnected (or never linked) — one consistent, no-dead-end state.
     return (
-      <Page title="Settings">
-        <EmptyState
-          heading="Link your Peakhour account"
-          action={{
-            content: "Set up Peakhour Commerce",
-            onAction: () => { (window.top ?? window).location.href = connectUrl; },
-          }}
-          image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
-        >
-          <Text as="p" variant="bodyMd">
-            {ctx.shop ? `${ctx.shop} isn't` : "This store isn't"} linked to a Peakhour account
-            yet. Finish setup to manage your store settings here.
-          </Text>
-        </EmptyState>
-      </Page>
+      <CommerceDisconnected
+        shop={shop}
+        pageTitle="Settings"
+        heading={ctx.status === "disconnected" ? "Commerce Disconnected" : "Set up Peakhour Commerce"}
+      />
     );
   }
 
   const storeName = ctx.storeName || ctx.shop;
+  const hasPaid = Boolean(ctx.assistantActive);
 
   return (
     <Page title="Settings" subtitle={storeName}>
@@ -314,22 +349,19 @@ export default function SettingsPage() {
           </BlockStack>
         </Card>
 
-        {/* ── Card 3 — Danger zone ────────────────────────────────────── */}
+        {/* ── Card 3 — Disconnect ─────────────────────────────────────── */}
         <Card>
           <BlockStack gap="400">
-            <Text as="h2" variant="headingMd">Danger zone</Text>
+            <Text as="h2" variant="headingMd">Disconnect</Text>
             <Divider />
-            <Banner tone="critical" title="Disconnect this store">
-              <Text as="p" variant="bodyMd">
-                Disconnecting unlinks {ctx.shop} from your Peakhour account and cancels any
-                active Commerce Assistant subscription. Your product catalog is preserved
-                and you can reconnect at any time.
-              </Text>
-            </Banner>
+            <Text as="p" variant="bodyMd" tone="subdued">
+              Want to step back from paid Commerce? You can downgrade to the free plan and keep your
+              store connected, or disconnect {ctx.shop} completely. Either way, your catalog is
+              preserved and you can come back any time.
+            </Text>
             <Box>
               <Button
-                onClick={() => { setDisconnectError(null); setModalOpen(true); }}
-                variant="primary"
+                onClick={() => { setActionError(null); setModalStep("confirm"); }}
                 tone="critical"
               >
                 Disconnect store
@@ -339,39 +371,89 @@ export default function SettingsPage() {
         </Card>
       </BlockStack>
 
-      {/* ── Disconnect confirmation ───────────────────────────────────── */}
+      {/* ── "Before You Leave" confirmation ───────────────────────────── */}
       <Modal
-        open={modalOpen}
-        onClose={() => { if (!disconnecting) setModalOpen(false); }}
-        title="Disconnect store?"
+        open={modalStep === "confirm"}
+        onClose={closeModal}
+        title="Before you leave…"
         primaryAction={{
-          content: "Disconnect",
-          destructive: true,
-          loading: disconnecting,
-          onAction: handleDisconnect,
+          content: hasPaid ? "Continue on Free Plan" : "Keep store connected",
+          loading: busy,
+          onAction: hasPaid ? continueOnFree : closeModal,
         }}
         secondaryActions={[
           {
-            content: "Cancel",
-            disabled: disconnecting,
-            onAction: () => setModalOpen(false),
+            content: "Disconnect completely",
+            destructive: true,
+            disabled: busy,
+            onAction: () => { setActionError(null); setModalStep("reason"); },
           },
+          { content: "Cancel", disabled: busy, onAction: closeModal },
         ]}
       >
         <Modal.Section>
           <BlockStack gap="300">
-            {/* Error must render INSIDE the modal — a banner in the card behind
-                the overlay would be invisible while the modal is open. */}
-            {disconnectError && (
+            {actionError && (
               <Banner tone="critical">
-                <Text as="p" variant="bodyMd">{disconnectError}</Text>
+                <Text as="p" variant="bodyMd">{actionError}</Text>
+              </Banner>
+            )}
+            <Text as="p" variant="bodyMd">Disconnecting Shopify will:</Text>
+            <List>
+              <List.Item>Disable the Commerce Assistant</List.Item>
+              <List.Item>Stop catalog syncing</List.Item>
+              <List.Item>Remove Commerce Insights</List.Item>
+              <List.Item>Pause AI-powered recommendations</List.Item>
+            </List>
+            <Text as="p" variant="bodyMd">
+              {hasPaid
+                ? "You can stay on Peakhour's free Growth Network at no cost — keep your store connected and drop the paid Commerce Assistant."
+                : "You can keep your store connected on the free plan and continue using the Growth Network at no cost."}
+            </Text>
+          </BlockStack>
+        </Modal.Section>
+      </Modal>
+
+      {/* ── Churn reason step (skippable) ─────────────────────────────── */}
+      <Modal
+        open={modalStep === "reason"}
+        onClose={closeModal}
+        title="Disconnect completely?"
+        primaryAction={{
+          content: "Disconnect completely",
+          destructive: true,
+          loading: busy,
+          onAction: disconnectCompletely,
+        }}
+        secondaryActions={[
+          { content: "Back", disabled: busy, onAction: () => { setActionError(null); setModalStep("confirm"); } },
+        ]}
+      >
+        <Modal.Section>
+          <BlockStack gap="300">
+            {actionError && (
+              <Banner tone="critical">
+                <Text as="p" variant="bodyMd">{actionError}</Text>
               </Banner>
             )}
             <Text as="p" variant="bodyMd">
-              This will disconnect {ctx.shop} from Peakhour and cancel any active Commerce
-              Assistant subscription. Your product catalog will be preserved. You can
-              reconnect at any time.
+              This unlinks {ctx.shop} and cancels any active Commerce Assistant subscription. Your
+              product catalog is preserved and you can reconnect at any time.
             </Text>
+            <ChoiceList
+              title="Why are you leaving? (optional)"
+              choices={REASON_CHOICES}
+              selected={reason}
+              onChange={setReason}
+            />
+            <TextField
+              label="Anything else? (optional)"
+              value={details}
+              onChange={setDetails}
+              autoComplete="off"
+              multiline={2}
+              maxLength={2000}
+            />
           </BlockStack>
         </Modal.Section>
       </Modal>

--- a/src/app/(commerce)/shopify/embedded/subscription/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/subscription/page.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   BlockStack,
   InlineStack,
+  InlineGrid,
   Text,
   Button,
   ButtonGroup,
@@ -65,11 +66,26 @@ const FEATURE_LABELS: Record<string, string> = {
   "commerce.whatsapp": "WhatsApp shopping channel",
   "commerce.in_app_assistant": "In-app product assistant",
   "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
-  "commerce.insights_network": "Insights Network access",
+  "commerce.insights_network": "Growth Network access",
 };
 
 function featureLabel(key: string): string {
   return FEATURE_LABELS[key] ?? key;
+}
+
+/** Annual savings computed from the tier's monthly/yearly prices (integer
+ *  cents) — replaces the hardcoded "2 months free" claim. Returns null when
+ *  there's no real annual discount to show. */
+function annualSavings(t?: PlanTier): { monthsFree: number; pct: number } | null {
+  const m = t?.pricing?.monthly;
+  const y = t?.pricing?.yearly;
+  if (!m || !y || y <= 0) return null;
+  const fullYear = m * 12;
+  if (y >= fullYear) return null;
+  return {
+    monthsFree: Math.round((fullYear - y) / m),
+    pct: Math.round(((fullYear - y) / fullYear) * 100),
+  };
 }
 
 function priceLabel(pricing: ContextData["pricing"], interval: "monthly" | "annual"): string | null {
@@ -252,6 +268,7 @@ export default function SubscriptionPage() {
   const trialDays = ctx?.pricing?.trialDays ?? 0;
   const lensTier = tiers.find((t) => t.key === "commerce_assistant.lens");
   const commerceTier = tiers.find((t) => t.key === "commerce_assistant.commerce");
+  const savings = annualSavings(commerceTier);
 
   // ── Active ───────────────────────────────────────────────────────────────
 
@@ -366,74 +383,58 @@ export default function SubscriptionPage() {
           </Text>
         </BlockStack>
 
-        {/* Tier comparison cards */}
+        {/* Tier comparison — two equal-height cards side by side */}
         {tiers.length > 0 ? (
-          <BlockStack gap="400">
-            {/* Lens — free, current */}
+          <InlineGrid columns={{ xs: 1, md: 2 }} gap="400">
+            {/* Free tier — current */}
             {lensTier && (
               <Card>
                 <BlockStack gap="400">
-                  <InlineStack align="space-between" blockAlign="start">
-                    <BlockStack gap="100">
+                  <BlockStack gap="100">
+                    <InlineStack align="space-between" blockAlign="center">
                       <Text as="h3" variant="headingMd">{lensTier.name}</Text>
-                      {lensTier.tagline && (
-                        <Text as="p" variant="bodySm" tone="subdued">{lensTier.tagline}</Text>
-                      )}
-                    </BlockStack>
-                    <BlockStack gap="100" inlineAlign="end">
-                      <Text as="p" variant="headingLg" fontWeight="bold">Free</Text>
-                      <Badge>Included</Badge>
-                    </BlockStack>
-                  </InlineStack>
+                      <Badge>Current plan</Badge>
+                    </InlineStack>
+                    {lensTier.tagline && (
+                      <Text as="p" variant="bodySm" tone="subdued">{lensTier.tagline}</Text>
+                    )}
+                  </BlockStack>
+                  <Text as="p" variant="heading2xl" fontWeight="bold">Free</Text>
+                  <Divider />
                   {lensTier.features.length > 0 && (
                     <BlockStack gap="200">
                       {lensTier.features.map((f) => (
-                        <InlineStack key={f} gap="200" blockAlign="center">
+                        <InlineStack key={f} gap="200" blockAlign="center" wrap={false}>
                           <Icon source={CheckCircleIcon} tone="base" />
                           <Text as="span" variant="bodySm">{featureLabel(f)}</Text>
                         </InlineStack>
                       ))}
                     </BlockStack>
                   )}
+                  <Button url="/shopify/embedded/pin" fullWidth size="large" variant="secondary">
+                    Start Free
+                  </Button>
                 </BlockStack>
               </Card>
             )}
 
-            {/* Peakhour Commerce — paid */}
+            {/* Paid tier — recommended */}
             {commerceTier && (
               <Card>
                 <BlockStack gap="400">
-                  <InlineStack align="space-between" blockAlign="start">
-                    <BlockStack gap="100">
+                  <BlockStack gap="100">
+                    <InlineStack align="space-between" blockAlign="center">
                       <Text as="h3" variant="headingMd">{commerceTier.name}</Text>
-                      {commerceTier.tagline && (
-                        <Text as="p" variant="bodySm" tone="subdued">{commerceTier.tagline}</Text>
-                      )}
-                    </BlockStack>
-                    <BlockStack gap="100" inlineAlign="end">
-                      {label ? (
-                        <>
-                          <Text as="p" variant="headingLg" fontWeight="bold">{label}</Text>
-                          <Badge tone="info">Recommended</Badge>
-                        </>
-                      ) : (
-                        <Badge tone="info">Recommended</Badge>
-                      )}
-                    </BlockStack>
-                  </InlineStack>
+                      <Badge tone="success">Most popular</Badge>
+                    </InlineStack>
+                    {commerceTier.tagline && (
+                      <Text as="p" variant="bodySm" tone="subdued">{commerceTier.tagline}</Text>
+                    )}
+                  </BlockStack>
 
-                  {commerceTier.features.length > 0 && (
-                    <BlockStack gap="200">
-                      {commerceTier.features.map((f) => (
-                        <InlineStack key={f} gap="200" blockAlign="center">
-                          <Icon source={CheckCircleIcon} tone="success" />
-                          <Text as="span" variant="bodySm">{featureLabel(f)}</Text>
-                        </InlineStack>
-                      ))}
-                    </BlockStack>
+                  {label && (
+                    <Text as="p" variant="heading2xl" fontWeight="bold">{label}</Text>
                   )}
-
-                  <Divider />
 
                   {hasAnnual && (
                     <ButtonGroup variant="segmented">
@@ -441,7 +442,9 @@ export default function SubscriptionPage() {
                         Monthly
                       </Button>
                       <Button pressed={billingInterval === "annual"} onClick={() => setBillingInterval("annual")}>
-                        Annual — 2 months free
+                        {savings
+                          ? `Annual — ${savings.monthsFree > 0 ? `${savings.monthsFree} months free` : `save ${savings.pct}%`}`
+                          : "Annual"}
                       </Button>
                     </ButtonGroup>
                   )}
@@ -450,6 +453,18 @@ export default function SubscriptionPage() {
                     <Text as="p" variant="bodySm" tone="subdued">
                       {trialDays}-day free trial — billing starts when the trial ends.
                     </Text>
+                  )}
+
+                  <Divider />
+                  {commerceTier.features.length > 0 && (
+                    <BlockStack gap="200">
+                      {commerceTier.features.map((f) => (
+                        <InlineStack key={f} gap="200" blockAlign="center" wrap={false}>
+                          <Icon source={CheckCircleIcon} tone="success" />
+                          <Text as="span" variant="bodySm">{featureLabel(f)}</Text>
+                        </InlineStack>
+                      ))}
+                    </BlockStack>
                   )}
 
                   {subError && (
@@ -463,15 +478,14 @@ export default function SubscriptionPage() {
                     loading={subscribing}
                     variant="primary"
                     size="large"
+                    fullWidth
                   >
-                    {trialDays > 0
-                      ? `Start ${trialDays}-day free trial`
-                      : "Subscribe to Peakhour Commerce"}
+                    {trialDays > 0 ? `Start ${trialDays}-day free trial` : "Upgrade"}
                   </Button>
                 </BlockStack>
               </Card>
             )}
-          </BlockStack>
+          </InlineGrid>
         ) : (
           /* Fallback when pricing endpoint returned no tiers (network issue) */
           <Card>
@@ -488,7 +502,9 @@ export default function SubscriptionPage() {
                     Monthly
                   </Button>
                   <Button pressed={billingInterval === "annual"} onClick={() => setBillingInterval("annual")}>
-                    Annual — 2 months free
+                    {savings
+                      ? `Annual — ${savings.monthsFree > 0 ? `${savings.monthsFree} months free` : `save ${savings.pct}%`}`
+                      : "Annual"}
                   </Button>
                 </ButtonGroup>
               )}


### PR DESCRIPTION
## Summary
Frontend of the Shopify Disconnect Experience Redesign. Pairs with the merged backend (peakhour-api #566 + peakhour-mongodb #246). All Polaris.

Fixes the blank-screen-after-disconnect, stale state, and no-retention-off-ramp problems, and repositions the free experience as a destination.

- **No more blank screen:** disconnect no longer `window.top`-redirects into OAuth. A shared `CommerceDisconnected` setup/recovery state renders **in place** (Home, Settings, Catalog, Growth Network) — always a next action (Reconnect Shopify / Explore Growth Network). (§1, §2, §10)
- **Shared context + persistent banner:** `EmbeddedContextProvider` fetches `/embedded/context` once for the shell and exposes `refresh()`; a persistent reconnect Banner shows on every page while `status === "disconnected"` (never on a fresh install). (§11)
- **"Before you leave…" modal (Settings):** Continue on Free Plan (cancels paid, keeps store connected → Growth Network welcome), Disconnect Completely (churn-reason step → `DELETE` with `{reason,details}` → in-app disconnected state), Cancel. (§7, §8, §9)
- **Growth Network:** Insights Network rebranded and positioned as a free community destination ("Join Free Community Now"), not a Commerce blocker. (§4)
- **Subscription cards:** two equal-height `InlineGrid` cards, Most-popular badge, full-width Start Free / Upgrade, **computed** annual savings (replaces hardcoded "2 months free"). Plan names stay CMS-driven. (§5, §6)

## Test plan
- `tsc --noEmit` + `eslint` clean.
- Adversarial subagent review: no CRITICAL/HIGH; verified provider-ancestor safety, refresh→re-render flow, loading/error guards, annualSavings math, and all Polaris props against 13.9.5. The one MEDIUM (cancel 404 dead-end on Continue-on-Free) is fixed in this branch.

## Notes
- Polaris-only (App Store requirement); "premium" delivered via consistent cards/badges/EmptyState, not custom CSS animation.
- A disconnected store briefly shows both the shell banner and the in-page disconnected state (redundant but not broken) — acceptable per the persistent-banner requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)