### PR TITLE
feat(pricing): 'N Peaks / month included' on tier cards

### DIFF
--- a/src/components/marketing/tier-card.tsx
+++ b/src/components/marketing/tier-card.tsx
@@ -71,6 +71,12 @@ export function TierCard({ tier, cta }: { tier: ResolvedProductTier; cta: TierCt
         {tier.tagline && <CardDescription className="mt-2">{tier.tagline}</CardDescription>}
       </CardHeader>
       <CardContent className="flex flex-1 flex-col gap-4">
+        {typeof tier.peaksIncluded === "number" && tier.peaksIncluded > 0 && (
+          <div className="rounded-md bg-primary/5 px-3 py-2 text-sm">
+            <span className="font-semibold">{tier.peaksIncluded.toLocaleString()} Peaks</span>
+            <span className="text-muted-foreground"> / month included</span>
+          </div>
+        )}
         <ul className="flex-1 space-y-2.5 text-sm">
           {features.map(({ key, label }) => (
             <li key={key} className="flex items-start gap-2.5">

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -75,6 +75,8 @@ export interface ResolvedProductTier {
   highlightAsRecommended: boolean;
   version: number;
   pricing: PricingEntry;
+  /** Included free Peaks/month for this tier (undefined = none/unlimited). */
+  peaksIncluded?: number;
 }
 
 /** A delivery channel available in this env, with its purchase path. */


### PR DESCRIPTION
Renders `tier.peaksIncluded` (per-tier allowance from the API) on the comparison card so Free vs Paid shows the included Peaks. Peaks stay opaque (never a dollar figure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)