### PR TITLE
feat(whatsapp): outcome analytics + flip channel to live (WABA PR-2.5b)

### DIFF
--- a/src/app/(site)/dashboard/content/channels.config.ts
+++ b/src/app/(site)/dashboard/content/channels.config.ts
@@ -225,7 +225,9 @@ export const CHANNELS: readonly ChannelConfig[] = [
     category: "Messaging",
     // Virtual Meta capability — see facebook-pages note above.
     providerKey: "whatsapp",
-    status: "available",
+    // LIVE (WABA build): autonomous agent, Template Studio, outcome billing,
+    // inbox, and analytics all shipped.
+    status: "live",
     // Self-serve connect via Embedded Signup lives on its own in-app page
     // (not the generic /dashboard/integrations OAuth grid).
     dashboardPath: "/dashboard/content/whatsapp",

--- a/src/app/(site)/dashboard/content/whatsapp/analytics/page.tsx
+++ b/src/app/(site)/dashboard/content/whatsapp/analytics/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { CheckCircle2, ShoppingBag } from "lucide-react";
+import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { KpiCard } from "@/components/molecules/kpi-card";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Peaks } from "@/components/peaks/peaks";
+import { useWaAnalytics } from "@/hooks/use-wa-analytics";
+
+const PILLAR_LABEL: Record<string, string> = {
+  support: "Support",
+  commerce: "Commerce",
+  growth: "Growth",
+  content: "Content",
+  general: "General",
+};
+
+export default function WhatsAppAnalyticsPage() {
+  const { data, isLoading } = useWaAnalytics(30);
+  const total = data?.totalPeaks ?? 0;
+  const maxPillar = Math.max(1, ...(data?.byPillar ?? []).map((p) => p.peaks));
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <CronToolbar crons={["wa-outcome-billing"]} />
+
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">WhatsApp outcomes</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          What your WhatsApp assistant delivered in the last {data?.windowDays ?? 30} days. You’re billed on outcomes, not chatter.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-4 sm:grid-cols-3">
+          {[0, 1, 2].map((i) => <Skeleton key={i} className="h-24 w-full" />)}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <KpiCard title="Resolved conversations" value={data?.resolved.count ?? 0} icon={CheckCircle2} />
+          <KpiCard title="Assisted orders" value={data?.assisted.count ?? 0} icon={ShoppingBag} />
+          <Card className="p-4">
+            <p className="text-sm font-medium text-muted-foreground">Peaks spent</p>
+            <div className="mt-2">
+              <Peaks amount={total} />
+            </div>
+          </Card>
+        </div>
+      )}
+
+      <Card className="p-4">
+        <p className="text-sm font-medium">Outcomes by product</p>
+        <div className="mt-3 space-y-2.5">
+          {isLoading && <Skeleton className="h-4 w-full" />}
+          {!isLoading && (data?.byPillar.length ?? 0) === 0 && (
+            <p className="text-sm text-muted-foreground">No billable outcomes yet.</p>
+          )}
+          {data?.byPillar.map((p) => (
+            <div key={p.pillar} className="flex items-center gap-3">
+              <span className="w-24 shrink-0 text-sm">{PILLAR_LABEL[p.pillar] ?? p.pillar}</span>
+              <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                <div className="h-full rounded-full bg-primary" style={{ width: `${(p.peaks / maxPillar) * 100}%` }} />
+              </div>
+              <span className="w-24 shrink-0 text-right">
+                <Peaks amount={p.peaks} />
+              </span>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/whatsapp/page.tsx
+++ b/src/app/(site)/dashboard/content/whatsapp/page.tsx
@@ -44,6 +44,19 @@ export default async function WhatsAppConnectPage({ searchParams }: Props) {
           Open the Template Studio →
         </a>
       </div>
+
+      <div className="rounded-lg border p-4">
+        <h2 className="text-sm font-medium">Outcomes</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Resolved conversations, assisted orders, and Peaks spent — you’re billed on outcomes, not chatter.
+        </p>
+        <a
+          href="/dashboard/content/whatsapp/analytics"
+          className="mt-2 inline-block text-sm font-medium text-primary hover:underline"
+        >
+          View WhatsApp analytics →
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/hooks/use-wa-analytics.ts
+++ b/src/hooks/use-wa-analytics.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+export interface WaAnalytics {
+  windowDays: number;
+  resolved: { count: number; peaks: number };
+  assisted: { count: number; peaks: number };
+  totalPeaks: number;
+  byPillar: Array<{ pillar: string; peaks: number }>;
+}
+
+/** WhatsApp outcome analytics for the active business (KPIs + by-pillar). */
+export function useWaAnalytics(days = 30) {
+  const { business } = useAuth();
+  return useQuery({
+    queryKey: ["wa-analytics", business?._id ?? "none", days],
+    queryFn: () => api.get<WaAnalytics>(`/v1/meta/whatsapp/analytics?days=${days}`),
+    enabled: Boolean(business?._id),
+  });
+}


### PR DESCRIPTION
## What
PR-2.5b — the WhatsApp **analytics** view + the go-live flip.

- New `/dashboard/content/whatsapp/analytics`:
  - **KPI row** — Resolved conversations, Assisted orders, Peaks spent (the `<Peaks>` glyph), 30-day window
  - **Outcomes-by-product** proportion bars per pillar, each valued in `<Peaks>`
  - Mandatory `<CronToolbar crons={["wa-outcome-billing"]}/>` (outcomes are cron-fed)
- **Flips `channels.config` WhatsApp `available → live`** — the WABA build (agent, Template Studio, outcome billing, inbox, analytics) is shipped. Linked from the WhatsApp surface.

## Verified
`tsc` + `eslint` clean; `next build` compiles and registers the route. Depends on merged PR-2.5a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)