### PR TITLE
feat(shopify): rename Insights Network → Growth Network (Phase 1, PR 1.1)

### DIFF
--- a/src/app/(commerce)/shopify/connect/_components/connect-wizard.tsx
+++ b/src/app/(commerce)/shopify/connect/_components/connect-wizard.tsx
@@ -42,7 +42,7 @@ const DASHBOARD_WHATSAPP_URL = "/dashboard/content/whatsapp";
 
 // ── Step indicator ─────────────────────────────────────────────────────────
 
-const STEP_LABELS = ["Connect account", "Link store", "Insights Network", "WhatsApp", "All set"];
+const STEP_LABELS = ["Connect account", "Link store", "Growth Network", "WhatsApp", "All set"];
 
 // The assistant is the headline value of the connection — these stay truthful
 // to what ships in P1 (catalog-grounded answers on the merchant's own number).
@@ -150,7 +150,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
   // reconnectNow), so the error UI offers a reconnect button.
   const [tokenExpired, setTokenExpired] = useState(false);
   // Which step the wizard was on when an error occurred, so the indicator
-  // doesn't show later steps (incl. Insights Network) as completed.
+  // doesn't show later steps (incl. Growth Network) as completed.
   const [failedAt, setFailedAt] = useState(0);
 
   // Restart OAuth for an already-installed app — Shopify skips the grant
@@ -208,7 +208,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
 
   // PIN opt-in from the wizard. Consent is never a gate on onboarding — a
   // failed call advances to the WhatsApp step anyway (the merchant can join
-  // later from the Insights Network page in the app nav); the eventual success
+  // later from the Growth Network page in the app nav); the eventual success
   // screen surfaces the join-failed banner instead of implying enrollment.
   const joinNetwork = useCallback(async () => {
     setJoining(true);
@@ -227,7 +227,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
   }, []);
 
   // Kick off the WhatsApp connection on peakhour.ai (new top-level tab) and
-  // advance — like the Insights step, this never gates onboarding. The
+  // advance — like the Growth Network step, this never gates onboarding. The
   // merchant can also connect later from the embedded Integrations page.
   const openWhatsApp = useCallback(() => {
     window.open(DASHBOARD_WHATSAPP_URL, "_blank", "noopener,noreferrer");
@@ -382,7 +382,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
               </BlockStack>
             )}
 
-            {/* Step 3 — Insights Network opt-in (the Lens-plan knowhow nudge) */}
+            {/* Step 3 — Growth Network opt-in (the Lens-plan knowhow nudge) */}
             {step === "consent" && (
               <BlockStack gap="500">
                 <Banner tone="success" title="Store connected!">
@@ -394,7 +394,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
 
                 <BlockStack gap="200">
                   <Text as="h2" variant="headingMd">
-                    Join the Peakhour Insights Network
+                    Join the Peakhour Growth Network
                   </Text>
                   <Text as="p" variant="bodyMd" tone="subdued">
                     Stores in the network contribute anonymized commerce signals — and get
@@ -432,7 +432,7 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
                 </BlockStack>
 
                 <Text as="p" variant="bodySm" tone="subdued" alignment="center">
-                  You can join or leave anytime from the Insights Network page
+                  You can join or leave anytime from the Growth Network page
                   in the app.
                 </Text>
               </BlockStack>
@@ -503,8 +503,8 @@ export function ConnectWizard({ shop, token, reconnect = false }: Props) {
                 {pinJoinFailed && (
                   <Banner tone="warning">
                     <Text as="p" variant="bodyMd">
-                      We couldn&apos;t enroll you in the Insights Network just now — you can
-                      join anytime from the Insights Network page in the app.
+                      We couldn&apos;t enroll you in the Growth Network just now — you can
+                      join anytime from the Growth Network page in the app.
                     </Text>
                   </Banner>
                 )}

--- a/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/commerce-disconnected.tsx
@@ -16,16 +16,16 @@ interface CommerceDisconnectedProps {
    *  already-titled page / card). Defaults to standalone. */
   withPage?: boolean;
   pageTitle?: string;
-  /** Show the "Explore Insights Network" secondary CTA. Off on the Insights
+  /** Show the "Explore Growth Network" secondary CTA. Off on the Growth
    *  Network page itself (would be self-referential). Defaults on. */
-  showInsightsNetworkLink?: boolean;
+  showGrowthNetworkLink?: boolean;
 }
 
 /**
  * The single, consistent "no live Commerce connection" state — used for both a
  * never-linked store and a disconnected one (Disconnect Redesign §1, §2, §10).
  * Always gives the merchant a next action: Reconnect Shopify (primary, escapes
- * the admin iframe to re-run OAuth) or Explore Insights Network (secondary, the
+ * the admin iframe to re-run OAuth) or Explore Growth Network (secondary, the
  * free destination). No blank screens, no dead ends.
  */
 export function CommerceDisconnected({
@@ -34,7 +34,7 @@ export function CommerceDisconnected({
   description = "Your Peakhour account is still active. Reconnect your Shopify store to sync your catalog, enable the AI Commerce Assistant, unlock product insights, and get AI-powered recommendations.",
   withPage = true,
   pageTitle = "Commerce",
-  showInsightsNetworkLink = true,
+  showGrowthNetworkLink = true,
 }: CommerceDisconnectedProps) {
   const content = (
     <EmptyState
@@ -48,9 +48,9 @@ export function CommerceDisconnected({
         },
       }}
       secondaryAction={
-        showInsightsNetworkLink
+        showGrowthNetworkLink
           ? {
-              content: "Explore Insights Network",
+              content: "Explore Growth Network",
               // In-iframe client nav (Polaris linkComponent = Next Link).
               url: "/shopify/embedded/pin",
             }

--- a/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/polaris-shell.tsx
@@ -55,11 +55,11 @@ const NAV_ITEMS = [
   { label: "Catalog", icon: ProductIcon, url: "/shopify/embedded/catalog" },
   // WhatsApp (and future channels) connect here (P1.12, launch-to-domain).
   { label: "Integrations", icon: ConnectIcon, url: "/shopify/embedded/integrations" },
-  // The free Insights Network (Peakhour Insights Network, "PIN") — its own surface
+  // The free Growth Network (Peakhour Growth Network, internal code "PIN") — its own surface
   // (product rule 2026-06-12): consent is captured first-time in the connect
   // wizard; this page is its standing home — members see the network,
   // non-members get the join nudge. Positioned as a valuable destination.
-  { label: "Insights Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
+  { label: "Growth Network", icon: GlobeIcon, url: "/shopify/embedded/pin" },
   { label: "Subscription", icon: CreditCardIcon, url: "/shopify/embedded/subscription" },
   { label: "Settings", icon: SettingsIcon, url: "/shopify/embedded/settings" },
 ];

--- a/src/app/(commerce)/shopify/embedded/pin/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/pin/page.tsx
@@ -25,10 +25,10 @@ import { CommerceDisconnected } from "../_components/commerce-disconnected";
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 /**
- * Peakhour Insights Network (PIN) — dedicated nav surface.
+ * Peakhour Growth Network (internal code "PIN") — dedicated nav surface.
  *
  * Product rule (Prashant, 2026-06-12): consent is CAPTURED first-time in
- * onboarding (the connect wizard's "Insights Network" step); this page is
+ * onboarding (the connect wizard's "Growth Network" step); this page is
  * the standing home for it afterwards — members see the network, everyone
  * else gets the consent ask with a proper nudge. Settings no longer hosts
  * the membership card.
@@ -42,7 +42,7 @@ interface PinState {
 }
 
 // Truthful-today framing (matches the wizard): benchmarks ship to members
-// FIRST as they roll out — never claimed as visible now. The Insights Network
+// FIRST as they roll out — never claimed as visible now. The Growth Network
 // is positioned as a valuable free destination, not a Commerce setup blocker.
 const INSIGHTS_BENEFITS = [
   "Industry insights and growth trends for stores like yours",
@@ -65,7 +65,7 @@ type Membership = "loading" | "member" | "nonmember" | "unknown" | "notlinked";
 
 /**
  * Privacy First by Design — the standing trust section. Privacy is the
- * Insights Network's key differentiator, so it's surfaced on the page for both
+ * Growth Network's key differentiator, so it's surfaced on the page for both
  * members and prospective members (not just buried in benefit bullets).
  */
 function PrivacyFirstCard() {
@@ -107,7 +107,7 @@ function PrivacyFirstCard() {
 
 function PinSkeleton() {
   return (
-    <SkeletonPage title="Insights Network">
+    <SkeletonPage title="Growth Network">
       <BlockStack gap="500">
         <Card>
           <BlockStack gap="400">
@@ -203,7 +203,7 @@ export default function PinPage() {
         body: JSON.stringify({ action: join ? "opt_in" : "withdraw" }),
       });
       if (!res.ok) {
-        setError("Could not update your Insights Network membership. Please try again.");
+        setError("Could not update your Growth Network membership. Please try again.");
       } else {
         setMembership(join ? "member" : "nonmember");
       }
@@ -217,7 +217,7 @@ export default function PinPage() {
 
   return (
     <Page
-      title="Insights Network"
+      title="Growth Network"
       subtitle="Smart insights. Zero personal tracking. Your identity stays yours."
     >
       <BlockStack gap="500">
@@ -287,7 +287,7 @@ export default function PinPage() {
         {membership === "nonmember" && (
           <Card>
             <BlockStack gap="400">
-              <Text as="h2" variant="headingMd">Join the Peakhour Insights Network</Text>
+              <Text as="h2" variant="headingMd">Join the Peakhour Growth Network</Text>
               <Divider />
               <Text as="p" variant="bodyMd" tone="subdued">
                 A free community for founders and operators growing smarter with AI. Smart insights,
@@ -323,14 +323,14 @@ export default function PinPage() {
           <CommerceDisconnected
             shop={shop}
             withPage={false}
-            showInsightsNetworkLink={false}
+            showGrowthNetworkLink={false}
           />
         )}
 
         {membership === "unknown" && (
           <Card>
             <BlockStack gap="300">
-              <Text as="h2" variant="headingMd">Peakhour Insights Network</Text>
+              <Text as="h2" variant="headingMd">Peakhour Growth Network</Text>
               <Divider />
               <Text as="p" variant="bodyMd" tone="subdued">
                 We couldn&apos;t load your membership status.

--- a/src/app/(commerce)/shopify/embedded/settings/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/settings/page.tsx
@@ -76,15 +76,15 @@ function SettingsSkeleton() {
   );
 }
 
-// ── Welcome to Insights Network (post-downgrade) ───────────────────────────────
+// ── Welcome to Growth Network (post-downgrade) ───────────────────────────────
 
-function InsightsNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
+function GrowthNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
   return (
     <Page title="You're on the free plan">
       <Card>
         <BlockStack gap="400">
           <Text as="h2" variant="headingLg">
-            Welcome to the Peakhour Insights Network
+            Welcome to the Peakhour Growth Network
           </Text>
           <Text as="p" variant="bodyMd" tone="subdued">
             Your store stays connected and your catalog keeps syncing. You&rsquo;re now part of a
@@ -98,7 +98,7 @@ function InsightsNetworkWelcome({ onDismiss }: { onDismiss: () => void }) {
           </List>
           <InlineStack gap="300">
             <Button variant="primary" url="/shopify/embedded/pin">
-              Explore Insights Network
+              Explore Growth Network
             </Button>
             <Button variant="tertiary" url="/shopify/embedded/subscription">
               Back to Commerce
@@ -254,7 +254,7 @@ export default function SettingsPage() {
   }
 
   if (flash === "downgraded") {
-    return <InsightsNetworkWelcome onDismiss={() => setFlash(null)} />;
+    return <GrowthNetworkWelcome onDismiss={() => setFlash(null)} />;
   }
 
   if (!ctx.connected) {
@@ -411,8 +411,8 @@ export default function SettingsPage() {
             </List>
             <Text as="p" variant="bodyMd">
               {hasPaid
-                ? "You can stay on Peakhour's free Insights Network at no cost — keep your store connected and drop the paid Commerce Assistant."
-                : "You can keep your store connected on the free plan and continue using the Insights Network at no cost."}
+                ? "You can stay on Peakhour's free Growth Network at no cost — keep your store connected and drop the paid Commerce Assistant."
+                : "You can keep your store connected on the free plan and continue using the Growth Network at no cost."}
             </Text>
           </BlockStack>
         </Modal.Section>

--- a/src/app/(commerce)/shopify/embedded/subscription/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/subscription/page.tsx
@@ -76,7 +76,7 @@ const FEATURE_LABELS: Record<string, string> = {
   "commerce.whatsapp": "WhatsApp shopping channel",
   "commerce.in_app_assistant": "In-app product assistant",
   "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
-  "commerce.insights_network": "Insights Network access",
+  "commerce.insights_network": "Growth Network access",
 };
 
 function featureLabel(key: string): string {
@@ -98,7 +98,7 @@ function featureIcon(key: string): typeof CheckCircleIcon {
   return FEATURE_ICONS[key] ?? CheckCircleIcon;
 }
 
-// The free experience IS the Insights Network community — its worth is the
+// The free experience IS the Growth Network community — its worth is the
 // community/insights, not the raw cfg feature keys, so these value props are
 // curated presentation copy (icon + label), not CMS-sourced.
 const INSIGHTS_EXPERIENCE_FEATURES: Array<{ icon: typeof CheckCircleIcon; label: string }> = [
@@ -416,7 +416,7 @@ export default function SubscriptionPage() {
   }
 
   // ── Inactive — experience-first comparison (#4) ──────────────────────────
-  // Two intentional entry points: the free Insights Network community vs the
+  // Two intentional entry points: the free Growth Network community vs the
   // paid Commerce Assistant — not "free vs locked features". The free card is
   // curated community value props; the paid card is CMS-driven (price/trial +
   // feature keys), falling back to the default feature set if tiers failed.
@@ -438,13 +438,13 @@ export default function SubscriptionPage() {
         </BlockStack>
 
         <InlineGrid columns={{ xs: 1, md: 2 }} gap="400">
-          {/* ── Experience 1 — Insights Network (free, standalone value) ── */}
+          {/* ── Experience 1 — Growth Network (free, standalone value) ── */}
           <div className="ph-hover-lift ph-plan-card">
             <Card>
               <BlockStack gap="400">
                 <BlockStack gap="100">
                   <InlineStack align="space-between" blockAlign="center" wrap={false}>
-                    <Text as="h3" variant="headingMd">Insights Network</Text>
+                    <Text as="h3" variant="headingMd">Growth Network</Text>
                     <Badge tone="success">Privacy First</Badge>
                   </InlineStack>
                   <Text as="p" variant="bodySm" tone="subdued">

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -185,5 +185,5 @@ export const FEATURE_LABELS: Record<string, string> = {
   "commerce.whatsapp": "WhatsApp shopping channel",
   "commerce.in_app_assistant": "In-app product assistant",
   "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
-  "commerce.insights_network": "Insights Network access",
+  "commerce.insights_network": "Growth Network access",
 };


### PR DESCRIPTION
## What
Renames the free community tier **Insights Network → Growth Network** across every merchant-facing surface of the Shopify embedded app, plus the marketing feature label. First PR of the **Lens onboarding unification** program ([plan](https://github.com/travelxp/peakhour-mongodb/blob/master/docs/idea/lens-onboarding-peaks-plan.md)).

## Canonical naming (locked)
- **Lens** = the plan (cards/billing)
- **Growth Network** = a feature/benefit *inside* Lens
- **Peaks** = the usage currency

## Scope — user-facing only
- Nav label, page titles, headings, CTAs, error/modal copy
- Connect wizard step label + Step 3 copy
- `showInsightsNetworkLink` → `showGrowthNetworkLink` prop
- `InsightsNetworkWelcome` → `GrowthNetworkWelcome` component
- `FEATURE_LABELS["commerce.insights_network"]` display label (embedded + marketing)

## Deliberately preserved (backend identifiers)
Renaming these would be a separate migration and is **out of scope**:
- `/shopify/embedded/pin` route, `/v1/pin/consent` API
- `commerce.insights_network` feature key, `pin_*` collections
- "PIN" kept in comments as the internal code name

## Verification
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean on all changed files
- ✅ No remaining `Insights Network` / old identifier references in `src/`

## Next in Phase 1
- PR 1.2 — `LensActivationHub` checklist home (Connect → Join Growth Network → Confirm Lens)
- PR 1.3 — demote nav items until activated + route dead-ends into the hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)