### PR TITLE
feat(settings): brand-mismatch message for the integration-fit guard

### DIFF
--- a/src/app/(site)/dashboard/settings/page.tsx
+++ b/src/app/(site)/dashboard/settings/page.tsx
@@ -162,7 +162,11 @@ function SettingsContent() {
       queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
     } else if (searchParams?.get("integration") === "error") {
       setConnectError(
-        oauthErrorMessage(searchParams.get("provider"), searchParams.get("msg")),
+        oauthErrorMessage(
+          searchParams.get("provider"),
+          searchParams.get("msg"),
+          searchParams.get("anchor"),
+        ),
       );
     }
   }, [searchParams, queryClient]);
@@ -445,9 +449,13 @@ function formatProviderName(slug: string): string {
 // Friendly copy for the OAuth callback's ?integration=error&msg=<code>.
 // Codes are emitted by peakhour-api integrations/routes.ts. Unknown codes
 // fall through to a generic message so a new backend code never renders raw.
-function oauthErrorMessage(provider: string | null, msg: string | null): string {
+function oauthErrorMessage(provider: string | null, msg: string | null, anchor?: string | null): string {
   const name = formatProviderName(provider ?? "");
   switch (msg) {
+    case "brand_mismatch":
+      // The integration-fit guard blocked a different-brand account from
+      // attaching to this workspace (one workspace = one business).
+      return `That ${name} account looks like a different brand${anchor ? ` from ${anchor}` : ""}. To keep your content on-message, each workspace is one business — connect it to its own workspace instead.`;
     case "store_already_connected":
       return `That Shopify store is already connected to another business. Each store can be linked to one business at a time.`;
     case "invalid_shop":


### PR DESCRIPTION
## Why
When the integration-fit guard (peakhour-api #698) blocks a wrong-brand account at the OAuth callback, the user is redirected back to settings and needs to understand why + what to do.

## What
Maps the new `msg=brand_mismatch` code (with optional `anchor`) — reusing the existing OAuth-error banner surface (`?integration=error&provider=&msg=`) — to clear copy:

> That *<provider>* account looks like a different brand from *<anchor>*. To keep your content on-message, each workspace is one business — connect it to its own workspace instead.

## Pairs with
peakhour-api #698 (the guard + OAuth callback enforcement).

## Follow-up
The full "create its own workspace" one-click escape hatch + the `ambiguous`-verdict confirm flow are a further follow-up (this v1 blocks hard mismatches and explains the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)