### PR TITLE
fix(shopify): rewrite embedded app entry onto /shopify/embedded

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,12 +11,6 @@ const apiOrigin = (() => {
   }
 })();
 
-/**
- * Build the per-request CSP + the request headers that carry the nonce (so
- * Next.js can stamp it onto framework `<script>` tags for 'strict-dynamic').
- * Only needed for full-document requests — prefetch/rsc/server-action requests
- * deliberately get no nonce/CSP (it can break RSC streaming).
- */
 /** The embedded Shopify surface must be iframeable by Shopify admin and load
  *  App Bridge from Shopify's CDN — so those routes get a distinct CSP. Every
  *  other route keeps `frame-ancestors 'none'`. */
@@ -49,6 +43,14 @@ function isShopifyEmbeddedEntry(req: NextRequest): boolean {
   return searchParams.has("host") && searchParams.has("embedded");
 }
 
+/**
+ * Build the per-request CSP + the request headers that carry the nonce (so
+ * Next.js can stamp it onto framework `<script>` tags for 'strict-dynamic').
+ * Only needed for full-document requests — prefetch/rsc/server-action requests
+ * deliberately get no nonce/CSP (it can break RSC streaming). `forceEmbedded`
+ * applies the embedded (iframeable + Shopify-CDN) CSP to a request whose path
+ * isn't under /shopify — used for the rewritten embedded entry load.
+ */
 function buildCsp(
   req: NextRequest,
   forceEmbedded = false,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,12 +33,34 @@ function isShopifyPath(pathname: string): boolean {
   return pathname === "/shopify" || pathname.startsWith("/shopify/");
 }
 
-function buildCsp(req: NextRequest): { csp: string; reqHeaders: Headers } {
+/** Shopify iframes the embedded app at the app's `application_url`, which has
+ *  NO path (it's the bare b2c host) — so a fresh open / refresh / search-launch
+ *  lands the iframe on `/?host=…&embedded=1`, i.e. the marketing root. That
+ *  root carries `frame-ancestors 'none'` (+ vercel.json `X-Frame-Options:
+ *  DENY`), so Shopify admin shows "refused to connect" on every open that
+ *  isn't a live in-app client navigation. The embedded UI actually lives under
+ *  /shopify/embedded, so detect this entry load (Shopify always passes `host`
+ *  + `embedded`) and rewrite it onto the embedded surface with the embedded
+ *  CSP — preserving the query so App Bridge can still read `host`. Live in-app
+ *  paths (already under /shopify) reload directly and need no rewrite. */
+function isShopifyEmbeddedEntry(req: NextRequest): boolean {
+  const { pathname, searchParams } = req.nextUrl;
+  if (isShopifyPath(pathname)) return false;
+  return searchParams.has("host") && searchParams.has("embedded");
+}
+
+function buildCsp(
+  req: NextRequest,
+  forceEmbedded = false,
+): { csp: string; reqHeaders: Headers } {
   const nonce = btoa(
     String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))),
   );
-  const embedded = isShopifyEmbeddedPath(req.nextUrl.pathname);
-  const shopify = isShopifyPath(req.nextUrl.pathname);
+  const embedded = forceEmbedded || isShopifyEmbeddedPath(req.nextUrl.pathname);
+  // The rewritten embedded entry must also receive the Shopify-CDN script /
+  // connect allowances (App Bridge loads from cdn.shopify.com), so treat a
+  // forced-embedded request as part of the /shopify surface too.
+  const shopify = forceEmbedded || isShopifyPath(req.nextUrl.pathname);
 
   // WhatsApp Embedded Signup: AFTER the merchant logs in, the Facebook JS SDK
   // executes a PARSER-INSERTED INLINE <script> in our page to process the
@@ -190,8 +212,12 @@ export function middleware(req: NextRequest) {
   const sessionBypass = hasSession && isAppRoute;
   // The embedded Shopify surface is loaded by Shopify admin (iframe) and
   // authenticates via the App Bridge session token, not our cookie — so it
-  // must stay reachable even while the coming-soon gate is on.
-  const isShopifyEmbedded = isShopifyEmbeddedPath(pathname);
+  // must stay reachable even while the coming-soon gate is on. This includes
+  // the entry load (root `/?host=…&embedded=1`) we rewrite onto the embedded
+  // surface below — without exempting it, the coming-soon gate would rewrite
+  // it to /coming-soon and the iframe would still never reach the app.
+  const embeddedEntry = isShopifyEmbeddedEntry(req);
+  const isShopifyEmbedded = isShopifyEmbeddedPath(pathname) || embeddedEntry;
   const gated =
     comingSoon &&
     pathname !== "/coming-soon" &&
@@ -211,6 +237,20 @@ export function middleware(req: NextRequest) {
     } else {
       // Full-document gated request → carry the nonce so the teaser HTML matches.
       const { csp, reqHeaders } = buildCsp(req);
+      res = NextResponse.rewrite(url, { request: { headers: reqHeaders } });
+      res.headers.set("Content-Security-Policy", csp);
+    }
+  } else if (embeddedEntry) {
+    // Shopify framed us at the bare app root — rewrite onto the embedded
+    // surface so the iframe loads the real app (frameable, App Bridge-ready)
+    // instead of the un-frameable marketing root. The browser URL is unchanged
+    // by the rewrite, so App Bridge still reads `host` from `/?host=…`.
+    const url = req.nextUrl.clone();
+    url.pathname = "/shopify/embedded";
+    if (isPassthrough) {
+      res = NextResponse.rewrite(url);
+    } else {
+      const { csp, reqHeaders } = buildCsp(req, true);
       res = NextResponse.rewrite(url, { request: { headers: reqHeaders } });
       res.headers.set("Content-Security-Policy", csp);
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,17 +30,26 @@ function isShopifyPath(pathname: string): boolean {
 /** Shopify iframes the embedded app at the app's `application_url`, which has
  *  NO path (it's the bare b2c host) — so a fresh open / refresh / search-launch
  *  lands the iframe on `/?host=…&embedded=1`, i.e. the marketing root. That
- *  root carries `frame-ancestors 'none'` (+ vercel.json `X-Frame-Options:
- *  DENY`), so Shopify admin shows "refused to connect" on every open that
- *  isn't a live in-app client navigation. The embedded UI actually lives under
- *  /shopify/embedded, so detect this entry load (Shopify always passes `host`
- *  + `embedded`) and rewrite it onto the embedded surface with the embedded
- *  CSP — preserving the query so App Bridge can still read `host`. Live in-app
- *  paths (already under /shopify) reload directly and need no rewrite. */
+ *  root carries `frame-ancestors 'none'` (+ vercel.json's global
+ *  `X-Frame-Options: DENY`, which `frame-ancestors` overrides in modern
+ *  browsers — that's why the direct /shopify/embedded surface already frames),
+ *  so Shopify admin shows "refused to connect" on every open that isn't a live
+ *  in-app client navigation. The embedded UI actually lives under
+ *  /shopify/embedded, so detect this entry load and rewrite it onto the
+ *  embedded surface with the embedded CSP — preserving the query so App Bridge
+ *  can still read `host`.
+ *
+ *  Scoped strictly to the ROOT path: Shopify's application_url is the bare
+ *  host, so the entry is always `/`; any deeper in-app reload resolves to
+ *  /shopify/embedded/* (already frameable, no rewrite). Keying on root +
+ *  Shopify's `embedded=1` + `host` (rather than just "has both params") avoids
+ *  hijacking unrelated pages that happen to carry generic `host`/`embedded`
+ *  query params (e.g. /privacy-policy?host=…&embedded=…), which would defeat
+ *  the PUBLIC_PATHS guarantee below. */
 function isShopifyEmbeddedEntry(req: NextRequest): boolean {
   const { pathname, searchParams } = req.nextUrl;
-  if (isShopifyPath(pathname)) return false;
-  return searchParams.has("host") && searchParams.has("embedded");
+  if (pathname !== "/") return false;
+  return searchParams.get("embedded") === "1" && searchParams.has("host");
 }
 
 /**


### PR DESCRIPTION
## Problem

After disconnecting Peakhour from Shopify, refreshing the embedded app page in Shopify admin shows **"dev.peakhour.ai refused to connect"** instead of the Reconnect surface.

Root cause is **not** the reconnect code — it's the embedded app's iframe entry point. The Shopify app's `application_url` is the bare b2c host `https://dev.peakhour.ai` (no path). So when Shopify (re)loads the app iframe — on a refresh, a fresh open, or a search-launch (the screenshot URL is the bare `/apps/peakhour-ai?link_source=search`, no in-app subpath) — it loads `https://dev.peakhour.ai/?host=…&embedded=1`, i.e. the **marketing root**.

That root is not an embedded path, so middleware gives it `frame-ancestors 'none'` and `vercel.json` layers `X-Frame-Options: DENY` → the browser refuses to frame it. The Reconnect button only appeared to work because the embedded SPA was already live at `/shopify/embedded`; a refresh reloads the iframe from the app root and fails. The embedded UI only ever survives a reload when the live in-app client path (`/shopify/embedded/*`) is preserved in the admin URL.

## Fix

Detect the embedded **entry** load in `src/middleware.ts` (request not already under `/shopify`, carrying Shopify's `host` + `embedded` query params) and **rewrite** it onto `/shopify/embedded` with the embedded CSP (`frame-ancestors https://admin.shopify.com …` + `cdn.shopify.com` script/connect allowances). The rewrite is internal, so the browser URL stays `/?host=…` and App Bridge can still read `host`. The entry is also exempted from the coming-soon gate (so prod, gated by `COMING_SOON`, doesn't rewrite it to the teaser).

Live in-app paths (`/shopify/embedded/*`) reload directly and are untouched.

## Why this is safe
- Functionally identical to a direct `/shopify/embedded` load — same `(commerce)` root layout (loads App Bridge first-in-`<head>`), same CSP/nonce plumbing.
- No false positives: nothing else in the app emits `?host=…&embedded=…` (grep-verified). A crafted external hit just lands on the embedded shell and shows the "open from your Shopify admin" message — no auth bypass (embedded auth is via App Bridge session token).
- Loop-proof: the rewrite target `/shopify/embedded` short-circuits `isShopifyEmbeddedEntry`.
- The global `X-Frame-Options: DENY` is already overridden by `frame-ancestors` on the embedded surface in modern browsers — the connected embedded view renders in the admin iframe today with the same header present.

## Review
- TypeScript: clean. ESLint: clean.
- Manual + subagent review (round 1) — confirmed correct on URL preservation, false-positive risk, gate ordering, loop safety, forced-embedded CSP, passthrough handling, and multiple-root-layout rendering. One pre-existing doc-drift fixed in a separate commit.

## Note (no code change)
The deploy-time root cause is `application_url` being the bare host. This PR fixes it in code (no `shopify app deploy` needed). Pointing `application_url` at `/shopify/embedded` in the toml is an alternative but risks App Bridge deep-link double-prefixing, so this middleware approach was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)