### PR TITLE
feat(wa): "Ask your inbox" card on the WhatsApp analytics page (WABA P3)

### DIFF
--- a/src/app/(site)/dashboard/content/whatsapp/analytics/page.tsx
+++ b/src/app/(site)/dashboard/content/whatsapp/analytics/page.tsx
@@ -6,6 +6,7 @@ import { KpiCard } from "@/components/molecules/kpi-card";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Peaks } from "@/components/peaks/peaks";
+import { AskYourInbox } from "@/components/whatsapp/ask-your-inbox";
 import { useWaAnalytics } from "@/hooks/use-wa-analytics";
 
 const PILLAR_LABEL: Record<string, string> = {
@@ -31,6 +32,8 @@ export default function WhatsAppAnalyticsPage() {
           What your WhatsApp assistant delivered in the last {data?.windowDays ?? 30} days. You’re billed on outcomes, not chatter.
         </p>
       </div>
+
+      <AskYourInbox />
 
       {isLoading ? (
         <div className="grid gap-4 sm:grid-cols-3">

--- a/src/components/whatsapp/ask-your-inbox.tsx
+++ b/src/components/whatsapp/ask-your-inbox.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles, Send } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useAskInbox } from "@/hooks/use-wa-inbox-intelligence";
+
+const SUGGESTIONS = [
+  "Who is at risk of churning, and why?",
+  "What are customers asking about most?",
+  "Who wanted to buy but didn't complete?",
+  "Any complaints this week?",
+];
+
+/**
+ * "Ask your inbox" — a natural-language question box over the business's own
+ * WhatsApp conversations. Each question is one priced query
+ * (whatsapp.inbox_intelligence); the answer is grounded in the merchant's inbox
+ * with contact citations.
+ */
+export function AskYourInbox() {
+  const [question, setQuestion] = useState("");
+  const ask = useAskInbox();
+  const answer = ask.data;
+
+  function submit(q: string) {
+    const trimmed = q.trim();
+    if (trimmed.length < 3 || ask.isPending) return;
+    setQuestion(trimmed);
+    ask.mutate(trimmed);
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center gap-2">
+        <Sparkles className="h-4 w-4 text-primary" />
+        <p className="text-sm font-medium">Ask your inbox</p>
+        <Badge variant="secondary" className="ml-auto text-xs">Charged per question</Badge>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Ask anything about your WhatsApp conversations — trends, complaints, buying signals, who to follow up with.
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {SUGGESTIONS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => submit(s)}
+            disabled={ask.isPending}
+            className="rounded-full border px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted disabled:opacity-50"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 flex items-start gap-2">
+        <Textarea
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) submit(question);
+          }}
+          placeholder="e.g. Which customers are unhappy and why?"
+          rows={2}
+          className="flex-1"
+          disabled={ask.isPending}
+        />
+        <Button onClick={() => submit(question)} disabled={ask.isPending || question.trim().length < 3}>
+          <Send className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {ask.isPending && <p className="mt-3 text-sm text-muted-foreground">Reading your inbox…</p>}
+
+      {ask.isError && (
+        <p className="mt-3 text-sm text-destructive">
+          Couldn’t analyse your inbox right now. Please try again.
+        </p>
+      )}
+
+      {answer && !ask.isPending && (
+        <div className="mt-4 rounded-lg border bg-muted/30 p-3">
+          <p className="whitespace-pre-wrap text-sm">{answer.answer}</p>
+          {answer.citations.length > 0 && (
+            <div className="mt-3 border-t pt-3">
+              <p className="text-xs font-medium text-muted-foreground">Based on</p>
+              <ul className="mt-1.5 space-y-1">
+                {answer.citations.map((c, i) => (
+                  <li key={`${c.waId}-${i}`} className="text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{c.contactName || c.waId}</span> — {c.reason}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/hooks/use-wa-inbox-intelligence.ts
+++ b/src/hooks/use-wa-inbox-intelligence.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export interface InboxCitation {
+  waId: string;
+  contactName?: string;
+  reason: string;
+}
+
+export interface InboxAnswer {
+  answer: string;
+  citations: InboxCitation[];
+  hasEnoughData: boolean;
+  /** false when the inbox was empty and no AI call (or charge) was made. */
+  billed: boolean;
+}
+
+/**
+ * "Ask your inbox" — a per-question priced query against the business's WhatsApp
+ * conversation history (whatsapp.inbox_intelligence). A mutation, not a query:
+ * each ask is a deliberate, billed action the merchant triggers.
+ */
+export function useAskInbox() {
+  return useMutation({
+    mutationFn: (question: string) =>
+      api.post<InboxAnswer>("/v1/meta/whatsapp/intelligence/ask", { question }),
+  });
+}


### PR DESCRIPTION
The b2c surface for **Conversation Intelligence** (api#768). A natural-language question box over the business's own WhatsApp conversations, on `/dashboard/content/whatsapp/analytics`.

- Each question is **one priced query** (`whatsapp.inbox_intelligence` via `POST /v1/meta/whatsapp/intelligence/ask`).
- The answer renders **grounded** in the merchant's inbox with contact citations ("Based on …").
- Suggestion chips seed common questions (churn risk, complaints, buying signals, incomplete purchases).
- `useAskInbox` is a **mutation** — each ask is a deliberate, billed action (⌘/Ctrl+Enter to send).

The API path was already driven end-to-end on dev (real LLM answer + billing row). `tsc` + `eslint` clean; Vercel preview builds the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)