### PR TITLE
refactor(shopify): rename Growth Network → Insights Network (PIN)

### DIFF
--- a/src/app/(commerce)/shopify/connect/_components/connect-wizard.tsx
+++ b/src/app/(commerce)/shopify/connect/_components/connect-wizard.tsx
@@ -129,11 +129,21 @@ interface Props {
   reconnect?: boolean;
 }
 
+const MISSING_PARAMS_ERROR =
+  "Missing shop or connection token. Please reinstall Peakhour Commerce from the Shopify App Store.";
+
 export function ConnectWizard({ shop, token, reconnect = false }: Props) {
   const router = useRouter();
-  const [step, setStep] = useState<Step>("checking");
+  // Pure from props (the page passes them from searchParams, fixed per mount),
+  // so seed the initial step/error from it rather than setting state
+  // synchronously inside the mount effect — the latter trips the react-hooks
+  // "setState in effect → cascading renders" rule.
+  const paramsMissing = !shop || (!token && !reconnect);
+  const [step, setStep] = useState<Step>(paramsMissing ? "error" : "checking");
   const [user, setUser] = useState<MeUser | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    paramsMissing ? MISSING_PARAMS_ERROR : null,
+  );
   const [joining, setJoining] = useState(false);
   const [pinJoinFailed, setPinJoinFailed] = useState(false);
   // Expired/consumed link token — recoverable without reinstalling (see
@@ -233,13 +243,9 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
   }, [step, router]);
 
   useEffect(() => {
-    if (!shop || (!token && !reconnect)) {
-      setError(
-        "Missing shop or connection token. Please reinstall Peakhour Commerce from the Shopify App Store.",
-      );
-      setStep("error");
-      return;
-    }
+    // Missing-params is already reflected in the seeded step/error (above), so
+    // just skip the session check — no synchronous setState in the effect.
+    if (paramsMissing) return;
 
     (async () => {
       try {
@@ -263,7 +269,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
         setStep("auth-required");
       }
     })();
-  }, [shop, token, reconnect, linkStore, reconnectNow]);
+  }, [paramsMissing, reconnect, linkStore, reconnectNow]);
 
   // The auth page is a unified magic-link flow (no separate sign-up route).
   // Both "sign in" and "create account" land on the same page; the merchant

--- a/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
@@ -16,9 +16,9 @@ interface CommerceDisconnectedProps {
    *  already-titled page / card). Defaults to standalone. */
   withPage?: boolean;
   pageTitle?: string;
-  /** Show the "Explore Insights Network" secondary CTA. Off on the Growth
+  /** Show the "Explore Insights Network" secondary CTA. Off on the Insights
    *  Network page itself (would be self-referential). Defaults on. */
-  showGrowthNetworkLink?: boolean;
+  showInsightsNetworkLink?: boolean;
 }
 
 /**
@@ -34,7 +34,7 @@ export function CommerceDisconnected({
   description = "Your Peakhour account is still active. Reconnect your Shopify store to sync your catalog, enable the AI Commerce Assistant, unlock product insights, and get AI-powered recommendations.",
   withPage = true,
   pageTitle = "Commerce",
-  showGrowthNetworkLink = true,
+  showInsightsNetworkLink = true,
 }: CommerceDisconnectedProps) {
   const content = (
     <EmptyState
@@ -48,7 +48,7 @@ export function CommerceDisconnected({
         },
       }}
       secondaryAction={
-        showGrowthNetworkLink
+        showInsightsNetworkLink
           ? {
               content: "Explore Insights Network",
               // In-iframe client nav (Polaris linkComponent = Next Link).

--- a/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
@@ -16,7 +16,7 @@ interface CommerceDisconnectedProps {
    *  already-titled page / card). Defaults to standalone. */
   withPage?: boolean;
   pageTitle?: string;
-  /** Show the "Explore Growth Network" secondary CTA. Off on the Growth
+  /** Show the "Explore Insights Network" secondary CTA. Off on the Growth
    *  Network page itself (would be self-referential). Defaults on. */
   showGrowthNetworkLink?: boolean;
 }
@@ -25,7 +25,7 @@ interface CommerceDisconnectedProps {
  * The single, consistent "no live Commerce connection" state — used for both a
  * never-linked store and a disconnected one (Disconnect Redesign §1, §2, §10).
  * Always gives the merchant a next action: Reconnect Shopify (primary, escapes
- * the admin iframe to re-run OAuth) or Explore Growth Network (secondary, the
+ * the admin iframe to re-run OAuth) or Explore Insights Network (secondary, the
  * free destination). No blank screens, no dead ends.
  */
 export function CommerceDisconnected({
@@ -50,7 +50,7 @@ export function CommerceDisconnected({
       secondaryAction={
         showGrowthNetworkLink
           ? {
-              content: "Explore Growth Network",
+              content: "Explore Insights Network",
               // In-iframe client nav (Polaris linkComponent = Next Link).
               url: "/shopify/embedded/pin",
             }

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -55,11 +55,11 @@ const NAV_ITEMS = [
   { label: "Catalog", icon: ProductIcon, url: "/shopify/embedded/catalog" },
   // WhatsApp (and future channels) connect here (P1.12, launch-to-domain).
   { label: "Integrations", icon: ConnectIcon, url: "/shopify/embedded/integrations" },
-  // The free Growth Network (formerly "Insights Network") — its own surface
+  // The free Insights Network (formerly "Insights Network") — its own surface
   // (product rule 2026-06-12): consent is captured first-time in the connect
   // wizard; this page is its standing home — members see the network,
   // non-members get the join nudge. Positioned as a valuable destination.
-  { label: "Growth Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
+  { label: "Insights Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
   { label: "Subscription", icon: CreditCardIcon, url: "/shopify/embedded/subscription" },
   { label: "Settings", icon: SettingsIcon, url: "/shopify/embedded/settings" },
 ];

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -55,7 +55,7 @@ const NAV_ITEMS = [
   { label: "Catalog", icon: ProductIcon, url: "/shopify/embedded/catalog" },
   // WhatsApp (and future channels) connect here (P1.12, launch-to-domain).
   { label: "Integrations", icon: ConnectIcon, url: "/shopify/embedded/integrations" },
-  // The free Insights Network (formerly "Insights Network") — its own surface
+  // The free Insights Network (Peakhour Insights Network, "PIN") — its own surface
   // (product rule 2026-06-12): consent is captured first-time in the connect
   // wizard; this page is its standing home — members see the network,
   // non-members get the join nudge. Positioned as a valuable destination.

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -40,7 +40,7 @@ interface PinState {
 }
 
 // Truthful-today framing (matches the wizard): benchmarks ship to members
-// FIRST as they roll out — never claimed as visible now. The Growth Network
+// FIRST as they roll out — never claimed as visible now. The Insights Network
 // is positioned as a valuable free destination, not a Commerce setup blocker.
 const GROWTH_BENEFITS = [
   "Industry insights and growth trends for stores like yours",
@@ -62,7 +62,7 @@ type Membership = "loading" | "member" | "nonmember" | "unknown" | "notlinked";
 
 function PinSkeleton() {
   return (
-    <SkeletonPage title="Growth Network">
+    <SkeletonPage title="Insights Network">
       <BlockStack gap="500">
         <Card>
           <BlockStack gap="400">
@@ -158,7 +158,7 @@ export default function PinPage() {
         body: JSON.stringify({ action: join ? "opt_in" : "withdraw" }),
       });
       if (!res.ok) {
-        setError("Could not update your Growth Network membership. Please try again.");
+        setError("Could not update your Insights Network membership. Please try again.");
       } else {
         setMembership(join ? "member" : "nonmember");
       }
@@ -172,7 +172,7 @@ export default function PinPage() {
 
   return (
     <Page
-      title="Growth Network"
+      title="Insights Network"
       subtitle="Smart insights. Zero personal tracking. Your identity stays yours."
     >
       <BlockStack gap="500">
@@ -242,7 +242,7 @@ export default function PinPage() {
         {membership === "nonmember" && (
           <Card>
             <BlockStack gap="400">
-              <Text as="h2" variant="headingMd">Join the Peakhour Growth Network</Text>
+              <Text as="h2" variant="headingMd">Join the Peakhour Insights Network</Text>
               <Divider />
               <Text as="p" variant="bodyMd" tone="subdued">
                 A free community for founders and operators growing smarter with AI. Smart insights,
@@ -281,7 +281,7 @@ export default function PinPage() {
         {membership === "unknown" && (
           <Card>
             <BlockStack gap="300">
-              <Text as="h2" variant="headingMd">Peakhour Growth Network</Text>
+              <Text as="h2" variant="headingMd">Peakhour Insights Network</Text>
               <Divider />
               <Text as="p" variant="bodyMd" tone="subdued">
                 We couldn&apos;t load your membership status.

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -42,7 +42,7 @@ interface PinState {
 // Truthful-today framing (matches the wizard): benchmarks ship to members
 // FIRST as they roll out — never claimed as visible now. The Insights Network
 // is positioned as a valuable free destination, not a Commerce setup blocker.
-const GROWTH_BENEFITS = [
+const INSIGHTS_BENEFITS = [
   "Industry insights and growth trends for stores like yours",
   "Community benchmarks — see how you compare, anonymously",
   "AI-powered recommendations as the network learns",
@@ -249,7 +249,7 @@ export default function PinPage() {
                 zero personal tracking — your identity stays yours.
               </Text>
               <List type="bullet">
-                {GROWTH_BENEFITS.map((b) => (
+                {INSIGHTS_BENEFITS.map((b) => (
                   <List.Item key={b}>
                     <Text as="span" variant="bodyMd">{b}</Text>
                   </List.Item>
@@ -274,7 +274,7 @@ export default function PinPage() {
           <CommerceDisconnected
             shop={shop}
             withPage={false}
-            showGrowthNetworkLink={false}
+            showInsightsNetworkLink={false}
           />
         )}
 

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -76,7 +76,7 @@ function SettingsSkeleton() {
   );
 }
 
-// ── Welcome to Growth Network (post-downgrade) ───────────────────────────────
+// ── Welcome to Insights Network (post-downgrade) ───────────────────────────────
 
 function GrowthNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
   return (
@@ -84,7 +84,7 @@ function GrowthNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
       <Card>
         <BlockStack gap="400">
           <Text as="h2" variant="headingLg">
-            Welcome to the Peakhour Growth Network
+            Welcome to the Peakhour Insights Network
           </Text>
           <Text as="p" variant="bodyMd" tone="subdued">
             Your store stays connected and your catalog keeps syncing. You&rsquo;re now part of a
@@ -98,7 +98,7 @@ function GrowthNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
           </List>
           <InlineStack gap="300">
             <Button variant="primary" url="/shopify/embedded/pin">
-              Explore Growth Network
+              Explore Insights Network
             </Button>
             <Button variant="tertiary" url="/shopify/embedded/subscription">
               Back to Commerce
@@ -411,8 +411,8 @@ export default function SettingsPage() {
             </List>
             <Text as="p" variant="bodyMd">
               {hasPaid
-                ? "You can stay on Peakhour's free Growth Network at no cost — keep your store connected and drop the paid Commerce Assistant."
-                : "You can keep your store connected on the free plan and continue using the Growth Network at no cost."}
+                ? "You can stay on Peakhour's free Insights Network at no cost — keep your store connected and drop the paid Commerce Assistant."
+                : "You can keep your store connected on the free plan and continue using the Insights Network at no cost."}
             </Text>
           </BlockStack>
         </Modal.Section>

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -78,7 +78,7 @@ function SettingsSkeleton() {
 
 // ── Welcome to Insights Network (post-downgrade) ───────────────────────────────
 
-function GrowthNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
+function InsightsNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
   return (
     <Page title="You're on the free plan">
       <Card>
@@ -254,7 +254,7 @@ export default function SettingsPage() {
   }
 
   if (flash === "downgraded") {
-    return <GrowthNetworkWelcome onDismiss={() => setFlash(null)} />;
+    return <InsightsNetworkWelcome onDismiss={() => setFlash(null)} />;
   }
 
   if (!ctx.connected) {

--- a/src/app/(commerce)/shopify/embedded/subscription/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/subscription/page.tsx
@@ -66,7 +66,7 @@ const FEATURE_LABELS: Record<string, string> = {
   "commerce.whatsapp": "WhatsApp shopping channel",
   "commerce.in_app_assistant": "In-app product assistant",
   "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
-  "commerce.insights_network": "Growth Network access",
+  "commerce.insights_network": "Insights Network access",
 };
 
 function featureLabel(key: string): string {


### PR DESCRIPTION
## #5 of the Shopify UI overhaul — Insight(s) Network naming

Unifies the community surface name to **Peakhour Insights Network (PIN)** — the canonical name matching the `/pin` route and `pin_*` collections.

**Commit 1 — rename:** the remaining "Growth Network" strings → "Insights Network": the nav item, pin page titles/headings, the `CommerceDisconnected` CTA, settings post-downgrade copy, and the subscription feature label. Text-only.

(The peakhour-api comments/error and the connect-wizard step label + `lib/pricing.ts` feature label were **already** "Insights Network", so no change needed there — the API needs no PR.)

**Commit 2 — bundled lint fix (requested):** `connect-wizard` set `error`/`step` synchronously inside the mount effect for the missing-params guard, which the react-hooks rule flags as cascading renders. Since `shop`/`token`/`reconnect` are props (fixed per mount), the initial `step`/`error` are now seeded from a derived `paramsMissing` and the effect early-returns — no synchronous setState. Behavior unchanged; clears the pre-existing lint error.

## Review
- TypeScript clean; `next build` green (eslint-during-build passes, incl. the now-fixed connect-wizard). Pure rename + a self-contained lint fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)