### PR TITLE
feat(reconnect): adopt-into-account UX + clearer errors

### DIFF
--- a/src/app/(site)/reconnect/wordpress/_components/wordpress-reconnect.tsx
+++ b/src/app/(site)/reconnect/wordpress/_components/wordpress-reconnect.tsx
@@ -27,7 +27,16 @@ function errCopy(code: string, fallback: string): { title: string; body: string 
     case "RECONNECT_NONE":
       return { title: "Nothing to reconnect", body: "Open WordPress and click Reconnect first, then enter the code here." };
     case "RECONNECT_FORBIDDEN":
-      return { title: "No permission", body: "You can only reconnect a site linked to an account you own or admin." };
+      return { title: "No permission", body: "Sign in to the Peakhour account you want to move this site into, then approve the code again." };
+    case "RECONNECT_NO_ACCOUNT":
+      return { title: "No account", body: "Sign in to a Peakhour account to move this site into it." };
+    case "RECONNECT_NO_BUSINESS":
+      return { title: "Set up a business first", body: "Create a business in your account, then approve the code again to move this site in." };
+    case "RECONNECT_ORG_HAS_SITE":
+      return { title: "Already connected", body: "Your account is already connected to this site." };
+    case "INTEGRATION_MISMATCH":
+    case "INTEGRATION_NEEDS_CONFIRMATION":
+      return { title: "Different brand", body: "This site looks like a different brand from your current workspace. Connect it to its own workspace to keep your content on-message." };
     case "RECONNECT_NOT_FOUND":
       return { title: "Site not found", body: "This site is no longer available to reconnect." };
     default:
@@ -45,6 +54,7 @@ export function WordpressReconnect() {
   const [errCode, setErrCode] = useState("");
   const [errMsg, setErrMsg] = useState("");
   const [host, setHost] = useState("");
+  const [adopted, setAdopted] = useState(false);
 
   async function handleApprove() {
     const trimmed = code.trim();
@@ -53,6 +63,7 @@ export function WordpressReconnect() {
     try {
       const r = await approveWordpressReconnect(site, trimmed);
       setHost(r.host || "");
+      setAdopted(!!r.adopted);
       setPhase("done");
     } catch (e: unknown) {
       setErrCode((e as { code?: string })?.code ?? "");
@@ -162,11 +173,12 @@ export function WordpressReconnect() {
             <div className="space-y-3">
               <div className="flex items-center gap-2 text-sm font-medium text-emerald-600 dark:text-emerald-400">
                 <CheckCircle2 className="size-5" aria-hidden />
-                Reconnected!
+                {adopted ? "Moved to your account!" : "Reconnected!"}
               </div>
               <p className="text-sm text-muted-foreground">
-                {host || "Your site"} is linked again. You can close this tab — WordPress will pick
-                it up automatically.
+                {adopted
+                  ? `${host || "Your site"} is now connected to this account. You can close this tab — WordPress will pick it up automatically.`
+                  : `${host || "Your site"} is linked again. You can close this tab — WordPress will pick it up automatically.`}
               </p>
               <Button asChild>
                 <Link href="/dashboard/overview">Go to dashboard</Link>

--- a/src/lib/api/wordpress-reconnect.ts
+++ b/src/lib/api/wordpress-reconnect.ts
@@ -12,9 +12,10 @@ import { api } from "@/lib/api";
 export async function approveWordpressReconnect(
   site: string,
   code: string,
-): Promise<{ reconnected: boolean; host: string }> {
-  return api.request<{ reconnected: boolean; host: string }>(
+  confirmed?: boolean,
+): Promise<{ reconnected: boolean; host: string; adopted?: boolean }> {
+  return api.request<{ reconnected: boolean; host: string; adopted?: boolean }>(
     "/v1/integrations/wordpress/reconnect-approve",
-    { method: "POST", body: JSON.stringify({ site, code }) },
+    { method: "POST", body: JSON.stringify({ site, code, ...(confirmed ? { confirmed: true } : {}) }) },
   );
 }


### PR DESCRIPTION
Companion to peakhour-api **#710**.

- The reconnect page no longer dead-ends on **"No permission."** When you approve the code for a site linked to a different account, the server re-parents it into your account and the page shows **"Moved to your account."**
- `approveWordpressReconnect` returns `adopted` and accepts `confirmed` (for the integration-fit ambiguous case).
- Clear copy for the new error codes (`RECONNECT_NO_ACCOUNT`/`NO_BUSINESS`/`ORG_HAS_SITE`, `INTEGRATION_MISMATCH`).

Ships with #710 (which changes the reconnect authorization model — for your review). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)