### PR TITLE
feat(commerce): "What Peakhour did" activity digest (P1.9b)

### DIFF
--- a/src/components/commerce/activity-digest.tsx
+++ b/src/components/commerce/activity-digest.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useLocale } from "@/hooks/use-locale";
+import { agentLabel } from "@/lib/commerce-agents";
+import { useCommerceActivity, type ActivityItem } from "@/hooks/use-commerce-activity";
+
+/**
+ * Command Center "What Peakhour did" digest — the recent ledger feed (api#839).
+ * The honest activity trail: which agent did what, when. Self-contained; hides
+ * on error (no store) and shows an all-quiet state when empty.
+ */
+
+/** Past-tense verb + badge tone per ledger status. */
+const STATUS_META: Record<string, { verb: string; tone: "secondary" | "outline" }> = {
+  approved: { verb: "approved", tone: "secondary" },
+  executed: { verb: "shipped", tone: "secondary" },
+  rejected: { verb: "dismissed", tone: "outline" },
+  reverted: { verb: "reverted", tone: "outline" },
+  proposed: { verb: "proposed", tone: "outline" },
+  executing: { verb: "running", tone: "secondary" },
+  failed: { verb: "failed", tone: "outline" },
+};
+
+export function ActivityDigest() {
+  const { data, isLoading, isError } = useCommerceActivity();
+
+  if (isError) return null;
+
+  const items = data?.items ?? [];
+
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      <CardHeader className="flex flex-row items-center gap-2 border-b bg-muted/30 px-4 py-3">
+        <Sparkles className="size-4 text-muted-foreground" />
+        <CardTitle className="text-base">What Peakhour did</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {isLoading ? (
+          <div className="divide-y">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="px-4 py-3">
+                <Skeleton className="h-4 w-3/4" />
+              </div>
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No activity yet. As you approve proposals, the engine&apos;s work shows up here.
+          </p>
+        ) : (
+          <ul className="divide-y">
+            {items.map((item) => (
+              <ActivityRow key={item.id} item={item} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ActivityRow({ item }: { item: ActivityItem }) {
+  const { formatRelativeTime } = useLocale();
+  const meta = STATUS_META[item.status] ?? { verb: item.status, tone: "outline" as const };
+
+  return (
+    <li className="flex items-start justify-between gap-3 px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm">
+          <span className="font-medium">{agentLabel(item.agent)}</span>{" "}
+          <span className="text-muted-foreground">— {item.title}</span>
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{formatRelativeTime(item.at)}</p>
+      </div>
+      <Badge variant={meta.tone} className="shrink-0">
+        {meta.verb}
+      </Badge>
+    </li>
+  );
+}

--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -14,6 +14,7 @@ import { EmptyState } from "@/components/molecules/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
+import { ActivityDigest } from "@/components/commerce/activity-digest";
 import { useLocale } from "@/hooks/use-locale";
 import { minorToMajor } from "@/lib/money";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
@@ -127,8 +128,9 @@ function CommandCenterBody() {
       )}
 
       {data && !isLoading && (
-        <div className="mt-6">
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
           <CommerceNeedsYou />
+          <ActivityDigest />
         </div>
       )}
     </div>

--- a/src/hooks/use-commerce-activity.ts
+++ b/src/hooks/use-commerce-activity.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Commerce "engine did this" activity — recent agent actions from the ledger
+ * (GET /v1/commerce/activity, api#839). Backs the Command Center digest.
+ */
+
+export interface ActivityItem {
+  id: string;
+  agent: string;
+  title: string;
+  status: string;
+  sourceType: string | null;
+  prediction: {
+    metric: string;
+    value?: number;
+    valueMinor?: number;
+    currency?: string;
+    confidence?: number;
+  } | null;
+  /** ISO timestamp of the decision/creation. */
+  at: string;
+}
+
+interface ActivityResponse {
+  items: ActivityItem[];
+}
+
+const ACTIVITY_KEY = "commerce-activity";
+
+export function useCommerceActivity(limit = 8) {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<ActivityResponse>({
+    queryKey: [ACTIVITY_KEY, org?._id ?? null, limit],
+    queryFn: () => api.get<ActivityResponse>(`/v1/commerce/activity?limit=${limit}`),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/src/lib/commerce-agents.ts
+++ b/src/lib/commerce-agents.ts
@@ -1,0 +1,14 @@
+/** Display name for each Commerce agent key (shared across Commerce surfaces). */
+export const AGENT_LABEL: Record<string, string> = {
+  merchandiser: "Merchandiser",
+  pricer: "Pricer",
+  replenisher: "Replenisher",
+  concierge: "Concierge",
+  reputation: "Reputation",
+  forecaster: "Forecaster",
+};
+
+/** Friendly name for an agent key, falling back to the raw key. */
+export function agentLabel(agent: string): string {
+  return AGENT_LABEL[agent] ?? agent;
+}


### PR DESCRIPTION
## P1.9b — Activity digest (b2c) · completes Phase 1

The honest **"engine did this"** feed on the Command Center, reading the actions ledger (`GET /v1/commerce/activity`, api#839). Completes the **P0.5b deferral** — the digest needed the `cmrc_actions` ledger to be truthful.

- **`use-commerce-activity`** hook + shared **`src/lib/commerce-agents.ts`** (`agentLabel`).
- **`ActivityDigest`** card — each row: agent + action title + per-status past-tense verb badge (approved→"approved", executed→"shipped", rejected→"dismissed", …) + relative time. All-quiet empty state; hides when no store.
- Placed beside the NeedsYou rail in a 2-col grid on the Command Center.

Composition-first (Card, Badge, Skeleton, useLocale). `eslint` + `tsc` clean.

**This completes Phase 1** — the canonical channel spine, `cmrc_listings`, the `cmrc_actions` ledger (now emitting + measured for confidence), Catalog & Listings, order-shaped GMV, and the confidence loop + digest. Part of the approved Commerce build plan.