### PR TITLE
fix(b2c): Shopify subscription page → commerce_assistant.paid

### DIFF
--- a/src/app/(commerce)/shopify/embedded/subscription/page.tsx
+++ b/src/app/(commerce)/shopify/embedded/subscription/page.tsx
@@ -336,7 +336,9 @@ export default function SubscriptionPage() {
   const hasAnnual = !!ctx?.pricing?.annual;
   // Extract once so ternary branches can reference it without non-null assertions.
   const trialDays = ctx?.pricing?.trialDays ?? 0;
-  const commerceTier = tiers.find((t) => t.key === "commerce_assistant.commerce");
+  // 10-plan catalog: the paid Commerce tier is commerce_assistant.paid
+  // (was the retired commerce_assistant.commerce).
+  const commerceTier = tiers.find((t) => t.key === "commerce_assistant.paid");
   const savings = annualSavings(commerceTier);
 
   // ── Active ───────────────────────────────────────────────────────────────

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -51,7 +51,7 @@ export interface UpgradeDrawerProps {
   /** Drawer mode. Defaults to "waitlist" — the v1 production posture. */
   mode?: UpgradeDrawerMode;
   /** In checkout mode, the cfg_plans tier key to subscribe to
-   *  (e.g. "commerce_assistant.commerce_woo"). Required for the checkout CTA. */
+   *  (e.g. "commerce_assistant.paid"). Required for the checkout CTA. */
   tier?: string;
   /** Optional intent override; defaults derived from featureKey/addonKey. */
   intent?: "plan_upgrade" | "addon" | "integration" | "general";


### PR DESCRIPTION
## What
The 10-plan catalog (mongodb #316) collapses Commerce's three tiers (`commerce`/`commerce_woo`/`lens`) into `commerce_assistant.free`/`.paid`. The Shopify embedded subscription page hard-coded the retired `commerce_assistant.commerce` key to find the tier for annual-savings — repointed to `commerce_assistant.paid`. Updated the upgrade-drawer tier example comment to match.

## Verification
`tsc --noEmit` clean.

> Companion to mongodb #316 / api #718 / cms per-country pricing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)