### PR TITLE
feat(shopify): Lens Activation Hub + Finish Setup card (Phase 1, PR 1.2)

### DIFF
--- a/src/app/(commerce)/shopify/embedded/_components/finish-setup-card.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/finish-setup-card.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Card, BlockStack, InlineStack, Text, Button, Badge, Banner } from "@shopify/polaris";
+import { getSessionToken } from "../_lib/session";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+// Namespaced per shop — embedded apps are inherently multi-store, so a single
+// global key would suppress the card on store B after dismissing it on store A.
+function dismissKey(shop?: string | null): string {
+  return `ph_finish_setup_dismissed:${shop ?? "default"}`;
+}
+
+/**
+ * Dismissible "Finish setup" card shown on the CONNECTED home when the merchant
+ * is on free Lens but hasn't joined the Growth Network yet — the soft, non-naggy
+ * completion of the activation journey (step 2 of 3). The full-takeover journey
+ * lives in LensActivationHub (disconnected state); this is its connected tail.
+ *
+ * Self-contained: reads membership from /pin/status, opts in via /pin/consent,
+ * and remembers a dismissal in localStorage so it never nags twice. Renders
+ * nothing unless the merchant is a known non-member and hasn't dismissed it
+ * (fails closed — on any load error it stays hidden rather than nagging).
+ */
+export function FinishSetupCard({ shop }: { shop?: string | null }) {
+  // null = unknown/loading/errored (render nothing); false = non-member (show);
+  // true = member (nothing to finish).
+  const [member, setMember] = useState<boolean | null>(null);
+  const [dismissed, setDismissed] = useState(true); // hidden until we confirm otherwise (no flash)
+  const [justJoined, setJustJoined] = useState(false); // brief success confirmation
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      let isDismissed = true;
+      try {
+        isDismissed = localStorage.getItem(dismissKey(shop)) === "1";
+      } catch {
+        isDismissed = false; // storage blocked — default to showing once
+      }
+      const token = await getSessionToken();
+      if (cancelled) return;
+      if (!token) return;
+      try {
+        const res = await fetch(`${API_URL}/v1/shopify/embedded/pin/status`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (cancelled) return;
+        if (!res.ok) return; // notlinked/blip — stay hidden
+        const data = (await res.json()) as {
+          pin?: { consentStatus?: { pin_contribution?: "opted_in" | "revoked" } } | null;
+        };
+        const isMember = data.pin?.consentStatus?.pin_contribution === "opted_in";
+        setMember(isMember);
+        setDismissed(isMember ? true : isDismissed);
+      } catch {
+        // stay hidden on error
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shop]);
+
+  const join = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    const token = await getSessionToken();
+    if (!token) {
+      setError("Couldn't get a Shopify session. Please reopen Peakhour from your Shopify admin.");
+      setBusy(false);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/v1/shopify/embedded/pin/consent`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "opt_in" }),
+      });
+      if (res.ok) {
+        setMember(true);
+        setJustJoined(true); // show a brief confirmation instead of silently vanishing
+      } else {
+        setError("Could not join the Growth Network. Please try again.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    }
+    setBusy(false);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    try {
+      localStorage.setItem(dismissKey(shop), "1");
+    } catch {
+      // non-fatal — it just won't persist across reloads
+    }
+    setDismissed(true);
+  }, [shop]);
+
+  // Success confirmation takes precedence — the merchant just clicked Join, so
+  // confirm it landed (the guard below would otherwise hide the card instantly).
+  if (justJoined) {
+    return (
+      <div className="ph-hover-lift">
+        <Card>
+          <BlockStack gap="300">
+            <InlineStack align="space-between" blockAlign="center" wrap={false}>
+              <InlineStack gap="200" blockAlign="center">
+                <Text as="h2" variant="headingMd">
+                  You&rsquo;re in the Growth Network
+                </Text>
+                <Badge tone="success">Joined</Badge>
+              </InlineStack>
+              <Button
+                variant="tertiary"
+                onClick={() => setJustJoined(false)}
+                accessibilityLabel="Dismiss"
+              >
+                Dismiss
+              </Button>
+            </InlineStack>
+            <Text as="p" variant="bodyMd" tone="subdued">
+              Setup complete. You&rsquo;ll get privacy-first benchmarks and insights for stores like
+              yours here as the network grows.
+            </Text>
+            <InlineStack gap="300">
+              <Button variant="tertiary" url="/shopify/embedded/pin">
+                View Growth Network
+              </Button>
+            </InlineStack>
+          </BlockStack>
+        </Card>
+      </div>
+    );
+  }
+
+  if (member !== false || dismissed) return null;
+
+  return (
+    <div className="ph-hover-lift">
+      <Card>
+        <BlockStack gap="300">
+          <InlineStack align="space-between" blockAlign="center" wrap={false}>
+            <InlineStack gap="200" blockAlign="center">
+              <Text as="h2" variant="headingMd">
+                Finish setup
+              </Text>
+              <Badge tone="attention">2 of 3</Badge>
+            </InlineStack>
+            <Button variant="tertiary" onClick={dismiss} accessibilityLabel="Dismiss finish setup">
+              Dismiss
+            </Button>
+          </InlineStack>
+          <Text as="p" variant="bodyMd" tone="subdued">
+            Your store is connected and you&rsquo;re on the free Lens plan. Join the Growth Network for
+            privacy-first benchmarks and insights for stores like yours — free, opt-in, leave anytime.
+          </Text>
+          {error && (
+            <Banner tone="critical">
+              <Text as="p" variant="bodyMd">
+                {error}
+              </Text>
+            </Banner>
+          )}
+          <InlineStack gap="300" blockAlign="center">
+            <Button variant="primary" onClick={join} loading={busy}>
+              Join the Growth Network
+            </Button>
+            <Button variant="tertiary" url="/shopify/embedded/pin">
+              Learn more
+            </Button>
+          </InlineStack>
+        </BlockStack>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(commerce)/shopify/embedded/_components/lens-activation-hub.tsx
+++ b/src/app/(commerce)/shopify/embedded/_components/lens-activation-hub.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Fragment, type CSSProperties } from "react";
+import { Page, Card, BlockStack, InlineStack, Text, Button, Badge, Box, Divider } from "@shopify/polaris";
+import { startReconnect } from "../_lib/context";
+
+/**
+ * Lens Activation Hub — the single, unified "get started" home for a merchant
+ * whose store isn't connected yet (fresh install or disconnected). Replaces the
+ * three fragmented CTAs (Connect / Join Network / Subscribe) with one journey:
+ *
+ *   1. Connect Shopify        — the only action needed right now
+ *   2. Join the Growth Network — free, opt-in, surfaced right after connecting
+ *   3. You're on Lens (free)   — Lens is free by default; no billing step
+ *
+ * Only step 1 is actionable here (the others require a linked store); steps 2–3
+ * are previewed so the merchant sees the whole, low-commitment journey up front.
+ * Once connected, the home shows the dashboard with a dismissible FinishSetupCard
+ * that completes step 2. Free Lens is an implicit default (no entitlement write),
+ * so there is no "subscribe to free" action — by design.
+ */
+
+type StepState = "done" | "current" | "upcoming";
+
+interface Step {
+  n: number;
+  title: string;
+  description: string;
+  state: StepState;
+  action?: { content: string; onAction: () => void };
+}
+
+/** Fixed-size circular step marker so every step title aligns on one gutter.
+ *  Uses Polaris color tokens (theme-correct in light/dark). Decorative — the
+ *  step title carries the meaning, so it's aria-hidden. */
+function StepMarker({ state, n }: { state: StepState; n: number }) {
+  const base: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 28,
+    height: 28,
+    borderRadius: "9999px",
+    flex: "0 0 auto",
+    fontSize: 13,
+    fontWeight: 600,
+    lineHeight: 1,
+  };
+  if (state === "done") {
+    return (
+      <span
+        aria-hidden
+        style={{
+          ...base,
+          background: "var(--p-color-bg-fill-success)",
+          color: "var(--p-color-text-on-bg-fill)",
+        }}
+      >
+        ✓
+      </span>
+    );
+  }
+  const current = state === "current";
+  return (
+    <span
+      aria-hidden
+      style={{
+        ...base,
+        background: current ? "var(--p-color-bg-fill-brand)" : "var(--p-color-bg-surface-secondary)",
+        color: current ? "var(--p-color-text-on-bg-fill)" : "var(--p-color-text-secondary)",
+        border: current ? "none" : "1px solid var(--p-color-border)",
+      }}
+    >
+      {n}
+    </span>
+  );
+}
+
+function StepRow({ step }: { step: Step }) {
+  return (
+    <InlineStack gap="400" blockAlign="start" wrap={false}>
+      <StepMarker state={step.state} n={step.n} />
+      <BlockStack gap="100">
+        <InlineStack gap="200" blockAlign="center">
+          <Text as="h3" variant="headingSm">
+            {step.title}
+          </Text>
+          {step.state === "current" && <Badge tone="attention">Do this now</Badge>}
+        </InlineStack>
+        <Text as="p" variant="bodyMd" tone="subdued">
+          {step.description}
+        </Text>
+        {step.action && step.state === "current" && (
+          <Box paddingBlockStart="100">
+            <Button variant="primary" onClick={step.action.onAction}>
+              {step.action.content}
+            </Button>
+          </Box>
+        )}
+      </BlockStack>
+    </InlineStack>
+  );
+}
+
+export function LensActivationHub({ shop, status }: { shop?: string | null; status?: string }) {
+  const reconnecting = status === "disconnected";
+
+  const steps: Step[] = [
+    {
+      n: 1,
+      title: reconnecting ? "Reconnect your Shopify store" : "Connect your Shopify store",
+      description: reconnecting
+        ? "Your Peakhour account is still active — reconnect to resume catalog sync and your AI Commerce Assistant."
+        : "Link your store so Peakhour can sync your catalog and power your AI Commerce Assistant.",
+      state: "current",
+      action: {
+        content: reconnecting ? "Reconnect Shopify" : "Connect Shopify",
+        onAction: () => {
+          void startReconnect(shop);
+        },
+      },
+    },
+    {
+      n: 2,
+      title: "Join the Growth Network",
+      description:
+        "Free, privacy-first benchmarks and insights for stores like yours. You'll be invited to join right after connecting — opt-in only, leave anytime.",
+      state: "upcoming",
+    },
+    {
+      n: 3,
+      title: "You're on Lens — free",
+      description:
+        "Lens is free, with no card and no charge. Upgrade to the paid Commerce Assistant whenever you want live AI selling on WhatsApp.",
+      state: "upcoming",
+    },
+  ];
+
+  return (
+    <Page title="Peakhour Commerce">
+      <BlockStack gap="500">
+        <Card>
+          <BlockStack gap="200">
+            <Text as="h2" variant="headingLg">
+              {reconnecting ? "Reconnect to continue" : "Get started with Lens"}
+            </Text>
+            <Text as="p" variant="bodyMd" tone="subdued">
+              Three quick steps — the first is the only one you need right now.
+            </Text>
+          </BlockStack>
+        </Card>
+
+        <Card>
+          <BlockStack gap="400">
+            {steps.map((s, i) => (
+              <Fragment key={s.n}>
+                {i > 0 && <Divider />}
+                <StepRow step={s} />
+              </Fragment>
+            ))}
+          </BlockStack>
+        </Card>
+      </BlockStack>
+    </Page>
+  );
+}

--- a/src/app/(commerce)/shopify/embedded/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/page.tsx
@@ -18,7 +18,8 @@ import {
   InlineGrid,
 } from "@shopify/polaris";
 import { getSessionToken } from "./_lib/session";
-import { CommerceDisconnected } from "./_components/commerce-disconnected";
+import { LensActivationHub } from "./_components/lens-activation-hub";
+import { FinishSetupCard } from "./_components/finish-setup-card";
 import { FadeIn } from "./_components/fade-in";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
@@ -122,6 +123,10 @@ function ConnectedHome({ ctx, onSync, syncing, syncError, onSubscribe, subscribi
       subtitle={storeName}
     >
       <BlockStack gap="500">
+        {/* Soft activation tail — only shows when on free Lens and not yet a
+            Growth Network member; dismissible and self-hiding (step 2 of 3). */}
+        <FinishSetupCard shop={ctx.shop} />
+
         {/* ── Card 1 — Store Health ───────────────────────────────────── */}
         <div className="ph-hover-lift">
         <Card>
@@ -394,11 +399,7 @@ export default function ShopifyEmbeddedHome() {
   if (!state.ctx.connected) {
     return (
       <FadeIn>
-        <CommerceDisconnected
-          shop={state.ctx.shop}
-          pageTitle="Peakhour Commerce"
-          heading={state.ctx.status === "disconnected" ? "Commerce Disconnected" : "Set up Peakhour Commerce"}
-        />
+        <LensActivationHub shop={state.ctx.shop} status={state.ctx.status} />
       </FadeIn>
     );
   }


### PR DESCRIPTION
## What
Replaces the three fragmented disconnected CTAs (**Connect / Join Network / Subscribe**) with **one unified activation journey**, plus a soft completion nudge on the connected home. Second PR of the [Lens onboarding unification](https://github.com/travelxp/peakhour-mongodb/blob/master/docs/idea/lens-onboarding-peaks-plan.md).

> **Stacked on #336** (the Growth Network rename). Base this PR's merge after #336, or merge #336 first and rebase.

## Components
- **`LensActivationHub`** — full-page 3-step journey on the `!connected` home: ① Connect Shopify (the only action needed now) → ② Join Growth Network (preview) → ③ You're on Lens, free (preview). Free Lens is an **implicit default state** (no entitlement write), so there is deliberately **no "subscribe to free" step**. Replaces `CommerceDisconnected` on the home; that component stays in use on settings/pin/catalog (those move to the hub in PR 1.3).
- **`FinishSetupCard`** — dismissible card on the connected home, shown only when the merchant is on free Lens and **not yet** a Growth Network member. Fail-closed (hidden on load error), no flash-of-content.

## UX behavior (locked decision: "soft")
Full journey on disconnected; dismissible "Finish setup (2 of 3)" card once connected. Respects merchants who skip — never takes over the dashboard.

## Review incorporated
An independent review pass flagged two LOW issues, both fixed here:
- **Per-shop dismissal key** — embedded apps are multi-store; a global key suppressed the card cross-store.
- **Silent post-join** — joining now shows a "You're in the Growth Network" confirmation instead of the card vanishing (which read as failure).

## Verification
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean
- ✅ Endpoints/payloads consistent with the existing `/pin` page (`GET /pin/status`, `POST /pin/consent {action:"opt_in"}`)
- ✅ `CommerceDisconnected` still imported/used by settings, pin, catalog — not broken

## Next in Phase 1
- PR 1.3 — demote nav items until activated + route settings/pin/catalog dead-ends into the hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)