### PR TITLE
feat(commerce): ConsentDial autonomy board on Autopilot (P0.8b)

### DIFF
--- a/src/components/commerce/autonomy-board.tsx
+++ b/src/components/commerce/autonomy-board.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import { ConsentDial, AUTONOMY_LEVEL_META } from "@/components/commerce/consent-dial";
+import {
+  useCommerceAutonomy,
+  useSetAutonomy,
+  type AutonomyEntry,
+  type AutonomyLevel,
+} from "@/hooks/use-commerce-autonomy";
+
+/**
+ * Commerce → Autopilot autonomy board (the consent dial per agent × channel).
+ * Reads GET /v1/commerce/autonomy and PUTs level changes optimistically. The
+ * confidence meter (written by the P1.9 loop) drives the future graduation
+ * invites; until measured it reads "not yet measured".
+ */
+
+/** Display copy for each agent (the api returns the raw agent key). */
+const AGENT_META: Record<string, { name: string; description: string }> = {
+  merchandiser: { name: "Merchandiser", description: "Listings, PDP copy, keywords & buy-box" },
+  pricer: { name: "Pricer", description: "Price & promotions within your margin floor" },
+  replenisher: { name: "Replenisher", description: "Availability & restock across locations" },
+  concierge: { name: "Concierge", description: "The conversational assistant" },
+  reputation: { name: "Reputation", description: "Reviews & drafted responses" },
+  forecaster: { name: "Forecaster", description: "Demand & assortment — advises only" },
+};
+
+export function AutonomyBoard() {
+  const { data, isLoading, isError } = useCommerceAutonomy();
+  const setAutonomy = useSetAutonomy();
+
+  if (isError) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Autonomy</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Set how much each agent can do on its own. The default is Recommend —
+          autonomy is earned, and every autonomous action stays reversible.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {isLoading ? (
+          Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-16 w-full" />)
+        ) : (
+          data?.agents.map((agent) => (
+            <AgentRow
+              key={agent.agent}
+              entry={agent}
+              busy={setAutonomy.isPending && setAutonomy.variables?.agent === agent.agent}
+              onSet={(level) =>
+                setAutonomy.mutate({ agent: agent.agent, channel: data.channel, level })
+              }
+            />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AgentRow({
+  entry,
+  busy,
+  onSet,
+}: {
+  entry: AutonomyEntry;
+  busy: boolean;
+  onSet: (level: AutonomyLevel) => void;
+}) {
+  const meta = AGENT_META[entry.agent] ?? { name: entry.agent, description: "" };
+  const hint = AUTONOMY_LEVEL_META.find((m) => m.value === entry.level)?.hint;
+  const conf = entry.confidence;
+  const confidencePct = conf ? Math.round(conf.score * 100) : null;
+
+  return (
+    <div className="flex flex-col gap-3 border-b pb-5 last:border-b-0 last:pb-0 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{meta.name}</p>
+        {meta.description && (
+          <p className="text-xs text-muted-foreground">{meta.description}</p>
+        )}
+        {confidencePct !== null ? (
+          <div className="mt-2 flex items-center gap-2">
+            <Progress value={confidencePct} className="h-1.5 w-24" />
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {confidencePct}% confidence
+            </span>
+          </div>
+        ) : (
+          <p className="mt-2 text-xs text-muted-foreground">Confidence — not yet measured</p>
+        )}
+      </div>
+      <div className="shrink-0 sm:text-right">
+        <ConsentDial level={entry.level} disabled={busy} onChange={onSet} />
+        {hint && <p className="mt-1.5 text-xs text-muted-foreground">{hint}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/commerce/autopilot.tsx
+++ b/src/components/commerce/autopilot.tsx
@@ -2,6 +2,7 @@
 
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
+import { AutonomyBoard } from "@/components/commerce/autonomy-board";
 
 /**
  * Commerce → Autopilot (Phase 0). The engine's cockpit: the approvals queue
@@ -31,7 +32,12 @@ export function CommerceAutopilot() {
           <CommerceNeedsYou />
         </section>
 
-        {/* Autonomy board (consent dial) lands in P0.8b. */}
+        <section aria-labelledby="autonomy-heading" className="mt-8">
+          <h2 id="autonomy-heading" className="sr-only">
+            Autonomy
+          </h2>
+          <AutonomyBoard />
+        </section>
       </div>
     </FeatureGate>
   );

--- a/src/components/commerce/autopilot.tsx
+++ b/src/components/commerce/autopilot.tsx
@@ -1,44 +1,70 @@
 "use client";
 
+import { Store } from "lucide-react";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { EmptyState } from "@/components/molecules/empty-state";
 import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
 import { AutonomyBoard } from "@/components/commerce/autonomy-board";
+import { useCommerceSummary } from "@/hooks/use-commerce-summary";
 
 /**
  * Commerce → Autopilot (Phase 0). The engine's cockpit: the approvals queue
- * (what needs your go-ahead) and — in P0.8b — the autonomy board (the consent
- * dial per agent × channel).
- *
- * P0.8a ships the page shell + the approvals section, reusing the same
- * CommerceNeedsYou rail as the Command Center (single source of the pending-
- * proposal list). Gated on `commerce.autopilot`.
+ * (what needs your go-ahead) and the autonomy board (the consent dial per
+ * agent × channel). Reuses the same CommerceNeedsYou rail as the Command Center.
+ * Gated on `commerce.autopilot`.
  */
 export function CommerceAutopilot() {
   return (
     <FeatureGate feature="commerce.autopilot" featureName="Commerce Autopilot">
-      <div className="mx-auto max-w-5xl px-4 py-8">
-        <header className="mb-6">
-          <h1 className="text-xl font-semibold">Autopilot</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Approve what the engine proposes and set how much it can do on its
-            own — channel by channel, at a pace you&apos;re comfortable with.
-          </p>
-        </header>
-
-        <section aria-labelledby="approvals-heading">
-          <h2 id="approvals-heading" className="mb-2 text-sm font-medium text-muted-foreground">
-            Approvals
-          </h2>
-          <CommerceNeedsYou />
-        </section>
-
-        <section aria-labelledby="autonomy-heading" className="mt-8">
-          <h2 id="autonomy-heading" className="sr-only">
-            Autonomy
-          </h2>
-          <AutonomyBoard />
-        </section>
-      </div>
+      <CommerceAutopilotBody />
     </FeatureGate>
+  );
+}
+
+function CommerceAutopilotBody() {
+  // commerce.autopilot is granted by plan, not by store connection — so a
+  // pre-connect merchant can reach here. The summary query 4xxs when no store
+  // is connected; use that as the connect signal (shared cache with Command
+  // Center, so no extra fetch when navigating from there).
+  const { isError: noStore } = useCommerceSummary();
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-xl font-semibold">Autopilot</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Approve what the engine proposes and set how much it can do on its
+          own — channel by channel, at a pace you&apos;re comfortable with.
+        </p>
+      </header>
+
+      {noStore ? (
+        <EmptyState
+          icon={Store}
+          title="Connect a store to get started"
+          description="Autopilot lights up once a Shopify or WooCommerce store is connected to this business."
+          action={{ label: "Connect a store", href: "/dashboard/integrations" }}
+        />
+      ) : (
+        <>
+          <section aria-labelledby="approvals-heading">
+            <h2
+              id="approvals-heading"
+              className="mb-2 text-sm font-medium text-muted-foreground"
+            >
+              Approvals
+            </h2>
+            <CommerceNeedsYou />
+          </section>
+
+          <section aria-labelledby="autonomy-heading" className="mt-8">
+            <h2 id="autonomy-heading" className="sr-only">
+              Autonomy
+            </h2>
+            <AutonomyBoard />
+          </section>
+        </>
+      )}
+    </div>
   );
 }

--- a/src/components/commerce/consent-dial.tsx
+++ b/src/components/commerce/consent-dial.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { AutonomyLevel } from "@/hooks/use-commerce-autonomy";
+
+/**
+ * The consent dial — a 4-step control (L0 Observe → L3 Autonomous) for one
+ * agent×channel. Built on the shadcn ToggleGroup (single-select); deselection
+ * is ignored so the dial always holds a level.
+ */
+export const AUTONOMY_LEVEL_META: {
+  value: AutonomyLevel;
+  label: string;
+  short: string;
+  hint: string;
+}[] = [
+  { value: "observe", label: "Observe", short: "L0", hint: "Watches and surfaces insight only." },
+  { value: "recommend", label: "Recommend", short: "L1", hint: "Proposes actions for your approval." },
+  { value: "approve", label: "Approve", short: "L2", hint: "Stages actions; one tap to ship." },
+  { value: "autonomous", label: "Autonomous", short: "L3", hint: "Acts within guardrails; reversible." },
+];
+
+export function ConsentDial({
+  level,
+  onChange,
+  disabled,
+}: {
+  level: AutonomyLevel;
+  onChange: (level: AutonomyLevel) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <ToggleGroup
+      type="single"
+      variant="outline"
+      size="sm"
+      value={level}
+      disabled={disabled}
+      onValueChange={(v) => {
+        // ToggleGroup emits "" when the active item is re-clicked — ignore it
+        // so the dial can't be emptied.
+        if (v) onChange(v as AutonomyLevel);
+      }}
+      className="flex-wrap justify-start"
+    >
+      {AUTONOMY_LEVEL_META.map((m) => (
+        <ToggleGroupItem
+          key={m.value}
+          value={m.value}
+          aria-label={`${m.label} — ${m.hint}`}
+          className="px-3"
+        >
+          {m.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}

--- a/src/hooks/use-commerce-autonomy.ts
+++ b/src/hooks/use-commerce-autonomy.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Commerce consent dial (GET/PUT /v1/commerce/autonomy, api#834). The board is
+ * the full agent roster for the connected store's channel; setting a level is
+ * optimistic (the dial moves immediately, rolls back on error).
+ */
+
+export type AutonomyLevel = "observe" | "recommend" | "approve" | "autonomous";
+
+export interface AutonomyGuardrails {
+  maxDiscountPct?: number;
+  maxSpendMinor?: number;
+  maxActionsPerDay?: number;
+  reversibilityWindowHours?: number;
+  businessHoursOnly?: boolean;
+}
+
+export interface AutonomyConfidence {
+  score: number;
+  sampleSize: number;
+  updatedAt: string;
+}
+
+export interface AutonomyEntry {
+  agent: string;
+  channel: string;
+  level: AutonomyLevel;
+  guardrails: AutonomyGuardrails | null;
+  confidence: AutonomyConfidence | null;
+}
+
+export interface AutonomyBoard {
+  channel: string;
+  agents: AutonomyEntry[];
+}
+
+const AUTONOMY_KEY = "commerce-autonomy";
+
+export function useCommerceAutonomy() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<AutonomyBoard>({
+    queryKey: [AUTONOMY_KEY, org?._id ?? null],
+    queryFn: () => api.get<AutonomyBoard>("/v1/commerce/autonomy"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+export function useSetAutonomy() {
+  const qc = useQueryClient();
+  const { org } = useAuth();
+  const key = [AUTONOMY_KEY, org?._id ?? null];
+
+  return useMutation({
+    mutationFn: ({
+      agent,
+      channel,
+      level,
+    }: {
+      agent: string;
+      channel: string;
+      level: AutonomyLevel;
+    }) => api.put<AutonomyEntry>("/v1/commerce/autonomy", { agent, channel, level }),
+    // Optimistically move the dial for this agent.
+    onMutate: async ({ agent, level }) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<AutonomyBoard>(key);
+      if (prev) {
+        qc.setQueryData<AutonomyBoard>(key, {
+          ...prev,
+          agents: prev.agents.map((a) => (a.agent === agent ? { ...a, level } : a)),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: key });
+    },
+  });
+}


### PR DESCRIPTION
## P0.8b — The consent dial (b2c)

The flagship **autonomy control**, completing the Autopilot cockpit. Per **agent × channel**, a 4-step dial (**Observe → Recommend → Approve → Autonomous**) wired to `GET/PUT /v1/commerce/autonomy` (api#834).

### What lands
- **`use-commerce-autonomy`** hook — board query + **optimistic** level set (dial moves immediately, rolls back on error).
- **`ConsentDial`** — built on the shadcn **`ToggleGroup`** (reuse over hand-roll); single-select, deselection ignored so the dial always holds a level; per-item `aria-label` with the level hint.
- **`AutonomyBoard`** — the agent roster with description, a **confidence meter** (`Progress`; reads "not yet measured" until the P1.9 loop writes it — the substrate for future graduation invites), the active level's hint, and a **row-scoped busy** state during a set. Default **Recommend**; copy states autonomy is earned and reversible.
- Mounted below **Approvals** on the Autopilot page.

### Composition-first
`ToggleGroup`, `Card`, `Progress`, `Skeleton` — no new primitives.

### Verification
- `eslint` clean; `tsc --noEmit` clean.
- Board renders the roster at Recommend; changing the dial PUTs and persists; confidence shows "not yet measured" until P1.9.

Part of the approved Commerce build plan (Phase 0) — completes the Autopilot cockpit.