### PR TITLE
fix(pricing): friendly WooCommerce feature labels + Peakhour Commerce title

### DIFF
--- a/src/app/(site)/pricing/page.tsx
+++ b/src/app/(site)/pricing/page.tsx
@@ -9,7 +9,7 @@ import { getPricing } from "@/lib/pricing";
 import { PeaksGlyph } from "@/components/peaks/peaks-glyph";
 
 export const metadata: Metadata = {
-  title: "Plans — Peakhour.ai for Shopify & WooCommerce",
+  title: "Peakhour Commerce — Plans for Shopify & WooCommerce",
   description:
     "Peakhour.ai commerce plans for Shopify and WooCommerce. Start free, upgrade when you're ready. Every paid plan includes Peaks — the AI credits that power the platform.",
 };
@@ -43,9 +43,15 @@ export default async function PricingPage() {
       <main>
         <section className="border-b">
           <div className="mx-auto max-w-3xl px-4 py-16 text-center sm:px-6">
-            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Plans</h1>
+            <span className="mb-3 inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+              Plans &amp; pricing
+            </span>
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+              Peakhour Commerce
+            </h1>
             <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
-              Commerce plans for Shopify and WooCommerce. Start free, upgrade when
+              The live, catalog-grounded AI assistant for Shopify and WooCommerce.
+              Start free, upgrade when
               you&rsquo;re ready — every paid plan includes{" "}
               <Link href="/peaks" className="font-medium underline underline-offset-2">
                 Peaks

--- a/src/components/marketing/commerce-plans.tsx
+++ b/src/components/marketing/commerce-plans.tsx
@@ -96,7 +96,15 @@ function TierCard({
   cta: { href: string; external: boolean; label: string };
 }) {
   const isFree = tier.pricing.monthly === 0;
-  const featureLabels = tier.features.map((k) => featureLabel(k));
+  // Prefer the catalog's own feature name (source of truth, from the API),
+  // falling back to the local label map for any key without a catalog row or
+  // when an older API response omits featureDetails.
+  const detailByKey = new Map(
+    (tier.featureDetails ?? []).map((f) => [f.key, f] as const),
+  );
+  const featureLabels = tier.features.map(
+    (k) => detailByKey.get(k)?.name ?? featureLabel(k),
+  );
 
   return (
     <Card

--- a/src/components/marketing/commerce-plans.tsx
+++ b/src/components/marketing/commerce-plans.tsx
@@ -11,7 +11,7 @@ import {
 import {
   formatMonthly,
   formatYearly,
-  FEATURE_LABELS,
+  featureLabel,
   type ResolvedProduct,
   type ResolvedProductTier,
 } from "@/lib/pricing";
@@ -96,7 +96,7 @@ function TierCard({
   cta: { href: string; external: boolean; label: string };
 }) {
   const isFree = tier.pricing.monthly === 0;
-  const featureLabels = tier.features.map((k) => FEATURE_LABELS[k] ?? k);
+  const featureLabels = tier.features.map((k) => featureLabel(k));
 
   return (
     <Card

--- a/src/components/marketing/commerce-plans.tsx
+++ b/src/components/marketing/commerce-plans.tsx
@@ -102,9 +102,10 @@ function TierCard({
   const detailByKey = new Map(
     (tier.featureDetails ?? []).map((f) => [f.key, f] as const),
   );
-  const featureLabels = tier.features.map(
-    (k) => detailByKey.get(k)?.name ?? featureLabel(k),
-  );
+  const features = tier.features.map((k) => ({
+    key: k,
+    label: detailByKey.get(k)?.name ?? featureLabel(k),
+  }));
 
   return (
     <Card
@@ -138,8 +139,8 @@ function TierCard({
       </CardHeader>
       <CardContent className="flex flex-1 flex-col gap-4">
         <ul className="flex-1 space-y-2.5 text-sm">
-          {featureLabels.map((label) => (
-            <li key={label} className="flex items-start gap-2.5">
+          {features.map(({ key, label }) => (
+            <li key={key} className="flex items-start gap-2.5">
               <Check className="mt-0.5 size-4 shrink-0 text-primary" />
               {label}
             </li>

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -178,12 +178,49 @@ export const PLAN_BULLETS: Record<PlanKey, string[]> = {
  * Display labels for cfg_feature keys used in product tier comparison cards.
  * Keyed by the feature key stored in cfg_features / cfg_plans.features[].
  * Kept client-side so marketing can tune copy without a DB write.
+ *
+ * Keys are stored under the platform-agnostic `commerce.<leaf>` form. The
+ * catalog namespaces commerce features per platform — Shopify ships them
+ * un-namespaced (`commerce.assistant`, migration 053) while WooCommerce ships
+ * them platform-scoped (`commerce.woocommerce.assistant`, migration 054).
+ * `featureLabel()` collapses the platform segment so a single entry covers both.
  */
 export const FEATURE_LABELS: Record<string, string> = {
+  "commerce.product_descriptions": "AI product descriptions",
   "commerce.assistant": "Live AI commerce assistant",
   "commerce.catalog_sync": "Automatic catalog sync",
   "commerce.whatsapp": "WhatsApp shopping channel",
   "commerce.in_app_assistant": "In-app product assistant",
   "commerce.multilingual": "Multilingual replies (inc. Hinglish)",
   "commerce.insights_network": "Insights Network access",
+  "commerce.inventory": "Inventory intelligence",
+  "commerce.smart_rails": "Self-updating product showcases",
+  "commerce.brand_voice": "Brand-voice recommendations",
+  "commerce.campaigns": "Daily campaign recommendations",
+  "commerce.autopilot": "Autopilot",
 };
+
+/** Platform segments that may sit between the category and the feature leaf. */
+const PLATFORM_SEGMENTS = new Set(["shopify", "woocommerce"]);
+
+/**
+ * Resolve a cfg_feature key to a human-readable label, platform-namespace
+ * agnostic. Tries an exact match, then collapses a platform segment
+ * (`commerce.woocommerce.assistant` → `commerce.assistant`), and finally falls
+ * back to a humanized leaf token so an unmapped key never renders raw.
+ */
+export function featureLabel(key: string): string {
+  if (FEATURE_LABELS[key]) return FEATURE_LABELS[key];
+
+  const parts = key.split(".");
+  if (parts.length >= 3 && PLATFORM_SEGMENTS.has(parts[1])) {
+    const collapsed = [parts[0], ...parts.slice(2)].join(".");
+    if (FEATURE_LABELS[collapsed]) return FEATURE_LABELS[collapsed];
+  }
+
+  const leaf = parts[parts.length - 1] ?? key;
+  return leaf
+    .split("_")
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -49,6 +49,14 @@ export interface ResolvedPlan {
   pricing: PricingEntry;
 }
 
+/** A cfg_feature granted by a tier, enriched with its catalog display copy. */
+export interface ResolvedFeature {
+  key: string;
+  /** cfg_features.name — the catalog's own display label (source of truth). */
+  name: string;
+  tagline?: string;
+}
+
 /** A single tier within a product (e.g. commerce_assistant.lens). */
 export interface ResolvedProductTier {
   key: string;
@@ -57,6 +65,12 @@ export interface ResolvedProductTier {
   description?: string;
   /** cfg_feature keys granted by this tier. */
   features: string[];
+  /**
+   * The same features enriched with catalog name/tagline, ordered by the
+   * catalog's sortOrder. Present from the API; absent on older API responses
+   * (the component then falls back to `features` + `featureLabel`).
+   */
+  featureDetails?: ResolvedFeature[];
   limits: Record<string, number | undefined>;
   highlightAsRecommended: boolean;
   version: number;


### PR DESCRIPTION
## What

Two fixes to the public `/pricing` page (reported on https://feature-2.peakhour.ai/pricing):

1. **WooCommerce features rendered as raw keys.** The WooCommerce plan listed `commerce.woocommerce.product_descriptions`, `commerce.woocommerce.assistant`, … instead of readable labels.
2. **Bare "Plans" hero** made the page look incomplete. The product is **Peakhour Commerce**.

## Why

`FEATURE_LABELS` only mapped the un-namespaced Shopify keys seeded by migration 053 (`commerce.assistant`, …). WooCommerce seeds its features **platform-scoped** in migration 054 (`commerce.woocommerce.*`), so none matched and the component fell back to `FEATURE_LABELS[k] ?? k` — printing the raw key.

## How

- New `featureLabel()` resolver in `lib/pricing.ts`:
  - exact match first (back-compat),
  - then collapses the platform segment (`commerce.woocommerce.assistant` → `commerce.assistant`),
  - then humanizes the leaf token so an unmapped key **never** renders raw again.
- Mapped the full WooCommerce commerce feature set. Keeping `commerce.` category prefix avoids collisions with `content.brand_voice`.
- `commerce-plans.tsx` now uses `featureLabel()`.
- Hero retitled from `Plans` → **Peakhour Commerce** with a "Plans & pricing" eyebrow chip.

Shopify is unaffected — its keys already matched. The Shopify embedded subscription page only uses the 6 already-labeled `commerce.*` keys, so it's untouched.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)