### PR TITLE
feat(commerce): Command Center outcomes home (P0.4)

### DIFF
--- a/src/app/(site)/dashboard/commerce/page.tsx
+++ b/src/app/(site)/dashboard/commerce/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { CommandCenter } from "@/components/commerce/command-center";
+
+export const metadata: Metadata = {
+  title: "Command Center · Commerce",
+};
+
+/**
+ * Commerce → Command Center (Phase 0). The outcome home of the Commerce pillar:
+ * honest, catalog+inventory-grounded outcomes with order-derived metrics shown
+ * as "Switching on" until order access lands. Gated on `commerce.command_center`
+ * inside the component (FeatureGate).
+ */
+export default function CommerceCommandCenterPage() {
+  return <CommandCenter />;
+}

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -138,15 +138,15 @@ const NAV_GROUPS: NavGroup[] = [
       // Commerce — the third pillar. Gated on `commerce.nav` (granted to every
       // plan bundling a Commerce product; migration 144), so only Commerce
       // customers carry the extra sidebar weight. Sub-items are added as each
-      // surface ships — Assistant + Inventory exist today; Command Center,
-      // Autopilot and Channels land in later Phase-0 PRs. The parent points at
-      // an existing leaf until the Command Center index page exists.
+      // surface ships — Command Center (outcomes home), Assistant + Inventory
+      // exist today; Autopilot and Channels land in later Phase-0 PRs.
       {
-        href: "/dashboard/commerce/inventory",
+        href: "/dashboard/commerce",
         label: "Commerce",
         icon: ShoppingBag,
         feature: "commerce.nav",
         subItems: [
+          { href: "/dashboard/commerce", label: "Command Center" },
           { href: "/dashboard/commerce/assistant", label: "Assistant" },
           { href: "/dashboard/commerce/inventory", label: "Inventory" },
         ],

--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -35,16 +35,31 @@ export function CommandCenter() {
   );
 }
 
+/** A currency's minor-unit exponent (2 for USD/INR, 0 for JPY, 3 for KWD). */
+function minorUnitExponent(currency: string): number {
+  try {
+    return (
+      new Intl.NumberFormat("en", { style: "currency", currency }).resolvedOptions()
+        .maximumFractionDigits ?? 2
+    );
+  } catch {
+    return 2; // unknown/invalid currency code → assume 2-decimal
+  }
+}
+
 function CommandCenterBody() {
   const { data, isLoading, isError } = useCommerceSummary();
   const { formatNumber } = useLocale();
 
-  const money = (minor: number, currency: string | null) =>
-    formatNumber(minor / 100, {
+  const money = (minor: number, currency: string | null) => {
+    const cur = currency ?? "USD";
+    const major = minor / 10 ** minorUnitExponent(cur);
+    return formatNumber(major, {
       style: "currency",
-      currency: currency ?? "USD",
+      currency: cur,
       maximumFractionDigits: 0,
     });
+  };
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">

--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import {
+  Boxes,
+  AlertTriangle,
+  MessageSquareText,
+  MousePointerClick,
+  Receipt,
+  ClipboardCheck,
+  Store,
+} from "lucide-react";
+import { KpiCard } from "@/components/molecules/kpi-card";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { useLocale } from "@/hooks/use-locale";
+import { useCommerceSummary } from "@/hooks/use-commerce-summary";
+
+/**
+ * Commerce → Command Center (Phase 0). The outcome home for the Commerce pillar:
+ * what the store is doing and what the engine has done, grounded in live catalog
+ * + inventory + our own assisted-order / storefront data. Order-derived outcomes
+ * (GMV / AOV / sell-through) show a "Switching on" state until order access lands
+ * — never a fabricated number (Shopify certification firewall).
+ *
+ * Composition-first: reuses KpiCard, EmptyState, Skeleton, FeatureGate. The
+ * "engine did this" digest + NeedsYouRail land in P0.5; the channel switcher
+ * arrives with the Channels hub (P0.9) — today there is a single D2C channel.
+ */
+export function CommandCenter() {
+  return (
+    <FeatureGate feature="commerce.command_center" featureName="Commerce Command Center">
+      <CommandCenterBody />
+    </FeatureGate>
+  );
+}
+
+function CommandCenterBody() {
+  const { data, isLoading, isError } = useCommerceSummary();
+  const { formatNumber } = useLocale();
+
+  const money = (minor: number, currency: string | null) =>
+    formatNumber(minor / 100, {
+      style: "currency",
+      currency: currency ?? "USD",
+      maximumFractionDigits: 0,
+    });
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-xl font-semibold">Command Center</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          What your store is doing and what Peakhour has done for it — grounded in
+          your live catalog, inventory and conversations.
+        </p>
+      </header>
+
+      {isLoading && <SummarySkeleton />}
+
+      {isError && !isLoading && (
+        <EmptyState
+          icon={Store}
+          title="Connect a store to get started"
+          description="Command Center lights up once a Shopify or WooCommerce store is connected to this business."
+          action={{ label: "Connect a store", href: "/dashboard/integrations" }}
+        />
+      )}
+
+      {data && !isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <KpiCard
+            title="Stock value (retail)"
+            value={money(data.inventory.stockValueRetailMinor, data.store.currency)}
+            description="On-hand inventory at retail price"
+            icon={Boxes}
+          />
+          <KpiCard
+            title="Needs attention"
+            value={data.inventory.atRisk}
+            description={`${data.inventory.atRisk} product${
+              data.inventory.atRisk === 1 ? "" : "s"
+            } at risk of stocking out or tying up capital`}
+            icon={AlertTriangle}
+          />
+          <KpiCard
+            title="Assisted-order revenue"
+            value={money(data.assistedOrders.revenueMinor, data.store.currency)}
+            description={`${data.assistedOrders.count} order${
+              data.assistedOrders.count === 1 ? "" : "s"
+            } the assistant helped close`}
+            icon={MessageSquareText}
+          />
+          <KpiCard
+            title="Storefront engagement"
+            value={formatNumber(data.storefront.impressions)}
+            description={`${data.storefront.clicks} clicks · ${data.storefront.addToCart} add-to-cart (30d)`}
+            icon={MousePointerClick}
+          />
+          <KpiCard
+            title="Sales from orders"
+            value={data.orderDerived.switchingOn ? "Switching on" : "Connected"}
+            description={
+              data.orderDerived.switchingOn
+                ? "Connect order access to see GMV, AOV & sell-through"
+                : "Order-based revenue is being wired into your reports"
+            }
+            icon={Receipt}
+          />
+          <KpiCard
+            title="Pending approvals"
+            value={data.pendingApprovals}
+            description="Agent actions waiting for your go-ahead"
+            icon={ClipboardCheck}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummarySkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Skeleton key={i} className="h-28 rounded-lg" />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/use-commerce-summary.ts
+++ b/src/hooks/use-commerce-summary.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Commerce Command Center summary (GET /v1/commerce/summary). Honest outcomes
+ * grounded in the connected store's catalog + inventory + our own assisted-order
+ * and storefront data — no order scope required. Order-derived outcomes are
+ * flagged `orderDerived.switchingOn` until order access lands (WooCommerce has it
+ * today; Shopify only after the post-certification read_orders escalation).
+ */
+
+export interface CommerceSummary {
+  store: { platform: string | null; currency: string | null };
+  ordersConnected: boolean;
+  inventory: {
+    scanned: number;
+    healthy: number;
+    watchlist: number;
+    slow: number;
+    atRisk: number;
+    /** Retail value of on-hand stock in the store's minor units (not cost basis). */
+    stockValueRetailMinor: number;
+  };
+  assistedOrders: { revenueMinor: number; count: number };
+  storefront: { impressions: number; clicks: number; addToCart: number };
+  pendingApprovals: number;
+  orderDerived: { switchingOn: boolean };
+  entitlements: { commerceAssistant: boolean };
+}
+
+const SUMMARY_KEY = "commerce-summary";
+
+export function useCommerceSummary() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<CommerceSummary>({
+    queryKey: [SUMMARY_KEY, org?._id ?? null],
+    queryFn: () => api.get<CommerceSummary>("/v1/commerce/summary"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 5 * 60_000,
+    // A missing store returns 4xx (NO_STORE_CONNECTED) — don't hammer it.
+    retry: false,
+  });
+}


### PR DESCRIPTION
## P0.4 — Commerce Command Center (b2c)

The Commerce pillar's landing surface: honest, catalog+inventory-grounded outcomes for the connected store. Consumes api#832 (`GET /v1/commerce/summary`).

### What lands
- **New `/dashboard/commerce` index page** (was missing) + `use-commerce-summary` hook.
- **KPI grid** (reuses `KpiCard`): retail stock value, needs-attention count, assisted-order revenue, storefront engagement, pending approvals — all real numbers. **"Sales from orders"** shows a **"Switching on"** state until order access lands — never a fabricated GMV (Shopify certification firewall). Money is formatted in the **store's** currency (not the viewer's pref).
- **No-store → `EmptyState`** with a Connect CTA; **loading → skeleton** grid.
- Repoints the Commerce nav parent to `/dashboard/commerce` and adds the **Command Center** sub-item (the P0.2 deferral).

### Composition-first
Reuses `KpiCard`, `EmptyState`, `Skeleton`, `FeatureGate`, `useLocale` — no new primitives. Gated on `commerce.command_center` via `FeatureGate` (locked-by-default) as defense-in-depth behind the nav gate.

### Deferred (by design, next PRs)
- "Engine did this" digest + `NeedsYouRail` → **P0.5**.
- Channel switcher → **P0.9** (single D2C channel today).

### Verification
- `eslint` clean; `tsc --noEmit` reports no errors.
- Entitled + store connected → KPI grid. No store → empty state. Not entitled (direct URL) → locked.

Part of the approved Commerce build plan (Phase 0).