### PR TITLE
feat(support): connect-time create-workspace escape + Contact support

### DIFF
--- a/src/app/(site)/dashboard/settings/page.tsx
+++ b/src/app/(site)/dashboard/settings/page.tsx
@@ -9,6 +9,8 @@ import { api, ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { IntegrationFitAttention } from "@/components/integrations/integration-fit-attention";
 import { RequestReviewButton } from "@/components/integrations/request-review-button";
+import { CreateWorkspaceButton } from "@/components/integrations/create-workspace-button";
+import { ContactSupportDialog } from "@/components/support/contact-support-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
@@ -200,11 +202,14 @@ function SettingsContent() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">General</h2>
-        <p className="text-muted-foreground mt-1">
-          Business details, budget, and connected accounts
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">General</h2>
+          <p className="text-muted-foreground mt-1">
+            Business details, budget, and connected accounts
+          </p>
+        </div>
+        <ContactSupportDialog />
       </div>
 
       {justConnectedProvider !== null && (
@@ -221,7 +226,11 @@ function SettingsContent() {
             {connectError}
           </div>
           {mismatchContext && (
-            <div className="pl-6">
+            <div className="flex flex-wrap gap-2 pl-6">
+              <CreateWorkspaceButton
+                provider={mismatchContext.provider}
+                suggestedName={mismatchContext.candidate}
+              />
               <RequestReviewButton
                 provider={mismatchContext.provider}
                 anchor={mismatchContext.anchor}

--- a/src/components/integrations/create-workspace-button.tsx
+++ b/src/components/integrations/create-workspace-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { FolderPlus } from "lucide-react";
+
+/**
+ * Connect-time escape hatch for the integration-fit guard: when a connect is
+ * hard-stopped as a different brand, create a NEW workspace for it and switch
+ * there, then send the user to the integrations page to reconnect (now against
+ * an empty workspace → anchors cleanly). Reuses POST /auth/businesses/create,
+ * which switches the active business + reissues the session cookie; the full
+ * navigation picks up the new active business. Works for OAuth and API-key
+ * providers alike (no provider-specific re-auth wiring).
+ */
+
+interface CreateWorkspaceButtonProps {
+  /** Provider being connected — used for the default workspace name + copy. */
+  provider: string;
+  /** Suggested workspace name (the blocked candidate's brand), if known. */
+  suggestedName?: string | null;
+}
+
+export function CreateWorkspaceButton({ provider, suggestedName }: CreateWorkspaceButtonProps) {
+  const [busy, setBusy] = useState(false);
+
+  async function run() {
+    setBusy(true);
+    try {
+      const name = suggestedName?.trim() || `${provider} workspace`;
+      await api.post("/v1/auth/businesses/create", { name });
+      toast.success(`Created workspace "${name}". Connect ${provider} here.`);
+      // Full navigation so the new active business (fresh cookie) is picked up.
+      window.location.href = "/dashboard/integrations";
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Couldn't create the workspace. Please try again.",
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Button type="button" size="sm" variant="outline" className="gap-1.5" disabled={busy} onClick={run}>
+      <FolderPlus className="h-3.5 w-3.5" />
+      {busy ? "Creating…" : "Create a separate workspace"}
+    </Button>
+  );
+}

--- a/src/components/support/contact-support-dialog.tsx
+++ b/src/components/support/contact-support-dialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { LifeBuoy } from "lucide-react";
+
+/**
+ * "Contact support" — a general in-app support entry point. Files into the same
+ * unified support inbox (POST /v1/support/contact → sup_inbox, source:"in_app")
+ * that the integration-fit disputes use, so the CMS triages everything in one
+ * queue.
+ */
+
+const CATEGORIES: Array<{ value: string; label: string }> = [
+  { value: "technical", label: "Something's not working" },
+  { value: "billing", label: "Billing & plans" },
+  { value: "integrations", label: "Integrations" },
+  { value: "account", label: "My account" },
+  { value: "content", label: "Content & AI" },
+  { value: "feedback", label: "Feedback / idea" },
+  { value: "other", label: "Something else" },
+];
+
+export function ContactSupportDialog({ trigger }: { trigger?: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState("technical");
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+
+  async function submit() {
+    if (!body.trim()) {
+      toast.error("Please describe what you need help with.");
+      return;
+    }
+    setSending(true);
+    try {
+      await api.post("/v1/support/contact", {
+        category,
+        subject: subject.trim() || undefined,
+        body: body.trim(),
+      });
+      toast.success("Thanks — our team will get back to you.");
+      setOpen(false);
+      setSubject("");
+      setBody("");
+      setCategory("technical");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't send your message. Please try again.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button variant="outline" size="sm" className="gap-1.5">
+            <LifeBuoy className="h-3.5 w-3.5" />
+            Contact support
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Contact support</DialogTitle>
+          <DialogDescription>
+            Tell us what you need — we&apos;ll pick it up and reply.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="support-category">Topic</Label>
+            <Select value={category} onValueChange={setCategory}>
+              <SelectTrigger id="support-category">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORIES.map((c) => (
+                  <SelectItem key={c.value} value={c.value}>
+                    {c.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="support-subject">Subject (optional)</Label>
+            <Input
+              id="support-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              maxLength={256}
+              placeholder="A one-line summary"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="support-body">How can we help?</Label>
+            <Textarea
+              id="support-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              maxLength={5000}
+              rows={5}
+              placeholder="Describe what you need…"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={sending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={sending}>
+            {sending ? "Sending…" : "Send"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## What

Finishes the deferred b2c support surfaces.

- **`CreateWorkspaceButton`** — the connect-time escape on the `brand_mismatch` banner. Creates a NEW workspace (named after the blocked brand) via `POST /auth/businesses/create` (which switches the active business + reissues the cookie), then navigates to `/dashboard/integrations` to reconnect against the empty workspace → anchors cleanly. Robust across OAuth **and** API-key providers (no provider-specific re-auth wiring). Sits beside the existing "request a review" button.
- **`ContactSupportDialog`** — a general in-app support form (topic / subject / message) → `POST /v1/support/contact` → `sup_inbox` (`source: "in_app"`). Triggered from the settings header; lands in the same CMS triage queue as fit disputes.

Depends on peakhour-api **#705** (merged). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)