### PR TITLE
feat(claim): WordPress claim landing + account chooser (onboarding PR D)

### DIFF
--- a/src/app/(site)/claim/wordpress/_components/wordpress-claim.tsx
+++ b/src/app/(site)/claim/wordpress/_components/wordpress-claim.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { CheckCircle2, AlertCircle, Globe, Loader2 } from "lucide-react";
+import { useAuth } from "@/providers/auth-provider";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  fetchClaimCandidates,
+  claimWordpressSite,
+  type ClaimCandidates,
+} from "@/lib/api/wordpress-claim";
+
+/** Result of the post-auth flow (fetch candidates → choose → claim). The
+ *  pre-auth phases (loading auth / missing link / need sign-in) are DERIVED at
+ *  render time from props, so the effect never sets state synchronously. */
+type FetchState = "loading" | "choose" | "claiming" | "done" | "error";
+
+function errCopy(code: string, fallback: string): { title: string; body: string } {
+  switch (code) {
+    case "CLAIM_ALREADY_CLAIMED":
+      return { title: "Already connected", body: "This site is already linked to a Peakhour account." };
+    case "CLAIM_EXPIRED":
+      return { title: "This link has expired", body: "Open Peakhour in your WordPress admin and use the fresh “Claim” link." };
+    case "CLAIM_INVALID":
+      return { title: "Invalid claim link", body: "Open Peakhour in your WordPress admin and use the “Claim” link there." };
+    case "CLAIM_FORBIDDEN_ORG":
+      return { title: "No permission", body: "You can only attach a site to an account you own or admin." };
+    case "CLAIM_NO_BUSINESS":
+      return { title: "Set up a business first", body: "Create a business in that account, then open the claim link again." };
+    case "CLAIM_SITE_NOT_FOUND":
+      return { title: "Site not found", body: "This site is no longer available to claim." };
+    default:
+      return { title: "Something went wrong", body: fallback };
+  }
+}
+
+export function WordpressClaim() {
+  const params = useSearchParams();
+  const site = params.get("site") ?? "";
+  const token = params.get("t") ?? "";
+  const { isAuthenticated, isLoading } = useAuth();
+
+  const [fetchState, setFetchState] = useState<FetchState>("loading");
+  const [data, setData] = useState<ClaimCandidates | null>(null);
+  const [selectedOrg, setSelectedOrg] = useState<string>("");
+  const [errCode, setErrCode] = useState<string>("");
+  const [errMsg, setErrMsg] = useState<string>("");
+  const [claimedName, setClaimedName] = useState<string>("");
+
+  const ready = !isLoading && isAuthenticated && !!site && !!token;
+
+  useEffect(() => {
+    // Only the async candidate fetch lives here; all setState is in the
+    // resolved/ rejected callbacks (never synchronous in the effect body).
+    if (!ready) return;
+    let cancelled = false;
+    fetchClaimCandidates(site, token)
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+        if (d.orgs.length === 1) setSelectedOrg(d.orgs[0]!.orgId);
+        setFetchState("choose");
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setErrCode((e as { code?: string })?.code ?? "");
+        setErrMsg((e as { message?: string })?.message ?? "Something went wrong.");
+        setFetchState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, site, token]);
+
+  async function handleClaim() {
+    if (!selectedOrg || !data) return;
+    setFetchState("claiming");
+    try {
+      await claimWordpressSite(site, token, selectedOrg);
+      setClaimedName(data.orgs.find((o) => o.orgId === selectedOrg)?.name ?? "your account");
+      setFetchState("done");
+    } catch (e: unknown) {
+      setErrCode((e as { code?: string })?.code ?? "");
+      setErrMsg((e as { message?: string })?.message ?? "Couldn't connect the site.");
+      setFetchState("error");
+    }
+  }
+
+  // Derived phase: pre-auth states from props, then the async fetchState.
+  const showLoading = isLoading || (ready && fetchState === "loading");
+  const showMissing = !isLoading && (!site || !token);
+  const showSignIn = !isLoading && !!site && !!token && !isAuthenticated;
+
+  return (
+    <div className="mx-auto flex min-h-[70vh] w-full max-w-lg items-center px-4 py-10">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Globe className="size-5 text-primary" aria-hidden />
+            Connect your WordPress site
+          </CardTitle>
+          {ready && fetchState === "choose" && data?.site?.host && (
+            <CardDescription>{data.site.host}</CardDescription>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {showLoading && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              Loading…
+            </div>
+          )}
+
+          {showMissing && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+                <AlertCircle className="size-5" aria-hidden />
+                Invalid claim link
+              </div>
+              <p className="text-sm text-muted-foreground">
+                This link is missing information. Open Peakhour in your WordPress admin and use the
+                “Claim” link there.
+              </p>
+            </div>
+          )}
+
+          {showSignIn && (
+            <div className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                Sign in to your Peakhour account to connect this WordPress site. After signing in,
+                reopen the “Claim” link from your WordPress admin.
+              </p>
+              <Button asChild>
+                <Link href="/auth">Sign in</Link>
+              </Button>
+            </div>
+          )}
+
+          {ready && fetchState === "choose" && data && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Choose which Peakhour account to attach this site to.
+              </p>
+              <div className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+                <div>
+                  Signed in as{" "}
+                  <span className="font-medium text-foreground">{data.signedInEmail ?? "your account"}</span>
+                </div>
+                {data.site.adminEmail && (
+                  <div>
+                    WordPress admin:{" "}
+                    <span className="font-medium text-foreground">{data.site.adminEmail}</span>
+                  </div>
+                )}
+              </div>
+
+              {data.orgs.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No account found on your sign-in. Create one in Peakhour, then reopen this link.
+                </p>
+              ) : data.orgs.length === 1 ? (
+                <p className="text-sm">
+                  Connect to <span className="font-medium">{data.orgs[0]!.name}</span>.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {data.orgs.map((o) => {
+                    const selected = o.orgId === selectedOrg;
+                    return (
+                      <li key={o.orgId}>
+                        <button
+                          type="button"
+                          onClick={() => setSelectedOrg(o.orgId)}
+                          className={`flex w-full items-center justify-between rounded-md border p-3 text-left text-sm hover:bg-muted/40 ${
+                            selected ? "border-primary ring-1 ring-primary" : ""
+                          }`}
+                        >
+                          <span className="font-medium">{o.name}</span>
+                          <span className="text-xs text-muted-foreground">{o.role}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              <Button
+                onClick={handleClaim}
+                disabled={!selectedOrg || data.orgs.length === 0}
+                className="w-full"
+              >
+                Connect this site
+              </Button>
+            </div>
+          )}
+
+          {ready && fetchState === "claiming" && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              Connecting…
+            </div>
+          )}
+
+          {ready && fetchState === "done" && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-medium text-emerald-600 dark:text-emerald-400">
+                <CheckCircle2 className="size-5" aria-hidden />
+                Connected!
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {data?.site?.host ?? "Your site"} is now linked to{" "}
+                <span className="font-medium text-foreground">{claimedName}</span>.
+              </p>
+              <Button asChild>
+                <Link href="/dashboard">Go to dashboard</Link>
+              </Button>
+            </div>
+          )}
+
+          {ready && fetchState === "error" && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+                <AlertCircle className="size-5" aria-hidden />
+                {errCopy(errCode, errMsg).title}
+              </div>
+              <p className="text-sm text-muted-foreground">{errCopy(errCode, errMsg).body}</p>
+              <Button asChild variant="outline">
+                <Link href="/dashboard">Go to dashboard</Link>
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(site)/claim/wordpress/_components/wordpress-claim.tsx
+++ b/src/app/(site)/claim/wordpress/_components/wordpress-claim.tsx
@@ -226,18 +226,21 @@ export function WordpressClaim() {
             </div>
           )}
 
-          {ready && fetchState === "error" && (
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-sm font-medium text-destructive">
-                <AlertCircle className="size-5" aria-hidden />
-                {errCopy(errCode, errMsg).title}
+          {ready && fetchState === "error" && (() => {
+            const ec = errCopy(errCode, errMsg);
+            return (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+                  <AlertCircle className="size-5" aria-hidden />
+                  {ec.title}
+                </div>
+                <p className="text-sm text-muted-foreground">{ec.body}</p>
+                <Button asChild variant="outline">
+                  <Link href="/dashboard">Go to dashboard</Link>
+                </Button>
               </div>
-              <p className="text-sm text-muted-foreground">{errCopy(errCode, errMsg).body}</p>
-              <Button asChild variant="outline">
-                <Link href="/dashboard">Go to dashboard</Link>
-              </Button>
-            </div>
-          )}
+            );
+          })()}
         </CardContent>
       </Card>
     </div>

--- a/src/app/(site)/claim/wordpress/page.tsx
+++ b/src/app/(site)/claim/wordpress/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from "react";
+import { WordpressClaim } from "./_components/wordpress-claim";
+
+/**
+ * /claim/wordpress?site=<id>&t=<token>
+ * Landing the WordPress plugin's "Claim" link points at. The merchant signs in
+ * (if needed), then attaches their silently-connected site to a real Peakhour
+ * account via the account chooser. The token rides in the body of the api calls,
+ * not onward URLs. Wrapped in Suspense because the client component reads
+ * useSearchParams.
+ */
+export default function WordpressClaimPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto flex min-h-[70vh] w-full max-w-lg items-center justify-center px-4 text-sm text-muted-foreground">
+          Loading…
+        </div>
+      }
+    >
+      <WordpressClaim />
+    </Suspense>
+  );
+}

--- a/src/lib/api/wordpress-claim.ts
+++ b/src/lib/api/wordpress-claim.ts
@@ -1,0 +1,52 @@
+import { api } from "@/lib/api";
+
+/**
+ * Typed client for the WordPress "claim a silently-connected site" flow
+ * (peakhour-api wp-bridge claim/candidates + claim). The plugin's silent-connect
+ * hands the WP admin a claim URL → /claim/wordpress?site=<id>&t=<token>; this
+ * page exchanges the token for the candidate accounts, then attaches the site to
+ * the chosen one. Both calls are cookie-authed (the user is signed in here) and
+ * pass the token in the POST body (never the query string).
+ */
+
+export interface ClaimSite {
+  host: string;
+  siteUrl: string;
+  adminEmail: string | null;
+}
+
+export interface ClaimOrg {
+  orgId: string;
+  name: string;
+  role: string;
+}
+
+export interface ClaimCandidates {
+  site: ClaimSite;
+  /** The signed-in Peakhour account's email (shown alongside the WP admin email
+   *  so the user knows which account they're attaching to). */
+  signedInEmail: string | null;
+  /** Orgs the signed-in user can attach the site to. UI auto-selects when 1. */
+  orgs: ClaimOrg[];
+}
+
+export async function fetchClaimCandidates(
+  site: string,
+  token: string,
+): Promise<ClaimCandidates> {
+  return api.request<ClaimCandidates>("/v1/integrations/wordpress/claim/candidates", {
+    method: "POST",
+    body: JSON.stringify({ site, token }),
+  });
+}
+
+export async function claimWordpressSite(
+  site: string,
+  token: string,
+  orgId: string,
+): Promise<{ claimed: boolean; orgId: string }> {
+  return api.request<{ claimed: boolean; orgId: string }>(
+    "/v1/integrations/wordpress/claim",
+    { method: "POST", body: JSON.stringify({ site, token, orgId }) },
+  );
+}


### PR DESCRIPTION
## What

The peakhour.ai page the WordPress plugin's **"Claim"** link points at — `/claim/wordpress?site=<id>&t=<token>`. It signs the merchant in (if needed) and attaches their **silently-connected free site** ([api #681](https://github.com/travelxp/peakhour-api/pull/681)) to a **real Peakhour account** via the candidates/claim endpoints ([#682](https://github.com/travelxp/peakhour-api/pull/682) + envelope fix [#683](https://github.com/travelxp/peakhour-api/pull/683)).

- **`src/lib/api/wordpress-claim.ts`** — typed client; token rides in the POST **body**, never the URL.
- **Claim page** (Suspense-wrapped client component) — derives the pre-auth states (loading / missing-link / need-sign-in) from props so the effect only runs the async candidate fetch (**no synchronous setState-in-effect**, per the repo's lint rule). Shows the site host + **both** the signed-in email and the WP admin email for context; **auto-selects** the org when there's one, else a chooser; maps the API error codes (`CLAIM_EXPIRED` / `CLAIM_ALREADY_CLAIMED` / `CLAIM_INVALID` / `CLAIM_FORBIDDEN_ORG` / `CLAIM_NO_BUSINESS` / …) to friendly copy. Success → "Connected!" + dashboard link.

## Checks
- `tsc --noEmit` clean · `eslint` clean · `next build` green (`/claim/wordpress` route present).

## Known follow-up
The b2c app has no generic post-login `returnTo`, so an unauthenticated visitor signs in then **reopens** the claim link (it's persistent, 30-day token). Matches the app's existing unauth pattern; smoother auto-return is a later nicety.

Plan: `docs/idea/wordpress-keyless-onboarding-plan.md`. **Shopify untouched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)