### PR TITLE
feat(shopify): subtle Polaris-native motion on the embedded surface

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -111,8 +111,15 @@ export function PolarisShell({ children }: { children: ReactNode }) {
           showMobileNavigation={mobileNavOpen}
           onNavigationDismiss={() => setMobileNavOpen(false)}
         >
+          {/* Persistent banner stays outside the keyed wrapper so it doesn't
+              re-animate on every in-app navigation. */}
           <ReconnectBanner />
-          {children}
+          {/* Keyed by pathname → the entrance animation replays on each
+              client-side navigation, giving a smooth page-to-page transition.
+              Disabled automatically under prefers-reduced-motion (motion.css). */}
+          <div key={pathname} className="ph-fade-in-up">
+            {children}
+          </div>
         </Frame>
       </EmbeddedContextProvider>
     </AppProvider>

--- a/src/app/(commerce)/shopify/embedded/_styles/motion.css
+++ b/src/app/(commerce)/shopify/embedded/_styles/motion.css
@@ -1,0 +1,55 @@
+/*
+ * Subtle, admin-native motion for the embedded Shopify surface.
+ *
+ * Built for Shopify rewards feeling consistent with the admin, so this is
+ * deliberately restrained: GPU-only properties (opacity / transform), no
+ * layout shift, and FULLY disabled under prefers-reduced-motion (a BFS
+ * accessibility expectation). Polaris overlays (Modal / Popover / Tooltip)
+ * portal to <body>, outside these wrappers, so the wrapper transform never
+ * affects their positioning. Class names are `ph-` prefixed to avoid clashes;
+ * this file is scoped to the (commerce) embedded tree via its layout import.
+ */
+
+@keyframes ph-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Page-content entrance — applied at the shell, keyed by pathname so it
+   replays on each in-app navigation for a smooth page-to-page feel. */
+.ph-fade-in-up {
+  animation: ph-fade-in-up 320ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+
+/* Gentle hover elevation for interactive cards. Transform-only lift so it
+   never nudges surrounding layout; radius + shadow use Polaris tokens so it
+   matches the admin's own card elevation. */
+.ph-hover-lift {
+  border-radius: var(--p-border-radius-300, 12px);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+.ph-hover-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--p-shadow-400, 0 6px 16px rgba(31, 33, 36, 0.12));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ph-fade-in-up {
+    animation: none;
+  }
+  .ph-hover-lift {
+    transition: none;
+  }
+  .ph-hover-lift:hover {
+    transform: none;
+    box-shadow: none;
+  }
+}

--- a/src/app/(commerce)/shopify/embedded/layout.tsx
+++ b/src/app/(commerce)/shopify/embedded/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import "@shopify/polaris/build/esm/styles.css";
+import "./_styles/motion.css";
 import { PolarisShell } from "./_components/polaris-shell";
 
 /**

--- a/src/app/(commerce)/shopify/embedded/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/page.tsx
@@ -122,6 +122,7 @@ function ConnectedHome({ ctx, onSync, syncing, syncError, onSubscribe, subscribi
     >
       <BlockStack gap="500">
         {/* ── Card 1 — Store Health ───────────────────────────────────── */}
+        <div className="ph-hover-lift">
         <Card>
           <BlockStack gap="400">
             <Text as="h2" variant="headingMd">
@@ -156,8 +157,10 @@ function ConnectedHome({ ctx, onSync, syncing, syncError, onSubscribe, subscribi
             </InlineGrid>
           </BlockStack>
         </Card>
+        </div>
 
         {/* ── Card 2 — Sync Status ────────────────────────────────────── */}
+        <div className="ph-hover-lift">
         <Card>
           <BlockStack gap="400">
             <InlineStack align="space-between" blockAlign="center">
@@ -209,8 +212,10 @@ function ConnectedHome({ ctx, onSync, syncing, syncError, onSubscribe, subscribi
             )}
           </BlockStack>
         </Card>
+        </div>
 
         {/* ── Card 3 — Commerce Assistant ─────────────────────────────── */}
+        <div className="ph-hover-lift">
         <Card>
           <BlockStack gap="400">
             <Text as="h2" variant="headingMd">
@@ -270,6 +275,7 @@ function ConnectedHome({ ctx, onSync, syncing, syncError, onSubscribe, subscribi
             )}
           </BlockStack>
         </Card>
+        </div>
       </BlockStack>
     </Page>
   );


### PR DESCRIPTION
## What

Adds tasteful, **admin-native** polish to the embedded Shopify app — kept deliberately restrained for Built for Shopify (which rewards feeling consistent with the admin):

- **Page-content entrance fade-in**, wired once at the Polaris shell and keyed by `pathname` so it replays on each in-app navigation → a smooth page-to-page feel across every embedded page from a single change.
- **Hover elevation** on the home action cards (2px lift + Polaris shadow token). Polaris `Card` takes no `className`, so each card is wrapped in a `ph-hover-lift` div.

## Cert-safe by construction
- **GPU-only** (`opacity`/`transform`) → zero layout shift (no CLS).
- Radius/shadow use **Polaris design tokens** (`--p-border-radius-300`, `--p-shadow-400`) so elevation matches the admin's own cards.
- **Fully disabled under `prefers-reduced-motion`** (animation + hover) — a BFS accessibility expectation.
- Polaris overlays (Modal/Popover/Tooltip) **portal to `<body>`**, so the wrapper transforms never affect their positioning.
- Restrained timings (320ms / 8px entrance, 160ms / 2px hover) — not flashy.
- Scoped via one `motion.css` imported by the embedded layout (same pattern as the existing Polaris styles import); class names are `ph-` prefixed.

## Review
- TypeScript + ESLint clean. Subagent review (round 1) confirmed App Router nested-CSS validity, Frame layout safety, token correctness, tag balance, reduced-motion completeness, and no BFS concern.

Note: this is the first visual polish pass scoped to the home + shell; easy to extend the same classes to other embedded surfaces later if we like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)