### PR TITLE
feat(shopify-claim): one-click account setup + zero-blank onboarding

### DIFF
--- a/src/app/(site)/auth/page.tsx
+++ b/src/app/(site)/auth/page.tsx
@@ -114,7 +114,12 @@ function AuthPageInner() {
   // Only same-origin relative paths are forwarded.
   const next = (() => {
     const raw = searchParams.get("next");
-    return raw && raw.startsWith("/") && !raw.startsWith("//") ? raw : null;
+    // Same-origin relative only: single leading slash, no protocol-relative
+    // form (// or /\ — browsers normalize backslash to slash). The server and
+    // the verify page re-validate; this just avoids forwarding a doomed value.
+    return raw && raw.startsWith("/") && !raw.startsWith("//") && !raw.includes("\\")
+      ? raw
+      : null;
   })();
   // When `next` is the store-claim page, lift the store+token so the magic-link
   // request can admit a brand-new merchant email through the pre-launch gate

--- a/src/app/(site)/auth/page.tsx
+++ b/src/app/(site)/auth/page.tsx
@@ -110,6 +110,28 @@ function AuthPageInner() {
     const upper = raw.toUpperCase();
     return REFERRAL_CODE_PATTERN.test(upper) ? upper : null;
   })();
+  // `?next=` — where to return after verify (server sanitizes it to same-origin).
+  // Only same-origin relative paths are forwarded.
+  const next = (() => {
+    const raw = searchParams.get("next");
+    return raw && raw.startsWith("/") && !raw.startsWith("//") ? raw : null;
+  })();
+  // When `next` is the store-claim page, lift the store+token so the magic-link
+  // request can admit a brand-new merchant email through the pre-launch gate
+  // (the server re-validates the token). Parsed with a fixed base — no `window`,
+  // so it's SSR-safe.
+  const shopifyClaim = (() => {
+    if (!next) return undefined;
+    try {
+      const u = new URL(next, "http://internal");
+      if (u.pathname !== "/claim/shopify") return undefined;
+      const store = u.searchParams.get("store");
+      const token = u.searchParams.get("t");
+      return store && token ? { store, token } : undefined;
+    } catch {
+      return undefined;
+    }
+  })();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   // Tick once per second while a cooldown is running so the button
@@ -200,7 +222,10 @@ function AuthPageInner() {
           })
           .catch(() => {});
       }
-      const res = await sendMagicLink(targetEmail);
+      const res = await sendMagicLink(targetEmail, {
+        ...(next ? { returnTo: next } : {}),
+        ...(shopifyClaim ? { shopifyClaim } : {}),
+      });
       // Pre-launch invite gate: the endpoint may return without sending a
       // link. Branch to the matching card instead of the "check your email"
       // cooldown. `sent` (or a legacy response with no `outcome`) falls

--- a/src/app/(site)/auth/verify/page.tsx
+++ b/src/app/(site)/auth/verify/page.tsx
@@ -13,6 +13,24 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/api";
+import { LoadingScreen } from "@/components/molecules/loading-screen";
+
+/**
+ * Same-origin relative path only — the `next` return path is attacker-influenced
+ * (it rode through the email link), so re-validate here before navigating even
+ * though the server already sanitized it. Rejects protocol-relative ("//host"),
+ * backslash ("/\\host" → browsers normalize to "//host"), schemes, and control
+ * chars/space.
+ */
+function safeReturnTo(v: string | null): string | null {
+  if (!v) return null;
+  if (!v.startsWith("/")) return null;
+  // Reject control chars, space, and backslash (browsers normalize backslash
+  // to "/", so "/\\host" would resolve to the protocol-relative "//host").
+  if (/[\u0000-\u0020\\]/.test(v)) return null;
+  if (v.startsWith("//") || v.includes("://")) return null;
+  return v;
+}
 
 function VerifyContent() {
   const searchParams = useSearchParams();
@@ -24,6 +42,9 @@ function VerifyContent() {
   useEffect(() => {
     const token = searchParams.get("token");
     const uid = searchParams.get("uid");
+    // Where to land after verify: an explicit same-origin `next` (e.g. the
+    // Shopify store-claim page the user came from) wins over the server default.
+    const next = safeReturnTo(searchParams.get("next"));
 
     if (!token || !uid) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time validation of URL search params on mount; necessary to surface the error UI
@@ -35,7 +56,7 @@ function VerifyContent() {
     verifyMagicLink(token, uid)
       .then(async (result) => {
         await refreshUser();
-        router.replace(result.redirectTo);
+        router.replace(next ?? result.redirectTo);
       })
       .catch((err) => {
         if (err instanceof ApiError) {
@@ -47,36 +68,33 @@ function VerifyContent() {
       });
   }, [searchParams, router, refreshUser]);
 
+  // While verifying (and until the redirect commits) show the sleek loader,
+  // never a blank card.
+  if (verifying) {
+    return (
+      <LoadingScreen
+        fullScreen
+        message="Signing you in…"
+        steps={["Verifying your link", "Setting up your session"]}
+      />
+    );
+  }
+
   return (
     <Card className="w-full max-w-md">
       <CardHeader className="text-center">
-        <CardTitle className="text-2xl font-bold">
-          {verifying ? "Verifying..." : "Verification failed"}
-        </CardTitle>
-        <CardDescription>
-          {verifying
-            ? "Please wait while we verify your sign-in link"
-            : "We couldn't verify your sign-in link"}
-        </CardDescription>
+        <CardTitle className="text-2xl font-bold">Verification failed</CardTitle>
+        <CardDescription>We couldn&apos;t verify your sign-in link</CardDescription>
       </CardHeader>
       <CardContent className="text-center">
-        {verifying ? (
-          <div className="flex justify-center py-8">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+        <div className="space-y-4">
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
           </div>
-        ) : (
-          <div className="space-y-4">
-            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
-            </div>
-            <Button
-              className="w-full"
-              onClick={() => router.push("/auth")}
-            >
-              Request a new link
-            </Button>
-          </div>
-        )}
+          <Button className="w-full" onClick={() => router.push("/auth")}>
+            Request a new link
+          </Button>
+        </div>
       </CardContent>
     </Card>
   );
@@ -85,15 +103,7 @@ function VerifyContent() {
 export default function VerifyPage() {
   return (
     <div className="flex flex-1 items-center justify-center px-4">
-      <Suspense
-        fallback={
-          <Card className="w-full max-w-md">
-            <CardContent className="flex justify-center py-12">
-              <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
-            </CardContent>
-          </Card>
-        }
-      >
+      <Suspense fallback={<LoadingScreen fullScreen message="Loading…" />}>
         <VerifyContent />
       </Suspense>
     </div>

--- a/src/app/(site)/claim/shopify/_components/shopify-claim.tsx
+++ b/src/app/(site)/claim/shopify/_components/shopify-claim.tsx
@@ -126,7 +126,9 @@ export function ShopifyClaim() {
     setFetchState("claiming");
     try {
       const res = await claimShopifyStore(store, token);
-      setClaimedName(data?.store?.name || "your new account");
+      // Adopt has no separate org to name — the store BECOMES the account, so
+      // avoid the "Acme is now part of Acme" tautology in the done copy.
+      setClaimedName("your new Peakhour account");
       try {
         await switchOrg(res.orgId);
         if (res.businessId) await switchBusiness(res.businessId);

--- a/src/app/(site)/claim/shopify/_components/shopify-claim.tsx
+++ b/src/app/(site)/claim/shopify/_components/shopify-claim.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { CheckCircle2, AlertCircle, ShoppingBag, Loader2 } from "lucide-react";
+import { CheckCircle2, AlertCircle, ShoppingBag } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +18,7 @@ import {
   claimShopifyStore,
   type ShopifyClaimCandidates,
 } from "@/lib/api/shopify-claim";
+import { LoadingScreen } from "@/components/molecules/loading-screen";
 
 /** Sentinel for "move the store in as a NEW Business" (vs an existing businessId). */
 const NEW_BUSINESS = "__new__";
@@ -116,6 +117,36 @@ export function ShopifyClaim() {
     }
   }
 
+  // One-click path for a merchant with no Peakhour account: adopt the store's
+  // auto-provisioned shell org (which already holds the catalog + Commerce plan)
+  // as their first workspace — no org to pick, no onboarding, no store URL to
+  // type. The server adopts when `orgId` is omitted and the operator owns none.
+  async function handleAdopt() {
+    if (!store || !token) return;
+    setFetchState("claiming");
+    try {
+      const res = await claimShopifyStore(store, token);
+      setClaimedName(data?.store?.name || "your new account");
+      try {
+        await switchOrg(res.orgId);
+        if (res.businessId) await switchBusiness(res.businessId);
+      } catch {
+        /* adopted regardless; the switchers pick it up on next load */
+      }
+      setFetchState("done");
+    } catch (e: unknown) {
+      setErrCode((e as { code?: string })?.code ?? "");
+      setErrMsg((e as { message?: string })?.message ?? "Couldn't set up your account.");
+      setFetchState("error");
+    }
+  }
+
+  // Sign-in that returns the merchant straight back here (with the store+token)
+  // after the magic link — no bouncing back to Shopify to re-click. `next` also
+  // carries the claim context so the API admits a brand-new merchant email.
+  const claimPath = `/claim/shopify?store=${encodeURIComponent(store)}&t=${encodeURIComponent(token)}`;
+  const signInHref = `/auth?next=${encodeURIComponent(claimPath)}`;
+
   // Derived phase: pre-auth states from props, then the async fetchState.
   const showLoading = isLoading || (ready && fetchState === "loading");
   const showMissing = !isLoading && (!store || !token);
@@ -135,10 +166,7 @@ export function ShopifyClaim() {
         </CardHeader>
         <CardContent className="space-y-4">
           {showLoading && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" aria-hidden />
-              Loading…
-            </div>
+            <LoadingScreen message="Loading your store…" />
           )}
 
           {showMissing && (
@@ -157,11 +185,11 @@ export function ShopifyClaim() {
           {showSignIn && (
             <div className="space-y-3">
               <p className="text-sm text-muted-foreground">
-                Sign in to your Peakhour account to claim this store. After signing in, reopen the
-                “Claim this store” button from the Peakhour app in your Shopify admin.
+                Sign in to finish linking <span className="font-medium text-foreground">this store</span> to
+                your Peakhour account. We&apos;ll bring you right back here — no need to return to Shopify.
               </p>
               <Button asChild>
-                <Link href="/auth">Sign in</Link>
+                <Link href={signInHref}>Sign in to continue</Link>
               </Button>
             </div>
           )}
@@ -183,9 +211,16 @@ export function ShopifyClaim() {
               </div>
 
               {data.orgs.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No account found on your sign-in. Create one in Peakhour, then reopen this link.
-                </p>
+                <div className="space-y-3">
+                  <p className="text-sm text-muted-foreground">
+                    Set up your Peakhour account from{" "}
+                    <span className="font-medium text-foreground">{data.store.name || "this store"}</span>.
+                    Your catalog and Commerce plan are already in place — nothing to configure.
+                  </p>
+                  <Button onClick={handleAdopt} className="w-full">
+                    Create my account with this store
+                  </Button>
+                </div>
               ) : (
                 <>
                   {data.orgs.length > 1 && (
@@ -256,21 +291,27 @@ export function ShopifyClaim() {
                 </>
               )}
 
-              <Button
-                onClick={handleClaim}
-                disabled={!selectedOrg || data.orgs.length === 0}
-                className="w-full"
-              >
-                Claim this store
-              </Button>
+              {data.orgs.length > 0 && (
+                <Button
+                  onClick={handleClaim}
+                  disabled={!selectedOrg}
+                  className="w-full"
+                >
+                  Claim this store
+                </Button>
+              )}
             </div>
           )}
 
           {ready && fetchState === "claiming" && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" aria-hidden />
-              Claiming…
-            </div>
+            <LoadingScreen
+              message="Setting up your store…"
+              steps={[
+                "Linking your Shopify store",
+                "Bringing your catalog across",
+                "Activating Commerce",
+              ]}
+            />
           )}
 
           {ready && fetchState === "done" && (

--- a/src/app/(site)/claim/shopify/page.tsx
+++ b/src/app/(site)/claim/shopify/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { ShopifyClaim } from "./_components/shopify-claim";
+import { LoadingScreen } from "@/components/molecules/loading-screen";
 
 /**
  * /claim/shopify?store=<connId>&t=<token>
@@ -11,13 +12,7 @@ import { ShopifyClaim } from "./_components/shopify-claim";
  */
 export default function ShopifyClaimPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="mx-auto flex min-h-[70vh] w-full max-w-lg items-center justify-center px-4 text-sm text-muted-foreground">
-          Loading…
-        </div>
-      }
-    >
+    <Suspense fallback={<LoadingScreen fullScreen message="Loading your store…" />}>
       <ShopifyClaim />
     </Suspense>
   );

--- a/src/components/molecules/loading-screen.tsx
+++ b/src/components/molecules/loading-screen.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface LoadingScreenProps {
+  /** Primary line, e.g. "Setting up your store…". */
+  message?: string;
+  /**
+   * Optional reassurance lines cycled every ~2.2s under the primary message —
+   * ideal for longer waits (verifying, provisioning) so the screen feels alive
+   * and communicates progress instead of stalling on one static string.
+   */
+  steps?: string[];
+  /**
+   * `true` → fixed full-viewport overlay (blocks the page while a critical
+   * async step runs). `false` (default) → fills its parent, for section-level
+   * loading inside a card/page.
+   */
+  fullScreen?: boolean;
+  className?: string;
+}
+
+/**
+ * Shared loading screen — a branded dual-ring spinner with a message and
+ * optional rotating sub-steps. Use anywhere the UI is doing async work
+ * (fetching, parsing URL params, verifying a token, provisioning) so the user
+ * never sees a blank screen. Accessible (role=status / aria-live) and
+ * theme-aware via design tokens.
+ */
+export function LoadingScreen({
+  message = "Loading…",
+  steps,
+  fullScreen = false,
+  className,
+}: LoadingScreenProps) {
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    if (!steps || steps.length < 2) return;
+    const id = setInterval(
+      () => setIdx((n) => (n + 1) % steps.length),
+      2200,
+    );
+    return () => clearInterval(id);
+  }, [steps]);
+
+  const sub = steps && steps.length > 0 ? steps[idx % steps.length] : undefined;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={cn(
+        fullScreen
+          ? "fixed inset-0 z-50 bg-background/85 backdrop-blur-sm"
+          : "relative w-full",
+        "flex min-h-60 flex-col items-center justify-center gap-5 p-8 text-center",
+        className,
+      )}
+    >
+      {/* Dual-ring: a faint full track + a spinning brand arc, with a soft
+          pulsing core. Reads as premium without a heavy dependency — only
+          the built-in spin/pulse keyframes. */}
+      <div className="relative flex size-14 items-center justify-center">
+        <span className="absolute inset-0 rounded-full border-4 border-muted" />
+        <span className="absolute inset-0 animate-spin rounded-full border-4 border-transparent border-t-primary" />
+        <span className="size-2 animate-pulse rounded-full bg-primary" />
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">{message}</p>
+        {sub ? (
+          <p className="text-xs text-muted-foreground">{sub}</p>
+        ) : null}
+      </div>
+
+      <span className="sr-only">{sub ? `${message} ${sub}` : message}</span>
+    </div>
+  );
+}

--- a/src/components/molecules/loading-screen.tsx
+++ b/src/components/molecules/loading-screen.tsx
@@ -36,14 +36,17 @@ export function LoadingScreen({
 }: LoadingScreenProps) {
   const [idx, setIdx] = useState(0);
 
+  // Key the effect on step CONTENT, not array identity, so a caller passing an
+  // inline `steps={[...]}` literal (new reference each render) inside a
+  // frequently-re-rendering parent doesn't tear down and restart the interval
+  // every render (which would stop the sub-steps from ever advancing).
+  const stepsKey = steps ? steps.join("") : "";
+  const stepCount = steps?.length ?? 0;
   useEffect(() => {
-    if (!steps || steps.length < 2) return;
-    const id = setInterval(
-      () => setIdx((n) => (n + 1) % steps.length),
-      2200,
-    );
+    if (stepCount < 2) return;
+    const id = setInterval(() => setIdx((n) => (n + 1) % stepCount), 2200);
     return () => clearInterval(id);
-  }, [steps]);
+  }, [stepsKey, stepCount]);
 
   const sub = steps && steps.length > 0 ? steps[idx % steps.length] : undefined;
 
@@ -69,14 +72,14 @@ export function LoadingScreen({
         <span className="size-2 animate-pulse rounded-full bg-primary" />
       </div>
 
+      {/* Inside the role=status / aria-live region, so message + sub-step
+          changes are announced to assistive tech without a duplicate node. */}
       <div className="space-y-1">
         <p className="text-sm font-medium text-foreground">{message}</p>
         {sub ? (
           <p className="text-xs text-muted-foreground">{sub}</p>
         ) : null}
       </div>
-
-      <span className="sr-only">{sub ? `${message} ${sub}` : message}</span>
     </div>
   );
 }

--- a/src/lib/api/shopify-claim.ts
+++ b/src/lib/api/shopify-claim.ts
@@ -49,20 +49,30 @@ export async function fetchShopifyClaimCandidates(
 }
 
 /**
- * Adopt the store. Omit `businessId` to move the store in as a NEW Business under
- * the org (plan-gated); pass an existing `businessId` to attach it to that brand.
+ * Adopt the store into an account.
+ *
+ * - Omit `orgId` entirely (one-click path): the server picks automatically —
+ *   a signed-in operator with no account has the store's shell org handed to
+ *   them as their first workspace (`adopted: true`), no onboarding needed.
+ * - Pass `orgId` with no `businessId` → move the store in as a NEW Business.
+ * - Pass `orgId` + `businessId` → attach it to that existing brand.
  */
 export async function claimShopifyStore(
   store: string,
   token: string,
-  orgId: string,
+  orgId?: string,
   businessId?: string,
-): Promise<{ claimed: boolean; orgId: string; businessId: string }> {
-  return api.request<{ claimed: boolean; orgId: string; businessId: string }>(
+): Promise<{ claimed: boolean; adopted?: boolean; orgId: string; businessId: string | null }> {
+  return api.request<{ claimed: boolean; adopted?: boolean; orgId: string; businessId: string | null }>(
     "/v1/shopify/claim",
     {
       method: "POST",
-      body: JSON.stringify({ store, token, orgId, ...(businessId ? { businessId } : {}) }),
+      body: JSON.stringify({
+        store,
+        token,
+        ...(orgId ? { orgId } : {}),
+        ...(businessId ? { businessId } : {}),
+      }),
     },
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -128,11 +128,22 @@ export interface VerifyMagicResponse {
 export type MagicLinkOutcome = "sent" | "waitlisted" | "not_found";
 
 export async function sendMagicLink(
-  email: string
+  email: string,
+  opts?: {
+    /** Same-origin path to return to after verify (e.g. the store-claim page). */
+    returnTo?: string;
+    /** Shopify claim context — admits a merchant's email through the pre-launch
+     *  gate when the token is valid (server re-checks it). */
+    shopifyClaim?: { store: string; token: string };
+  },
 ): Promise<{ outcome?: MagicLinkOutcome; message: string }> {
   return api.post<{ outcome?: MagicLinkOutcome; message: string }>(
     "/v1/auth/magic-link",
-    { email }
+    {
+      email,
+      ...(opts?.returnTo ? { returnTo: opts.returnTo } : {}),
+      ...(opts?.shopifyClaim ? { shopifyClaim: opts.shopifyClaim } : {}),
+    },
   );
 }
 


### PR DESCRIPTION
## What
Makes the Shopify **"Link this store" → Peakhour** flow buttery smooth. Fixes the reported bug where a merchant was asked to type their **store URL** — the store we already know.

### Root cause
A merchant with no Peakhour account hit a dead-end on the claim page (*"create one, then reopen this link"*) → they went off to generic onboarding, which asked them to paste a business URL.

### Fixes
- **One-click adopt.** A signed-in merchant with no account now sees **"Create my account with this store"** → adopts the store's auto-provisioned shell org (catalog + Commerce plan already in place). No onboarding, no URL. `claimShopifyStore()` supports omitting `orgId` for the server adopt path.
- **No Shopify round-trip.** The "Sign in" link carries `?next=<claim url>`, so after the magic link the merchant returns **straight back to the claim page** (and the request carries the claim context so a brand-new merchant email is admitted through the pre-launch gate — pairs with api #827).
- **Verify honors `next`** — a re-validated same-origin return path over the default dashboard redirect.

### Sleek loading everywhere
New reusable **`LoadingScreen`** (branded dual-ring + pulsing core + rotating reassurance steps, accessible `role=status`, theme-aware) used on the claim + verify surfaces — the user never sees a blank page while params are parsed / tokens verified.

## Review
Double-reviewed (incl. adversarial). The full token round-trip was traced hop-by-hop and proven to net exactly one encode/decode (base64 `+/=` and the `&` separator survive). Fixes applied: `/auth` `next` backslash guard, adopt done-copy tautology, and LoadingScreen steps-identity + a11y hardening. `tsc` + `eslint` + `next build` all green.

Pairs with **peakhour-api #827** (returnTo + shopifyClaim bypass); both degrade gracefully if one lags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)