### PR TITLE
feat(theme): Solar default + token theme system (feature-2)

### DIFF
--- a/design-system/DESIGN-GUIDE.md
+++ b/design-system/DESIGN-GUIDE.md
@@ -1,0 +1,63 @@
+# Peakhour — Design Guide
+
+The visual system behind `peakhour-b2c`. Tokens are the contract: every component reads CSS custom-property slots, so the whole product re-skins by swapping the token layer. Open **`Peakhour-Themes.html`** in this folder for the live, switchable reference.
+
+---
+
+## 1. Brand POV — "Solar / Peak"
+Warmth, used with discipline. A deep **warm ink** (never pure black), warm paper neutrals, and **one brave accent — Peak Amber** — carried by the logo, the "Peaks" currency, focus states, and key moments. Cold indigo "AI-tech" is deliberately avoided. Premium = space + restraint + one confident color.
+
+## 2. Color tokens (light)
+Authoring uses the shadcn slot names; brand truth is in OKLCH.
+
+| Token | Value (OKLCH) | Role |
+|---|---|---|
+| `--brand` | `0.77 0.146 67` | Peak Amber — accent, focus, Peaks |
+| `--brand-strong` | `0.66 0.156 50` | Ember — hovers, gradients |
+| `--brand-gold` | `0.86 0.13 88` | Sun Gold — highlights |
+| `--background` | `0.985 0.007 78` | warm paper |
+| `--foreground` | `0.205 0.014 58` | warm ink |
+| `--primary` | `0.205 0.014 58` | primary actions = ink (premium, high-contrast) |
+| `--muted-foreground` | `0.52 0.016 62` | supporting text |
+| `--border` | `0.9 0.011 78` | hairline |
+| `--ring` | `var(--brand)` | focus glows amber |
+| `--destructive` | `0.585 0.2 27` | warm red |
+
+Full light + dark sets live in `src/app/globals.css` (`:root` / `.dark`). Data-viz ramp is warm-led: amber → teal → terracotta → gold → plum (`--chart-1…5`).
+
+## 3. Themes (token overlays)
+Same components, different token set. Switch via `:root[data-theme="…"]`.
+
+| Theme | Type | Character |
+|---|---|---|
+| **Solar / Peak** | flagship (default) | warm amber, disciplined, premium |
+| **Tidal / Deep** | direction | cool ocean teal, technical, calm |
+| **Noir / Editorial** | direction | high-contrast ink, serif display, one sharp red |
+| **Diwali** | seasonal | jewel plum, marigold, magenta |
+| **Christmas** | seasonal | snow, pine, cranberry |
+
+Seasonal/country themes are scheduled by the CMS (see `CLAUDE-CODE-CMS-DYNAMIC.md`).
+
+## 4. Typography
+| Family | Token | Use |
+|---|---|---|
+| Sora | `--font-display` | headlines, hero, big numbers |
+| Plus Jakarta Sans / Geist | `--font-sans` | body, UI |
+| Space Grotesk | `--font-numeric` | metrics, Peaks currency, data |
+| Geist Mono | `--font-mono` | code, IDs, logs |
+
+Scale (rem): `2xs .625 · xs .75 · sm .875 · base 1 · lg 1.125 · xl 1.375 · 2xl 1.625 · 3xl 2 · 4xl 2.5 · 5xl 3.25 · 6xl 4.25 · 7xl 5.25`. Headings run tight (`tracking -0.02em`); display goes tighter (`-0.03em`). Body stays warm and very legible (`line-height 1.55`).
+
+## 5. Spacing, radius, elevation
+- **Spacing:** 4px grid. Default card padding/gap `24px`; section rhythm `80px`; hero `96px`.
+- **Radius:** derived from one `--radius` (10px) — `sm 6 · md 8 · lg 10 · xl 14 · 2xl 18`. Retune one number, everything stays in proportion. (Noir overrides `--radius` to 4px for a sharp editorial feel; Tidal to 12px.)
+- **Elevation:** restrained shadow ladder (`xs → lg`). Borders do most of the separation; shadows are a secondary cue. Surfaces lift on hover (`sm → md`).
+- **Focus:** `3px` ring at `--ring` (amber), 50% mixed.
+
+## 6. Usage rules
+- One brave accent. Don't introduce a second saturated color per surface — let amber lead.
+- Primary actions are **ink** in light, **amber** in dark. Keep that inversion.
+- Use `--brand-soft` for amber tints/chips; `--brand-ink` for text **on** amber.
+- Dark dramatic sections use `--surface-ink`; the logo sits on the dark tile.
+- Charts follow the warm-led ramp; don't recolor series ad hoc.
+- Never hard-code a hex in a component — read the slot, so themes keep working.

--- a/design-system/Peakhour-Themes.html
+++ b/design-system/Peakhour-Themes.html
@@ -1,0 +1,488 @@
+<!doctype html>
+<html lang="en" data-theme="solar">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Peakhour · Theme Directions</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600;6..72,700&display=swap" rel="stylesheet" />
+<style>
+/* ============================================================
+   PEAKHOUR · base tokens (shared, non-color)
+   ============================================================ */
+:root{
+  --font-display:"Sora","Plus Jakarta Sans",ui-sans-serif,system-ui,sans-serif;
+  --font-sans:"Plus Jakarta Sans",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --font-numeric:"Space Grotesk","Plus Jakarta Sans",ui-sans-serif,sans-serif;
+  --font-mono:"Geist Mono",ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  --fw-medium:500;--fw-semibold:600;--fw-bold:700;--fw-extrabold:800;
+  --tracking-tight:-0.02em;--tracking-eyebrow:0.12em;--tracking-display:-0.03em;
+  --space-2:.5rem;--space-3:.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;
+  --radius:.625rem;
+  --shadow-sm:0 1px 3px 0 rgb(0 0 0/.08),0 1px 2px -1px rgb(0 0 0/.08);
+  --shadow-md:0 4px 6px -1px rgb(0 0 0/.08),0 2px 4px -2px rgb(0 0 0/.07);
+  --shadow-lg:0 10px 15px -3px rgb(0 0 0/.10),0 4px 6px -4px rgb(0 0 0/.06);
+  --shadow-xl:0 20px 28px -8px rgb(0 0 0/.18);
+  --ring-width:3px;
+  --ease:cubic-bezier(.4,0,.2,1);
+}
+
+/* ============================================================
+   THEME LAYERS — each block below is a drop-in token file.
+   To ship one as code: copy a [data-theme] block into
+   tokens/theme-<name>.css. Nothing else changes.
+   ============================================================ */
+
+/* ---- SOLAR / PEAK (flagship) ---- */
+[data-theme="solar"]{
+  --brand:oklch(.77 .146 67);--brand-strong:oklch(.66 .156 50);--brand-gold:oklch(.86 .13 88);--brand-soft:oklch(.95 .045 78);--brand-ink:oklch(.27 .05 55);
+  --background:oklch(.985 .007 78);--foreground:oklch(.205 .014 58);--card:oklch(.998 .004 80);
+  --primary:oklch(.205 .014 58);--primary-foreground:oklch(.985 .006 80);
+  --secondary:oklch(.955 .009 78);--secondary-foreground:oklch(.205 .014 58);
+  --muted:oklch(.955 .009 78);--muted-foreground:oklch(.52 .016 62);
+  --accent:oklch(.95 .012 78);--border:oklch(.9 .011 78);--ring:var(--brand);
+  --c1:var(--brand);--c2:oklch(.62 .092 200);--c3:oklch(.62 .14 40);--c4:var(--brand-gold);--c5:oklch(.52 .11 330);
+  --grad:linear-gradient(135deg,var(--brand-gold) 0%,var(--brand) 45%,var(--brand-strong) 100%);
+  --radius:.625rem;--font-display:"Sora","Plus Jakarta Sans",sans-serif;
+}
+[data-theme="solar"].dark{
+  --background:oklch(.165 .012 60);--foreground:oklch(.97 .006 82);--card:oklch(.215 .013 60);
+  --primary:var(--brand);--primary-foreground:oklch(.22 .04 55);
+  --secondary:oklch(.27 .013 60);--secondary-foreground:oklch(.97 .006 82);
+  --muted:oklch(.27 .013 60);--muted-foreground:oklch(.72 .014 70);
+  --accent:oklch(.3 .016 62);--border:oklch(1 0 0/.11);--brand-soft:oklch(.32 .05 60);
+}
+
+/* ---- TIDAL / DEEP (cool, technical) ---- */
+[data-theme="tidal"]{
+  --brand:oklch(.68 .13 200);--brand-strong:oklch(.55 .13 222);--brand-gold:oklch(.83 .1 195);--brand-soft:oklch(.95 .03 205);--brand-ink:oklch(.99 .01 210);
+  --background:oklch(.985 .004 230);--foreground:oklch(.23 .022 248);--card:oklch(.998 .003 230);
+  --primary:oklch(.23 .022 248);--primary-foreground:oklch(.99 .004 230);
+  --secondary:oklch(.955 .008 235);--secondary-foreground:oklch(.23 .022 248);
+  --muted:oklch(.955 .008 235);--muted-foreground:oklch(.5 .025 245);
+  --accent:oklch(.95 .012 230);--border:oklch(.9 .01 235);--ring:var(--brand);
+  --c1:var(--brand);--c2:oklch(.6 .12 250);--c3:oklch(.7 .11 180);--c4:oklch(.55 .13 280);--c5:oklch(.6 .04 240);
+  --grad:linear-gradient(135deg,oklch(.82 .1 195) 0%,var(--brand) 50%,var(--brand-strong) 100%);
+  --radius:.75rem;--font-display:"Sora","Plus Jakarta Sans",sans-serif;
+}
+[data-theme="tidal"].dark{
+  --background:oklch(.17 .012 245);--foreground:oklch(.97 .005 230);--card:oklch(.21 .013 245);
+  --primary:var(--brand);--primary-foreground:oklch(.2 .03 230);
+  --secondary:oklch(.26 .014 245);--secondary-foreground:oklch(.97 .005 230);
+  --muted:oklch(.26 .014 245);--muted-foreground:oklch(.7 .015 240);
+  --accent:oklch(.3 .016 245);--border:oklch(1 0 0/.11);--brand-soft:oklch(.3 .05 230);
+}
+
+/* ---- NOIR / EDITORIAL (high-contrast, serif display, one sharp red) ---- */
+[data-theme="noir"]{
+  --brand:oklch(.55 .18 28);--brand-strong:oklch(.47 .18 27);--brand-gold:oklch(.7 .13 40);--brand-soft:oklch(.94 .04 30);--brand-ink:oklch(.99 .01 30);
+  --background:oklch(.99 .001 100);--foreground:oklch(.17 .004 50);--card:oklch(1 0 0);
+  --primary:oklch(.17 .004 50);--primary-foreground:oklch(.99 0 0);
+  --secondary:oklch(.95 .002 80);--secondary-foreground:oklch(.17 .004 50);
+  --muted:oklch(.95 .002 80);--muted-foreground:oklch(.45 .006 60);
+  --accent:oklch(.95 .002 80);--border:oklch(.86 .003 70);--ring:var(--brand);
+  --c1:oklch(.17 .004 50);--c2:oklch(.55 .18 28);--c3:oklch(.55 .01 60);--c4:oklch(.7 .13 40);--c5:oklch(.72 .006 60);
+  --grad:linear-gradient(135deg,oklch(.34 .02 40) 0%,oklch(.17 .004 50) 100%);
+  --radius:.25rem;--font-display:"Newsreader",Georgia,serif;
+}
+[data-theme="noir"].dark{
+  --background:oklch(.15 .003 50);--foreground:oklch(.97 .002 90);--card:oklch(.19 .004 50);
+  --primary:oklch(.97 .002 90);--primary-foreground:oklch(.15 .003 50);
+  --secondary:oklch(.24 .004 50);--secondary-foreground:oklch(.97 .002 90);
+  --muted:oklch(.24 .004 50);--muted-foreground:oklch(.65 .005 70);
+  --accent:oklch(.26 .004 50);--border:oklch(1 0 0/.12);--brand-soft:oklch(.3 .06 30);
+}
+
+/* ---- DIWALI (seasonal · jewel plum, marigold & magenta) ---- */
+[data-theme="diwali"]{
+  --brand:oklch(.78 .16 72);--brand-strong:oklch(.68 .17 55);--brand-gold:oklch(.85 .14 92);--brand-soft:oklch(.34 .07 340);--brand-ink:oklch(.2 .04 60);
+  --background:oklch(.2 .035 335);--foreground:oklch(.96 .02 80);--card:oklch(.25 .045 338);
+  --primary:oklch(.78 .16 72);--primary-foreground:oklch(.2 .04 60);
+  --secondary:oklch(.3 .05 338);--secondary-foreground:oklch(.96 .02 80);
+  --muted:oklch(.3 .05 338);--muted-foreground:oklch(.8 .04 330);
+  --accent:oklch(.34 .06 340);--border:oklch(1 0 0/.13);--ring:var(--brand);
+  --c1:var(--brand);--c2:oklch(.6 .2 350);--c3:var(--brand-gold);--c4:oklch(.6 .15 300);--c5:oklch(.7 .13 30);
+  --grad:linear-gradient(135deg,var(--brand-gold) 0%,var(--brand) 45%,oklch(.6 .2 350) 100%);
+  --radius:.875rem;--font-display:"Sora","Plus Jakarta Sans",sans-serif;
+}
+
+/* ---- CHRISTMAS (seasonal · snow, pine & cranberry) ---- */
+[data-theme="christmas"]{
+  --brand:oklch(.46 .1 155);--brand-strong:oklch(.38 .1 152);--brand-gold:oklch(.8 .12 85);--brand-soft:oklch(.94 .04 150);--brand-ink:oklch(.98 .01 150);
+  --background:oklch(.987 .005 150);--foreground:oklch(.24 .04 152);--card:oklch(1 0 0);
+  --primary:oklch(.46 .1 155);--primary-foreground:oklch(.98 .01 150);
+  --secondary:oklch(.95 .015 150);--secondary-foreground:oklch(.24 .04 152);
+  --muted:oklch(.95 .015 150);--muted-foreground:oklch(.46 .03 150);
+  --accent:oklch(.95 .02 150);--border:oklch(.89 .015 150);--ring:oklch(.52 .17 20);
+  --c1:var(--brand);--c2:oklch(.52 .17 20);--c3:var(--brand-gold);--c4:oklch(.55 .09 155);--c5:oklch(.7 .1 60);
+  --grad:linear-gradient(135deg,oklch(.52 .17 20) 0%,var(--brand) 100%);
+  --radius:.625rem;--font-display:"Sora","Plus Jakarta Sans",sans-serif;
+}
+
+/* ============================================================
+   PAGE + COMPONENT STYLES (token-driven — never hard-coded)
+   ============================================================ */
+*,*::before,*::after{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;background:var(--background);color:var(--foreground);
+  font-family:var(--font-sans);font-size:.875rem;line-height:1.55;
+  -webkit-font-smoothing:antialiased;
+  transition:background .35s var(--ease),color .35s var(--ease);
+}
+h1,h2,h3,h4{margin:0;font-family:var(--font-display);font-weight:var(--fw-bold);letter-spacing:var(--tracking-tight);line-height:1.12;text-wrap:balance}
+p{margin:0;text-wrap:pretty}
+.num{font-family:var(--font-numeric);font-feature-settings:"tnum"}
+.eyebrow{font-size:.6875rem;font-weight:var(--fw-semibold);letter-spacing:var(--tracking-eyebrow);text-transform:uppercase;color:var(--muted-foreground)}
+
+.wrap{max-width:1180px;margin:0 auto;padding:0 var(--space-6)}
+
+/* header */
+.topbar{position:sticky;top:0;z-index:20;background:color-mix(in oklch,var(--background) 86%,transparent);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topbar-in{display:flex;align-items:center;gap:var(--space-4);height:60px}
+.brand{display:flex;align-items:center;gap:.6rem;font-family:var(--font-display);font-weight:var(--fw-extrabold);letter-spacing:-.02em;font-size:1.05rem}
+.peak{width:26px;height:26px;display:grid;place-items:center;background:var(--brand);border-radius:7px;box-shadow:var(--shadow-sm)}
+.peak svg{display:block}
+.spacer{flex:1}
+.control{display:flex;align-items:center;gap:.5rem}
+select.theme{
+  appearance:none;font-family:var(--font-sans);font-weight:var(--fw-semibold);font-size:.85rem;color:var(--foreground);
+  background:var(--card);border:1px solid var(--border);border-radius:calc(var(--radius) - 2px);
+  padding:.5rem 2rem .5rem .8rem;cursor:pointer;box-shadow:var(--shadow-sm);
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2 4l4 4 4-4' stroke='%23888' stroke-width='1.6' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;background-position:right .7rem center;
+}
+.iconbtn{width:38px;height:38px;display:grid;place-items:center;background:var(--card);border:1px solid var(--border);border-radius:calc(var(--radius) - 2px);cursor:pointer;color:var(--foreground);box-shadow:var(--shadow-sm)}
+.iconbtn:disabled{opacity:.4;cursor:not-allowed}
+
+/* hero */
+.hero{padding:var(--space-12) 0 var(--space-8)}
+.hero h1{font-size:clamp(2rem,4.4vw,3.1rem);letter-spacing:var(--tracking-display)}
+.hero p{color:var(--muted-foreground);font-size:1.05rem;max-width:46ch;margin-top:var(--space-4)}
+.theme-pills{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:var(--space-6)}
+.pill{display:inline-flex;align-items:center;gap:.5rem;padding:.45rem .8rem;border-radius:999px;border:1px solid var(--border);background:var(--card);cursor:pointer;font-weight:var(--fw-semibold);font-size:.8rem;color:var(--foreground);transition:.18s var(--ease)}
+.pill .dot{width:11px;height:11px;border-radius:50%}
+.pill[aria-pressed="true"]{border-color:var(--brand);box-shadow:0 0 0 1px var(--brand) inset}
+.pill .tag{font-size:.62rem;font-weight:var(--fw-bold);letter-spacing:.06em;text-transform:uppercase;color:var(--brand-strong);background:var(--brand-soft);padding:.05rem .35rem;border-radius:4px}
+
+/* board grid */
+.board{display:grid;grid-template-columns:repeat(12,1fr);gap:var(--space-5);padding-bottom:var(--space-12)}
+.card{background:var(--card);border:1px solid var(--border);border-radius:calc(var(--radius) + 4px);box-shadow:var(--shadow-sm);transition:box-shadow .2s var(--ease),background .35s var(--ease),border-color .35s var(--ease)}
+.card:hover{box-shadow:var(--shadow-md)}
+.card-pad{padding:var(--space-6)}
+.card h3{font-size:1.05rem}
+.card .sub{color:var(--muted-foreground);font-size:.8rem;margin-top:.2rem}
+.col-3{grid-column:span 3}.col-4{grid-column:span 4}.col-5{grid-column:span 5}.col-6{grid-column:span 6}.col-7{grid-column:span 7}.col-8{grid-column:span 8}.col-12{grid-column:span 12}
+
+/* KPI */
+.kpi{display:flex;flex-direction:column;gap:.4rem}
+.kpi .label{font-size:.75rem;color:var(--muted-foreground);font-weight:var(--fw-medium)}
+.kpi .val{font-family:var(--font-numeric);font-weight:var(--fw-bold);font-size:2.1rem;letter-spacing:-.02em;display:flex;align-items:center;gap:.4rem}
+.kpi .val .peaks{color:var(--brand-strong)}
+.delta{font-size:.72rem;font-weight:var(--fw-semibold);display:inline-flex;align-items:center;gap:.25rem;color:var(--c2)}
+.delta.up{color:oklch(.58 .13 162)}
+
+/* buttons */
+.row{display:flex;flex-wrap:wrap;gap:.6rem;align-items:center}
+.btn{font-family:var(--font-sans);font-weight:var(--fw-semibold);font-size:.83rem;border-radius:calc(var(--radius) - 2px);padding:.55rem .95rem;border:1px solid transparent;cursor:pointer;transition:.16s var(--ease);display:inline-flex;align-items:center;gap:.4rem}
+.btn:active{transform:translateY(1px)}
+.btn-primary{background:var(--primary);color:var(--primary-foreground)}
+.btn-primary:hover{filter:brightness(1.08)}
+.btn-brand{background:var(--brand);color:var(--brand-ink)}
+.btn-brand:hover{background:var(--brand-strong)}
+.btn-secondary{background:var(--secondary);color:var(--secondary-foreground);border-color:var(--border)}
+.btn-secondary:hover{background:var(--accent)}
+.btn-ghost{background:transparent;color:var(--foreground)}
+.btn-ghost:hover{background:var(--accent)}
+.btn-outline{background:transparent;color:var(--foreground);border-color:var(--border)}
+.btn-outline:hover{border-color:var(--brand);color:var(--brand-strong)}
+
+/* badges */
+.badge{font-size:.7rem;font-weight:var(--fw-semibold);padding:.22rem .55rem;border-radius:999px;display:inline-flex;align-items:center;gap:.3rem}
+.badge::before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor}
+.b-brand{color:var(--brand-strong);background:var(--brand-soft)}
+.b-success{color:oklch(.5 .13 162);background:color-mix(in oklch,oklch(.6 .13 162) 16%,var(--card))}
+.b-info{color:oklch(.5 .1 235);background:color-mix(in oklch,oklch(.62 .1 235) 16%,var(--card))}
+.b-violet{color:oklch(.5 .13 330);background:color-mix(in oklch,oklch(.55 .13 330) 16%,var(--card))}
+
+/* form */
+.field{display:flex;flex-direction:column;gap:.35rem;margin-bottom:var(--space-4)}
+.field label{font-size:.75rem;font-weight:var(--fw-semibold)}
+.input,.sel{font-family:var(--font-sans);font-size:.85rem;color:var(--foreground);background:var(--card);border:1px solid var(--border);border-radius:calc(var(--radius) - 2px);padding:.55rem .7rem;width:100%;transition:.16s var(--ease)}
+.input:focus,.sel:focus{outline:none;border-color:var(--brand);box-shadow:0 0 0 var(--ring-width) color-mix(in oklch,var(--ring) 45%,transparent)}
+.input::placeholder{color:var(--muted-foreground)}
+.switch{position:relative;width:42px;height:24px;border-radius:999px;background:var(--muted);border:1px solid var(--border);cursor:pointer;transition:.18s var(--ease);flex:none}
+.switch.on{background:var(--brand);border-color:var(--brand)}
+.switch::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:#fff;box-shadow:var(--shadow-sm);transition:.18s var(--ease)}
+.switch.on::after{left:21px}
+.switch-row{display:flex;align-items:center;justify-content:space-between;gap:.8rem;padding:.5rem 0}
+.switch-row span{font-size:.82rem;font-weight:var(--fw-medium)}
+
+/* chart */
+.chart{display:flex;align-items:flex-end;gap:.5rem;height:150px;margin-top:var(--space-5)}
+.bar{flex:1;border-radius:6px 6px 0 0;min-height:8px;transition:height .4s var(--ease),background .35s var(--ease)}
+.legend{display:flex;flex-wrap:wrap;gap:.6rem .9rem;margin-top:var(--space-4)}
+.legend span{display:inline-flex;align-items:center;gap:.35rem;font-size:.72rem;color:var(--muted-foreground)}
+.legend i{width:9px;height:9px;border-radius:3px;display:inline-block}
+
+/* CTA banner */
+.cta{position:relative;overflow:hidden;border-radius:calc(var(--radius) + 8px);background:var(--grad);color:#fff;padding:var(--space-8);display:flex;align-items:center;justify-content:space-between;gap:var(--space-6);flex-wrap:wrap}
+.cta h3{font-size:1.5rem;color:#fff;max-width:22ch}
+.cta p{color:rgba(255,255,255,.85);margin-top:.4rem;font-size:.9rem}
+.cta .btn-brand{background:#fff;color:#1a1a1a}
+.cta .btn-brand:hover{background:rgba(255,255,255,.88)}
+
+/* swatch ramp */
+.ramp{display:flex;gap:6px;margin-top:var(--space-4)}
+.ramp i{flex:1;height:46px;border-radius:7px;border:1px solid var(--border)}
+.ramp-label{font-size:.68rem;color:var(--muted-foreground);font-family:var(--font-mono);margin-top:.5rem}
+
+/* at-a-glance rail */
+.glance{padding:var(--space-12) 0 var(--space-16)}
+.glance-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:var(--space-4);margin-top:var(--space-6)}
+.tcard{border:1px solid var(--border);border-radius:calc(var(--radius) + 2px);overflow:hidden;cursor:pointer;background:var(--card);transition:.18s var(--ease)}
+.tcard:hover{transform:translateY(-3px);box-shadow:var(--shadow-lg)}
+.tcard[aria-current="true"]{outline:2px solid var(--brand);outline-offset:1px}
+.tcard .preview{height:84px;display:flex}
+.tcard .preview b{flex:1}
+.tcard .meta{padding:.7rem .8rem}
+.tcard .meta strong{font-size:.82rem;display:block}
+.tcard .meta small{font-size:.68rem;color:var(--muted-foreground);display:block;margin-top:.2rem;line-height:1.4}
+.tcard .meta .tag{font-size:.58rem;font-weight:var(--fw-bold);letter-spacing:.06em;text-transform:uppercase;color:var(--brand-strong)}
+
+/* architecture note */
+.arch{background:var(--secondary);border-top:1px solid var(--border);border-bottom:1px solid var(--border)}
+.arch-in{padding:var(--space-16) 0;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-12)}
+.arch h2{font-size:1.9rem;letter-spacing:var(--tracking-tight)}
+.arch .lead{color:var(--muted-foreground);margin-top:var(--space-4);font-size:1rem;max-width:42ch}
+.steps{display:flex;flex-direction:column;gap:var(--space-5)}
+.step{display:flex;gap:var(--space-4)}
+.step .n{flex:none;width:30px;height:30px;border-radius:8px;background:var(--brand);color:var(--brand-ink);display:grid;place-items:center;font-family:var(--font-numeric);font-weight:var(--fw-bold);font-size:.85rem}
+.step h4{font-size:.95rem}
+.step p{color:var(--muted-foreground);font-size:.85rem;margin-top:.2rem}
+.codeblock{font-family:var(--font-mono);font-size:.76rem;background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:var(--space-5);margin-top:var(--space-6);color:var(--muted-foreground);line-height:1.7;overflow-x:auto}
+.codeblock .k{color:var(--brand-strong);font-weight:var(--fw-semibold)}
+.codeblock .c{color:var(--muted-foreground);opacity:.7}
+
+footer{padding:var(--space-12) 0;text-align:center;color:var(--muted-foreground);font-size:.78rem}
+
+@media(max-width:900px){
+  .arch-in{grid-template-columns:1fr;gap:var(--space-8)}
+  .glance-grid{grid-template-columns:repeat(2,1fr)}
+  .col-3,.col-4,.col-5,.col-6,.col-7,.col-8{grid-column:span 12}
+}
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="wrap topbar-in">
+    <div class="brand">
+      <span class="peak"><svg width="14" height="12" viewBox="0 0 14 12"><path d="M7 0l4 7H3l4-7zM2.5 12l2.2-4 1.3 2.3L8 12H2.5z" fill="var(--brand-ink)"/></svg></span>
+      Peakhour
+    </div>
+    <span class="spacer"></span>
+    <div class="control">
+      <label class="eyebrow" for="themeSelect" style="margin-right:.2rem">Theme</label>
+      <select id="themeSelect" class="theme">
+        <optgroup label="Flagship directions">
+          <option value="solar">Solar / Peak</option>
+          <option value="tidal">Tidal / Deep</option>
+          <option value="noir">Noir / Editorial</option>
+        </optgroup>
+        <optgroup label="Seasonal (auto-scheduled)">
+          <option value="diwali">Diwali</option>
+          <option value="christmas">Christmas</option>
+        </optgroup>
+      </select>
+      <button class="iconbtn" id="modeBtn" title="Toggle light / dark" aria-label="Toggle light / dark">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+      </button>
+    </div>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="wrap">
+    <p class="eyebrow">Design system · theme directions</p>
+    <h1>Three directions,<br>one system.</h1>
+    <p>Every component below is driven entirely by tokens. Switch the theme and the whole product re-skins — no component edits. That same swap is what lets the CMS rotate seasonal and country themes on a schedule.</p>
+    <div class="theme-pills" id="pills"></div>
+  </div>
+</section>
+
+<main class="wrap">
+  <div class="board">
+    <!-- KPI tiles -->
+    <div class="card col-3"><div class="card-pad kpi"><span class="label">Peaks balance</span><span class="val"><span class="peaks">◣</span><span class="num">12,480</span></span><span class="delta up">▲ 8.2% this week</span></div></div>
+    <div class="card col-3"><div class="card-pad kpi"><span class="label">Active streak</span><span class="val"><span class="num">37</span><span style="font-size:.9rem;color:var(--muted-foreground);font-family:var(--font-sans)">days</span></span><span class="delta up">▲ personal best</span></div></div>
+    <div class="card col-3"><div class="card-pad kpi"><span class="label">Conversion</span><span class="val"><span class="num">4.8%</span></span><span class="delta">▲ 0.6 pts</span></div></div>
+    <div class="card col-3"><div class="card-pad kpi"><span class="label">Members</span><span class="val"><span class="num">8,912</span></span><span class="delta up">▲ 312 new</span></div></div>
+
+    <!-- buttons + badges -->
+    <div class="card col-5"><div class="card-pad">
+      <h3>Actions &amp; status</h3>
+      <p class="sub">Buttons inherit primary / brand / secondary slots.</p>
+      <div class="row" style="margin-top:var(--space-5)">
+        <button class="btn btn-primary">Primary</button>
+        <button class="btn btn-brand">Brand</button>
+        <button class="btn btn-secondary">Secondary</button>
+        <button class="btn btn-outline">Outline</button>
+        <button class="btn btn-ghost">Ghost</button>
+      </div>
+      <div class="row" style="margin-top:var(--space-5)">
+        <span class="badge b-brand">Peak hour</span>
+        <span class="badge b-success">Live</span>
+        <span class="badge b-info">Syncing</span>
+        <span class="badge b-violet">Beta</span>
+      </div>
+      <div class="ramp">
+        <i style="background:var(--brand-gold)"></i><i style="background:var(--brand)"></i><i style="background:var(--brand-strong)"></i><i style="background:var(--secondary)"></i><i style="background:var(--foreground)"></i>
+      </div>
+      <div class="ramp-label" id="rampLabel">brand · ramp</div>
+    </div></div>
+
+    <!-- form -->
+    <div class="card col-4"><div class="card-pad">
+      <h3>Form controls</h3>
+      <p class="sub">Focus ring follows the theme accent.</p>
+      <div class="field" style="margin-top:var(--space-5)"><label>Workspace name</label><input class="input" value="Acme Growth" /></div>
+      <div class="field"><label>Region</label><select class="sel"><option>India · IST</option><option>United Kingdom · GMT</option><option>United States · PST</option></select></div>
+      <div class="switch-row"><span>Seasonal theming</span><div class="switch on" data-switch></div></div>
+      <div class="switch-row"><span>Auto-propose festivals</span><div class="switch on" data-switch></div></div>
+    </div></div>
+
+    <!-- chart -->
+    <div class="card col-3"><div class="card-pad">
+      <h3>Engagement</h3>
+      <p class="sub">5-series data ramp</p>
+      <div class="chart">
+        <div class="bar" style="height:55%;background:var(--c1)"></div>
+        <div class="bar" style="height:78%;background:var(--c2)"></div>
+        <div class="bar" style="height:42%;background:var(--c3)"></div>
+        <div class="bar" style="height:92%;background:var(--c4)"></div>
+        <div class="bar" style="height:64%;background:var(--c5)"></div>
+      </div>
+    </div></div>
+
+    <!-- CTA -->
+    <div class="col-12">
+      <div class="cta">
+        <div>
+          <p class="eyebrow" style="color:rgba(255,255,255,.8)">Make it yours</p>
+          <h3 id="ctaTitle">Solar / Peak — warm, disciplined, premium.</h3>
+          <p id="ctaDesc">One brave accent carried by the logo, the Peaks currency and every focus state.</p>
+        </div>
+        <div class="row">
+          <button class="btn btn-brand">Apply theme</button>
+          <button class="btn btn-ghost" style="color:#fff;border-color:rgba(255,255,255,.4)">Export tokens</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<!-- AT A GLANCE -->
+<section class="glance">
+  <div class="wrap">
+    <p class="eyebrow">Compare</p>
+    <h2 style="font-size:1.7rem;margin-top:.4rem">All directions at a glance</h2>
+    <div class="glance-grid" id="glance"></div>
+  </div>
+</section>
+
+<!-- ARCHITECTURE -->
+<section class="arch">
+  <div class="wrap arch-in">
+    <div>
+      <p class="eyebrow">My take · the architecture</p>
+      <h2>Themes as data, scheduled by occasion &amp; country.</h2>
+      <p class="lead">Because every component reads the same shadcn token slots, a theme is just a small CSS file — a row in a database. That's the unlock: the CMS doesn't redesign anything, it swaps the active token set. Diwali in Mumbai, Christmas in London, a national-day palette in Riyadh — all the same mechanism, scheduled ahead of time.</p>
+      <div class="codeblock">
+<span class="c">/* a theme = one drop-in token file */</span><br>
+<span class="k">[data-theme="diwali"]</span> {<br>
+&nbsp;&nbsp;--brand: <span class="k">oklch(.78 .16 72)</span>; <span class="c">/* marigold */</span><br>
+&nbsp;&nbsp;--background: oklch(.2 .035 335);<br>
+&nbsp;&nbsp;--primary: var(--brand); …<br>
+}<br><br>
+<span class="c">// CMS schedule (proposed 3 months ahead)</span><br>
+{ region:<span class="k">"IN"</span>, theme:<span class="k">"diwali"</span>, start:<span class="k">"2026-10-20"</span> }
+      </div>
+    </div>
+    <div>
+      <div class="steps">
+        <div class="step"><div class="n">1</div><div><h4>Token-only themes</h4><p>Each theme ships as <code style="font-family:var(--font-mono)">tokens/theme-&lt;name&gt;.css</code>. Zero component changes — copy a block from this page and it's production code.</p></div></div>
+        <div class="step"><div class="n">2</div><div><h4>Scheduled by calendar &amp; country</h4><p>A theme registry maps region + date window → active theme. The CMS sets <code style="font-family:var(--font-mono)">data-theme</code> at request time.</p></div></div>
+        <div class="step"><div class="n">3</div><div><h4>Proposed ahead of time</h4><p>Claude generates festival palettes from a calendar of events per country and opens them for review ~3 months out — never a last-minute scramble.</p></div></div>
+        <div class="step"><div class="n">4</div><div><h4>Reviewed, then auto-published</h4><p>Approved themes go live on schedule and retire automatically. Every theme stays on-system because it can only touch the token layer.</p></div></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer><div class="wrap">Peakhour design system · theme directions · token-driven, CMS-ready</div></footer>
+
+<script>
+const THEMES={
+  solar:{name:"Solar / Peak",tag:"Flagship",dot:"#f0a23c",dark:true,cta:"Solar / Peak — warm, disciplined, premium.",desc:"One brave accent carried by the logo, the Peaks currency and every focus state.",blurb:"Warm amber, restraint, premium."},
+  tidal:{name:"Tidal / Deep",tag:"Direction",dot:"#2c9fc0",dark:true,cta:"Tidal / Deep — calm, technical, trustworthy.",desc:"Cool ocean teal on cool-slate neutrals. Reads precise and data-forward.",blurb:"Cool teal, technical, calm."},
+  noir:{name:"Noir / Editorial",tag:"Direction",dot:"#cf3b2a",dark:true,cta:"Noir / Editorial — high-contrast, confident, sharp.",desc:"Serif display, near-black ink and one decisive red. Magazine-grade contrast.",blurb:"Ink + serif, one sharp red."},
+  diwali:{name:"Diwali",tag:"Seasonal",dot:"#efb13c",dark:false,cta:"Diwali — jewel plum, marigold &amp; magenta.",desc:"A warm festive overlay for the Festival of Lights. Auto-scheduled per region.",blurb:"Plum, marigold, magenta."},
+  christmas:{name:"Christmas",tag:"Seasonal",dot:"#2f7d4f",dark:false,cta:"Christmas — snow, pine &amp; cranberry.",desc:"A winter-celebration overlay. Scheduled and retired automatically.",blurb:"Snow, pine, cranberry."}
+};
+const order=["solar","tidal","noir","diwali","christmas"];
+const root=document.documentElement, sel=document.getElementById('themeSelect');
+const modeBtn=document.getElementById('modeBtn');
+const pills=document.getElementById('pills'), glance=document.getElementById('glance');
+const ctaTitle=document.getElementById('ctaTitle'), ctaDesc=document.getElementById('ctaDesc'), rampLabel=document.getElementById('rampLabel');
+
+let cur=localStorage.getItem('ph-theme')||'solar';
+let dark=localStorage.getItem('ph-mode')==='dark';
+
+function apply(){
+  root.setAttribute('data-theme',cur);
+  const meta=THEMES[cur];
+  if(!meta.dark){dark=false}
+  root.classList.toggle('dark',dark);
+  sel.value=cur;
+  modeBtn.disabled=!meta.dark;
+  ctaTitle.innerHTML=meta.cta; ctaDesc.innerHTML=meta.desc;
+  rampLabel.textContent=cur+' · brand ramp';
+  document.querySelectorAll('.pill').forEach(p=>p.setAttribute('aria-pressed',p.dataset.t===cur));
+  document.querySelectorAll('.tcard').forEach(p=>p.setAttribute('aria-current',p.dataset.t===cur));
+  localStorage.setItem('ph-theme',cur); localStorage.setItem('ph-mode',dark?'dark':'light');
+}
+function set(t){cur=t;apply()}
+
+// build pills
+order.forEach(t=>{
+  const m=THEMES[t];
+  const b=document.createElement('button');
+  b.className='pill';b.dataset.t=t;
+  b.innerHTML=`<span class="dot" style="background:${m.dot}"></span>${m.name}`+(m.tag==='Seasonal'?` <span class="tag">${m.tag}</span>`:'');
+  b.onclick=()=>set(t);
+  pills.appendChild(b);
+});
+// build glance cards
+order.forEach(t=>{
+  const m=THEMES[t];
+  const c=document.createElement('div');
+  c.className='tcard';c.dataset.t=t;
+  c.innerHTML=`<div class="preview" data-theme="${t}">
+      <b style="background:var(--background)"></b><b style="background:var(--brand)"></b><b style="background:var(--brand-strong)"></b><b style="background:var(--foreground)"></b>
+    </div>
+    <div class="meta"><span class="tag">${m.tag}</span><strong>${m.name}</strong><small>${m.blurb}</small></div>`;
+  c.onclick=()=>{set(t);window.scrollTo({top:0,behavior:'smooth'})};
+  glance.appendChild(c);
+});
+
+sel.onchange=e=>set(e.target.value);
+modeBtn.onclick=()=>{if(THEMES[cur].dark){dark=!dark;apply()}};
+// switches
+document.querySelectorAll('[data-switch]').forEach(s=>s.onclick=()=>s.classList.toggle('on'));
+
+apply();
+</script>
+</body>
+</html>

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Newsreader } from "next/font/google";
 import { connection } from "next/server";
+import { headers } from "next/headers";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { QueryProvider } from "@/providers/query-provider";
 import { AuthProvider } from "@/providers/auth-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
+import registry from "@/styles/themes/theme-registry.json";
+import { resolveTheme } from "@/styles/themes/theme-resolver.js";
 import "../globals.css";
 
 const geistSans = Geist({
@@ -15,6 +18,13 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+// Serif display face for the "noir" theme (--font-display). Self-hosted via
+// next/font; theme-noir.css reads it through the --font-newsreader variable.
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
   subsets: ["latin"],
 });
 
@@ -42,10 +52,17 @@ export default async function SiteLayout({
   // Shopify surface gets its own dynamic behaviour independently.
   await connection();
 
+  // Resolve the active brand/seasonal theme server-side from the visitor's
+  // region (Vercel geo header) + today's date, and stamp it on <html>. Every
+  // component reads shadcn token slots, so this re-skins the whole surface
+  // with zero component edits. next-themes still owns light/dark (.dark).
+  const region = (await headers()).get("x-vercel-ip-country") ?? "*";
+  const theme = resolveTheme(registry, { region, date: new Date() });
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" data-theme={theme} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${newsreader.variable} font-sans antialiased`}
       >
         <ThemeProvider>
           <QueryProvider>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import "../styles/themes/theme-solar.css";
+@import "../styles/themes/theme-tidal.css";
+@import "../styles/themes/theme-noir.css";
+@import "../styles/themes/theme-diwali.css";
+@import "../styles/themes/theme-christmas.css";
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
@@ -48,73 +53,92 @@
   --radius-4xl: calc(var(--radius) + 16px);
 }
 
+/* ===========================================================================
+   DEFAULT THEME = Peakhour "Solar / Peak". Replaces the old shadcn-neutral
+   :root/.dark so feature-2.peakhour.ai renders the brand with no attribute.
+   The other directions (tidal/noir) and seasonal themes (diwali/christmas)
+   layer on top via :root[data-theme="…"] from the @imports above.
+   =========================================================================== */
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  --brand: oklch(0.77 0.146 67);
+  --brand-strong: oklch(0.66 0.156 50);
+  --brand-gold: oklch(0.86 0.13 88);
+  --brand-soft: oklch(0.95 0.045 78);
+  --brand-ink: oklch(0.27 0.05 55);
+
+  --background: oklch(0.985 0.007 78);
+  --foreground: oklch(0.205 0.014 58);
+  --card: oklch(0.998 0.004 80);
+  --card-foreground: oklch(0.205 0.014 58);
+  --popover: oklch(0.998 0.004 80);
+  --popover-foreground: oklch(0.205 0.014 58);
+  --primary: oklch(0.205 0.014 58);
+  --primary-foreground: oklch(0.985 0.006 80);
+  --secondary: oklch(0.955 0.009 78);
+  --secondary-foreground: oklch(0.205 0.014 58);
+  --muted: oklch(0.955 0.009 78);
+  --muted-foreground: oklch(0.52 0.016 62);
+  --accent: oklch(0.95 0.012 78);
+  --accent-foreground: oklch(0.205 0.014 58);
+  --destructive: oklch(0.585 0.2 27);
+  --border: oklch(0.9 0.011 78);
+  --input: oklch(0.9 0.011 78);
+  --ring: oklch(0.77 0.146 67);
+
+  --chart-1: oklch(0.77 0.146 67);
+  --chart-2: oklch(0.62 0.092 200);
+  --chart-3: oklch(0.62 0.14 40);
+  --chart-4: oklch(0.86 0.13 88);
+  --chart-5: oklch(0.52 0.11 330);
+
+  --sidebar: oklch(0.975 0.008 78);
+  --sidebar-foreground: oklch(0.205 0.014 58);
+  --sidebar-primary: oklch(0.205 0.014 58);
+  --sidebar-primary-foreground: oklch(0.985 0.006 80);
+  --sidebar-accent: oklch(0.95 0.012 78);
+  --sidebar-accent-foreground: oklch(0.205 0.014 58);
+  --sidebar-border: oklch(0.9 0.011 78);
+  --sidebar-ring: oklch(0.77 0.146 67);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --brand-soft: oklch(0.32 0.05 60);
+
+  --background: oklch(0.165 0.012 60);
+  --foreground: oklch(0.97 0.006 82);
+  --card: oklch(0.215 0.013 60);
+  --card-foreground: oklch(0.97 0.006 82);
+  --popover: oklch(0.215 0.013 60);
+  --popover-foreground: oklch(0.97 0.006 82);
+  --primary: oklch(0.77 0.146 67);
+  --primary-foreground: oklch(0.22 0.04 55);
+  --secondary: oklch(0.27 0.013 60);
+  --secondary-foreground: oklch(0.97 0.006 82);
+  --muted: oklch(0.27 0.013 60);
+  --muted-foreground: oklch(0.72 0.014 70);
+  --accent: oklch(0.3 0.016 62);
+  --accent-foreground: oklch(0.97 0.006 82);
+  --destructive: oklch(0.7 0.18 25);
+  --border: oklch(1 0 0 / 11%);
+  --input: oklch(1 0 0 / 14%);
+  --ring: oklch(0.77 0.146 67);
+
+  --chart-1: oklch(0.77 0.146 67);
+  --chart-2: oklch(0.7 0.1 195);
+  --chart-3: oklch(0.68 0.15 40);
+  --chart-4: oklch(0.86 0.13 88);
+  --chart-5: oklch(0.66 0.13 330);
+
+  --sidebar: oklch(0.185 0.012 60);
+  --sidebar-foreground: oklch(0.97 0.006 82);
+  --sidebar-primary: oklch(0.77 0.146 67);
+  --sidebar-primary-foreground: oklch(0.22 0.04 55);
+  --sidebar-accent: oklch(0.3 0.016 62);
+  --sidebar-accent-foreground: oklch(0.97 0.006 82);
+  --sidebar-border: oklch(1 0 0 / 11%);
+  --sidebar-ring: oklch(0.77 0.146 67);
 }
 
 @layer base {

--- a/src/styles/themes/theme-christmas.css
+++ b/src/styles/themes/theme-christmas.css
@@ -1,0 +1,28 @@
+/* ===========================================================================
+   Peakhour · THEME — Christmas   (seasonal · auto-scheduled)
+   Drop-in token overlay, activated by  <html data-theme="christmas">.
+   Snow neutrals, pine-green lead, cranberry + gold accents. Complete slot set.
+   =========================================================================== */
+:root[data-theme="christmas"] {
+  --brand: oklch(0.46 0.1 155); --brand-strong: oklch(0.38 0.1 152);
+  --brand-gold: oklch(0.8 0.12 85); --brand-soft: oklch(0.94 0.04 150);
+  --brand-ink: oklch(0.98 0.01 150);
+  --background: oklch(0.987 0.005 150); --foreground: oklch(0.24 0.04 152);
+  --card: oklch(1 0 0); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: oklch(0.46 0.1 155); --primary-foreground: oklch(0.98 0.01 150);
+  --secondary: oklch(0.95 0.015 150); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.95 0.015 150); --muted-foreground: oklch(0.46 0.03 150);
+  --accent: oklch(0.95 0.02 150); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.52 0.17 20);
+  --border: oklch(0.89 0.015 150); --input: oklch(0.89 0.015 150); --ring: oklch(0.52 0.17 20);
+  --chart-1: var(--brand); --chart-2: oklch(0.52 0.17 20); --chart-3: var(--brand-gold);
+  --chart-4: oklch(0.55 0.09 155); --chart-5: oklch(0.7 0.1 60);
+  --sidebar: oklch(0.97 0.012 150); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary); --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent); --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border); --sidebar-ring: oklch(0.52 0.17 20);
+  --grad-solar: linear-gradient(135deg, oklch(0.52 0.17 20) 0%, var(--brand) 100%);
+  --radius: 0.625rem;
+  --font-display: "Sora", "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+}

--- a/src/styles/themes/theme-diwali.css
+++ b/src/styles/themes/theme-diwali.css
@@ -1,0 +1,29 @@
+/* ===========================================================================
+   Peakhour · THEME — Diwali   (seasonal · auto-scheduled)
+   Drop-in token overlay, activated by  <html data-theme="diwali">.
+   Jewel plum surfaces, marigold lead, magenta + gold accents. Inherently
+   dark — no .dark variant needed. Complete shadcn slot set.
+   =========================================================================== */
+:root[data-theme="diwali"] {
+  --brand: oklch(0.78 0.16 72); --brand-strong: oklch(0.68 0.17 55);
+  --brand-gold: oklch(0.85 0.14 92); --brand-soft: oklch(0.34 0.07 340);
+  --brand-ink: oklch(0.2 0.04 60);
+  --background: oklch(0.2 0.035 335); --foreground: oklch(0.96 0.02 80);
+  --card: oklch(0.25 0.045 338); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: oklch(0.78 0.16 72); --primary-foreground: oklch(0.2 0.04 60);
+  --secondary: oklch(0.3 0.05 338); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.3 0.05 338); --muted-foreground: oklch(0.8 0.04 330);
+  --accent: oklch(0.34 0.06 340); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.62 0.2 18);
+  --border: oklch(1 0 0 / 13%); --input: oklch(1 0 0 / 15%); --ring: var(--brand);
+  --chart-1: var(--brand); --chart-2: oklch(0.6 0.2 350); --chart-3: var(--brand-gold);
+  --chart-4: oklch(0.6 0.15 300); --chart-5: oklch(0.7 0.13 30);
+  --sidebar: oklch(0.23 0.04 337); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--brand); --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent); --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border); --sidebar-ring: var(--brand);
+  --grad-solar: linear-gradient(135deg, var(--brand-gold) 0%, var(--brand) 45%, oklch(0.6 0.2 350) 100%);
+  --radius: 0.875rem;
+  --font-display: "Sora", "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+}

--- a/src/styles/themes/theme-noir.css
+++ b/src/styles/themes/theme-noir.css
@@ -1,0 +1,46 @@
+/* ===========================================================================
+   Peakhour · THEME — Noir / Editorial   (direction · high-contrast)
+   Drop-in token overlay, activated by  <html data-theme="noir">.
+   Serif display, near-black ink, one decisive red. Complete shadcn slot set.
+   NOTE: overrides --font-display to a serif (Newsreader) — load that face on
+   pages using this theme, or change the one line to your licensed serif.
+   =========================================================================== */
+:root[data-theme="noir"] {
+  --brand: oklch(0.55 0.18 28); --brand-strong: oklch(0.47 0.18 27);
+  --brand-gold: oklch(0.7 0.13 40); --brand-soft: oklch(0.94 0.04 30);
+  --brand-ink: oklch(0.99 0.01 30);
+  --background: oklch(0.99 0.001 100); --foreground: oklch(0.17 0.004 50);
+  --card: oklch(1 0 0); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: oklch(0.17 0.004 50); --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.95 0.002 80); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.95 0.002 80); --muted-foreground: oklch(0.45 0.006 60);
+  --accent: oklch(0.95 0.002 80); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.5 0.2 25);
+  --border: oklch(0.86 0.003 70); --input: oklch(0.86 0.003 70); --ring: var(--brand);
+  --chart-1: oklch(0.17 0.004 50); --chart-2: oklch(0.55 0.18 28); --chart-3: oklch(0.55 0.01 60);
+  --chart-4: oklch(0.7 0.13 40); --chart-5: oklch(0.72 0.006 60);
+  --sidebar: oklch(0.97 0.001 90); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary); --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent); --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border); --sidebar-ring: var(--brand);
+  --grad-solar: linear-gradient(135deg, oklch(0.34 0.02 40) 0%, oklch(0.17 0.004 50) 100%);
+  --radius: 0.25rem;
+  --font-display: var(--font-newsreader), "Newsreader", Georgia, "Times New Roman", serif;
+}
+
+:root[data-theme="noir"].dark {
+  --background: oklch(0.15 0.003 50); --foreground: oklch(0.97 0.002 90);
+  --card: oklch(0.19 0.004 50); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: oklch(0.97 0.002 90); --primary-foreground: oklch(0.15 0.003 50);
+  --secondary: oklch(0.24 0.004 50); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.24 0.004 50); --muted-foreground: oklch(0.65 0.005 70);
+  --accent: oklch(0.26 0.004 50); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.62 0.2 25);
+  --border: oklch(1 0 0 / 12%); --input: oklch(1 0 0 / 14%);
+  --brand-soft: oklch(0.3 0.06 30);
+  --sidebar: oklch(0.17 0.003 50); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--brand); --sidebar-primary-foreground: oklch(0.99 0.01 30);
+  --sidebar-accent: var(--accent); --sidebar-border: var(--border);
+}

--- a/src/styles/themes/theme-registry.json
+++ b/src/styles/themes/theme-registry.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "Peakhour theme registry — the single source of truth the CMS reads.",
+  "default": "solar",
+  "fallback": "solar",
+  "themes": [
+    { "id": "solar",     "label": "Solar / Peak",     "kind": "flagship", "supportsDark": true,  "href": "tokens/themes/theme-solar.css" },
+    { "id": "tidal",     "label": "Tidal / Deep",     "kind": "direction","supportsDark": true,  "href": "tokens/themes/theme-tidal.css" },
+    { "id": "noir",      "label": "Noir / Editorial", "kind": "direction","supportsDark": true,  "href": "tokens/themes/theme-noir.css", "fonts": ["Newsreader"] },
+    { "id": "diwali",    "label": "Diwali",           "kind": "seasonal", "supportsDark": false, "href": "tokens/themes/theme-diwali.css" },
+    { "id": "christmas", "label": "Christmas",        "kind": "seasonal", "supportsDark": false, "href": "tokens/themes/theme-christmas.css" }
+  ],
+  "schedule": [
+    { "id": "in-diwali-2026",  "theme": "diwali",    "regions": ["IN"],            "start": "2026-11-05", "end": "2026-11-12", "priority": 10, "status": "approved" },
+    { "id": "uk-xmas-2026",    "theme": "christmas", "regions": ["GB", "US", "IE"], "start": "2026-12-01", "end": "2026-12-26", "priority": 10, "status": "approved" },
+    { "id": "in-xmas-2026",    "theme": "christmas", "regions": ["IN"],            "start": "2026-12-20", "end": "2026-12-26", "priority": 9,  "status": "approved" }
+  ],
+  "comment": "Resolver picks the highest-priority active entry whose region matches the request; if none, uses `default`. `status` gates publishing — only 'approved' entries go live."
+}

--- a/src/styles/themes/theme-resolver.js
+++ b/src/styles/themes/theme-resolver.js
@@ -1,0 +1,66 @@
+/* ===========================================================================
+   Peakhour · theme-resolver.js
+   Tiny, dependency-free runtime that turns the registry + (region, date) into
+   an active theme: loads the theme's CSS once and sets <html data-theme>.
+   The whole design system re-skins because every component reads token slots.
+
+   Usage (client or SSR-hydrated):
+     import { applyTheme, resolveTheme } from './theme-resolver.js';
+     applyTheme({ region: 'IN', dark: false });           // auto by today's date
+     applyTheme({ themeId: 'diwali' });                   // force a specific theme
+
+   SSR: call resolveTheme() on the server and render
+     <html data-theme="diwali"> + the matching <link> in <head>
+     so there is zero flash. This client file is the progressive-enhancement
+     fallback and the live theme switcher.
+   =========================================================================== */
+
+const DEFAULT_REGISTRY_URL = "tokens/themes/theme-registry.json";
+let REGISTRY = null;
+
+export async function loadRegistry(url = DEFAULT_REGISTRY_URL) {
+  if (REGISTRY) return REGISTRY;
+  REGISTRY = await fetch(url).then((r) => r.json());
+  return REGISTRY;
+}
+
+/* Pure: given a registry, region and date, return the winning theme id. */
+export function resolveTheme(registry, { region = "*", date = new Date() } = {}) {
+  const day = (date instanceof Date ? date : new Date(date)).toISOString().slice(0, 10);
+  const active = (registry.schedule || [])
+    .filter((s) => s.status === "approved")
+    .filter((s) => s.start <= day && day <= s.end)
+    .filter((s) => s.regions.includes(region) || s.regions.includes("*"))
+    .sort((a, b) => (b.priority || 0) - (a.priority || 0));
+  return active.length ? active[0].theme : (registry.default || "solar");
+}
+
+const loadedHrefs = new Set();
+function ensureCss(href) {
+  if (!href || loadedHrefs.has(href)) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  link.dataset.peakhourTheme = "1";
+  document.head.appendChild(link);
+  loadedHrefs.add(href);
+}
+function ensureFonts(families = []) {
+  if (!families.length) return;
+  const q = families.map((f) => "family=" + f.replace(/ /g, "+") + ":wght@400;600;700").join("&");
+  ensureCss("https://fonts.googleapis.com/css2?" + q + "&display=swap");
+}
+
+/* Apply a theme to the document. Loads its CSS + fonts, sets data-theme. */
+export async function applyTheme({ region = "*", date = new Date(), themeId = null, dark = false, registryUrl } = {}) {
+  const reg = await loadRegistry(registryUrl);
+  const id = themeId || resolveTheme(reg, { region, date });
+  const meta = (reg.themes || []).find((t) => t.id === id) || reg.themes.find((t) => t.id === reg.default);
+  ensureCss(meta.href);
+  ensureFonts(meta.fonts);
+  const root = document.documentElement;
+  root.setAttribute("data-theme", meta.id);
+  root.classList.toggle("dark", !!dark && meta.supportsDark);
+  root.dispatchEvent(new CustomEvent("peakhour:theme", { detail: { id: meta.id, dark } }));
+  return meta.id;
+}

--- a/src/styles/themes/theme-solar.css
+++ b/src/styles/themes/theme-solar.css
@@ -1,0 +1,50 @@
+/* ===========================================================================
+   Peakhour · THEME — Solar / Peak   (flagship · the brand default)
+   Drop-in token overlay, activated by  <html data-theme="solar">.
+   Sets the COMPLETE shadcn slot set used by peakhour-b2c (incl. sidebar,
+   popover, input) so every surface re-skins. Token-only — no components.
+   =========================================================================== */
+:root[data-theme="solar"] {
+  /* brand */
+  --brand: oklch(0.77 0.146 67); --brand-strong: oklch(0.66 0.156 50);
+  --brand-gold: oklch(0.86 0.13 88); --brand-soft: oklch(0.95 0.045 78);
+  --brand-ink: oklch(0.27 0.05 55);
+  /* core */
+  --background: oklch(0.985 0.007 78); --foreground: oklch(0.205 0.014 58);
+  --card: oklch(0.998 0.004 80); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: oklch(0.205 0.014 58); --primary-foreground: oklch(0.985 0.006 80);
+  --secondary: oklch(0.955 0.009 78); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.955 0.009 78); --muted-foreground: oklch(0.52 0.016 62);
+  --accent: oklch(0.95 0.012 78); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.585 0.2 27);
+  --border: oklch(0.9 0.011 78); --input: oklch(0.9 0.011 78); --ring: var(--brand);
+  /* charts */
+  --chart-1: var(--brand); --chart-2: oklch(0.62 0.092 200); --chart-3: oklch(0.62 0.14 40);
+  --chart-4: var(--brand-gold); --chart-5: oklch(0.52 0.11 330);
+  /* sidebar */
+  --sidebar: oklch(0.975 0.008 78); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary); --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent); --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border); --sidebar-ring: var(--brand);
+  /* extras (used by the design system / showcase) */
+  --grad-solar: linear-gradient(135deg, var(--brand-gold) 0%, var(--brand) 45%, var(--brand-strong) 100%);
+  --radius: 0.625rem;
+  --font-display: "Sora", "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+}
+
+:root[data-theme="solar"].dark {
+  --background: oklch(0.165 0.012 60); --foreground: oklch(0.97 0.006 82);
+  --card: oklch(0.215 0.013 60); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: var(--brand); --primary-foreground: oklch(0.22 0.04 55);
+  --secondary: oklch(0.27 0.013 60); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.27 0.013 60); --muted-foreground: oklch(0.72 0.014 70);
+  --accent: oklch(0.3 0.016 62); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.7 0.18 25);
+  --border: oklch(1 0 0 / 11%); --input: oklch(1 0 0 / 14%);
+  --brand-soft: oklch(0.32 0.05 60);
+  --sidebar: oklch(0.185 0.012 60); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--brand); --sidebar-primary-foreground: oklch(0.22 0.04 55);
+  --sidebar-accent: var(--accent); --sidebar-border: var(--border);
+}

--- a/src/styles/themes/theme-tidal.css
+++ b/src/styles/themes/theme-tidal.css
@@ -1,0 +1,44 @@
+/* ===========================================================================
+   Peakhour · THEME — Tidal / Deep   (direction · cool, technical)
+   Drop-in token overlay, activated by  <html data-theme="tidal">.
+   Cool ocean teal on cool-slate neutrals. Complete shadcn slot set.
+   =========================================================================== */
+:root[data-theme="tidal"] {
+  --brand: oklch(0.68 0.13 200); --brand-strong: oklch(0.55 0.13 222);
+  --brand-gold: oklch(0.83 0.1 195); --brand-soft: oklch(0.95 0.03 205);
+  --brand-ink: oklch(0.99 0.01 210);
+  --background: oklch(0.985 0.004 230); --foreground: oklch(0.23 0.022 248);
+  --card: oklch(0.998 0.003 230); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: oklch(0.23 0.022 248); --primary-foreground: oklch(0.99 0.004 230);
+  --secondary: oklch(0.955 0.008 235); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.955 0.008 235); --muted-foreground: oklch(0.5 0.025 245);
+  --accent: oklch(0.95 0.012 230); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.585 0.2 27);
+  --border: oklch(0.9 0.01 235); --input: oklch(0.9 0.01 235); --ring: var(--brand);
+  --chart-1: var(--brand); --chart-2: oklch(0.6 0.12 250); --chart-3: oklch(0.7 0.11 180);
+  --chart-4: oklch(0.55 0.13 280); --chart-5: oklch(0.6 0.04 240);
+  --sidebar: oklch(0.975 0.006 232); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary); --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent); --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border); --sidebar-ring: var(--brand);
+  --grad-solar: linear-gradient(135deg, oklch(0.82 0.1 195) 0%, var(--brand) 50%, var(--brand-strong) 100%);
+  --radius: 0.75rem;
+  --font-display: "Sora", "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+}
+
+:root[data-theme="tidal"].dark {
+  --background: oklch(0.17 0.012 245); --foreground: oklch(0.97 0.005 230);
+  --card: oklch(0.21 0.013 245); --card-foreground: var(--foreground);
+  --popover: var(--card); --popover-foreground: var(--foreground);
+  --primary: var(--brand); --primary-foreground: oklch(0.2 0.03 230);
+  --secondary: oklch(0.26 0.014 245); --secondary-foreground: var(--foreground);
+  --muted: oklch(0.26 0.014 245); --muted-foreground: oklch(0.7 0.015 240);
+  --accent: oklch(0.3 0.016 245); --accent-foreground: var(--foreground);
+  --destructive: oklch(0.7 0.18 25);
+  --border: oklch(1 0 0 / 11%); --input: oklch(1 0 0 / 14%);
+  --brand-soft: oklch(0.3 0.05 230);
+  --sidebar: oklch(0.19 0.012 245); --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--brand); --sidebar-primary-foreground: oklch(0.2 0.03 230);
+  --sidebar-accent: var(--accent); --sidebar-border: var(--border);
+}


### PR DESCRIPTION
# PR: Peakhour design system — Solar default + theme tokens (feature-2)

**Base:** `feature-2`  ·  **Head:** `feat/theme-tokens`  ·  **Scope:** token layer + docs only (no component logic changed)

## Summary
Introduces the Peakhour token theme system and makes **"Solar / Peak"** the default palette so it renders on `feature-2.peakhour.ai`. Adds four more themes — **Tidal / Deep**, **Noir / Editorial** (directions) and **Diwali**, **Christmas** (seasonal) — as drop-in token overlays, plus a region/date resolver and a committed design guide. Because every component reads the shadcn token slots, the entire product re-skins with zero component edits.

## What changed
- **`src/app/globals.css`** — `:root` / `.dark` swapped from default-shadcn-neutral to **Solar** (complete slot set incl. `--sidebar-*`, `--popover-*`, `--chart-*`). Added `@import`s for the five theme files. Everything else (`@theme inline`, `@layer base`, `@property`, keyframes) unchanged.
- **`src/styles/themes/theme-*.css`** — solar, tidal, noir, diwali, christmas. Each scoped to `:root[data-theme="…"]` (specificity 0,2,0 so it reliably outranks `:root`).
- **`src/styles/themes/theme-registry.json`** + **`theme-resolver.js`** — `resolveTheme(region, date)` (pure) + `applyTheme()` (client switcher).
- **`src/app/(site)/layout.tsx`** — resolves theme server-side from the Vercel geo header + date and stamps `<html data-theme>`. Coexists with next-themes (which still owns `.dark`).
- **`design-system/`** — committed design guide (`DESIGN-GUIDE.md`) + live switchable reference (`Peakhour-Themes.html`).

## How to test
1. Open the `feature-2.peakhour.ai` preview → default palette is **Solar** (warm amber), not neutral gray.
2. Light/dark toggle still works (next-themes).
3. Force a theme to sanity-check overlays: set `data-theme="tidal" | "noir" | "diwali" | "christmas"` on `<html>` (devtools) → buttons, cards, **sidebar**, popovers, charts all re-skin.
4. Open `design-system/Peakhour-Themes.html` for the side-by-side reference.

## Screenshots (attach)
- [ ] Dashboard — Solar light
- [ ] Dashboard — Solar dark
- [ ] Sidebar + popover re-skinned under one non-default theme
- [ ] Charts under Solar

## Risk & rollback
- **Low / reversible.** Pure CSS-variable change; no component or API edits.
- Rollback = revert this PR (restores the neutral `:root`/`.dark`). No data or schema impact.
- Accessibility: foreground/background, primary, and on-accent pairs target ≥ 4.5:1 — verify with axe on the preview before merge.

## Follow-ups (separate PRs)
- Autonomous CMS theming — schedule + AI festival proposals (`CLAUDE-CODE-CMS-DYNAMIC.md`), wired to existing `cms/ai-*` + `cms/crons`.
- Decide whether to promote Solar to `master` default after review.
