### PR TITLE
fix(peaks): QC fixes — reachable cap banner + correct notlinked copy

### DIFF
--- a/src/app/(commerce)/shopify/embedded/peaks/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/peaks/page.tsx
@@ -75,7 +75,7 @@ interface PeaksData {
 
 type State =
   | { status: "loading" }
-  | { status: "notlinked" }
+  | { status: "notlinked"; disconnected: boolean }
   | { status: "error"; message: string }
   | { status: "ready"; data: PeaksData };
 
@@ -180,10 +180,10 @@ function BalanceCard({ balance }: { balance: Balance }) {
               allowance, top up below, or wait until they reset.
             </Text>
           </Banner>
-        ) : atHardCap && topUp === 0 ? (
+        ) : atHardCap && topUp > 0 ? (
           <Banner tone="warning">
             <Text as="p" variant="bodyMd">
-              You&rsquo;ve hit your plan allowance for this period.
+              You&rsquo;ve hit your plan allowance — now drawing from your top-up Peaks.
             </Text>
           </Banner>
         ) : overSoftCap ? (
@@ -381,7 +381,8 @@ export default function PeaksPage() {
         // 404 = store not linked, 400 = store inactive — both route to the
         // unified activation journey rather than a dead end.
         if (res.status === 404 || res.status === 400) {
-          setState({ status: "notlinked" });
+          // 404 = never linked (Connect), 400 = store inactive/disconnected (Reconnect).
+          setState({ status: "notlinked", disconnected: res.status === 400 });
           return;
         }
         if (!res.ok) {
@@ -401,7 +402,8 @@ export default function PeaksPage() {
   }, []);
 
   if (state.status === "loading") return <PeaksSkeleton />;
-  if (state.status === "notlinked") return <LensActivationHub shop={shop} />;
+  if (state.status === "notlinked")
+    return <LensActivationHub shop={shop} status={state.disconnected ? "disconnected" : undefined} />;
 
   if (state.status === "error") {
     return (


### PR DESCRIPTION
## What
Two LOW-severity fixes from the adversarial QC audit of the embedded Peaks page.

- **Unreachable banner branch** — `atHardCap && topUp===0` is always also `exhausted` (`remaining===0`), so the critical "used all your Peaks" banner always won and the warning never rendered. Re-aimed at the real case: **`atHardCap && topUp > 0`** → "You've hit your plan allowance — now drawing from your top-up Peaks."
- **`notlinked` copy** — the hub was rendered without `status`, so a *disconnected* store (api 400) saw "**Connect**" instead of "**Reconnect**". Now passes `status="disconnected"` for 400 vs none for 404 (never linked), matching settings/catalog.

## Verification
- ✅ `tsc --noEmit` clean · `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)