### PR TITLE
fix(billing): show feature display names, not internal keys

### DIFF
--- a/src/app/(site)/dashboard/settings/billing/page.tsx
+++ b/src/app/(site)/dashboard/settings/billing/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { featureLabel } from "@/lib/pricing";
 import { useQueryClient } from "@tanstack/react-query";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 
@@ -219,8 +220,12 @@ export default function BillingPage() {
               <ul className="flex flex-wrap gap-1.5">
                 {features.map((f) => (
                   <li key={f}>
-                    <Badge variant="outline" className="font-mono text-[11px]">
-                      {f}
+                    {/* Resolve the raw cfg_feature key (e.g. "content.brand_voice")
+                        to its customer-facing label via the shared featureLabel()
+                        helper — the same resolver the upgrade drawer and plan cards
+                        use — so Billing never shows internal developer keys. */}
+                    <Badge variant="outline" className="text-[11px]">
+                      {featureLabel(f)}
                     </Badge>
                   </li>
                 ))}


### PR DESCRIPTION
## What
Settings → Billing → **Features included** rendered raw `cfg_feature` keys (`content.brand_voice`, `commerce.assistant`, …) in a mono badge — exposing internal developer names to customers.

## Fix
Resolve each key through the shared `featureLabel()` helper (`@/lib/pricing`) — the same resolver the upgrade drawer and marketing plan cards already use — so it shows customer-facing names like **Brand-voice learning**, **Content Repurposing**, etc. Also dropped the `font-mono` styling that read like a code string.

`featureLabel()` never renders raw: exact match → platform-segment collapse → humanized leaf fallback.

## Test
`tsc --noEmit` clean.

Quick win from the onboarding-flow series (item #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)