### PR TITLE
feat(shopify): point embedded Reconnect CTAs at the token endpoint

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Page, EmptyState, Text } from "@shopify/polaris";
-import { reconnectUrl } from "../_lib/context";
+import { startReconnect } from "../_lib/context";
 
 /** Shared illustration for the Commerce setup / disconnected states. One asset
  *  everywhere so the experience is consistent (Disconnect Redesign §12). */
@@ -41,10 +41,10 @@ export function CommerceDisconnected({
       heading={heading}
       action={{
         content: "Reconnect Shopify",
-        // Top-level navigation escapes the admin iframe so OAuth can run; a
-        // relative redirect would only move the iframe itself.
+        // Token-based reconnect: escapes the iframe and re-runs OAuth via the
+        // API, landing the merchant back inside the connected embedded app.
         onAction: () => {
-          (window.top ?? window).location.href = reconnectUrl(shop);
+          void startReconnect(shop);
         },
       }}
       secondaryAction={

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -18,7 +18,7 @@ import { useState, type ReactNode } from "react";
 import {
   EmbeddedContextProvider,
   useEmbeddedContext,
-  reconnectUrl,
+  startReconnect,
 } from "../_lib/context";
 
 type PolarisLinkComponent = NonNullable<AppProviderProps["linkComponent"]>;
@@ -81,7 +81,7 @@ function ReconnectBanner() {
         action={{
           content: "Reconnect Shopify",
           onAction: () => {
-            (window.top ?? window).location.href = reconnectUrl(ctx.shop);
+            void startReconnect(ctx.shop);
           },
         }}
       >

--- a/src/app/(commerce)/shopify/embedded/_lib/context.tsx
+++ b/src/app/(commerce)/shopify/embedded/_lib/context.tsx
@@ -129,3 +129,25 @@ export function reconnectUrl(shop?: string | null): string {
     : "/shopify/connect";
   return `${origin}${path}`;
 }
+
+/**
+ * Start the one-click, token-based embedded reconnect. Hands the App Bridge
+ * session token to the API's /shopify/reconnect via a top-level navigation
+ * (which escapes the admin iframe; the token rides in the query because a
+ * navigation can't send an Authorization header). The API resolves the shop's
+ * linked org/business and re-runs OAuth, landing the merchant back inside the
+ * embedded app — no Peakhour cookie, no magic-link, no org/business gate.
+ *
+ * Falls back to the connect wizard (cookie flow) only when no session token is
+ * available — e.g. opened outside the admin iframe, where App Bridge can't
+ * mint one.
+ */
+export async function startReconnect(shop?: string | null): Promise<void> {
+  const top = window.top ?? window;
+  const token = await getSessionToken();
+  if (token) {
+    top.location.href = `${API_URL}/v1/integrations/shopify/reconnect?token=${encodeURIComponent(token)}`;
+  } else {
+    top.location.href = reconnectUrl(shop);
+  }
+}

--- a/src/app/(commerce)/shopify/embedded/_lib/context.tsx
+++ b/src/app/(commerce)/shopify/embedded/_lib/context.tsx
@@ -144,10 +144,15 @@ export function reconnectUrl(shop?: string | null): string {
  */
 export async function startReconnect(shop?: string | null): Promise<void> {
   const top = window.top ?? window;
-  const token = await getSessionToken();
-  if (token) {
-    top.location.href = `${API_URL}/v1/integrations/shopify/reconnect?token=${encodeURIComponent(token)}`;
-  } else {
-    top.location.href = reconnectUrl(shop);
+  let token: string | null = null;
+  try {
+    token = await getSessionToken();
+  } catch {
+    // getSessionToken shouldn't throw, but never let a token hiccup turn the
+    // CTA into a no-op — fall through to the cookie-flow URL below.
+    token = null;
   }
+  top.location.href = token
+    ? `${API_URL}/v1/integrations/shopify/reconnect?token=${encodeURIComponent(token)}`
+    : reconnectUrl(shop);
 }

--- a/src/app/(commerce)/shopify/embedded/assistant/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/assistant/page.tsx
@@ -17,7 +17,7 @@ import {
   Spinner,
 } from "@shopify/polaris";
 import { getSessionToken } from "../_lib/session";
-import { reconnectUrl } from "../_lib/context";
+import { startReconnect } from "../_lib/context";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
@@ -160,7 +160,7 @@ export default function AssistantPage() {
               <Box>
                 <Button
                   onClick={() => {
-                    (window.top ?? window).location.href = reconnectUrl();
+                    void startReconnect();
                   }}
                 >
                   Set up Peakhour Commerce

--- a/src/app/(commerce)/shopify/embedded/integrations/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/integrations/page.tsx
@@ -17,7 +17,7 @@ import {
   SkeletonDisplayText,
 } from "@shopify/polaris";
 import { getSessionToken } from "../_lib/session";
-import { reconnectUrl } from "../_lib/context";
+import { startReconnect } from "../_lib/context";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
@@ -167,7 +167,7 @@ export default function IntegrationsPage() {
                 <Box>
                   <Button
                     onClick={() => {
-                      (window.top ?? window).location.href = reconnectUrl();
+                      void startReconnect();
                     }}
                   >
                     Set up Peakhour Commerce


### PR DESCRIPTION
Client side of the token-based reconnect (pairs with peakhour-api #568). Fixes #7 of the Shopify UI overhaul — Reconnect no longer loops back to an error.

Adds `startReconnect(shop)` in `_lib/context`: gets the App Bridge session token and top-navigates to `/v1/integrations/shopify/reconnect?token=…`, which re-runs OAuth server-side and lands the merchant back in the **connected** embedded app — no Peakhour cookie, no magic-link, no org/business 403 loop. Falls back to the connect wizard when no session token is available (opened outside admin), and guards the token fetch so the CTA is never a silent no-op.

Wired into all four reconnect/setup CTAs: `CommerceDisconnected` EmptyState, the persistent `ReconnectBanner`, and the Integrations + Assistant "Set up Peakhour Commerce" buttons.

## Review
- TypeScript + ESLint clean. Subagent review (round 1) confirmed `getSessionToken` never throws, the token-in-URL/encoding, `window.top` escape, fallback correctness, and no dead code. Token-fetch guard added per the one Medium recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)