### PR TITLE
feat(peaks): per-task usage breakdown UI (transparency for cert)

### DIFF
--- a/src/app/(commerce)/shopify/embedded/peaks/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/peaks/page.tsx
@@ -57,11 +57,20 @@ interface PeaksPack {
   currency: string;
 }
 
+interface UsageByTask {
+  useCase: string;
+  label: string;
+  peaks: number;
+  calls: number;
+}
+
 interface PeaksData {
   balance: Balance;
   rateCard: { useCases: RateCardUseCase[] };
   /** Active, public top-up packs. Empty until ops activates one (dormant). */
   availablePacks?: PeaksPack[];
+  /** Per-task consumption over the current period. */
+  usage?: { byTask: UsageByTask[]; total: number; periodDays: number };
 }
 
 type State =
@@ -225,6 +234,50 @@ function RateCard({ useCases }: { useCases: RateCardUseCase[] }) {
   );
 }
 
+function UsageBreakdown({
+  usage,
+}: {
+  usage: { byTask: UsageByTask[]; total: number; periodDays: number };
+}) {
+  return (
+    <Card>
+      <BlockStack gap="300">
+        <InlineStack align="space-between" blockAlign="center" wrap={false}>
+          <Text as="h2" variant="headingMd">
+            Where your Peaks go
+          </Text>
+          {usage.byTask.length > 0 && (
+            <Text as="span" variant="bodySm" tone="subdued">
+              last {usage.periodDays} days · {usage.total.toLocaleString()} Peaks
+            </Text>
+          )}
+        </InlineStack>
+        <Text as="p" variant="bodySm" tone="subdued">
+          What you&rsquo;ve actually spent Peaks on this period, by task.
+        </Text>
+        <Divider />
+        {usage.byTask.length > 0 ? (
+          <DataTable
+            columnContentTypes={["text", "numeric", "numeric"]}
+            headings={["Task", "Peaks used", "Times"]}
+            rows={usage.byTask.map((t) => [
+              t.label,
+              t.peaks.toLocaleString(),
+              t.calls.toLocaleString(),
+            ])}
+          />
+        ) : (
+          <Box paddingBlock="400">
+            <Text as="p" variant="bodyMd" tone="subdued">
+              No Peaks used yet this period — your usage by task will appear here.
+            </Text>
+          </Box>
+        )}
+      </BlockStack>
+    </Card>
+  );
+}
+
 function BuyPeaks({ packs }: { packs: PeaksPack[] }) {
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -366,6 +419,7 @@ export default function PeaksPage() {
     <Page title="Peaks" subtitle="Your AI credits — what you have and what each task costs.">
       <BlockStack gap="500">
         <BalanceCard balance={state.data.balance} />
+        {state.data.usage && <UsageBreakdown usage={state.data.usage} />}
         {state.data.availablePacks && state.data.availablePacks.length > 0 && (
           <BuyPeaks packs={state.data.availablePacks} />
         )}


### PR DESCRIPTION
## What
Adds **"Where your Peaks go"** to the embedded Peaks page — a per-task table (Task / Peaks used / Times) for the current period, between the balance and the rate card. The usage-transparency artifact a Shopify reviewer asks for. Pairs with **peakhour-api#573**.

## Result — the embedded Peaks page now shows the full picture
1. **Balance** — used / remaining this period (+ top-up).
2. **Where your Peaks go** — *actual* per-task consumption (this PR).
3. **Rate card** — what each task *costs*.
4. **Buy more Peaks** — top-ups (dormant until activated).

So a reviewer sees both **cost per task** and **what was actually spent, by task** — the transparency they require.

## Notes
- Reads the new `usage` field; **backwards-compatible** (renders only when present).
- Has an empty state ("No Peaks used yet this period…").

## Verification
- ✅ `tsc --noEmit` clean · `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)