### PR TITLE
feat(support): request-a-review on fit blocks + wrong-brand flags

### DIFF
--- a/src/app/(site)/dashboard/settings/page.tsx
+++ b/src/app/(site)/dashboard/settings/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/providers/auth-provider";
 import { api, ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { IntegrationFitAttention } from "@/components/integrations/integration-fit-attention";
+import { RequestReviewButton } from "@/components/integrations/request-review-button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
@@ -102,6 +103,13 @@ function SettingsContent() {
   const [error, setError] = useState("");
   const [justConnectedProvider, setJustConnectedProvider] = useState<string | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
+  // Raw context for a brand_mismatch block, so the user can dispute it ("request
+  // a review"). Null unless the last connect was blocked as a wrong brand.
+  const [mismatchContext, setMismatchContext] = useState<{
+    provider: string;
+    anchor: string | null;
+    candidate: string | null;
+  } | null>(null);
 
   // Edit state
   const [editingBusiness, setEditingBusiness] = useState(false);
@@ -162,13 +170,16 @@ function SettingsContent() {
       queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
       queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
     } else if (searchParams?.get("integration") === "error") {
-      setConnectError(
-        oauthErrorMessage(
-          searchParams.get("provider"),
-          searchParams.get("msg"),
-          searchParams.get("anchor"),
-        ),
-      );
+      const provider = searchParams.get("provider");
+      const msg = searchParams.get("msg");
+      const anchor = searchParams.get("anchor");
+      setConnectError(oauthErrorMessage(provider, msg, anchor));
+      // Only a brand-mismatch block is disputable via "request a review".
+      if (msg === "brand_mismatch" && provider) {
+        setMismatchContext({ provider, anchor, candidate: searchParams.get("candidate") });
+      } else {
+        setMismatchContext(null);
+      }
     }
   }, [searchParams, queryClient]);
 
@@ -204,9 +215,26 @@ function SettingsContent() {
       )}
 
       {connectError !== null && (
-        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-4 text-sm text-destructive">
-          <AlertCircle className="h-4 w-4 shrink-0" />
-          {connectError}
+        <div className="flex flex-col gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-4 text-sm text-destructive">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            {connectError}
+          </div>
+          {mismatchContext && (
+            <div className="pl-6">
+              <RequestReviewButton
+                provider={mismatchContext.provider}
+                anchor={mismatchContext.anchor}
+                candidate={
+                  mismatchContext.candidate
+                    ? { displayName: mismatchContext.candidate }
+                    : undefined
+                }
+                variant="outline"
+                className="gap-1.5"
+              />
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/integrations/integration-fit-attention.tsx
+++ b/src/components/integrations/integration-fit-attention.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, ArrowRightLeft } from "lucide-react";
+import { RequestReviewButton } from "@/components/integrations/request-review-button";
 
 /**
  * "Needs attention" surface for the settings page: lists connected accounts the
@@ -114,16 +115,34 @@ export function IntegrationFitAttention() {
                 .
               </p>
             </div>
-            <Button
-              size="sm"
-              variant="outline"
-              className="shrink-0 gap-1.5"
-              disabled={moving === f.connectionId}
-              onClick={() => moveToOwnWorkspace(f)}
-            >
-              <ArrowRightLeft className="h-3.5 w-3.5" />
-              {moving === f.connectionId ? "Moving…" : "Move to its own workspace"}
-            </Button>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-1.5"
+                disabled={moving === f.connectionId}
+                onClick={() => moveToOwnWorkspace(f)}
+              >
+                <ArrowRightLeft className="h-3.5 w-3.5" />
+                {moving === f.connectionId ? "Moving…" : "Move to its own workspace"}
+              </Button>
+              <RequestReviewButton
+                provider={f.provider ?? "integration"}
+                anchor={f.fit.anchor}
+                candidate={
+                  f.fit.identity?.value
+                    ? {
+                        identity: {
+                          kind: f.fit.identity.kind === "domain" ? "domain" : "handle",
+                          value: f.fit.identity.value,
+                        },
+                      }
+                    : undefined
+                }
+                variant="ghost"
+                label="Not right?"
+              />
+            </div>
           </div>
         ))}
       </CardContent>

--- a/src/components/integrations/request-review-button.tsx
+++ b/src/components/integrations/request-review-button.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { MessageSquareWarning } from "lucide-react";
+
+/**
+ * "We got this wrong — request a review" action for the integration-fit guard.
+ * Files a support ticket (POST /v1/integrations/review-requests → sup_inbox) when
+ * a user disputes a connect block or a wrong-brand flag. Shared by the connect-
+ * time mismatch banner and the settings "Needs attention" card.
+ */
+
+interface ReviewCandidate {
+  identity?: { kind: "domain" | "handle"; value: string };
+  displayName?: string;
+}
+
+interface RequestReviewButtonProps {
+  provider: string;
+  anchor?: string | null;
+  candidate?: ReviewCandidate;
+  className?: string;
+  size?: "sm" | "default";
+  variant?: "outline" | "ghost" | "link";
+  label?: string;
+}
+
+export function RequestReviewButton({
+  provider,
+  anchor,
+  candidate,
+  className,
+  size = "sm",
+  variant = "ghost",
+  label = "We got this wrong — request a review",
+}: RequestReviewButtonProps) {
+  const [sending, setSending] = useState(false);
+  const [done, setDone] = useState(false);
+
+  async function submit() {
+    setSending(true);
+    try {
+      await api.post("/v1/integrations/review-requests", {
+        provider,
+        ...(anchor ? { anchor } : {}),
+        ...(candidate ? { candidate } : {}),
+      });
+      setDone(true);
+      toast.success("Thanks — our team will review this and get back to you.");
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Couldn't send your request. Please try again.",
+      );
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (done) {
+    return <span className="text-xs text-muted-foreground">Review requested ✓</span>;
+  }
+
+  return (
+    <Button
+      type="button"
+      size={size}
+      variant={variant}
+      className={className}
+      disabled={sending}
+      onClick={submit}
+    >
+      <MessageSquareWarning className="h-3.5 w-3.5" />
+      {sending ? "Sending…" : label}
+    </Button>
+  );
+}

--- a/src/components/integrations/request-review-button.tsx
+++ b/src/components/integrations/request-review-button.tsx
@@ -60,7 +60,11 @@ export function RequestReviewButton({
   }
 
   if (done) {
-    return <span className="text-xs text-muted-foreground">Review requested ✓</span>;
+    return (
+      <span role="status" className="text-xs text-muted-foreground">
+        Review requested ✓
+      </span>
+    );
   }
 
   return (


### PR DESCRIPTION
## What

The user-facing **dispute path** for the integration-fit guard — files into the support inbox (`POST /v1/integrations/review-requests` → `sup_inbox`, api #704).

- **`RequestReviewButton`** — shared "we got this wrong — request a review" action (posts `provider` + `anchor` + `candidate`; success toast; one-shot).
- **Connect-time mismatch banner** (`brand_mismatch`) now shows the button, using the blocked `candidate` threaded through the OAuth error redirect (api #704).
- **"Needs attention" card** rows get a secondary **"Not right?"** review action beside "Move to its own workspace".

Depends on peakhour-api **#704** (merged). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)