### PR TITLE
feat(inbox): "Return to AI" — hand a taken-over thread back to the assistant

### DIFF
--- a/src/app/(site)/dashboard/inbox/page.tsx
+++ b/src/app/(site)/dashboard/inbox/page.tsx
@@ -9,6 +9,7 @@ import {
   useWaConversations,
   useWaThread,
   useWaHandoff,
+  useWaResume,
   type WaConversation,
 } from "@/hooks/use-wa-conversations";
 
@@ -46,6 +47,7 @@ export default function InboxPage() {
   const [selected, setSelected] = useState<string | null>(null);
   const { data: thread, isLoading: threadLoading } = useWaThread(selected);
   const handoff = useWaHandoff();
+  const resume = useWaResume();
 
   return (
     <div className="mx-auto w-full max-w-6xl space-y-6 p-4 md:p-6">
@@ -98,19 +100,35 @@ export default function InboxPage() {
                   <p className="truncate text-sm font-medium">{thread?.contactName || selected.split(":").slice(2).join(":")}</p>
                   {thread && <StatusPill status={thread.status} />}
                 </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={handoff.isPending || thread?.status === "escalated"}
-                  onClick={() =>
-                    handoff.mutate(selected, {
-                      onSuccess: () => toast.success("Flagged for you — the assistant will hold off."),
-                      onError: (e: Error) => toast.error(e?.message || "Couldn't hand off"),
-                    })
-                  }
-                >
-                  {thread?.status === "escalated" ? "With you" : handoff.isPending ? "…" : "Take over"}
-                </Button>
+                {thread?.status === "escalated" ? (
+                  <Button
+                    size="sm"
+                    variant="default"
+                    disabled={resume.isPending}
+                    onClick={() =>
+                      resume.mutate(selected, {
+                        onSuccess: () => toast.success("Handed back — the assistant will reply again."),
+                        onError: (e: Error) => toast.error(e?.message || "Couldn't hand back"),
+                      })
+                    }
+                  >
+                    {resume.isPending ? "…" : "Return to AI"}
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={handoff.isPending}
+                    onClick={() =>
+                      handoff.mutate(selected, {
+                        onSuccess: () => toast.success("Flagged for you — the assistant will hold off."),
+                        onError: (e: Error) => toast.error(e?.message || "Couldn't hand off"),
+                      })
+                    }
+                  >
+                    {handoff.isPending ? "…" : "Take over"}
+                  </Button>
+                )}
               </div>
               <div className="flex-1 space-y-2 overflow-y-auto bg-[#e5ddd5] p-3 dark:bg-neutral-800">
                 {threadLoading && <Skeleton className="h-20 w-full" />}

--- a/src/hooks/use-wa-conversations.ts
+++ b/src/hooks/use-wa-conversations.ts
@@ -65,3 +65,16 @@ export function useWaHandoff() {
     },
   });
 }
+
+/** Hand a thread back to the AI (clears escalated → active). Inverse of handoff. */
+export function useWaResume() {
+  const qc = useQueryClient();
+  const { business } = useAuth();
+  return useMutation({
+    mutationFn: (threadId: string) => api.post(`${BASE}/${encodeURIComponent(threadId)}/resume`),
+    onSuccess: (_r, threadId) => {
+      qc.invalidateQueries({ queryKey: ["wa-conversations", business?._id ?? "none"] });
+      qc.invalidateQueries({ queryKey: ["wa-thread", business?._id ?? "none", threadId] });
+    },
+  });
+}


### PR DESCRIPTION
## Why

In the dashboard inbox, once you clicked **Take over**, the thread showed a **disabled "With you"** button — there was **no way to give control back to the AI**.

## What

Flip "With you" into an active primary **"Return to AI"** button:
- `useWaResume()` → `POST /v1/meta/whatsapp/conversations/:id/resume` (clears `escalated → active`).
- Non-escalated threads keep the existing **"Take over"** button.

So the inbox now toggles cleanly: **Take over ⇄ Return to AI**.

## Pairs with
[peakhour-api#815](https://github.com/travelxp/peakhour-api/pull/815) — which (a) makes "Take over" *actually* pause the AI in the webhook (it didn't before) and (b) adds the `/resume` endpoint this button calls. **Merge the api PR first.**

## Notes
`tsc --noEmit` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)