### PR TITLE
feat(theme): dev-only theme switcher dropdown (non-production)

### DIFF
--- a/src/app/(site)/dashboard/content/autopilot/page.tsx
+++ b/src/app/(site)/dashboard/content/autopilot/page.tsx
@@ -7,6 +7,7 @@ import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { useHomeSummary, homeSummaryKey } from "@/hooks/use-home-summary";
+import { isProductionEnv } from "@/lib/env";
 import { AutopilotStatus } from "./_components/autopilot-status";
 import { KpiRow } from "./_components/kpi-row";
 import { NeedsYouRail } from "./_components/needs-you-rail";
@@ -27,10 +28,6 @@ import { CommerceLane } from "./_components/commerce-lane";
  * redirected in prod until we flip it on. The nav item is gated the same
  * way in the dashboard layout.
  */
-
-function isProductionEnv(): boolean {
-  return process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
-}
 
 function LoadingState() {
   return (

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -7,6 +7,7 @@ import { QueryProvider } from "@/providers/query-provider";
 import { AuthProvider } from "@/providers/auth-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
+import { ThemeSwitcher } from "@/components/dev/theme-switcher";
 import registry from "@/styles/themes/theme-registry.json";
 import { resolveTheme } from "@/styles/themes/theme-resolver.js";
 import "../globals.css";
@@ -23,9 +24,14 @@ const geistMono = Geist_Mono({
 
 // Serif display face for the "noir" theme (--font-display). Self-hosted via
 // next/font; theme-noir.css reads it through the --font-newsreader variable.
+// preload:false — only the (non-default) noir theme uses it, so we let the
+// browser fetch it on demand instead of eagerly preloading an unused font on
+// every page (keeps LCP/SEO clean for the Solar default).
 const newsreader = Newsreader({
   variable: "--font-newsreader",
   subsets: ["latin"],
+  display: "swap",
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -71,6 +77,8 @@ export default async function SiteLayout({
                 {children}
               </TooltipProvider>
               <Toaster richColors position="bottom-right" />
+              {/* Test-only theme switcher; renders null on production. */}
+              <ThemeSwitcher />
             </AuthProvider>
           </QueryProvider>
         </ThemeProvider>

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { isProductionEnv } from "@/lib/env";
 import { getCronMetadata, summarizeCronBody } from "./cron-metadata";
 
 interface DevCronResult {
@@ -63,10 +64,6 @@ interface Props {
    *  on a known-failed cron run would be wasteful (and on a real error,
    *  the toast already surfaces the failure to the user). */
   onTriggered?: (result: DevCronResult) => void;
-}
-
-function isProductionEnv(): boolean {
-  return process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 }
 
 // Module-scoped re-entry guard. Per-instance refs would still race in

--- a/src/components/dev/theme-switcher.tsx
+++ b/src/components/dev/theme-switcher.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * <ThemeSwitcher> — a floating, test-only control to flip the active brand
+ * theme without DevTools or editing the registry schedule.
+ *
+ * WHY THIS EXISTS. Production picks the theme server-side from the visitor's
+ * region + date (resolveTheme in (site)/layout.tsx). That's correct for real
+ * users but useless for QA — you can't see Tidal/Noir/Diwali/Christmas on
+ * feature-2 without spoofing a geo header or moving a schedule window over
+ * today. This widget just sets <html data-theme> directly (all five themes
+ * are already bundled in globals.css, so it's a pure attribute flip — no CSS
+ * injection, no reload) and persists the choice so it survives navigation.
+ *
+ * SCOPE. Renders nothing when NEXT_PUBLIC_VERCEL_ENV === "production" — same
+ * gate as <CronToolbar>. It is a token-layer testing aid, not a user feature;
+ * the real in-app/CMS switcher is a separate effort (CLAUDE-CODE-CMS-DYNAMIC).
+ *
+ * Dark mode stays owned by next-themes (.dark on <html>); the toggle here just
+ * proxies setTheme() so QA can check each theme's light + dark slots in one place.
+ */
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { Palette, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import registry from "@/styles/themes/theme-registry.json";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { isProductionEnv } from "@/lib/env";
+
+const STORAGE_KEY = "peakhour:theme-override";
+const AUTO = "auto";
+
+type ThemeMeta = { id: string; label: string };
+const THEMES = (registry.themes ?? []) as ThemeMeta[];
+
+/** Read the persisted override (client only); null/invalid → "Auto". */
+function readStoredOverride(): string | null {
+  if (typeof window === "undefined") return null;
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored && THEMES.some((t) => t.id === stored) ? stored : null;
+}
+
+const noopSubscribe = () => () => {};
+
+/**
+ * false during SSR + the first (hydration) render, true thereafter — without a
+ * setState-in-effect. Lets us render null on the server (the switcher is
+ * client-only) and the real control once hydrated, with no hydration mismatch.
+ */
+function useHydrated(): boolean {
+  return useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+}
+
+export function ThemeSwitcher() {
+  // Hooks run unconditionally; the prod gate decides render, not mount.
+  const { resolvedTheme, setTheme } = useTheme();
+  const hydrated = useHydrated();
+  // null = "Auto" (defer to whatever the server resolver stamped on <html>).
+  // Seeded once from storage on the client; the !hydrated render below outputs
+  // null, so this client-only seed never causes a hydration mismatch.
+  const [override, setOverride] = useState<string | null>(readStoredOverride);
+
+  // Sync the chosen override onto <html> (external DOM, no setState). On "Auto"
+  // (null) we leave the server-stamped data-theme untouched.
+  useEffect(() => {
+    if (override) document.documentElement.setAttribute("data-theme", override);
+  }, [override]);
+
+  if (isProductionEnv() || !hydrated) return null;
+
+  function applyTheme(value: string) {
+    if (value === AUTO) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      setOverride(null);
+      // The server-resolved theme is the source of truth for "auto"; a reload
+      // lets resolveTheme() reassert it (region + today's date) cleanly.
+      window.location.reload();
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, value);
+    setOverride(value);
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <div
+      className="fixed bottom-3 left-3 z-60 flex items-center gap-1.5 rounded-md border border-dashed bg-background/90 px-2 py-1.5 text-xs shadow-sm backdrop-blur"
+      aria-label="Theme switcher (preview + local dev only)"
+    >
+      <Palette className="size-3.5 text-muted-foreground" />
+      <Select value={override ?? AUTO} onValueChange={applyTheme}>
+        <SelectTrigger size="sm" className="h-7 w-37.5 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={AUTO}>Auto (region + date)</SelectItem>
+          {THEMES.map((t) => (
+            <SelectItem key={t.id} value={t.id}>
+              {t.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        className="size-7"
+        onClick={() => setTheme(isDark ? "light" : "dark")}
+        title={isDark ? "Switch to light" : "Switch to dark"}
+        aria-label={isDark ? "Switch to light" : "Switch to dark"}
+      >
+        {isDark ? <Sun className="size-3.5" /> : <Moon className="size-3.5" />}
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,17 @@
+/**
+ * Environment helpers. `NEXT_PUBLIC_VERCEL_ENV` is set by Vercel to
+ * "production" | "preview" | "development" and inlined at build time, so these
+ * are safe to call on the server or the client.
+ *
+ * Use `isProductionEnv()` to gate test-only affordances (dev cron triggers,
+ * the theme switcher, in-development surfaces) — anything that should appear on
+ * preview/local but never on the production deployment.
+ */
+export function isProductionEnv(): boolean {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+}
+
+/** Inverse of {@link isProductionEnv} — true on preview + local dev. */
+export function isNonProductionEnv(): boolean {
+  return !isProductionEnv();
+}


### PR DESCRIPTION
## Summary
Adds a floating, **test-only** theme switcher to the site surface so QA can flip between Solar/Tidal/Noir/Diwali/Christmas (+ light/dark) on `feature-2` without DevTools or moving a registry schedule window over today.

Region/date auto-resolution (the production behaviour) is **kept** — it's the default `Auto (region + date)` option. The dropdown is a client-side override only.

## What changed
- **`src/lib/env.ts`** (new) — reusable `isProductionEnv()` / `isNonProductionEnv()`. Migrated the two duplicated local copies (`cron-toolbar.tsx`, `autopilot/page.tsx`) onto it.
- **`src/components/dev/theme-switcher.tsx`** (new) — dropdown (themes from `theme-registry.json`) + dark toggle (proxies next-themes). Flips `<html data-theme>`, persists to localStorage. Lint-clean hydration via `useSyncExternalStore` (no setState-in-effect).
- **`src/app/(site)/layout.tsx`** — renders `<ThemeSwitcher/>`; Newsreader font set `preload:false` (noir-only).

## SEO / safety
- Switcher renders **null on the server and on production** (`isProductionEnv()` gate, same as `<CronToolbar>`) → **zero markup, zero SEO impact** in prod.
- Region only swaps CSS tokens — identical content/links per region, no cloaking.
- Newsreader no longer eagerly preloaded on every page (LCP-safe).

## How to test
On the `feature-2` preview (non-prod): bottom-left palette dropdown → pick a theme → whole surface re-skins; dark toggle flips light/dark; `Auto` clears the override and reloads to the region/date-resolved theme.