### PR TITLE
feat(shopify): fade embedded content in on data arrival

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_components/fade-in.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/fade-in.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Fades its children in on mount — for the skeleton→content (data-arrival)
+ * transition. Complements the shell's pathname-keyed entrance: the skeleton
+ * fades in on navigation, then the real content fades in when it loads.
+ *
+ * Mount is the trigger, so place it on the LOADED branch only (never around a
+ * loading skeleton — the shell already animates that). It re-runs only when
+ * the loaded subtree first mounts, not on subsequent in-page re-renders.
+ *
+ * Motion is GPU-only and disabled under prefers-reduced-motion (the
+ * `ph-fade-in-up` rule in _styles/motion.css).
+ */
+export function FadeIn({ children }: { children: ReactNode }) {
+  return <div className="ph-fade-in-up">{children}</div>;
+}

--- a/src/app/(commerce)/shopify/embedded/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@shopify/polaris";
 import { getSessionToken } from "./_lib/session";
 import { CommerceDisconnected } from "./_components/commerce-disconnected";
+import { FadeIn } from "./_components/fade-in";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
@@ -378,35 +379,41 @@ export default function ShopifyEmbeddedHome() {
 
   if (state.status === "error") {
     return (
-      <Page title="Peakhour Commerce">
-        <Banner tone="critical" title="Could not load your store">
-          <Text as="p" variant="bodyMd">
-            {state.message}
-          </Text>
-        </Banner>
-      </Page>
+      <FadeIn>
+        <Page title="Peakhour Commerce">
+          <Banner tone="critical" title="Could not load your store">
+            <Text as="p" variant="bodyMd">
+              {state.message}
+            </Text>
+          </Banner>
+        </Page>
+      </FadeIn>
     );
   }
 
   if (!state.ctx.connected) {
     return (
-      <CommerceDisconnected
-        shop={state.ctx.shop}
-        pageTitle="Peakhour Commerce"
-        heading={state.ctx.status === "disconnected" ? "Commerce Disconnected" : "Set up Peakhour Commerce"}
-      />
+      <FadeIn>
+        <CommerceDisconnected
+          shop={state.ctx.shop}
+          pageTitle="Peakhour Commerce"
+          heading={state.ctx.status === "disconnected" ? "Commerce Disconnected" : "Set up Peakhour Commerce"}
+        />
+      </FadeIn>
     );
   }
 
   return (
-    <ConnectedHome
-      ctx={state.ctx}
-      onSync={handleSync}
-      syncing={syncing}
-      syncError={syncError}
-      onSubscribe={handleSubscribe}
-      subscribing={subscribing}
-      subError={subError}
-    />
+    <FadeIn>
+      <ConnectedHome
+        ctx={state.ctx}
+        onSync={handleSync}
+        syncing={syncing}
+        syncError={syncError}
+        onSubscribe={handleSubscribe}
+        subscribing={subscribing}
+        subError={subError}
+      />
+    </FadeIn>
   );
 }


### PR DESCRIPTION
Follow-up to #330. The shell-level entrance fades content in on **navigation**, but not on the **skeleton→content swap** within a page (the shell wrapper stays mounted across that transition).

This adds a tiny reusable `FadeIn` (animates on mount) on the home page's **loaded** branches (ready / disconnected / error) — so the real content fades in when it replaces the loading skeleton. The skeleton stays unwrapped (the shell already animates it), so it isn't double-animated.

## Correctness
- Mount-triggered: the `FadeIn` div is a fresh DOM node when `status` flips loading→ready, so the CSS animation fires exactly once on data arrival.
- Does **not** replay on unrelated in-page re-renders (sync/subscribe state changes) — same element at the same tree position → React updates in place, no remount.
- Reuses the existing `ph-fade-in-up` rule → GPU-only, zero CLS, fully disabled under `prefers-reduced-motion`. No new CSS.
- `FadeIn` is reusable — trivial to extend to the other embedded pages later.

## Review
- TypeScript + ESLint clean. Subagent review (round 1) confirmed the mount-trigger mechanism, no-replay-on-rerender, tag balance, layout safety, and reduced-motion coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)