### PR TITLE
feat(pricing): expose per-channel data on ResolvedProduct

### DIFF
--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -77,6 +77,13 @@ export interface ResolvedProductTier {
   pricing: PricingEntry;
 }
 
+/** A delivery channel available in this env, with its purchase path. */
+export interface ResolvedChannel {
+  key: string;
+  status: string;
+  purchaseMode: string;
+}
+
 /** A product with its resolved tiers (e.g. Commerce Assistant: [Lens, Commerce]). */
 export interface ResolvedProduct {
   key: string;
@@ -84,6 +91,9 @@ export interface ResolvedProduct {
   tagline?: string;
   pillar: string;
   status: string;
+  /** Delivery channels available in this env (in_development/hidden suppressed
+   *  in prod), each with its per-channel status + purchase path. */
+  channels?: ResolvedChannel[];
   tiers: ResolvedProductTier[];
 }
 


### PR DESCRIPTION
Adds `ResolvedChannel` + optional `channels[]` to `ResolvedProduct` so the pricing site can consume the env-gated per-channel status + purchase path the API now returns. Non-breaking (optional field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)