### PR TITLE
feat(commerce): Needs-you intent rail on Command Center (P0.5b)

### DIFF
--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -13,6 +13,7 @@ import { KpiCard } from "@/components/molecules/kpi-card";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
 import { useLocale } from "@/hooks/use-locale";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
 
@@ -128,6 +129,12 @@ function CommandCenterBody() {
             description="Agent actions waiting for your go-ahead"
             icon={ClipboardCheck}
           />
+        </div>
+      )}
+
+      {data && !isLoading && (
+        <div className="mt-6">
+          <CommerceNeedsYou />
         </div>
       )}
     </div>

--- a/src/components/commerce/needs-you-rail.tsx
+++ b/src/components/commerce/needs-you-rail.tsx
@@ -66,7 +66,9 @@ export function CommerceNeedsYou() {
               <RecommendationRow
                 key={rec.id}
                 rec={rec}
-                busy={decide.isPending}
+                // Only the row being decided is disabled — other proposals stay
+                // actionable while one request is in flight.
+                busy={decide.isPending && decide.variables?.id === rec.id}
                 onDecide={(decision) => decide.mutate({ id: rec.id, decision })}
               />
             ))}

--- a/src/components/commerce/needs-you-rail.tsx
+++ b/src/components/commerce/needs-you-rail.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { CheckCircle2, TrendingUp } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useLocale } from "@/hooks/use-locale";
+import {
+  useCommerceRecommendations,
+  useDecideRecommendation,
+  type Recommendation,
+  type RecommendationDecision,
+} from "@/hooks/use-commerce-recommendations";
+
+/**
+ * Commerce → Command Center "Needs you" rail. The engine's proposals as
+ * actionable intents: approve or dismiss inline (optimistic), each with its
+ * projected revenue lift and confidence. Models the Autopilot Home NeedsYouRail
+ * pattern (Card + count pill + divided list + "all caught up" empty state), but
+ * decisions happen in place rather than jumping elsewhere.
+ *
+ * Self-contained (fetches its own data); hides entirely when no store is
+ * connected — the Command Center already shows that connect state.
+ */
+export function CommerceNeedsYou() {
+  const { data, isLoading, isError } = useCommerceRecommendations();
+  const decide = useDecideRecommendation();
+
+  if (isError) return null;
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      <CardHeader className="flex flex-row items-center justify-between gap-2 border-b bg-muted/30 px-4 py-3">
+        <CardTitle className="text-base">Needs you</CardTitle>
+        {total > 0 && (
+          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-700 dark:bg-amber-950/60 dark:text-amber-400">
+            {total}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {isLoading ? (
+          <div className="divide-y">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="px-4 py-3">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-2 h-3 w-full" />
+              </div>
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center gap-1.5 px-4 py-10 text-center">
+            <CheckCircle2 className="size-7 text-emerald-500" />
+            <p className="text-sm font-medium">You&apos;re all caught up</p>
+            <p className="text-xs text-muted-foreground">
+              No proposals waiting. Peakhour will surface new ones here as it finds
+              opportunities.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {items.map((rec) => (
+              <RecommendationRow
+                key={rec.id}
+                rec={rec}
+                busy={decide.isPending}
+                onDecide={(decision) => decide.mutate({ id: rec.id, decision })}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecommendationRow({
+  rec,
+  busy,
+  onDecide,
+}: {
+  rec: Recommendation;
+  busy: boolean;
+  onDecide: (decision: RecommendationDecision) => void;
+}) {
+  const { formatNumber } = useLocale();
+  const range = rec.expectedRevenueRange;
+  const money = (v: number, currency: string) =>
+    formatNumber(v, { style: "currency", currency, maximumFractionDigits: 0 });
+  // confidenceScore may be a 0–1 fraction or an already-scaled 0–100 value.
+  const confidencePct = Math.round(
+    rec.confidenceScore <= 1 ? rec.confidenceScore * 100 : rec.confidenceScore,
+  );
+
+  return (
+    <li className="border-l-2 border-l-amber-500 px-4 py-3">
+      <p className="text-sm font-medium">{rec.title}</p>
+      <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{rec.reasonSummary}</p>
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+        {range && (
+          <span className="inline-flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+            <TrendingUp aria-hidden="true" className="size-3" />
+            {money(range.min, range.currency)}–{money(range.max, range.currency)}
+          </span>
+        )}
+        <span className="text-muted-foreground">confidence {confidencePct}%</span>
+      </div>
+      <div className="mt-2.5 flex gap-2">
+        <Button size="sm" disabled={busy} onClick={() => onDecide("approve")}>
+          Approve
+        </Button>
+        <Button size="sm" variant="ghost" disabled={busy} onClick={() => onDecide("reject")}>
+          Dismiss
+        </Button>
+      </div>
+    </li>
+  );
+}

--- a/src/hooks/use-commerce-recommendations.ts
+++ b/src/hooks/use-commerce-recommendations.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Commerce recommendations — the engine's proposals for the Command Center's
+ * "Needs you" rail (GET /v1/commerce/recommendations, api#833). Approve/reject
+ * are optimistic: the row leaves the pending list immediately and the summary's
+ * pending-approvals count is refreshed.
+ */
+
+export interface RecommendationPreview {
+  id: string;
+  title: string | null;
+  imageUrl: string | null;
+}
+
+export interface Recommendation {
+  id: string;
+  type: string;
+  title: string;
+  subtitle: string | null;
+  suggestedDiscount: number;
+  suggestedDurationHours: number;
+  /** AI-estimated revenue lift in MAJOR units of `currency` (not minor units). */
+  expectedRevenueRange: { min: number; max: number; currency: string } | null;
+  confidenceScore: number;
+  reasonSummary: string;
+  approvalStatus: string;
+  productCount: number;
+  productsPreview: RecommendationPreview[];
+  createdAt: string | null;
+}
+
+export interface RecommendationPage {
+  items: Recommendation[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+const RECS_KEY = "commerce-recommendations";
+const SUMMARY_KEY = "commerce-summary";
+
+export function useCommerceRecommendations() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<RecommendationPage>({
+    queryKey: [RECS_KEY, org?._id ?? null],
+    queryFn: () =>
+      api.get<RecommendationPage>("/v1/commerce/recommendations?status=pending"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 60_000,
+    // A missing store returns 4xx — don't hammer it.
+    retry: false,
+  });
+}
+
+export type RecommendationDecision = "approve" | "reject";
+
+export function useDecideRecommendation() {
+  const qc = useQueryClient();
+  const { org } = useAuth();
+  const recsKey = [RECS_KEY, org?._id ?? null];
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      decision,
+      reason,
+    }: {
+      id: string;
+      decision: RecommendationDecision;
+      reason?: string;
+    }) =>
+      api.post(
+        `/v1/commerce/recommendations/${id}/${decision}`,
+        decision === "reject" && reason ? { reason } : {},
+      ),
+    // Optimistically drop the decided row from the pending list.
+    onMutate: async ({ id }) => {
+      await qc.cancelQueries({ queryKey: recsKey });
+      const prev = qc.getQueryData<RecommendationPage>(recsKey);
+      if (prev) {
+        qc.setQueryData<RecommendationPage>(recsKey, {
+          ...prev,
+          items: prev.items.filter((i) => i.id !== id),
+          total: Math.max(0, prev.total - 1),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(recsKey, ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: recsKey });
+      // pending-approvals count on the Command Center summary
+      qc.invalidateQueries({ queryKey: [SUMMARY_KEY, org?._id ?? null] });
+    },
+  });
+}


### PR DESCRIPTION
## P0.5b — Needs-you intent rail (b2c)

Wires the engine's proposals (api#833) into the Command Center as **actionable intents** — the "action-based intents" surface. Reuses the Autopilot Home `NeedsYouRail` visual pattern (Card + amber count pill + divided list + "all caught up" empty state), but decisions happen **inline** rather than jumping away.

### What lands
- **`use-commerce-recommendations`** hook — pending list + **optimistic** approve/reject: the row leaves the list immediately, rolls back on error, and refreshes the summary's pending-approvals count on settle.
- **`CommerceNeedsYou`** rail — each proposal shows its reason, **projected revenue lift** (major-unit range in the store currency) and **confidence** (handles 0–1 or 0–100 scores); Approve / Dismiss inline. A **single mutation at rail level** so a row unmounting mid-flight (optimistic removal) can't drop the settle/invalidate. Hides entirely when no store is connected.
- Mounted below the KPI grid on the Command Center.

### Deferred (honest)
A richer **"engine did this" activity digest** needs the `cmrc_actions` ledger to be truthful (what the engine actually did/executed), so it lands in **P1.4/Phase 1**. P0 surfaces the actionable intents, which is the higher-value half.

### Composition-first
Reuses `Card`, `Button`, `Skeleton`, `useLocale`, and the NeedsYouRail visual grammar — no new primitives.

### Verification
- `eslint` clean; `tsc --noEmit` reports no errors.
- Pending proposals → rail with Approve/Dismiss; empty → "all caught up"; no store → hidden.

Part of the approved Commerce build plan (Phase 0).