### PR TITLE
fix(shopify): make embedded Reconnect escape with an absolute URL

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_lib/context.tsx
+++ b/src/app/(commerce)/shopify/embedded/_lib/context.tsx
@@ -110,9 +110,19 @@ export function useEmbeddedContext(): EmbeddedContextValue {
   return v;
 }
 
-/** The top-level connect URL that re-runs OAuth. Used by every Reconnect CTA. */
+/** The top-level connect URL that re-runs OAuth. Used by every Reconnect CTA.
+ *  Returns an ABSOLUTE URL (origin + path) on purpose: the CTAs assign it to
+ *  `window.top.location.href` to escape the Shopify admin iframe, and a
+ *  RELATIVE path assigned to the cross-origin top window doesn't reliably
+ *  resolve against our origin — it resolves against the admin origin (or stays
+ *  in-frame), so Shopify shows "<host> refused to connect". An absolute URL
+ *  escapes cleanly to the connect flow (→ OAuth → the Peakhour dashboard), the
+ *  same way the billing `confirmationUrl` top-redirect already works. SSR has
+ *  no `window`, but these CTAs only fire from client click handlers. */
 export function reconnectUrl(shop?: string | null): string {
-  return shop
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const path = shop
     ? `/shopify/connect?shop=${encodeURIComponent(shop)}&reconnect=1`
     : "/shopify/connect";
+  return `${origin}${path}`;
 }

--- a/src/app/(commerce)/shopify/embedded/_lib/context.tsx
+++ b/src/app/(commerce)/shopify/embedded/_lib/context.tsx
@@ -112,13 +112,16 @@ export function useEmbeddedContext(): EmbeddedContextValue {
 
 /** The top-level connect URL that re-runs OAuth. Used by every Reconnect CTA.
  *  Returns an ABSOLUTE URL (origin + path) on purpose: the CTAs assign it to
- *  `window.top.location.href` to escape the Shopify admin iframe, and a
- *  RELATIVE path assigned to the cross-origin top window doesn't reliably
- *  resolve against our origin — it resolves against the admin origin (or stays
- *  in-frame), so Shopify shows "<host> refused to connect". An absolute URL
- *  escapes cleanly to the connect flow (→ OAuth → the Peakhour dashboard), the
- *  same way the billing `confirmationUrl` top-redirect already works. SSR has
- *  no `window`, but these CTAs only fire from client click handlers. */
+ *  `window.top.location.href` to escape the Shopify admin iframe. A RELATIVE
+ *  path is resolved by the Location setter against the TARGET document's base
+ *  URL — and `window.top` is the cross-origin admin document — so
+ *  `/shopify/connect` becomes `https://admin.shopify.com/shopify/connect`
+ *  (never our origin), which dead-ends in admin and surfaces as
+ *  "<host> refused to connect". An absolute URL navigates the top window to
+ *  OUR origin, escaping the iframe cleanly to the connect flow (→ OAuth → the
+ *  Peakhour dashboard) — the same pattern the billing `confirmationUrl`
+ *  top-redirect already uses. SSR has no `window`, but these CTAs only fire
+ *  from client click handlers. */
 export function reconnectUrl(shop?: string | null): string {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const path = shop

--- a/src/app/(commerce)/shopify/embedded/assistant/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/assistant/page.tsx
@@ -17,6 +17,7 @@ import {
   Spinner,
 } from "@shopify/polaris";
 import { getSessionToken } from "../_lib/session";
+import { reconnectUrl } from "../_lib/context";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
@@ -159,7 +160,7 @@ export default function AssistantPage() {
               <Box>
                 <Button
                   onClick={() => {
-                    (window.top ?? window).location.href = "/shopify/connect";
+                    (window.top ?? window).location.href = reconnectUrl();
                   }}
                 >
                   Set up Peakhour Commerce

--- a/src/app/(commerce)/shopify/embedded/integrations/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/integrations/page.tsx
@@ -17,6 +17,7 @@ import {
   SkeletonDisplayText,
 } from "@shopify/polaris";
 import { getSessionToken } from "../_lib/session";
+import { reconnectUrl } from "../_lib/context";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
@@ -166,7 +167,7 @@ export default function IntegrationsPage() {
                 <Box>
                   <Button
                     onClick={() => {
-                      (window.top ?? window).location.href = "/shopify/connect";
+                      (window.top ?? window).location.href = reconnectUrl();
                     }}
                   >
                     Set up Peakhour Commerce


### PR DESCRIPTION
## Problem

In the embedded Shopify app, clicking **Reconnect Shopify** (or the persistent reconnect banner) showed **"dev.peakhour.ai refused to connect"** instead of escaping the admin iframe to the connect/OAuth flow.

The Reconnect CTAs break out of the iframe via `(window.top ?? window).location.href = reconnectUrl(shop)`. But `reconnectUrl()` returned a **relative** path (`/shopify/connect?…`). The `Location` setter resolves a relative URL against the **target** document's base URL — and `window.top` is the cross-origin **admin.shopify.com** document — so it became `https://admin.shopify.com/shopify/connect`, which dead-ends in admin and surfaces as the refusal. It never reached our origin.

The working billing **Subscribe** escape uses the identical `window.top.location.href` assignment but with an **absolute** `confirmationUrl` — which is exactly why it works. The only difference was relative vs absolute.

## Fix

Make `reconnectUrl()` return an **absolute** URL (`window.location.origin + path`). The top-window navigation now goes to **our** origin, escaping the iframe cleanly: `/shopify/connect` → OAuth → the Peakhour dashboard (`/dashboard/settings`), as expected.

Also routed the two sibling "Set up Peakhour Commerce" buttons (Integrations + Assistant not-linked states) through `reconnectUrl()` — they had the identical relative-`window.top` bug (latent).

## Why it's safe / verified
- App Bridge top-navigation is **not** required: the existing billing escape (same `window.top` + absolute URL) proves absolute top-navigation works in the admin iframe.
- `window.location.origin` inside the iframe is always the b2c host (Shopify frames our document; it doesn't proxy it) — never the admin origin.
- No regression on the sibling buttons: they previously navigated to a bare relative `/shopify/connect` (no shop); they still pass no shop, and the wizard degrades gracefully to a friendly message. They're now simply fixed to escape correctly.
- `reconnectUrl` is SSR-guarded and only called from client click handlers.

## Out of scope (follow-up)
`billing/return/page.tsx` has the same relative-`window.top` pattern (→ `/shopify/embedded`), but its correct fix differs: that page loads **top-level** after billing approval, so it needs the Shopify admin **deep link** to re-enter the iframe (an absolute peakhour URL would load standalone, where App Bridge can't initialize). Tracked separately.

## Review
- TypeScript + ESLint clean.
- Manual + subagent review (round 1); subagent independently confirmed the absolute-URL fix resolves the refusal and App Bridge isn't required. One doc-accuracy fix applied in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)