### PR TITLE
feat(commerce): register gated Commerce nav pillar (P0.2)

### DIFF
--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -56,6 +56,7 @@ import {
   ListChecks,
   Zap,
   MessagesSquare,
+  ShoppingBag,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -71,6 +72,13 @@ interface NavItem {
   label: string;
   icon: LucideIcon;
   badge?: () => React.ReactNode;
+  /**
+   * Optional entitlement gate (a cfg_features.key). When set, the item renders
+   * only if the key is present in the org's entitlements snapshot — the same
+   * check `useFeature` runs. Absent = always visible (the default for the core
+   * Content/Growth items). Used to gate the Commerce pillar on `commerce.nav`.
+   */
+  feature?: string;
   subItems?: { href: string; label: string; badge?: () => React.ReactNode }[];
 }
 
@@ -125,6 +133,22 @@ const NAV_GROUPS: NavGroup[] = [
           { href: "/dashboard/ads", label: "Ads" },
           { href: "/dashboard/outcomes", label: "Outcomes" },
           { href: "/dashboard/optimizer", label: "Optimizer" },
+        ],
+      },
+      // Commerce — the third pillar. Gated on `commerce.nav` (granted to every
+      // plan bundling a Commerce product; migration 144), so only Commerce
+      // customers carry the extra sidebar weight. Sub-items are added as each
+      // surface ships — Assistant + Inventory exist today; Command Center,
+      // Autopilot and Channels land in later Phase-0 PRs. The parent points at
+      // an existing leaf until the Command Center index page exists.
+      {
+        href: "/dashboard/commerce/inventory",
+        label: "Commerce",
+        icon: ShoppingBag,
+        feature: "commerce.nav",
+        subItems: [
+          { href: "/dashboard/commerce/assistant", label: "Assistant" },
+          { href: "/dashboard/commerce/inventory", label: "Inventory" },
         ],
       },
       { href: "/dashboard/inbox", label: "Inbox", icon: MessagesSquare },
@@ -182,7 +206,7 @@ export default function DashboardLayout({
 
 function DashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const { user, org, logout, isLoading, isAuthenticated } = useAuth();
+  const { user, org, logout, isLoading, isAuthenticated, entitlements } = useAuth();
 
   if (isLoading) {
     return (
@@ -258,7 +282,13 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
               )}
               <SidebarGroupContent>
                 <SidebarMenu>
-                  {group.items.map((item) => {
+                  {group.items
+                    .filter(
+                      (item) =>
+                        !item.feature ||
+                        Boolean(entitlements?.features?.includes(item.feature)),
+                    )
+                    .map((item) => {
                     const Icon = item.icon;
                     const isActive = item.subItems
                       ? item.subItems.some((s) => pathname === s.href || pathname?.startsWith(s.href + "/"))


### PR DESCRIPTION
## P0.2 — Commerce sidebar pillar (b2c)

Promotes **Commerce** to a first-class main-menu pillar, next to Content and Growth. Builds on mongodb#368 (the `commerce.nav` entitlement seed).

### What this does
- Adds an optional **`feature?`** field (a `cfg_features.key`) to `NavItem`. The sidebar render loop now filters out any item whose gate isn't present in the org's entitlements snapshot — the same check `useFeature` runs, locked-by-default. Items without a `feature` stay always-visible (all the existing Content/Growth items).
- Registers the **Commerce** pillar gated on **`commerce.nav`**, so only orgs on a Commerce-bundling plan see it.
- Sub-items are the two surfaces that already exist — **Assistant** and **Inventory**. Command Center, Autopilot and Channels are added as those pages land in later Phase-0 PRs; the parent points at an existing leaf until the Command Center index exists (so every link resolves).

### Notes
- Reuses the existing entitlements plumbing (`useAuth().entitlements`); no new hook.
- Command palette (`command-menu.tsx`) is **not** touched — it has no entitlement filtering, and adding Commerce there would surface gated routes to non-Commerce orgs. Deferred until the palette supports gating.

### Verification
- `eslint` clean on the changed file.
- `tsc --noEmit` reports no errors.
- Non-Commerce orgs: pillar hidden. Commerce orgs: pillar visible with Assistant + Inventory.

Part of the approved Commerce build plan (Phase 0). No `peakhour-shopify` changes.