### PR TITLE
feat(repurpose): blog destinations in the recommend→select sheet (PR 6.1b)

### DIFF
--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -23,6 +23,7 @@ import {
   CalendarClock,
   ArrowLeft,
   FileEdit,
+  FileText,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -34,6 +35,7 @@ import {
   type PlatformRecommendation,
   type RepurposeResponse,
   type RepurposedAdaptation,
+  type BlogDraftResult,
 } from "@/lib/api/repurpose";
 import { SchedulerComposer } from "@/components/scheduler/scheduler-composer";
 import { sourceTextHash } from "@/lib/scheduler/source-hash";
@@ -189,15 +191,20 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
     mutationFn: (args: { source: RepurposeSource; platforms: string[]; platformFitId: string }) =>
       repurpose(args),
     onSuccess: (data: RepurposeResponse) => {
-      const real = data.adaptations.length;
-      if (real === 0) {
+      // Count BOTH social variants (soc_social_posts) and blog drafts
+      // (cnt_drafts) so a blog-only repurpose isn't mis-reported as "nothing
+      // generated". `?? 0` guards against an API that predates blogDrafts.
+      const social = data.adaptations.length;
+      const blog = data.blogDrafts?.length ?? 0;
+      const total = social + blog;
+      if (total === 0) {
         toast.info(
-          "No variants generated — every selected channel is either coming soon or failed.",
+          "Nothing generated — every selected channel is either coming soon or failed.",
         );
       } else if (data.idempotent) {
-        toast.success(`Showing your previous repurpose (${real} variant${real === 1 ? "" : "s"})`);
+        toast.success(`Showing your previous repurpose (${total} item${total === 1 ? "" : "s"})`);
       } else {
-        toast.success(`Generated ${real} variant${real === 1 ? "" : "s"}`);
+        toast.success(`Generated ${total} item${total === 1 ? "" : "s"}`);
       }
     },
     onError: (err: Error) => {
@@ -645,14 +652,16 @@ function RecommendationList({
               <div className="flex items-center gap-2">
                 <span className={`size-2 rounded-full ${band.dot}`} aria-hidden />
                 <span className="text-sm font-medium">{display.label}</span>
+                {display.isBlog && (
+                  <Badge variant="outline" className="text-[10px]">
+                    Blog article
+                  </Badge>
+                )}
                 <Badge variant="outline" className={`text-[10px] ${band.chip}`}>
                   {band.label}
                 </Badge>
-                {!isHardBlocked && (
-                  <span className="text-[10px] text-muted-foreground tabular-nums">
-                    {r.fitScore}/100
-                  </span>
-                )}
+                {/* No raw fitScore/% — plan §4.5 keeps the score internal
+                    (false precision); the band + rationale carry the signal. */}
               </div>
               <p className="text-xs text-muted-foreground">
                 {r.rationale}
@@ -662,6 +671,20 @@ function RecommendationList({
                   </span>
                 )}
               </p>
+              {/* suggestedAngle — the hook the writer will lead with. Doubles
+                  as a preview of how the piece would read on this channel. */}
+              {r.suggestedAngle && (
+                <p className="text-xs text-foreground/80">
+                  <span className="font-medium">Angle:</span> {r.suggestedAngle}
+                </p>
+              )}
+              {/* Grey but not hard-blocked = selectable with a warning
+                  (plan §4.1: grey is "repurpose anyway?", not fix-first). */}
+              {!isHardBlocked && r.band === "grey" && (
+                <p className="text-[10px] text-amber-600 dark:text-amber-400">
+                  Usually doesn&apos;t land well here — repurpose anyway?
+                </p>
+              )}
             </label>
           </li>
         );
@@ -761,6 +784,12 @@ function DoneState({ response }: { response: RepurposeResponse }) {
           </div>
         );
       })}
+      {/* Long-form blog drafts (WordPress/Shopify). Unlike social variants,
+          these are saved to cnt_drafts as pending_approval — the merchant
+          reviews + publishes them from the channel's content dashboard. */}
+      {(response.blogDrafts ?? []).map((d) => (
+        <BlogDraftCard key={`${d.channel}-${d.draftId}`} draft={d} />
+      ))}
       {response.failedPlatforms.length > 0 && (
         <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3">
           <div className="mb-1 flex items-center gap-2 text-xs font-medium text-destructive">
@@ -780,6 +809,31 @@ function DoneState({ response }: { response: RepurposeResponse }) {
           </ul>
         </div>
       )}
+    </div>
+  );
+}
+
+/** A saved blog article draft (WordPress/Shopify). These don't enter the
+ *  scheduler flow here — they're written to cnt_drafts as pending_approval and
+ *  reviewed/published from the channel's content dashboard. */
+function BlogDraftCard({ draft }: { draft: BlogDraftResult }) {
+  const display = getChannelDisplay(draft.channel);
+  return (
+    <div className="rounded-md border bg-card">
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <FileText className="size-4 text-primary" />
+        <span className="text-sm font-medium">{display.label}</span>
+        <Badge variant="outline" className="text-[10px]">
+          Article draft
+        </Badge>
+      </div>
+      <div className="space-y-1 px-3 py-2">
+        <p className="text-sm font-medium">{draft.title}</p>
+        <p className="text-xs text-muted-foreground">
+          Saved as a draft, pending your approval. Review and publish it from your{" "}
+          {display.label} content in Peakhour.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/repurpose/repurpose-sheet.tsx
+++ b/src/components/repurpose/repurpose-sheet.tsx
@@ -197,14 +197,18 @@ export function RepurposeSheet({ open, onOpenChange, source }: Props) {
       const social = data.adaptations.length;
       const blog = data.blogDrafts?.length ?? 0;
       const total = social + blog;
+      // Keep the existing social-only copy ("variant"); use "draft" for
+      // blog-only and a neutral "item" only for a mixed batch.
+      const noun = blog === 0 ? "variant" : social === 0 ? "draft" : "item";
+      const label = `${total} ${noun}${total === 1 ? "" : "s"}`;
       if (total === 0) {
         toast.info(
           "Nothing generated — every selected channel is either coming soon or failed.",
         );
       } else if (data.idempotent) {
-        toast.success(`Showing your previous repurpose (${total} item${total === 1 ? "" : "s"})`);
+        toast.success(`Showing your previous repurpose (${label})`);
       } else {
-        toast.success(`Generated ${total} item${total === 1 ? "" : "s"}`);
+        toast.success(`Generated ${label}`);
       }
     },
     onError: (err: Error) => {

--- a/src/lib/api/repurpose.test.ts
+++ b/src/lib/api/repurpose.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { getChannelDisplay, CHANNEL_DISPLAY, BAND_STYLES } from "./repurpose";
+
+/**
+ * Pure display-metadata for the repurpose recommend→select surface.
+ * PR 6.1b adds the blog_article destinations + plan §4.5 band copy.
+ */
+
+describe("getChannelDisplay", () => {
+  it("returns the social channel labels", () => {
+    expect(getChannelDisplay("linkedin").label).toBe("LinkedIn");
+    expect(getChannelDisplay("x").label).toBe("X (Twitter)");
+  });
+
+  it("flags WordPress + Shopify as blog destinations", () => {
+    const wp = getChannelDisplay("wordpress");
+    expect(wp.label).toBe("WordPress");
+    expect(wp.isBlog).toBe(true);
+    const sh = getChannelDisplay("shopify");
+    expect(sh.label).toBe("Shopify blog");
+    expect(sh.isBlog).toBe(true);
+  });
+
+  it("social channels are not flagged isBlog", () => {
+    expect(getChannelDisplay("linkedin").isBlog).toBeUndefined();
+    expect(CHANNEL_DISPLAY.x?.isBlog).toBeUndefined();
+  });
+
+  it("falls back to a generic chip for unknown channels", () => {
+    const u = getChannelDisplay("mastodon");
+    expect(u.label).toBe("mastodon");
+    expect(u.icon).toBeNull();
+    expect(u.isBlog).toBeUndefined();
+  });
+});
+
+describe("BAND_STYLES (plan §4.5 copy — qualitative, never a raw %)", () => {
+  it("uses SME-friendly band labels", () => {
+    expect(BAND_STYLES.green.label).toBe("Recommended");
+    expect(BAND_STYLES.amber.label).toBe("Worth a try");
+    expect(BAND_STYLES.grey.label).toBe("Not a fit");
+  });
+});

--- a/src/lib/api/repurpose.ts
+++ b/src/lib/api/repurpose.ts
@@ -22,11 +22,17 @@ export type PlatformFitHardBlock =
 export interface PlatformRecommendation {
   /** cfg_channels.key — flat lowercase alphanumeric ("linkedin", "x", …) */
   channel: string;
-  /** 0–100 composite fit score */
+  /** 0–100 composite fit score. INTERNAL — sort key / band threshold only.
+   *  Per plan §4.5 it is deliberately NOT rendered to the user (false
+   *  precision); the band + rationale carry everything actionable. */
   fitScore: number;
   band: PlatformFitBand;
-  /** One-line rationale, safe to render verbatim in the UI tooltip */
+  /** One-line rationale, safe to render verbatim in the UI */
   rationale: string;
+  /** The hook/angle to lead with on this channel — set by the LLM
+   *  recommender (tier "industry"/"personal"). Previews how the piece would
+   *  read on the channel AND seeds the write skill. Absent on rules-tier rows. */
+  suggestedAngle?: string;
   /** Present iff the recommender forced grey regardless of soft signals */
   hardBlocks?: PlatformFitHardBlock[];
   /** "linkedin@1.0.0" — useful for ops dashboards, not user-facing */
@@ -102,6 +108,22 @@ export interface RepurposeFailure {
   error: string;
 }
 
+/**
+ * A long-form blog draft produced by the blog_article path (WordPress /
+ * Shopify). Unlike social adaptations (soc_social_posts), these persist to
+ * cnt_drafts as `pending_approval` — the merchant reviews + publishes them
+ * from the content dashboard (or, later, the scheduler). One row per channel.
+ */
+export interface BlogDraftResult {
+  /** cfg_channels.key — "wordpress" | "shopify" */
+  channel: string;
+  /** cnt_drafts._id (string) of the saved blog draft */
+  draftId: string;
+  title: string;
+  /** Which body markup was stored: Gutenberg blocks vs classic HTML. */
+  format: "blocks" | "classic";
+}
+
 export interface RepurposeResponse {
   /** soc_social_posts._id (string) when at least one variant was
    *  persisted; null when every requested platform failed or was a
@@ -109,6 +131,10 @@ export interface RepurposeResponse {
   socialPostId: string | null;
   sourceTitle: string;
   adaptations: RepurposedAdaptation[];
+  /** Long-form blog drafts (cnt_drafts) — populated when a blog_article
+   *  destination (WordPress/Shopify) was requested + connected. Empty for
+   *  the social-only path. */
+  blogDrafts: BlogDraftResult[];
   failedPlatforms: RepurposeFailure[];
   /** True when the route's idempotency short-circuit returned a
    *  prior post instead of generating fresh variants. UI can show
@@ -144,7 +170,19 @@ export interface ChannelDisplay {
   label: string;
   /** Lucide icon name OR null for channels we don't have a brand-true
    *  icon for. Renderer falls back to a generic chip. */
-  icon: "linkedin" | "twitter" | "facebook" | "instagram" | "message-circle" | null;
+  icon:
+    | "linkedin"
+    | "twitter"
+    | "facebook"
+    | "instagram"
+    | "message-circle"
+    | "globe"
+    | "shopping-bag"
+    | null;
+  /** Long-form blog destination (WordPress/Shopify) → the result is a saved
+   *  cnt_drafts article (pending approval), not a social variant. Lets the UI
+   *  branch the recommend/done rendering on a capability, not a channel name. */
+  isBlog?: boolean;
 }
 
 export const CHANNEL_DISPLAY: Record<string, ChannelDisplay> = {
@@ -153,6 +191,9 @@ export const CHANNEL_DISPLAY: Record<string, ChannelDisplay> = {
   facebook: { label: "Facebook", icon: "facebook" },
   instagram: { label: "Instagram", icon: "instagram" },
   threads: { label: "Threads", icon: "message-circle" },
+  // blog_article destinations — the result is a long-form article draft.
+  wordpress: { label: "WordPress", icon: "globe", isBlog: true },
+  shopify: { label: "Shopify blog", icon: "shopping-bag", isBlog: true },
 };
 
 export function getChannelDisplay(channel: string): ChannelDisplay {
@@ -163,6 +204,7 @@ export function getChannelDisplay(channel: string): ChannelDisplay {
 // One place so the chip / row / badge stays consistent across the
 // sheet, suggested-drafts card preview, and any future surface.
 
+// Band copy follows plan §4.5 — qualitative, SME-friendly, never a raw %.
 export const BAND_STYLES: Record<PlatformFitBand, { dot: string; chip: string; label: string }> = {
   green: {
     dot: "bg-emerald-500",
@@ -172,11 +214,11 @@ export const BAND_STYLES: Record<PlatformFitBand, { dot: string; chip: string; l
   amber: {
     dot: "bg-amber-500",
     chip: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-    label: "Optional",
+    label: "Worth a try",
   },
   grey: {
     dot: "bg-slate-400",
     chip: "border-slate-400/40 bg-slate-400/10 text-slate-600 dark:text-slate-400",
-    label: "Not recommended",
+    label: "Not a fit",
   },
 };


### PR DESCRIPTION
## What

Extends the existing **RepurposeSheet** (the two-step recommend→select→generate flow) to handle **WordPress / Shopify** `blog_article` destinations — now that the on-demand recommender scores them ([api #678](https://github.com/travelxp/peakhour-api/pull/678)) and the engine writes blog drafts ([api #674](https://github.com/travelxp/peakhour-api/pull/674)).

### `lib/api/repurpose.ts`
- `PlatformRecommendation` gains **`suggestedAngle`** (the LLM hook/preview).
- `RepurposeResponse` gains **`blogDrafts[]`** (`BlogDraftResult`: channel/draftId/title/format) — the `cnt_drafts` articles the engine returns.
- `CHANNEL_DISPLAY` adds wordpress/shopify with an **`isBlog`** flag (UI branches on a capability, not a channel name).
- `BAND_STYLES` copy aligned to **plan §4.5**: *Recommended / Worth a try / Not a fit*.

### `repurpose-sheet.tsx`
- **Recommend list**: drops the raw `fitScore/100` (plan §4.5 — score stays internal, no false precision); shows the **suggestedAngle** preview; grey-but-not-hard-blocked rows show a *"repurpose anyway?"* warning and stay **selectable**; hard-blocks stay disabled (fix-first).
- **Done state**: blog drafts render as **"Article draft — pending approval"** cards (they persist to `cnt_drafts`, reviewed/published from the content dashboard; they don't enter the social scheduler flow here).
- Success toast counts social variants **+** blog drafts (a blog-only repurpose isn't mis-reported as "nothing generated").

## Deferred (need API/route support — noted as follow-ups, per plan)
- Per-platform **Peaks cost + running total** (the recommend/repurpose responses don't carry a Peaks cost yet).
- **Full article preview** (`blogDrafts` returns metadata, not the rendered body).
- **"Already repurposed for X"** idempotency for blog-only (the route's short-circuit currently keys on social `socialPostIds`).

## Checks
- `npx tsc --noEmit` — clean · `eslint` — clean · `next build` — green.
- `vitest` — +5 unit tests for the display metadata (blog flags, fallback, plan band copy).

Social path is unchanged (additive types + a blog branch in the done view). Still gated overall — blog channels only appear for merchants who connected WordPress/Shopify; `cfg_channels` availability stays `coming_soon`.

Plan: `docs/idea/repurpose-to-wordpress-shopify-plan.md` §6 (PR 6.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)