### PR TITLE
fix(referral): share link → /auth + credit inviter on signup (re-apply of #191)

### DIFF
--- a/src/app/(site)/auth/page.tsx
+++ b/src/app/(site)/auth/page.tsx
@@ -16,8 +16,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ApiError } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { SITE } from "@/lib/utils";
+
+// Bounded length + char set so a tampered link can't smuggle arbitrary strings
+// into the waitlist payload. Mirrors the referredByCode validator on
+// /v1/waitlist/signup (min 4, max 32); the mint alphabet is a stricter subset.
+const REFERRAL_CODE_PATTERN = /^[0-9A-Z]{4,32}$/;
 
 /**
  * Mirrors peakhour-cms/src/app/login/login-form.tsx so the b2c
@@ -97,6 +102,14 @@ const INTENT_COPY: Record<string, { title: string; subtitle: string }> = {
 function AuthPageInner() {
   const searchParams = useSearchParams();
   const intentCopy = INTENT_COPY[searchParams.get("intent") ?? ""];
+  // Inviter code from a `?ref=` share link, sanitised — any non-conforming
+  // value is dropped so the page behaves as a plain sign-in. null = no inviter.
+  const referralCode = (() => {
+    const raw = searchParams.get("ref");
+    if (!raw) return null;
+    const upper = raw.toUpperCase();
+    return REFERRAL_CODE_PATTERN.test(upper) ? upper : null;
+  })();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   // Tick once per second while a cooldown is running so the button
@@ -173,6 +186,20 @@ function AuthPageInner() {
         : Date.now() + RESEND_COOLDOWN_SECONDS * 1000;
 
     try {
+      // Referral credit fires alongside (not before) the magic link so a
+      // transient signup error can't block sign-in. The waitlist endpoint is
+      // idempotent on (email, active), so a resend with the same code is safe;
+      // only the initial send attempts it. Best-effort — never surfaced.
+      if (referralCode && mode === "send") {
+        api
+          .post("/v1/waitlist/signup", {
+            email: targetEmail,
+            intent: "general",
+            referredByCode: referralCode,
+            channel: "direct",
+          })
+          .catch(() => {});
+      }
       const res = await sendMagicLink(targetEmail);
       // Pre-launch invite gate: the endpoint may return without sending a
       // link. Branch to the matching card instead of the "check your email"
@@ -302,6 +329,17 @@ function AuthPageInner() {
 
       {/* Right panel — auth form */}
       <div className="flex flex-1 flex-col">
+        {referralCode ? (
+          <div
+            role="status"
+            className="border-b bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+          >
+            <div className="mx-auto flex max-w-md items-center gap-2">
+              <Sparkles className="size-4 shrink-0" aria-hidden />
+              <span>You were invited by a friend. Sign up to claim your spot.</span>
+            </div>
+          </div>
+        ) : null}
         <div className="flex flex-1 items-center justify-center px-4 py-12">
           {status.kind === "waitlisted" ? (
             <Card className="w-full max-w-md">

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import {
   ArrowRight,
   Sparkles,
@@ -103,7 +104,30 @@ const INTEGRATIONS = [
   { name: "X (Twitter)", icon: TwitterIcon, color: "bg-black", description: "Posts & promoted content" },
 ] as const;
 
-export default async function Home() {
+// Same validator as /auth — sanitises a tampered ?ref= so the redirect target
+// only ever carries a well-formed inviter code.
+const REFERRAL_CODE_PATTERN = /^[0-9A-Z]{4,32}$/;
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string | string[]; n?: string | string[] }>;
+}) {
+  // Back-compat redirect for waitlist share links minted with the old
+  // `/?ref=…` shape → forward to /auth so the inviter code is captured + the
+  // inviter credited on signup. `n` (cache-bust nonce) forwarded when present.
+  const params = await searchParams;
+  const refRaw = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  const nRaw = Array.isArray(params.n) ? params.n[0] : params.n;
+  if (refRaw) {
+    const refUpper = refRaw.toUpperCase();
+    if (REFERRAL_CODE_PATTERN.test(refUpper)) {
+      const qs = new URLSearchParams({ ref: refUpper });
+      if (nRaw) qs.set("n", nRaw);
+      redirect(`/auth?${qs.toString()}`);
+    }
+  }
+
   // Integration catalog from the platform resolver (CMS-driven, env-gated,
   // stage-capped). Falls back to the static list below if the API is
   // unreachable so the landing never hard-fails (mirrors the pricing fallback).

--- a/src/components/upgrade/upgrade-drawer.tsx
+++ b/src/components/upgrade/upgrade-drawer.tsx
@@ -205,7 +205,10 @@ export function UpgradeDrawer(props: UpgradeDrawerProps) {
   function shareReferral() {
     if (!success) return;
     const base = typeof window !== "undefined" ? window.location.origin : "";
-    const url = `${base}/?ref=${success.referralCode}&n=${clientNonce()}`;
+    // /auth captures `ref` and stamps it onto the recipient's waitlist signup,
+    // crediting the inviter. The marketing root (`/`) ignores the param, so
+    // pointing referrals there silently drops attribution.
+    const url = `${base}/auth?ref=${success.referralCode}&n=${clientNonce()}`;
     if (navigator.share) {
       navigator.share({
         title: "Peakhour — early access",


### PR DESCRIPTION
Clean re-application of **#191** onto current master (its branch was 90+ commits stale with `(site)/` route-group conflicts, so a 3-way merge risked mis-merging the landing page).

- **upgrade-drawer**: `shareReferral` `/?ref=` → `/auth?ref=` (root ignored the param → dropped attribution).
- **(site)/auth**: capture + sanitise `?ref=`, credit the inviter via an idempotent best-effort `POST /v1/waitlist/signup` on initial send, + an 'invited by a friend' banner.
- **(site) landing**: back-compat redirect `/?ref=` → `/auth?ref=` (preserves the `n` nonce).

Verified against current master: master had added Suspense/`useSearchParams` (for `?intent=`) but **no referral capture**, and `shareReferral` still used the broken `/?ref=` — so this is still needed. **Supersedes #191** (being closed). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)