### PR TITLE
feat(commerce): Autopilot page + approvals section (P0.8a)

### DIFF
--- a/src/app/(site)/dashboard/commerce/autopilot/page.tsx
+++ b/src/app/(site)/dashboard/commerce/autopilot/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { CommerceAutopilot } from "@/components/commerce/autopilot";
+
+export const metadata: Metadata = {
+  title: "Autopilot · Commerce",
+};
+
+/**
+ * Commerce → Autopilot. The engine's cockpit — approvals queue + (P0.8b) the
+ * autonomy consent dial. Gated on `commerce.autopilot` inside the component.
+ */
+export default function CommerceAutopilotPage() {
+  return <CommerceAutopilot />;
+}

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -147,6 +147,7 @@ const NAV_GROUPS: NavGroup[] = [
         feature: "commerce.nav",
         subItems: [
           { href: "/dashboard/commerce", label: "Command Center" },
+          { href: "/dashboard/commerce/autopilot", label: "Autopilot" },
           { href: "/dashboard/commerce/assistant", label: "Assistant" },
           { href: "/dashboard/commerce/inventory", label: "Inventory" },
         ],

--- a/src/components/commerce/autopilot.tsx
+++ b/src/components/commerce/autopilot.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
+
+/**
+ * Commerce → Autopilot (Phase 0). The engine's cockpit: the approvals queue
+ * (what needs your go-ahead) and — in P0.8b — the autonomy board (the consent
+ * dial per agent × channel).
+ *
+ * P0.8a ships the page shell + the approvals section, reusing the same
+ * CommerceNeedsYou rail as the Command Center (single source of the pending-
+ * proposal list). Gated on `commerce.autopilot`.
+ */
+export function CommerceAutopilot() {
+  return (
+    <FeatureGate feature="commerce.autopilot" featureName="Commerce Autopilot">
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        <header className="mb-6">
+          <h1 className="text-xl font-semibold">Autopilot</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Approve what the engine proposes and set how much it can do on its
+            own — channel by channel, at a pace you&apos;re comfortable with.
+          </p>
+        </header>
+
+        <section aria-labelledby="approvals-heading">
+          <h2 id="approvals-heading" className="mb-2 text-sm font-medium text-muted-foreground">
+            Approvals
+          </h2>
+          <CommerceNeedsYou />
+        </section>
+
+        {/* Autonomy board (consent dial) lands in P0.8b. */}
+      </div>
+    </FeatureGate>
+  );
+}


### PR DESCRIPTION
## P0.8a — Autopilot cockpit shell (b2c)

First half of the Autopilot cockpit (split per the "split fat PRs" decision).

- New `/dashboard/commerce/autopilot` page + **Autopilot** nav sub-item.
- **Approvals** section reuses the existing `CommerceNeedsYou` rail — one source of truth for the pending-proposal list, shared with the Command Center.
- Gated on `commerce.autopilot` via `FeatureGate`.

### Next
- **P0.8b** — the net-new **ConsentDial autonomy board** (per agent × channel, wired to `GET/PUT /v1/commerce/autonomy`, api#834) lands below the approvals section.

### Verification
- `eslint` clean; `tsc --noEmit` clean.

Part of the approved Commerce build plan (Phase 0).