### PR TITLE
feat(billing): on-site PaymentModal — embedded overlay for all 3 gateways

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@hookform/resolvers": "^5.2.2",
         "@shopify/polaris": "^13.0.0",
         "@shopify/polaris-icons": "^9.0.0",
+        "@stripe/react-stripe-js": "^6.7.0",
+        "@stripe/stripe-js": "^9.9.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.100.2",
         "@tanstack/react-table": "^8.21.3",
@@ -4682,6 +4684,29 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.7.0.tgz",
+      "integrity": "sha512-KSWTQHcDlAOlxcOz+uq0pTA/k9G4+IBF/X8mtSFkkBX+nb74buMTIFcCUCHWNhjuPqfD+yJm7NWDan1EaxSyzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=9.5.0 <10.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.9.0.tgz",
+      "integrity": "sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@shopify/polaris": "^13.0.0",
-    "@shopify/polaris-icons": "^9.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
+    "@shopify/polaris": "^13.0.0",
+    "@shopify/polaris-icons": "^9.0.0",
+    "@stripe/react-stripe-js": "^6.7.0",
+    "@stripe/stripe-js": "^9.9.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.100.2",
     "@tanstack/react-table": "^8.21.3",

--- a/src/components/upgrade/payment-modal.tsx
+++ b/src/components/upgrade/payment-modal.tsx
@@ -51,7 +51,12 @@ function loadScript(src: string, id: string): Promise<void> {
     s.id = id;
     s.async = true;
     s.onload = () => resolve();
-    s.onerror = () => reject(new Error(`Failed to load ${src}`));
+    s.onerror = () => {
+      // Remove the failed tag so a later attempt actually re-injects instead of
+      // seeing a dead tag by id and resolving against a missing global.
+      s.remove();
+      reject(new Error(`Failed to load ${src}`));
+    };
     document.body.appendChild(s);
   });
 }
@@ -84,13 +89,32 @@ function StripeEmbedded({
   onOpenChange: (open: boolean) => void;
 }) {
   const isMobile = useIsMobile();
+  // useIsMobile resolves false→real inside an effect; gate the first paint on a
+  // `mounted` flag so the correct shell (Dialog vs Drawer) is chosen ONCE —
+  // otherwise the Stripe embedded iframe mounts in Dialog then remounts in
+  // Drawer on mobile ("multiple Embedded Checkout objects").
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  // Missing keys (e.g. STRIPE_PUBLISHABLE_KEY unset) would make loadStripe('')
+  // reject into a blank modal — fail friendly instead.
+  const invalid = !embed.publishableKey || !embed.clientSecret;
+  useEffect(() => {
+    if (invalid) {
+      toast.error("Payment isn't available right now. Please try again later.");
+      onOpenChange(false);
+    }
+  }, [invalid, onOpenChange]);
+
   // loadStripe returns a promise; memoise per publishable key so we don't
   // re-init Stripe.js on every render.
-  const stripePromise = useMemo<Promise<Stripe | null>>(
-    () => loadStripe(embed.publishableKey),
-    [embed.publishableKey],
+  const stripePromise = useMemo<Promise<Stripe | null> | null>(
+    () => (invalid ? null : loadStripe(embed.publishableKey)),
+    [invalid, embed.publishableKey],
   );
   const options = useMemo(() => ({ clientSecret: embed.clientSecret }), [embed.clientSecret]);
+
+  if (invalid || !mounted) return null;
 
   const body = (
     <EmbeddedCheckoutProvider stripe={stripePromise} options={options}>
@@ -105,7 +129,11 @@ function StripeEmbedded({
           <DrawerHeader className="sr-only">
             <DrawerTitle>Complete your payment</DrawerTitle>
           </DrawerHeader>
-          <div className="overflow-y-auto px-2 pb-4">{body}</div>
+          {/* data-vaul-no-drag: let the Stripe iframe scroll without vaul
+              hijacking the touch as a drag-to-dismiss gesture. */}
+          <div data-vaul-no-drag className="overflow-y-auto px-2 pb-4">
+            {body}
+          </div>
         </DrawerContent>
       </Drawer>
     );

--- a/src/components/upgrade/payment-modal.tsx
+++ b/src/components/upgrade/payment-modal.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { loadStripe, type Stripe } from "@stripe/stripe-js";
+import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js";
+import { toast } from "sonner";
+
+import { useIsMobile } from "@/hooks/use-mobile";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+
+/**
+ * On-site payment overlay for native subscription checkout. The API's
+ * /v1/billing/checkout returns a { gateway, embed } payload; this renders the
+ * matching gateway's native surface:
+ *   • stripe   → embedded Checkout mounted INSIDE our modal (desktop) /
+ *                bottom sheet (mobile).
+ *   • razorpay → Razorpay Checkout.js overlay (its own full-screen surface).
+ *   • payu     → PayU Bolt overlay (its own surface).
+ * Only Stripe renders inside our shell; Razorpay/PayU bring their own overlays,
+ * so for those we just launch the SDK and render nothing.
+ */
+
+export type CheckoutResult =
+  | { gateway: "stripe"; embed: { kind: "stripe"; clientSecret: string; publishableKey: string } }
+  | {
+      gateway: "razorpay";
+      embed: {
+        kind: "razorpay";
+        subscriptionId: string;
+        keyId: string;
+        prefill?: { name?: string; email?: string };
+      };
+    }
+  | { gateway: "payu"; embed: { kind: "payu"; action: string; params: Record<string, string> } };
+
+declare global {
+  interface Window {
+    // Razorpay Checkout.js + PayU Bolt are external globals — we call a narrow slice.
+    Razorpay?: new (opts: Record<string, unknown>) => { open: () => void };
+    bolt?: { launch: (data: Record<string, string>, handlers: Record<string, unknown>) => void };
+  }
+}
+
+function loadScript(src: string, id: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof document === "undefined") return reject(new Error("no document"));
+    if (document.getElementById(id)) return resolve();
+    const s = document.createElement("script");
+    s.src = src;
+    s.id = id;
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.body.appendChild(s);
+  });
+}
+
+interface PaymentModalProps {
+  checkout: CheckoutResult | null;
+  onOpenChange: (open: boolean) => void;
+  /** Fired when the buyer completes the gateway flow (Razorpay/PayU handlers);
+   *  Stripe redirects to its return_url so it closes via navigation. */
+  onSuccess?: () => void;
+}
+
+export function PaymentModal({ checkout, onOpenChange, onSuccess }: PaymentModalProps) {
+  if (!checkout) return null;
+  if (checkout.gateway === "stripe") {
+    return <StripeEmbedded embed={checkout.embed} onOpenChange={onOpenChange} />;
+  }
+  return (
+    <GatewayLauncher checkout={checkout} onOpenChange={onOpenChange} onSuccess={onSuccess} />
+  );
+}
+
+// ── Stripe: embedded Checkout inside our responsive shell ────────────────────
+
+function StripeEmbedded({
+  embed,
+  onOpenChange,
+}: {
+  embed: Extract<CheckoutResult, { gateway: "stripe" }>["embed"];
+  onOpenChange: (open: boolean) => void;
+}) {
+  const isMobile = useIsMobile();
+  // loadStripe returns a promise; memoise per publishable key so we don't
+  // re-init Stripe.js on every render.
+  const stripePromise = useMemo<Promise<Stripe | null>>(
+    () => loadStripe(embed.publishableKey),
+    [embed.publishableKey],
+  );
+  const options = useMemo(() => ({ clientSecret: embed.clientSecret }), [embed.clientSecret]);
+
+  const body = (
+    <EmbeddedCheckoutProvider stripe={stripePromise} options={options}>
+      <EmbeddedCheckout />
+    </EmbeddedCheckoutProvider>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open onOpenChange={onOpenChange}>
+        <DrawerContent className="max-h-[92vh]">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>Complete your payment</DrawerTitle>
+          </DrawerHeader>
+          <div className="overflow-y-auto px-2 pb-4">{body}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Complete your payment</DialogTitle>
+        </DialogHeader>
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Razorpay / PayU: launch the gateway's own overlay ────────────────────────
+//
+// ⚠️ VERIFY(sdk): the Razorpay Checkout.js + PayU Bolt call shapes below follow
+// the vendors' documented signatures but are UNTESTED until the IN test keys
+// land — round-trip both before enabling. PayU is the IN backup gateway.
+
+const RAZORPAY_SRC = "https://checkout.razorpay.com/v1/checkout.js";
+const PAYU_BOLT_SRC = "https://jssdk.payu.in/bolt/bolt.min.js";
+
+function GatewayLauncher({
+  checkout,
+  onOpenChange,
+  onSuccess,
+}: {
+  checkout: Extract<CheckoutResult, { gateway: "razorpay" | "payu" }>;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+}) {
+  // Guard so the overlay is launched exactly once per checkout payload.
+  const launched = useRef(false);
+
+  useEffect(() => {
+    if (launched.current) return;
+    launched.current = true;
+
+    (async () => {
+      try {
+        if (checkout.gateway === "razorpay") {
+          const { subscriptionId, keyId, prefill } = checkout.embed;
+          await loadScript(RAZORPAY_SRC, "razorpay-checkout");
+          if (!window.Razorpay) throw new Error("Razorpay SDK unavailable");
+          const rzp = new window.Razorpay({
+            key: keyId,
+            subscription_id: subscriptionId,
+            name: "Peakhour",
+            ...(prefill ? { prefill } : {}),
+            handler: () => {
+              onSuccess?.();
+              onOpenChange(false);
+            },
+            modal: { ondismiss: () => onOpenChange(false) },
+          });
+          rzp.open();
+        } else {
+          // PayU Bolt: launch with the server-built params (incl. hash).
+          await loadScript(PAYU_BOLT_SRC, "payu-bolt");
+          if (!window.bolt) throw new Error("PayU Bolt SDK unavailable");
+          window.bolt.launch(checkout.embed.params, {
+            responseHandler: (res: { response?: { txnStatus?: string } }) => {
+              if (res?.response?.txnStatus === "SUCCESS") onSuccess?.();
+              onOpenChange(false);
+            },
+            catchException: () => {
+              toast.error("Payment could not be started. Please try again.");
+              onOpenChange(false);
+            },
+          });
+        }
+      } catch {
+        toast.error("Payment could not be started. Please try again.");
+        onOpenChange(false);
+      }
+    })();
+  }, [checkout, onOpenChange, onSuccess]);
+
+  // The gateway renders its own overlay; nothing for us to draw.
+  return null;
+}

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { PaymentModal, type CheckoutResult } from "@/components/upgrade/payment-modal";
 
 /**
  * UpgradeDrawer — reusable Sheet that opens on any plan-gated
@@ -107,6 +108,8 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
   const [email, setEmail] = useState(user?.email ?? "");
   const [businessContext, setBusinessContext] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  // When checkout mints a gateway payload, this opens the on-site PaymentModal.
+  const [checkoutResult, setCheckoutResult] = useState<CheckoutResult | null>(null);
   const [success, setSuccess] = useState<{
     referralCode: string;
     foundingMember: boolean;
@@ -184,10 +187,11 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
     if (!tier) return;
     setSubmitting(true);
     try {
-      const r = await api.post<{ url: string }>("/v1/billing/checkout", { tier });
-      if (r?.url) {
-        window.location.href = r.url;
-        return; // navigating away — keep the spinner until unload
+      const r = await api.post<CheckoutResult>("/v1/billing/checkout", { tier });
+      if (r?.gateway && r?.embed) {
+        setCheckoutResult(r); // opens the on-site PaymentModal overlay
+        setSubmitting(false);
+        return;
       }
       toast.error("Could not start checkout. Please try again.");
       setSubmitting(false);
@@ -216,6 +220,7 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
   }
 
   return (
+    <>
     <Sheet open={open} onOpenChange={handleClose}>
       <SheetContent className="sm:max-w-md flex flex-col">
         <SheetHeader>
@@ -378,5 +383,16 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
         </SheetFooter>
       </SheetContent>
     </Sheet>
+    <PaymentModal
+      checkout={checkoutResult}
+      onOpenChange={(o) => {
+        if (!o) setCheckoutResult(null);
+      }}
+      onSuccess={() => {
+        setCheckoutResult(null);
+        toast.success("Payment received — activating your plan…");
+      }}
+    />
+    </>
   );
 }

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -123,6 +123,7 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
     setBusinessContext("");
     setSuccess(null);
     setSubmitting(false);
+    setCheckoutResult(null); // dismiss any open payment overlay with the drawer
   }
 
   function handleClose(next: boolean) {


### PR DESCRIPTION
## Embedded payment overlay (peakhour-b2c)

Depends on **peakhour-api#733** (the `/v1/billing/checkout` → `{ gateway, embed }` contract). Replaces the hosted-redirect checkout with a native **on-site overlay** per gateway.

- **Stripe** → `@stripe/react-stripe-js` **EmbeddedCheckout** mounted inside our shell: **Dialog on desktop, bottom sheet (vaul Drawer) on mobile**. Fully testable now (Stripe keys are in).
- **Razorpay** → Checkout.js overlay via `{ subscriptionId, keyId, prefill }`.
- **PayU** → Bolt overlay via the server-built `{ params }` (incl. hash).
- `UpgradeDrawer.submitCheckout` opens the modal instead of `window.location.href`.

Adds `@stripe/stripe-js` + `@stripe/react-stripe-js`.

### ⚠️ Verify before enabling IN gateways
The Razorpay Checkout.js + PayU Bolt call shapes follow the vendors' documented signatures but are **untested until the India test keys land** — round-trip both. Marked `VERIFY(sdk)` in the code. Stripe embedded is testable today.

### Verification
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)