### PR TITLE
feat(commerce): render real GMV in the Sales-from-orders tile (P1.8b)

### DIFF
--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -103,11 +103,17 @@ function CommandCenterBody() {
           />
           <KpiCard
             title="Sales from orders"
-            value={data.orderDerived.switchingOn ? "Switching on" : "Connected"}
+            value={
+              data.orderDerived.switchingOn
+                ? "Switching on"
+                : money(data.orderDerived.gmvMinor, data.store.currency)
+            }
             description={
               data.orderDerived.switchingOn
                 ? "Connect order access to see GMV, AOV & sell-through"
-                : "Order-based revenue is being wired into your reports"
+                : `${data.orderDerived.orderCount} order${
+                    data.orderDerived.orderCount === 1 ? "" : "s"
+                  } · AOV ${money(data.orderDerived.aovMinor, data.store.currency)} (${data.orderDerived.windowDays}d)`
             }
             icon={Receipt}
           />

--- a/src/hooks/use-commerce-summary.ts
+++ b/src/hooks/use-commerce-summary.ts
@@ -27,7 +27,14 @@ export interface CommerceSummary {
   assistedOrders: { revenueMinor: number; count: number };
   storefront: { impressions: number; clicks: number; addToCart: number };
   pendingApprovals: number;
-  orderDerived: { switchingOn: boolean };
+  orderDerived: {
+    switchingOn: boolean;
+    windowDays: number;
+    /** GMV over the window in minor units of the store currency (0 while switching on). */
+    gmvMinor: number;
+    orderCount: number;
+    aovMinor: number;
+  };
   entitlements: { commerceAssistant: boolean };
 }
 


### PR DESCRIPTION
## P1.8b — GMV tile (b2c)

The Command Center **"Sales from orders"** tile now shows **real GMV + order count + AOV** (from api#838) when order access is live — **WooCommerce today; Shopify after the post-cert `read_orders` escalation** — and keeps the honest **"Switching on"** state until then.

- `use-commerce-summary` `orderDerived` type extended (`windowDays`, `gmvMinor`, `orderCount`, `aovMinor`).
- Tile value = GMV (store-currency, via `money`), description = "N orders · AOV X (30d)".

`eslint` + `tsc` clean. Part of the approved Commerce build plan (Phase 1) — completes P1.8.