### PR TITLE
feat(pricing): render the Content pillar on /pricing (T3)

### DIFF
--- a/src/app/(site)/pricing/page.tsx
+++ b/src/app/(site)/pricing/page.tsx
@@ -5,25 +5,29 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 import { Button } from "@/components/ui/button";
 import { CommercePlans } from "@/components/marketing/commerce-plans";
+import { ContentPlans } from "@/components/marketing/content-plans";
 import { getPricing } from "@/lib/pricing";
 import { PeaksGlyph } from "@/components/peaks/peaks-glyph";
 
 export const metadata: Metadata = {
-  title: "Peakhour Commerce — Plans for Shopify & WooCommerce",
+  title: "Peakhour.ai — Plans & Pricing",
   description:
-    "Peakhour.ai commerce plans for Shopify and WooCommerce. Start free, upgrade when you're ready. Every paid plan includes Peaks — the AI credits that power the platform.",
+    "Peakhour.ai plans across Commerce (Shopify & WooCommerce) and Content (WordPress). Start free, upgrade when you're ready. Every paid plan includes Peaks — the AI credits that power the platform.",
 };
 
 /**
- * /pricing — the public Plans page. Shows the COMMERCE plans only, split into a
- * Shopify section and a WooCommerce section (the catalog's `commerce_assistant`
- * tiers). The legacy all-in-one "Suite" tiers (free/starter/growth/agency/
- * enterprise) and the Content product are intentionally not surfaced here.
+ * /pricing — the public Plans page. Renders every product pillar the pricing
+ * API returns: the COMMERCE plans (the `commerce_assistant` tiers, split into a
+ * Shopify and a WooCommerce section) and the CONTENT plans (the `content_studio`
+ * tiers — Scout free → Peakhour Content paid). The legacy all-in-one "Suite"
+ * tiers (free/starter/growth/agency/enterprise) are intentionally not surfaced
+ * here.
  *
  * Server-rendered with the visitor's country resolved from the Vercel edge geo
- * header so prices show in the right currency. Note: the commerce product is
- * env-gated by its catalog status — it only appears in production once ops sets
- * its status to coming_soon/live.
+ * header so prices show in the right currency. Each product is env-gated by its
+ * catalog status on the API side — a product only appears in production once ops
+ * sets its status to coming_soon/live (content_studio is in_development → dev
+ * only until promoted), so the page degrades gracefully when a pillar is absent.
  */
 export default async function PricingPage() {
   const h = await headers();
@@ -35,6 +39,9 @@ export default async function PricingPage() {
 
   const pricing = await getPricing(country);
   const commerce = pricing?.products.find((p) => p.pillar === "commerce");
+  const content = pricing?.products.find((p) => p.pillar === "content");
+  const hasCommerce = !!commerce && commerce.tiers.length > 0;
+  const hasContent = !!content && content.tiers.length > 0;
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -47,12 +54,11 @@ export default async function PricingPage() {
               Plans &amp; pricing
             </span>
             <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-              Peakhour Commerce
+              Peakhour.ai plans
             </h1>
             <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
-              The live, catalog-grounded AI assistant for Shopify and WooCommerce.
-              Start free, upgrade when
-              you&rsquo;re ready — every paid plan includes{" "}
+              Catalog-grounded AI for your store and your content. Start free,
+              upgrade when you&rsquo;re ready — every paid plan includes{" "}
               <Link href="/peaks" className="font-medium underline underline-offset-2">
                 Peaks
               </Link>
@@ -63,17 +69,18 @@ export default async function PricingPage() {
 
         <section className="py-16">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
-            {commerce && commerce.tiers.length > 0 ? (
-              <>
-                <CommercePlans product={commerce} />
+            {hasCommerce || hasContent ? (
+              <div className="space-y-24">
+                {hasCommerce && <CommercePlans product={commerce!} />}
+                {hasContent && <ContentPlans product={content!} />}
                 {pricing && pricing.country !== "DEFAULT" && (
-                  <p className="mt-12 text-center text-[11px] text-muted-foreground">
+                  <p className="text-center text-[11px] text-muted-foreground">
                     Prices shown for{" "}
                     <code className="font-mono">{pricing.country}</code>, detected from
                     your IP — contact sales for a custom-currency invoice.
                   </p>
                 )}
-              </>
+              </div>
             ) : (
               <div className="mx-auto max-w-xl rounded-xl border bg-card p-8 text-center">
                 <div className="mb-4 flex justify-center">

--- a/src/components/marketing/commerce-plans.tsx
+++ b/src/components/marketing/commerce-plans.tsx
@@ -34,7 +34,7 @@ export function CommercePlans({ product }: { product: ResolvedProduct }) {
       name: "Shopify",
       blurb: "For Shopify stores — installed from the Shopify App Store.",
       tiers: [...free, ...shopifyPaid],
-      cta: { href: SHOPIFY_APP_STORE_URL, external: true, label: "Shopify App Store" },
+      cta: { href: SHOPIFY_APP_STORE_URL, external: true },
       note: "Billed through your Shopify account.",
     },
     {
@@ -42,7 +42,7 @@ export function CommercePlans({ product }: { product: ResolvedProduct }) {
       name: "WooCommerce",
       blurb: "For WordPress + WooCommerce stores — via the Peakhour plugin.",
       tiers: [...free, ...wooPaid],
-      cta: { href: "/auth", external: false, label: "Get started" },
+      cta: { href: "/auth", external: false },
       note: "Billed securely online — no in-WordPress checkout.",
     },
   ].filter((p) => p.tiers.length > 0);

--- a/src/components/marketing/commerce-plans.tsx
+++ b/src/components/marketing/commerce-plans.tsx
@@ -1,17 +1,5 @@
-import Link from "next/link";
-import { Check } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { TierCard } from "@/components/marketing/tier-card";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  formatMonthly,
-  formatYearly,
-  featureLabel,
   type ResolvedProduct,
   type ResolvedProductTier,
 } from "@/lib/pricing";
@@ -85,85 +73,5 @@ export function CommercePlans({ product }: { product: ResolvedProduct }) {
         </section>
       ))}
     </div>
-  );
-}
-
-function TierCard({
-  tier,
-  cta,
-}: {
-  tier: ResolvedProductTier;
-  cta: { href: string; external: boolean; label: string };
-}) {
-  const isFree = tier.pricing.monthly === 0;
-  // Prefer the catalog's own feature name (source of truth, from the API),
-  // falling back to the local label map for any key without a catalog row or
-  // when an older API response omits featureDetails.
-  const detailByKey = new Map(
-    (tier.featureDetails ?? []).map((f) => [f.key, f] as const),
-  );
-  const features = tier.features.map((k) => ({
-    key: k,
-    label: detailByKey.get(k)?.name ?? featureLabel(k),
-  }));
-
-  return (
-    <Card
-      className={`relative flex flex-col transition-shadow hover:shadow-md ${
-        tier.highlightAsRecommended ? "border-primary shadow-lg ring-1 ring-primary/20" : ""
-      }`}
-    >
-      {tier.highlightAsRecommended && (
-        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground">
-          Recommended
-        </div>
-      )}
-      <CardHeader>
-        <CardTitle className="text-lg">{tier.name}</CardTitle>
-        <div className="mt-2 flex items-baseline gap-1">
-          {isFree ? (
-            <span className="text-3xl font-bold">Free</span>
-          ) : (
-            <>
-              <span className="text-3xl font-bold">{formatMonthly(tier.pricing)}</span>
-              <span className="text-sm text-muted-foreground">/month</span>
-            </>
-          )}
-        </div>
-        {!isFree && tier.pricing.yearly > 0 && (
-          <p className="text-xs text-muted-foreground">
-            {formatYearly(tier.pricing)} billed yearly · 2 months free
-          </p>
-        )}
-        {tier.tagline && <CardDescription className="mt-2">{tier.tagline}</CardDescription>}
-      </CardHeader>
-      <CardContent className="flex flex-1 flex-col gap-4">
-        <ul className="flex-1 space-y-2.5 text-sm">
-          {features.map(({ key, label }) => (
-            <li key={key} className="flex items-start gap-2.5">
-              <Check className="mt-0.5 size-4 shrink-0 text-primary" />
-              {label}
-            </li>
-          ))}
-        </ul>
-        <Button
-          asChild
-          className="w-full"
-          variant={tier.highlightAsRecommended ? "default" : "outline"}
-        >
-          <Link
-            href={cta.href}
-            {...(cta.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-          >
-            {isFree ? "Get started free" : `Get ${tier.name}`}
-          </Link>
-        </Button>
-        {!isFree && tier.pricing.trialDays > 0 && (
-          <p className="text-center text-[11px] text-muted-foreground">
-            {tier.pricing.trialDays}-day free trial
-          </p>
-        )}
-      </CardContent>
-    </Card>
   );
 }

--- a/src/components/marketing/content-plans.tsx
+++ b/src/components/marketing/content-plans.tsx
@@ -1,0 +1,45 @@
+import { TierCard } from "@/components/marketing/tier-card";
+import { type ResolvedProduct } from "@/lib/pricing";
+
+/**
+ * Content plans (the Content pillar — the `content_studio` product, tiers
+ * "Scout" free → "Peakhour Content" paid). Unlike Commerce there is no platform
+ * split: WordPress is the only content surface today, so the tiers render as a
+ * single section. Billing is peakhour.ai-native (Stripe/Razorpay), so the CTA
+ * leads to sign-up rather than an app store.
+ *
+ * The product is env-gated server-side by its catalog status — it only reaches
+ * this component when the pricing API returns it (dev, or once promoted in
+ * prod), so the page can render this unconditionally when `content` is present.
+ */
+export function ContentPlans({ product }: { product: ResolvedProduct }) {
+  const tiers = product.tiers;
+  if (tiers.length === 0) return null;
+
+  const cta = { href: "/auth", external: false, label: "Get started" } as const;
+
+  return (
+    <section className="space-y-8">
+      <div className="text-center">
+        <span className="mb-3 inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+          Content
+        </span>
+        <h2 className="text-3xl font-semibold text-pretty lg:text-4xl">Content plans</h2>
+        <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+          {product.tagline ??
+            "AI content for WordPress — start free with Scout, upgrade to Peakhour Content for autonomous publishing."}
+        </p>
+      </div>
+
+      <div className="mx-auto grid max-w-3xl gap-6 sm:grid-cols-2">
+        {tiers.map((tier) => (
+          <TierCard key={tier.key} tier={tier} cta={cta} />
+        ))}
+      </div>
+
+      <p className="text-center text-xs text-muted-foreground">
+        Billed securely online — no in-WordPress checkout.
+      </p>
+    </section>
+  );
+}

--- a/src/components/marketing/content-plans.tsx
+++ b/src/components/marketing/content-plans.tsx
@@ -16,7 +16,7 @@ export function ContentPlans({ product }: { product: ResolvedProduct }) {
   const tiers = product.tiers;
   if (tiers.length === 0) return null;
 
-  const cta = { href: "/auth", external: false, label: "Get started" } as const;
+  const cta = { href: "/auth", external: false } as const;
 
   return (
     <section className="space-y-8">

--- a/src/components/marketing/tier-card.tsx
+++ b/src/components/marketing/tier-card.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  formatMonthly,
+  formatYearly,
+  featureLabel,
+  type ResolvedProductTier,
+} from "@/lib/pricing";
+
+/** Call-to-action for a tier card — shared across pillar plan sections. */
+export interface TierCta {
+  href: string;
+  external: boolean;
+  label: string;
+}
+
+/**
+ * A single product-tier comparison card. Pillar-agnostic: used by the Commerce
+ * (platform-split) and Content plan sections alike. Feature labels prefer the
+ * catalog's own `featureDetails` name (source of truth, from the API) and fall
+ * back to the local `featureLabel` map for any key without a catalog row or
+ * when an older API response omits `featureDetails`.
+ */
+export function TierCard({ tier, cta }: { tier: ResolvedProductTier; cta: TierCta }) {
+  const isFree = tier.pricing.monthly === 0;
+  const detailByKey = new Map(
+    (tier.featureDetails ?? []).map((f) => [f.key, f] as const),
+  );
+  const features = tier.features.map((k) => ({
+    key: k,
+    label: detailByKey.get(k)?.name ?? featureLabel(k),
+  }));
+
+  return (
+    <Card
+      className={`relative flex flex-col transition-shadow hover:shadow-md ${
+        tier.highlightAsRecommended ? "border-primary shadow-lg ring-1 ring-primary/20" : ""
+      }`}
+    >
+      {tier.highlightAsRecommended && (
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground">
+          Recommended
+        </div>
+      )}
+      <CardHeader>
+        <CardTitle className="text-lg">{tier.name}</CardTitle>
+        <div className="mt-2 flex items-baseline gap-1">
+          {isFree ? (
+            <span className="text-3xl font-bold">Free</span>
+          ) : (
+            <>
+              <span className="text-3xl font-bold">{formatMonthly(tier.pricing)}</span>
+              <span className="text-sm text-muted-foreground">/month</span>
+            </>
+          )}
+        </div>
+        {!isFree && tier.pricing.yearly > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {formatYearly(tier.pricing)} billed yearly · 2 months free
+          </p>
+        )}
+        {tier.tagline && <CardDescription className="mt-2">{tier.tagline}</CardDescription>}
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        <ul className="flex-1 space-y-2.5 text-sm">
+          {features.map(({ key, label }) => (
+            <li key={key} className="flex items-start gap-2.5">
+              <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+              {label}
+            </li>
+          ))}
+        </ul>
+        <Button
+          asChild
+          className="w-full"
+          variant={tier.highlightAsRecommended ? "default" : "outline"}
+        >
+          <Link
+            href={cta.href}
+            {...(cta.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+          >
+            {isFree ? "Get started free" : `Get ${tier.name}`}
+          </Link>
+        </Button>
+        {!isFree && tier.pricing.trialDays > 0 && (
+          <p className="text-center text-[11px] text-muted-foreground">
+            {tier.pricing.trialDays}-day free trial
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/marketing/tier-card.tsx
+++ b/src/components/marketing/tier-card.tsx
@@ -15,11 +15,12 @@ import {
   type ResolvedProductTier,
 } from "@/lib/pricing";
 
-/** Call-to-action for a tier card — shared across pillar plan sections. */
+/** Call-to-action for a tier card — shared across pillar plan sections. The
+ *  button label is derived from the tier (free vs. paid), so only the link
+ *  target + external flag are needed here. */
 export interface TierCta {
   href: string;
   external: boolean;
-  label: string;
 }
 
 /**

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -212,6 +212,18 @@ export const FEATURE_LABELS: Record<string, string> = {
   "commerce.brand_voice": "Brand-voice recommendations",
   "commerce.campaigns": "Daily campaign recommendations",
   "commerce.autopilot": "Autopilot",
+  // Content pillar (content_studio — Scout / Peakhour Content). Fallback labels
+  // for when the API response omits `featureDetails`; the catalog's own
+  // cfg_features.name is preferred when present.
+  "content.ai_draft": "AI article drafts",
+  "content.autonomous_publish": "Autonomous publishing",
+  "content.meta_sync": "AI SEO meta (Yoast / Rank Math / SEOPress)",
+  "content.aeo_audit": "Answer-Engine (AEO) audit",
+  "content.schema": "Structured data (schema)",
+  "content.internal_links": "Internal link suggestions",
+  "content.refresh": "Automatic content refresh",
+  "content.brand_voice": "Brand-voice learning",
+  "content.insights_lens": "Content Insights",
 };
 
 /** Platform segments that may sit between the category and the feature leaf. */


### PR DESCRIPTION
## What (AUDIT-REMEDIATION-PLAN T3)
The public `/pricing` page rendered **only** the Commerce pillar; the Content product (`content_studio` — **Scout** free / **Peakhour Content** paid) never appeared even though the pricing API returns it. This renders the Content pillar too.

- **Extract a shared `TierCard`** (`marketing/tier-card.tsx`) from `commerce-plans.tsx`; `CommercePlans` now imports it — **no behaviour change** (verified byte-identical).
- **Add `ContentPlans`** (`marketing/content-plans.tsx`): single section (no platform split — WordPress is the only content surface today), peakhour.ai-native sign-up CTA.
- **`pricing/page.tsx`**: pillar-neutral hero; render Commerce + Content for whichever pillars the env-gated API returns; empty state only when **neither** is present.
- **`lib/pricing.ts`**: add `content.*` fallback labels to `FEATURE_LABELS` (used when the API omits `featureDetails`; the catalog's `cfg_features.name` is preferred). Keys verified 1:1 against migration 054 `CONTENT_FEATURES`.

## Graceful degradation
`content_studio` is `in_development` (after [mongodb#252](https://github.com/travelxp/peakhour-mongodb/pull/252)), so the API returns it on **dev** (no env gate) and **suppresses it in prod** until promoted. The page renders whatever the API returns — Content shows on dev, prod is unaffected. Tier display names come from the catalog (post-migration-057: Scout / Peakhour Content).

## Verification
- `tsc --noEmit` ✓ · `eslint` ✓.
- Two-round review: refactor fidelity confirmed identical; non-null assertions (`commerce!`/`content!`) are guarded by `hasCommerce`/`hasContent`; RSC-only (no client hooks); a11y/keys fine.

## Base
Targets **`master`** — master holds the current pricing architecture (`CommercePlans`/`featureLabel`/`featureDetails`). (The stale `feat/woocommerce-launch` b2c branch is on an older `feature-1` base predating this refactor; its connect-card commits are a separate rebase, tracked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)