### PR TITLE
chore: gitignore local agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ next-env.d.ts
 .claude/settings.json
 .claude/settings.local.json
 .claude/worktrees/
+
+# agent skills (installed via `npx skills`, kept local)
+.agents/
+skills-lock.json


### PR DESCRIPTION
Ignore `.agents/` and `skills-lock.json` produced by `npx skills`.

Vercel agent skills (React, Next.js, view-transitions, design-review) are installed locally for the dev agent and kept as local config rather than committed. No app/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)