### PR TITLE
fix(shopify): return into embedded admin after billing approval

### DIFF
--- a/src/app/(commerce)/shopify/embedded/billing/return/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/billing/return/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   Page,
   Card,
@@ -18,127 +19,109 @@ import { getSessionToken } from "../../_lib/session";
  * Shopify Billing return page (SB-2d).
  *
  * After the merchant approves the charge on Shopify's hosted billing page,
- * Shopify redirects here (the app's `returnUrl`). We get a fresh App Bridge
- * session token, call `billing/confirm` to reconcile the subscription and
- * grant the `commerce.assistant` entitlement, then redirect home.
+ * Shopify redirects the TOP window to our `returnUrl` — so this page loads
+ * STANDALONE (the whole tab is on our host, NOT inside the admin iframe),
+ * where App Bridge can't mint a session token (`idToken()` never resolves
+ * outside admin — see _lib/session.ts). The `commerce.assistant` entitlement
+ * is granted server-side by the `app_subscriptions/update` webhook (SB-2b), so
+ * this page's job is NOT to reconcile here — it's to return the merchant into
+ * the embedded app INSIDE Shopify admin (where the now-active subscription
+ * shows). We bounce to the admin app deep link built from the shop + the
+ * public API key. A best-effort confirm runs first in case we ever DO load
+ * in-frame (a working token), but it never blocks the bounce.
+ *
+ * (Previously this page tried to confirm via App Bridge and then did
+ * `window.top.location.href = "/shopify/embedded"` — both broken standalone:
+ * confirm failed for lack of a token, and the relative top-redirect resolved
+ * against the admin origin. Hence merchants were stranded post-payment.)
  */
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+const SHOPIFY_API_KEY = process.env.NEXT_PUBLIC_SHOPIFY_API_KEY ?? "";
 
-type State =
-  | { status: "confirming" }
-  | { status: "active" }
-  | { status: "inactive" }
-  | { status: "error"; message: string };
+/** The Shopify-admin deep link that re-opens our embedded app for this store,
+ *  built from the shop (→ store handle) + the public API key (= client id).
+ *  App Bridge then initializes inside admin and the embedded surface can
+ *  authenticate. Falls back to the (standalone) Peakhour dashboard if we can't
+ *  build a deep link (missing shop or API key) — a relative path, which
+ *  resolves against our own origin on this top-level page. */
+function adminAppUrl(shop: string): string {
+  const handle = shop.replace(/\.myshopify\.com$/, "");
+  if (handle && SHOPIFY_API_KEY) {
+    return `https://admin.shopify.com/store/${handle}/apps/${SHOPIFY_API_KEY}`;
+  }
+  return "/dashboard";
+}
 
-export default function ShopifyBillingReturn() {
-  const [state, setState] = useState<State>({ status: "confirming" });
+function ShopifyBillingReturn() {
+  const searchParams = useSearchParams();
+  const dest = adminAppUrl(searchParams.get("shop") ?? "");
+
   useEffect(() => {
+    let cancelled = false;
     const ctrl = new AbortController();
     (async () => {
-      const token = await getSessionToken();
-      if (ctrl.signal.aborted) return;
-      if (!token) {
-        setState({ status: "error", message: "Couldn't confirm — please reopen from your Shopify admin." });
-        return;
-      }
-      try {
-        const res = await fetch(`${API_URL}/v1/shopify/embedded/billing/confirm`, {
-          method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
-          signal: ctrl.signal,
-        });
-        if (ctrl.signal.aborted) return;
-        if (!res.ok) {
-          setState({ status: "error", message: "Couldn't confirm your subscription. Please try again." });
-          return;
+      // Best-effort reconcile ONLY if we happen to have a working App Bridge
+      // token (true only when loaded in-frame). Short timeout so the common
+      // standalone case — where idToken() never resolves — doesn't stall the
+      // return. The webhook is the authoritative grant either way.
+      const token = await getSessionToken(2500);
+      if (cancelled) return;
+      if (token) {
+        try {
+          await fetch(`${API_URL}/v1/shopify/embedded/billing/confirm`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+            signal: ctrl.signal,
+          });
+        } catch {
+          // Non-fatal — the app_subscriptions/update webhook grants the
+          // entitlement; this call is just an immediacy optimisation.
         }
-        const data = (await res.json()) as { active?: boolean };
-        setState({ status: data.active ? "active" : "inactive" });
-      } catch (err) {
-        if ((err as { name?: string }).name === "AbortError") return;
-        setState({ status: "error", message: "Network error confirming your subscription." });
       }
+      if (cancelled) return;
+      // Return the merchant into the embedded app inside Shopify admin.
+      (window.top ?? window).location.href = dest;
     })();
-    return () => ctrl.abort();
-  }, []);
-
-  // Auto-redirect to home 2 s after successful confirmation.
-  // Use window.top navigation — router.replace only navigates the iframe.
-  useEffect(() => {
-    if (state.status !== "active") return;
-    const t = setTimeout(() => { (window.top ?? window).location.href = "/shopify/embedded"; }, 2000);
-    return () => clearTimeout(t);
-  }, [state.status]);
-
-  // ── Confirming ────────────────────────────────────────────────────────────
-
-  if (state.status === "confirming") {
-    return (
-      <SkeletonPage title="Confirming subscription…">
-        <Card>
-          <BlockStack gap="500" inlineAlign="center">
-            <Spinner size="large" />
-            <Text as="p" variant="bodyMd" tone="subdued" alignment="center">
-              Confirming your subscription with Shopify…
-            </Text>
-          </BlockStack>
-        </Card>
-      </SkeletonPage>
-    );
-  }
-
-  // ── Post-confirm states ───────────────────────────────────────────────────
+    return () => {
+      cancelled = true;
+      ctrl.abort();
+    };
+  }, [dest]);
 
   return (
     <Page title="Peakhour Commerce">
       <Card>
         <BlockStack gap="500">
-          {state.status === "active" && (
-            <>
-              <Banner tone="success" title="Commerce Assistant is now active!">
-                <Text as="p" variant="bodyMd">
-                  Your catalog-grounded WhatsApp assistant is live. Redirecting you back…
-                </Text>
-              </Banner>
-              <InlineStack align="start">
-                <Button url="/shopify/embedded" variant="primary">
-                  Back to Peakhour Commerce
-                </Button>
-              </InlineStack>
-            </>
-          )}
-
-          {state.status === "inactive" && (
-            <>
-              <Banner tone="warning" title="Subscription not confirmed yet">
-                <Text as="p" variant="bodyMd">
-                  We couldn&apos;t find an active subscription. If you just approved it, give
-                  it a moment and refresh — or contact support if this persists.
-                </Text>
-              </Banner>
-              <InlineStack align="start">
-                <Button url="/shopify/embedded/subscription" variant="plain">
-                  Back to subscription page
-                </Button>
-              </InlineStack>
-            </>
-          )}
-
-          {state.status === "error" && (
-            <>
-              <Banner tone="critical" title="Something went wrong">
-                <Text as="p" variant="bodyMd">{state.message}</Text>
-              </Banner>
-              <InlineStack align="start">
-                <Button url="/shopify/embedded/subscription" variant="plain">
-                  Back to subscription page
-                </Button>
-              </InlineStack>
-            </>
-          )}
+          <Banner tone="success" title="Subscription confirmed!">
+            <Text as="p" variant="bodyMd">
+              Your Commerce Assistant is being activated. Taking you back to
+              Peakhour in your Shopify admin…
+            </Text>
+          </Banner>
+          <BlockStack gap="300" inlineAlign="center">
+            <Spinner size="small" accessibilityLabel="Returning to Peakhour" />
+          </BlockStack>
+          <InlineStack align="start">
+            {/* Manual fallback — absolute admin deep link, opened at the top
+                level so it escapes any frame and re-enters the admin app. */}
+            <Button url={dest} variant="primary" external>
+              Back to Peakhour Commerce
+            </Button>
+          </InlineStack>
         </BlockStack>
       </Card>
     </Page>
+  );
+}
+
+// useSearchParams() must sit under a Suspense boundary (Next.js build
+// requirement). The page renders instantly then redirects, so the fallback is
+// only a flash.
+export default function ShopifyBillingReturnPage() {
+  return (
+    <Suspense fallback={<SkeletonPage title="Peakhour Commerce" />}>
+      <ShopifyBillingReturn />
+    </Suspense>
   );
 }

--- a/src/app/(commerce)/shopify/embedded/billing/return/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/billing/return/page.tsx
@@ -80,8 +80,10 @@ function ShopifyBillingReturn() {
         }
       }
       if (cancelled) return;
-      // Return the merchant into the embedded app inside Shopify admin.
-      (window.top ?? window).location.href = dest;
+      // Return the merchant into the embedded app inside Shopify admin. Use
+      // replace() so this single-use return page isn't left in back-history
+      // (a Back press would otherwise just re-bounce through here).
+      (window.top ?? window).location.replace(dest);
     })();
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Problem

After a merchant approves the Commerce Assistant charge, Shopify redirects the **top window** to our `returnUrl` (`dev.peakhour.ai/shopify/embedded/billing/return`) — so the billing return page loads **standalone**, outside the admin iframe. There App Bridge can't mint a session token, so the old page's `getSessionToken()`/`confirm` failed, it showed *"Couldn't confirm — please reopen from your Shopify admin"*, and it never even reached its final `window.top.location.href = "/shopify/embedded"` redirect (which was itself broken — a relative URL on the cross-origin top window, the same class of bug as the Reconnect fix in #328). Net result: **merchants were stranded right after paying.**

This is the follow-up flagged in #328.

## Fix

The `commerce.assistant` entitlement is granted server-side by the `app_subscriptions/update` webhook (SB-2b), so the return page's job is simply to **return the merchant into the embedded app inside Shopify admin** — where the now-active subscription shows. It bounces (top-level `location.replace`) to the admin app **deep link**:

```
https://admin.shopify.com/store/{store_handle}/apps/{api_key}
```

built from the `shop` query param + `NEXT_PUBLIC_SHOPIFY_API_KEY` (= the public client_id, already used for the App Bridge meta tag). A best-effort `confirm` still runs first *if* a token is somehow available (i.e. if ever loaded in-frame), but never blocks the bounce. Falls back to `/dashboard` if the deep link can't be built.

## Why it's correct
- Deep-link format verified against Shopify docs: the app path segment is the **api_key** (= client_id), not the app handle — canonical admin app deep link.
- `NEXT_PUBLIC_SHOPIFY_API_KEY` matches `shopify.app.toml` `client_id` and is already exposed to this client surface.
- `useSearchParams()` wrapped in `<Suspense>` (Next build requirement); no setState-in-effect; `dest` resolves identically server/client (no hydration mismatch); `AbortController`/`cancelled` cleanup intact.
- `location.replace` keeps the single-use interstitial out of back-history.

## Known minor: webhook race
There's a brief window where the merchant could land in the app before the webhook grants the entitlement (the authoritative confirm needs a session token that doesn't exist standalone). The copy ("being activated") sets expectations; a stronger follow-up would be for the embedded landing page to poll entitlement on mount — destination-page concern, not this page.

## Review
- TypeScript + ESLint clean.
- Manual + subagent review (round 1); subagent confirmed the deep-link format, env exposure, React/Suspense correctness, and agreed the fix returns the merchant into the working embedded app. One polish item (`location.replace`) applied in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)