### PR TITLE
feat(commerce): Catalog & Listings page (P1.7)

### DIFF
--- a/src/app/(site)/dashboard/commerce/catalog/page.tsx
+++ b/src/app/(site)/dashboard/commerce/catalog/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { CommerceCatalog } from "@/components/commerce/catalog";
+
+export const metadata: Metadata = {
+  title: "Catalog · Commerce",
+};
+
+/**
+ * Commerce → Catalog & Listings. Canonical products with per-listing quality
+ * health, a health-band filter, and a per-product drawer. Gated on
+ * `commerce.nav` inside the component.
+ */
+export default function CommerceCatalogPage() {
+  return <CommerceCatalog />;
+}

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -149,6 +149,7 @@ const NAV_GROUPS: NavGroup[] = [
           { href: "/dashboard/commerce", label: "Command Center" },
           { href: "/dashboard/commerce/channels", label: "Channels" },
           { href: "/dashboard/commerce/autopilot", label: "Autopilot" },
+          { href: "/dashboard/commerce/catalog", label: "Catalog" },
           { href: "/dashboard/commerce/assistant", label: "Assistant" },
           { href: "/dashboard/commerce/inventory", label: "Inventory" },
         ],

--- a/src/components/commerce/catalog.tsx
+++ b/src/components/commerce/catalog.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { PackageSearch, Store } from "lucide-react";
+import { DataTable } from "@/components/molecules/data-table";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { useLocale } from "@/hooks/use-locale";
+import { minorToMajor } from "@/lib/money";
+import {
+  useCommerceCatalog,
+  LISTING_ISSUE_LABEL,
+  type CatalogItem,
+} from "@/hooks/use-commerce-catalog";
+
+/**
+ * Commerce → Catalog & Listings (Phase 0/1). The canonical catalog with a
+ * per-listing quality score (api#837). A health-band filter narrows the list; a
+ * row opens a drawer showing the product's issues and the "fix listing" intent
+ * (the Merchandiser agent, wired in Phase 2). Gated on `commerce.nav`.
+ */
+
+const HEALTHY_THRESHOLD = 0.75;
+
+function healthBand(score: number): "healthy" | "needs_work" {
+  return score >= HEALTHY_THRESHOLD ? "healthy" : "needs_work";
+}
+
+export function CommerceCatalog() {
+  return (
+    <FeatureGate feature="commerce.nav" featureName="Commerce">
+      <CatalogBody />
+    </FeatureGate>
+  );
+}
+
+type BandFilter = "all" | "needs_work" | "healthy";
+
+function CatalogBody() {
+  const { data, isLoading, isError } = useCommerceCatalog();
+  const { formatNumber } = useLocale();
+  const [band, setBand] = useState<BandFilter>("all");
+  const [selected, setSelected] = useState<CatalogItem | null>(null);
+
+  const money = useCallback(
+    (minor: number | null, currency: string | null) => {
+      if (minor === null) return "—";
+      const cur = currency ?? "USD";
+      return formatNumber(minorToMajor(minor, cur), {
+        style: "currency",
+        currency: cur,
+        maximumFractionDigits: 0,
+      });
+    },
+    [formatNumber],
+  );
+
+  const columns = useMemo<ColumnDef<CatalogItem>[]>(
+    () => [
+      {
+        accessorKey: "title",
+        header: "Product",
+        cell: ({ row }) => {
+          const item = row.original;
+          return (
+            <div className="flex items-center gap-3">
+              {item.imageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={item.imageUrl}
+                  alt=""
+                  className="size-9 shrink-0 rounded-md object-cover"
+                />
+              ) : (
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted">
+                  <PackageSearch className="size-4 text-muted-foreground" />
+                </div>
+              )}
+              <span className="line-clamp-1 font-medium">{item.title || "Untitled product"}</span>
+            </div>
+          );
+        },
+      },
+      {
+        id: "health",
+        header: "Listing health",
+        cell: ({ row }) => {
+          const { qualityScore, issues } = row.original.health;
+          const pct = Math.round(qualityScore * 100);
+          const good = healthBand(qualityScore) === "healthy";
+          return (
+            <div className="flex items-center gap-2">
+              <Badge variant={good ? "secondary" : "outline"} className="tabular-nums">
+                {pct}%
+              </Badge>
+              {issues.length > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  {issues.length} issue{issues.length === 1 ? "" : "s"}
+                </span>
+              )}
+            </div>
+          );
+        },
+      },
+      {
+        id: "price",
+        header: () => <div className="text-right">Price</div>,
+        cell: ({ row }) => (
+          <div className="text-right tabular-nums">
+            {money(row.original.priceMinor, row.original.currency)}
+          </div>
+        ),
+      },
+    ],
+    [money],
+  );
+
+  const filtered = useMemo(() => {
+    const items = data?.items ?? [];
+    if (band === "all") return items;
+    return items.filter((i) => healthBand(i.health.qualityScore) === band);
+  }, [data, band]);
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        <Header />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        <Header />
+        <EmptyState
+          icon={Store}
+          title="Connect a store to see your catalog"
+          description="Catalog & Listings lights up once a Shopify or WooCommerce store is connected to this business."
+          action={{ label: "Connect a store", href: "/dashboard/integrations" }}
+        />
+      </div>
+    );
+  }
+
+  const needsWork = data.items.filter((i) => healthBand(i.health.qualityScore) === "needs_work").length;
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <Header />
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <FilterPill active={band === "all"} onClick={() => setBand("all")}>
+          All ({data.total})
+        </FilterPill>
+        <FilterPill active={band === "needs_work"} onClick={() => setBand("needs_work")}>
+          Needs work ({needsWork})
+        </FilterPill>
+        <FilterPill active={band === "healthy"} onClick={() => setBand("healthy")}>
+          Healthy ({data.items.length - needsWork})
+        </FilterPill>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={filtered}
+        onRowClick={(row) => setSelected(row)}
+        emptyMessage="No products in this view."
+      />
+
+      <ListingDrawer item={selected} money={money} onClose={() => setSelected(null)} />
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="mb-6">
+      <h1 className="text-xl font-semibold">Catalog &amp; Listings</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Your products and how well each one is listed. Fix the weak spots to sell
+        more — Peakhour&apos;s Merchandiser can do it for you.
+      </p>
+    </header>
+  );
+}
+
+function FilterPill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button variant={active ? "default" : "outline"} size="sm" onClick={onClick}>
+      {children}
+    </Button>
+  );
+}
+
+function ListingDrawer({
+  item,
+  money,
+  onClose,
+}: {
+  item: CatalogItem | null;
+  money: (minor: number | null, currency: string | null) => string;
+  onClose: () => void;
+}) {
+  return (
+    <Sheet open={item !== null} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent className="w-full sm:max-w-md">
+        {item && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="line-clamp-2">{item.title || "Untitled product"}</SheetTitle>
+              <SheetDescription>
+                {money(item.priceMinor, item.currency)} · {item.channel}
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="space-y-4 px-4">
+              {item.imageUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={item.imageUrl}
+                  alt=""
+                  className="aspect-square w-full rounded-lg object-cover"
+                />
+              )}
+
+              <div>
+                <p className="text-sm font-medium">
+                  Listing health — {Math.round(item.health.qualityScore * 100)}%
+                </p>
+                {item.health.issues.length === 0 ? (
+                  <p className="mt-1 text-sm text-emerald-600 dark:text-emerald-400">
+                    This listing looks great.
+                  </p>
+                ) : (
+                  <ul className="mt-2 space-y-1">
+                    {item.health.issues.map((issue) => (
+                      <li key={issue} className="text-sm text-muted-foreground">
+                        • {LISTING_ISSUE_LABEL[issue] ?? issue}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <Button className="w-full" disabled>
+                Fix with Merchandiser — coming soon
+              </Button>
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/commerce/catalog.tsx
+++ b/src/components/commerce/catalog.tsx
@@ -155,7 +155,11 @@ function CatalogBody() {
     );
   }
 
+  const loaded = data.items.length;
   const needsWork = data.items.filter((i) => healthBand(i.health.qualityScore) === "needs_work").length;
+  // Counts are over the LOADED set (a single page), so they always reconcile;
+  // surface the cap explicitly when the store has more than we fetched.
+  const capped = data.total > loaded;
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
@@ -163,15 +167,21 @@ function CatalogBody() {
 
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <FilterPill active={band === "all"} onClick={() => setBand("all")}>
-          All ({data.total})
+          All ({loaded})
         </FilterPill>
         <FilterPill active={band === "needs_work"} onClick={() => setBand("needs_work")}>
           Needs work ({needsWork})
         </FilterPill>
         <FilterPill active={band === "healthy"} onClick={() => setBand("healthy")}>
-          Healthy ({data.items.length - needsWork})
+          Healthy ({loaded - needsWork})
         </FilterPill>
       </div>
+
+      {capped && (
+        <p className="mb-3 text-xs text-muted-foreground">
+          Showing the first {loaded} of {data.total} products.
+        </p>
+      )}
 
       <DataTable
         columns={columns}

--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
 import { useLocale } from "@/hooks/use-locale";
+import { minorToMajor } from "@/lib/money";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
 
 /**
@@ -36,26 +37,13 @@ export function CommandCenter() {
   );
 }
 
-/** A currency's minor-unit exponent (2 for USD/INR, 0 for JPY, 3 for KWD). */
-function minorUnitExponent(currency: string): number {
-  try {
-    return (
-      new Intl.NumberFormat("en", { style: "currency", currency }).resolvedOptions()
-        .maximumFractionDigits ?? 2
-    );
-  } catch {
-    return 2; // unknown/invalid currency code → assume 2-decimal
-  }
-}
-
 function CommandCenterBody() {
   const { data, isLoading, isError } = useCommerceSummary();
   const { formatNumber } = useLocale();
 
   const money = (minor: number, currency: string | null) => {
     const cur = currency ?? "USD";
-    const major = minor / 10 ** minorUnitExponent(cur);
-    return formatNumber(major, {
+    return formatNumber(minorToMajor(minor, cur), {
       style: "currency",
       currency: cur,
       maximumFractionDigits: 0,

--- a/src/hooks/use-commerce-catalog.ts
+++ b/src/hooks/use-commerce-catalog.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Commerce catalog + per-listing health (GET /v1/commerce/catalog, api#837).
+ * Backs the Catalog & Listings page.
+ */
+
+export interface ListingHealth {
+  qualityScore: number;
+  issues: string[];
+}
+
+export interface CatalogItem {
+  productId: string;
+  title: string;
+  imageUrl: string | null;
+  priceMinor: number | null;
+  currency: string | null;
+  status: string;
+  channel: string;
+  health: ListingHealth;
+}
+
+export interface CatalogPage {
+  channel: string;
+  items: CatalogItem[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+const CATALOG_KEY = "commerce-catalog";
+
+export function useCommerceCatalog(page = 1, limit = 100) {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<CatalogPage>({
+    queryKey: [CATALOG_KEY, org?._id ?? null, page, limit],
+    queryFn: () => api.get<CatalogPage>(`/v1/commerce/catalog?page=${page}&limit=${limit}`),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
+/** Human-readable label for a machine-readable listing issue. */
+export const LISTING_ISSUE_LABEL: Record<string, string> = {
+  short_title: "Title too short",
+  missing_images: "No images",
+  thin_description: "Description too thin",
+  no_price: "No price set",
+};

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,22 @@
+/**
+ * Minor-unit money helpers. Amounts from the Commerce API are integer minor
+ * units of a store currency; the exponent varies (2 for USD/INR, 0 for JPY, 3
+ * for KWD), so never assume ÷100.
+ */
+
+/** A currency's minor-unit exponent, derived from Intl (2 if unknown/invalid). */
+export function minorUnitExponent(currency: string): number {
+  try {
+    return (
+      new Intl.NumberFormat("en", { style: "currency", currency }).resolvedOptions()
+        .maximumFractionDigits ?? 2
+    );
+  } catch {
+    return 2;
+  }
+}
+
+/** Convert integer minor units to a major-unit number for `currency`. */
+export function minorToMajor(minor: number, currency: string): number {
+  return minor / 10 ** minorUnitExponent(currency);
+}


### PR DESCRIPTION
## P1.7 — Catalog & Listings (b2c)

The canonical catalog with a **per-listing quality score** (api#837).

### What lands
- **`DataTable`** (molecule) over products — columns: product (image + title), listing health (score badge + issue count), price.
- **Health-band filter** — All / Needs work / Healthy (client-side over the fetched page; the table molecule owns its own state so a lightweight band control is cleaner than wiring a faceted filter into its internal table).
- **Row → drawer** (`Sheet`) showing the product image, its issues in plain language (`LISTING_ISSUE_LABEL`), and the **"Fix with Merchandiser"** intent (disabled — the agent lands in Phase 2).
- No-store → connect `EmptyState`; loading → skeleton. Gated on `commerce.nav`.

### Reuse / cleanup
- Extracted **`src/lib/money.ts`** (`minorUnitExponent` + `minorToMajor`) and adopted it in the **Command Center** too — removes the duplicated currency-exponent helper (one source now).
- Reuses `DataTable`, `EmptyState`, `Sheet`, `Badge`, `Skeleton`, `useLocale`.
- Adds the **Catalog** nav sub-item.

### Verification
- `eslint` clean (columns/`money` memoised so the React compiler doesn't skip); `tsc --noEmit` clean.

Part of the approved Commerce build plan (Phase 1).