### PR TITLE
feat(commerce): Inventory & Supply — restock plan matrix + inline intents (P2.3)

### DIFF
--- a/src/app/(site)/dashboard/commerce/inventory/page.tsx
+++ b/src/app/(site)/dashboard/commerce/inventory/page.tsx
@@ -1,28 +1,35 @@
 import type { Metadata } from "next";
 import { InventoryPanel } from "@/components/commerce/inventory-panel";
+import { ReplenisherPanel } from "@/components/commerce/replenisher-panel";
 
 export const metadata: Metadata = {
-  title: "Inventory · Commerce",
+  title: "Inventory & Supply · Commerce",
 };
 
 /**
- * Commerce → Inventory intelligence (WS3). Stock-health breakdown
- * (Healthy / Watchlist / Slow / At-risk) over the connected store's catalog +
- * recent sell-through, with a Peaks-metered AI "recommended actions" diagnosis.
- * Platform-agnostic — the same view serves Shopify and WooCommerce stores.
+ * Commerce → Inventory & Supply (WS3 + P2.3). Two halves over the connected
+ * store's catalog + recent sell-through, platform-agnostic (Shopify + Woo):
+ *   • Inventory health — Healthy / Watchlist / Slow / At-risk breakdown with a
+ *     Peaks-metered AI "recommended actions" diagnosis.
+ *   • Restock plan — the Replenisher's per-location SKU × location restock plan
+ *     (days of cover, suggested quantity, revenue-at-risk) with inline restock
+ *     intents and a Peaks-metered AI restock brief.
  */
 export default function CommerceInventoryPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">
       <header className="mb-6">
-        <h1 className="text-xl font-semibold">Inventory intelligence</h1>
+        <h1 className="text-xl font-semibold">Inventory &amp; Supply</h1>
         <p className="mt-1 text-sm text-neutral-500">
           See which products are at risk of stocking out, which are tying up
-          capital, and what to do about it — graded from your live stock and the
-          last 30 days of sales.
+          capital, and exactly what to reorder — graded from your live stock and
+          the last 30 days of sales.
         </p>
       </header>
-      <InventoryPanel />
+      <div className="space-y-10">
+        <InventoryPanel />
+        <ReplenisherPanel />
+      </div>
     </div>
   );
 }

--- a/src/components/commerce/replenisher-panel.tsx
+++ b/src/components/commerce/replenisher-panel.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  Loader2,
+  Sparkles,
+  PackagePlus,
+  Warehouse,
+  Check,
+  TriangleAlert,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { useLocale } from "@/hooks/use-locale";
+import { minorToMajor } from "@/lib/money";
+import {
+  useReplenisher,
+  useReplenisherBrief,
+  useProposeRestock,
+  type RestockCandidate,
+} from "@/hooks/use-commerce-replenisher";
+
+/**
+ * Commerce → Inventory & Supply, restock half (P2.3). Renders the Replenisher's
+ * per-location restock plan as a SKU × location table (current stock, days of
+ * cover, suggested restock quantity, projected revenue-at-risk) with an inline
+ * "Propose restock" intent per row, plus a Peaks-metered AI restock brief.
+ * Degrades honestly when no store / nothing to restock.
+ */
+export function ReplenisherPanel() {
+  const { data, isLoading, isError, error } = useReplenisher();
+  const brief = useReplenisherBrief();
+  const propose = useProposeRestock();
+  const { formatNumber } = useLocale();
+  const [proposed, setProposed] = useState<Set<string>>(new Set());
+
+  const money = useCallback(
+    (minor: number | null, currency: string | null) => {
+      if (minor === null) return null;
+      const cur = currency ?? "USD";
+      return formatNumber(minorToMajor(minor, cur), {
+        style: "currency",
+        currency: cur,
+        maximumFractionDigits: 0,
+      });
+    },
+    [formatNumber],
+  );
+
+  const onPropose = useCallback(
+    (c: RestockCandidate) => {
+      propose.mutate(c.sourceProductId, {
+        onSuccess: () => {
+          setProposed((prev) => new Set(prev).add(c.sourceProductId));
+          toast.success("Restock proposed", {
+            description: `${c.title || "Product"} — the Replenisher logged the intent.`,
+          });
+        },
+        onError: () =>
+          toast.error("Couldn't propose restock", { description: "Please try again shortly." }),
+      });
+    },
+    [propose],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="mr-2 size-5 animate-spin" /> Loading restock plan…
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          {(error as { code?: string })?.code === "NO_STORE_CONNECTED"
+            ? "Connect a store to see your restock plan."
+            : "The restock plan is unavailable right now. Please try again shortly."}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { candidates, locations } = data;
+  const briefText = brief.data?.brief;
+
+  return (
+    <div className="space-y-6">
+      {/* Locations context */}
+      {locations.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-muted-foreground">Locations:</span>
+          {locations.map((l) => (
+            <Badge key={l.id} variant="outline" className="gap-1 font-normal">
+              <Warehouse className="size-3" />
+              {l.name || "Unnamed"}
+              {l.isDefault && <span className="text-muted-foreground">· default</span>}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* AI restock brief */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-2">
+          <CardTitle className="text-base">Restock brief</CardTitle>
+          <Button size="sm" onClick={() => brief.mutate()} disabled={brief.isPending || candidates.length === 0}>
+            {brief.isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" /> Writing…
+              </>
+            ) : (
+              <>
+                <Sparkles className="mr-2 size-4" /> Get restock brief
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {brief.isError ? (
+            <p className="text-sm text-muted-foreground">
+              {(brief.error as { message?: string })?.message ||
+                "Couldn't generate the brief. Please try again."}
+            </p>
+          ) : briefText ? (
+            <p className="whitespace-pre-wrap text-sm">{briefText}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              A prioritised, plain-language restock plan — what to reorder this week and roughly
+              how much. Uses Peaks.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Restock plan — SKU × location */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Restock plan</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {candidates.length === 0 ? (
+            <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+              {data.scanned
+                ? "Nothing needs restocking right now — no at-risk product has recent demand outrunning its stock."
+                : "No products have synced yet. Your restock plan appears once your catalog and recent orders sync."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs text-muted-foreground">
+                    <th className="px-4 py-2 font-medium">Product</th>
+                    <th className="px-4 py-2 font-medium">Location</th>
+                    <th className="px-4 py-2 text-right font-medium">In stock</th>
+                    <th className="px-4 py-2 text-right font-medium">Cover</th>
+                    <th className="px-4 py-2 text-right font-medium">Restock</th>
+                    <th className="px-4 py-2 text-right font-medium">At risk</th>
+                    <th className="px-4 py-2" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {candidates.map((c) => {
+                    const risk = money(c.lostSalesAvoidedMinor, c.currency);
+                    const isDone = proposed.has(c.sourceProductId);
+                    const isBusy = propose.isPending && propose.variables === c.sourceProductId;
+                    const stockLabel =
+                      c.locationStock !== null ? `${c.locationStock}` : `${c.currentStock}`;
+                    return (
+                      <tr key={c.sourceProductId} className="align-middle">
+                        <td className="max-w-[16rem] px-4 py-3">
+                          <p className="line-clamp-1 font-medium">{c.title || "Untitled product"}</p>
+                          <p className="text-xs text-muted-foreground">{c.unitsSold} sold · {c.dailyVelocity}/day</p>
+                        </td>
+                        <td className="px-4 py-3">
+                          {c.locationName ? (
+                            <span className="inline-flex items-center gap-1 text-muted-foreground">
+                              <Warehouse className="size-3" />
+                              {c.locationName}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums">{stockLabel}</td>
+                        <td className="px-4 py-3 text-right tabular-nums">
+                          {c.daysOfCover === null ? (
+                            <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400">
+                              <TriangleAlert className="size-3" /> OOS
+                            </span>
+                          ) : (
+                            `${c.daysOfCover}d`
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right font-medium tabular-nums">
+                          +{c.recommendedRestockQty}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums">{risk ?? "—"}</td>
+                        <td className="px-4 py-3 text-right">
+                          {isDone ? (
+                            <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                              <Check className="size-3" /> Proposed
+                            </span>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => onPropose(c)}
+                              disabled={isBusy}
+                            >
+                              {isBusy ? (
+                                <Loader2 className="size-4 animate-spin" />
+                              ) : (
+                                <>
+                                  <PackagePlus className="mr-1 size-4" /> Propose
+                                </>
+                              )}
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {candidates.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Restock targets {data.targetCoverDays} days of cover; “at risk” is the revenue a
+          stock-out over a {data.leadTimeDays}-day lead window would cost. Proposing logs an
+          intent for the Replenisher — nothing is ordered automatically.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-commerce-activity.ts
+++ b/src/hooks/use-commerce-activity.ts
@@ -30,7 +30,7 @@ interface ActivityResponse {
   items: ActivityItem[];
 }
 
-const ACTIVITY_KEY = "commerce-activity";
+export const ACTIVITY_KEY = "commerce-activity";
 
 export function useCommerceActivity(limit = 8) {
   const { isAuthenticated, org } = useAuth();

--- a/src/hooks/use-commerce-replenisher.ts
+++ b/src/hooks/use-commerce-replenisher.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * Commerce Replenisher hooks (P2.2/P2.3). `useReplenisher` reads the free
+ * per-location restock plan (GET /v1/commerce/replenisher); `useReplenisherBrief`
+ * runs the paid AI restock brief (POST /v1/commerce/replenisher/brief,
+ * Peaks-metered); `useProposeRestock` records a restock intent as a proposed
+ * cmrc_actions row (POST /v1/commerce/replenisher/propose).
+ */
+
+export interface RestockCandidate {
+  productId: string | null;
+  sourceProductId: string;
+  title: string;
+  locationId: string | null;
+  locationName: string | null;
+  currentStock: number;
+  locationStock: number | null;
+  unitsSold: number;
+  dailyVelocity: number;
+  daysOfCover: number | null;
+  recommendedRestockQty: number;
+  lostSalesAvoidedMinor: number | null;
+  currency: string | null;
+  reason: string;
+}
+
+export interface RestockLocation {
+  id: string;
+  name: string;
+  type: string;
+  isDefault: boolean;
+}
+
+export interface RestockPlan {
+  windowDays: number;
+  targetCoverDays: number;
+  leadTimeDays: number;
+  scanned: boolean;
+  truncated: boolean;
+  locations: RestockLocation[];
+  candidates: RestockCandidate[];
+  totalLostSalesAvoidedMinor: number;
+  currency: string | null;
+}
+
+const REPLENISHER_KEY = "commerce-replenisher";
+const ACTIVITY_KEY = "commerce-activity";
+
+export function useReplenisher() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<RestockPlan>({
+    queryKey: [REPLENISHER_KEY, org?._id ?? null],
+    queryFn: () => api.get<RestockPlan>("/v1/commerce/replenisher"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 5 * 60_000,
+    // A missing store / unsynced catalog returns 4xx — don't hammer it.
+    retry: false,
+  });
+}
+
+export interface ReplenisherBrief {
+  plan: RestockPlan;
+  brief: string;
+}
+
+export function useReplenisherBrief() {
+  return useMutation<ReplenisherBrief, Error>({
+    mutationFn: () => api.post<ReplenisherBrief>("/v1/commerce/replenisher/brief", {}),
+  });
+}
+
+export interface ProposeRestockResult {
+  actionId: string | null;
+  candidate: RestockCandidate;
+}
+
+export function useProposeRestock() {
+  const qc = useQueryClient();
+  const { org } = useAuth();
+  return useMutation<ProposeRestockResult, Error, string>({
+    mutationFn: (sourceProductId: string) =>
+      api.post<ProposeRestockResult>("/v1/commerce/replenisher/propose", { sourceProductId }),
+    onSettled: () => {
+      // The proposal shows up in the "engine did this" digest.
+      qc.invalidateQueries({ queryKey: [ACTIVITY_KEY, org?._id ?? null] });
+    },
+  });
+}

--- a/src/hooks/use-commerce-replenisher.ts
+++ b/src/hooks/use-commerce-replenisher.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useAuth } from "@/providers/auth-provider";
+import { ACTIVITY_KEY } from "@/hooks/use-commerce-activity";
 
 /**
  * Commerce Replenisher hooks (P2.2/P2.3). `useReplenisher` reads the free
@@ -49,7 +50,6 @@ export interface RestockPlan {
 }
 
 const REPLENISHER_KEY = "commerce-replenisher";
-const ACTIVITY_KEY = "commerce-activity";
 
 export function useReplenisher() {
   const { isAuthenticated, org } = useAuth();


### PR DESCRIPTION
## What

Phase 2, PR 3. Extends the shipped Inventory surface into **Inventory & Supply**: below the existing stock-health `InventoryPanel`, it renders the Replenisher's **per-location restock plan** (from api P2.2 #840) as a SKU × location table with **inline restock intents**.

## Surface

- **`use-commerce-replenisher.ts`** — three hooks:
  - `useReplenisher` → `GET /v1/commerce/replenisher` (free deterministic plan)
  - `useReplenisherBrief` → `POST /v1/commerce/replenisher/brief` (**Peaks-metered** AI brief)
  - `useProposeRestock` → `POST /v1/commerce/replenisher/propose` (records a `proposed` cmrc_actions intent; invalidates the activity digest so it shows in "what the engine did")
- **`replenisher-panel.tsx`**:
  - **Locations** context chips (warehouse / dark_store / distributor / store; default flagged).
  - **Restock plan** table — Product · Location · In stock · Days of cover (OOS flagged) · suggested Restock qty · revenue **At risk** · inline **Propose** button (per-row busy/done state + sonner toast).
  - **Restock brief** card — the Peaks-metered AI narrative.
  - Honest degradation: `NO_STORE_CONNECTED`, no-candidates, and unsynced-catalog states all handled; **nothing fabricated** when there's no data.
- **Inventory page** renamed **"Inventory & Supply"**, renders `InventoryPanel` then `ReplenisherPanel`.

## Reuse

`money.ts` (`minorToMajor`), `useLocale().formatNumber`, `Card`/`Badge`/`Button`, `sonner` toast, react-query invalidation pattern (mirrors `use-commerce-recommendations`). No new nav item — the **Inventory** sub-item already exists.

## Notes / honesty

- The "matrix" surfaces the per-location dimension the Replenisher resolves (target location per SKU + its stock). A full locations-as-columns grid stays deferred until the per-location inventory sync populates `cmrc_inventory` — rendering an empty grid would mislead. Days-of-cover is the coverage metric; no fabricated fill-rate.
- Proposing logs an **intent** only — nothing is ordered automatically (execution is P2.9).

## Verification (local — b2c has no CI, so local + review is the gate)

- `npx eslint` (new files) ✅
- `npx tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)