### PR TITLE
fix(dashboard): redirect /dashboard → /dashboard/overview (was 404)

### DIFF
--- a/src/app/(site)/dashboard/page.tsx
+++ b/src/app/(site)/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+
+/**
+ * `/dashboard` has no page of its own — the app's home is `/dashboard/overview`.
+ * Without this, bare `/dashboard` links (the WordPress claim page's "Go to
+ * dashboard", the Shopify surface, not-found, plus any server-issued
+ * dashboard_url) 404. Redirect to the canonical overview.
+ */
+export default function DashboardIndex() {
+  redirect("/dashboard/overview");
+}


### PR DESCRIPTION
`/dashboard` had no index route, so every bare `/dashboard` link 404'd: the WordPress claim page's 'Go to dashboard' buttons, the Shopify embedded/connect surface, not-found, and any server-issued `dashboard_url`. Adds an index page that `redirect()`s to the canonical `/dashboard/overview`. tsc + eslint + next build clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)