### PR TITLE
feat(commerce): kill switch + graduation invites on the autonomy board (P2.9)

### DIFF
--- a/src/components/commerce/autonomy-board.tsx
+++ b/src/components/commerce/autonomy-board.tsx
@@ -1,15 +1,28 @@
 "use client";
 
+import { ArrowUpCircle, ShieldAlert } from "lucide-react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { ConsentDial, AUTONOMY_LEVEL_META } from "@/components/commerce/consent-dial";
 import {
   useCommerceAutonomy,
   useSetAutonomy,
+  useSetKillSwitch,
+  useDismissGraduation,
   type AutonomyEntry,
   type AutonomyLevel,
 } from "@/hooks/use-commerce-autonomy";
+
+const LEVEL_LABEL: Record<AutonomyLevel, string> = {
+  observe: "Observe",
+  recommend: "Recommend",
+  approve: "Approve",
+  autonomous: "Autonomous",
+};
 
 /**
  * Commerce → Autopilot autonomy board (the consent dial per agent × channel).
@@ -31,6 +44,8 @@ const AGENT_META: Record<string, { name: string; description: string }> = {
 export function AutonomyBoard() {
   const { data, isLoading, isError } = useCommerceAutonomy();
   const setAutonomy = useSetAutonomy();
+  const setKillSwitch = useSetKillSwitch();
+  const dismiss = useDismissGraduation();
 
   if (isError) return null;
 
@@ -42,6 +57,37 @@ export function AutonomyBoard() {
           Set how much each agent can do on its own. The default is Recommend —
           autonomy is earned, and every autonomous action stays reversible.
         </p>
+        {data && (
+          <div
+            className={`mt-3 flex items-center justify-between gap-3 rounded-lg border p-3 ${
+              data.killSwitch ? "border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/40" : ""
+            }`}
+          >
+            <div className="flex items-start gap-2">
+              <ShieldAlert className={`mt-0.5 size-4 ${data.killSwitch ? "text-red-600 dark:text-red-400" : "text-muted-foreground"}`} />
+              <div>
+                <p className="text-sm font-medium">Kill switch</p>
+                <p className="text-xs text-muted-foreground">
+                  {data.killSwitch
+                    ? "Execution is halted — no agent can ship. Proposals and drafts still work."
+                    : "Emergency brake. Turn on to halt all agent execution instantly."}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={data.killSwitch}
+              disabled={setKillSwitch.isPending}
+              aria-label="Kill switch"
+              onCheckedChange={(on) =>
+                setKillSwitch.mutate(on, {
+                  onSuccess: () =>
+                    toast.success(on ? "Kill switch on — execution halted" : "Kill switch off"),
+                  onError: () => toast.error("Couldn't update the kill switch"),
+                })
+              }
+            />
+          </div>
+        )}
       </CardHeader>
       <CardContent className="space-y-5">
         {isLoading ? (
@@ -55,6 +101,11 @@ export function AutonomyBoard() {
               onSet={(level) =>
                 setAutonomy.mutate({ agent: agent.agent, channel: data.channel, level })
               }
+              onGraduate={(level) => {
+                setAutonomy.mutate({ agent: agent.agent, channel: data.channel, level });
+                toast.success(`${AGENT_META[agent.agent]?.name ?? agent.agent} raised to ${LEVEL_LABEL[level]}`);
+              }}
+              onDismiss={() => dismiss.mutate({ agent: agent.agent, channel: data.channel })}
             />
           ))
         )}
@@ -67,10 +118,14 @@ function AgentRow({
   entry,
   busy,
   onSet,
+  onGraduate,
+  onDismiss,
 }: {
   entry: AutonomyEntry;
   busy: boolean;
   onSet: (level: AutonomyLevel) => void;
+  onGraduate: (level: AutonomyLevel) => void;
+  onDismiss: () => void;
 }) {
   const meta = AGENT_META[entry.agent] ?? { name: entry.agent, description: "" };
   const hint = AUTONOMY_LEVEL_META.find((m) => m.value === entry.level)?.hint;
@@ -78,27 +133,51 @@ function AgentRow({
   const confidencePct = conf ? Math.round(conf.score * 100) : null;
 
   return (
-    <div className="flex flex-col gap-3 border-b pb-5 last:border-b-0 last:pb-0 sm:flex-row sm:items-start sm:justify-between">
-      <div className="min-w-0">
-        <p className="text-sm font-medium">{meta.name}</p>
-        {meta.description && (
-          <p className="text-xs text-muted-foreground">{meta.description}</p>
-        )}
-        {confidencePct !== null ? (
-          <div className="mt-2 flex items-center gap-2">
-            <Progress value={confidencePct} className="h-1.5 w-24" />
-            <span className="text-xs tabular-nums text-muted-foreground">
-              {confidencePct}% confidence
-            </span>
+    <div className="border-b pb-5 last:border-b-0 last:pb-0">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-medium">{meta.name}</p>
+          {meta.description && (
+            <p className="text-xs text-muted-foreground">{meta.description}</p>
+          )}
+          {confidencePct !== null ? (
+            <div className="mt-2 flex items-center gap-2">
+              <Progress value={confidencePct} className="h-1.5 w-24" />
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {confidencePct}% confidence
+              </span>
+            </div>
+          ) : (
+            <p className="mt-2 text-xs text-muted-foreground">Confidence — not yet measured</p>
+          )}
+        </div>
+        <div className="shrink-0 sm:text-right">
+          <ConsentDial level={entry.level} disabled={busy} onChange={onSet} />
+          {hint && <p className="mt-1.5 text-xs text-muted-foreground">{hint}</p>}
+        </div>
+      </div>
+
+      {/* Earned graduation invite — the merchant opts in, never auto-raised. */}
+      {entry.graduation && (
+        <div className="mt-3 flex flex-col gap-2 rounded-lg border border-emerald-300 bg-emerald-50 p-3 dark:border-emerald-900 dark:bg-emerald-950/40 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-2">
+            <ArrowUpCircle className="mt-0.5 size-4 text-emerald-600 dark:text-emerald-400" />
+            <p className="text-xs">
+              <span className="font-medium">{meta.name} has earned more autonomy.</span>{" "}
+              It&apos;s been reliable — raise it to{" "}
+              <span className="font-medium">{LEVEL_LABEL[entry.graduation.nextLevel]}</span>?
+            </p>
           </div>
-        ) : (
-          <p className="mt-2 text-xs text-muted-foreground">Confidence — not yet measured</p>
-        )}
-      </div>
-      <div className="shrink-0 sm:text-right">
-        <ConsentDial level={entry.level} disabled={busy} onChange={onSet} />
-        {hint && <p className="mt-1.5 text-xs text-muted-foreground">{hint}</p>}
-      </div>
+          <div className="flex shrink-0 gap-2">
+            <Button size="sm" variant="ghost" disabled={busy} onClick={onDismiss}>
+              Not now
+            </Button>
+            <Button size="sm" disabled={busy} onClick={() => onGraduate(entry.graduation!.nextLevel)}>
+              Raise to {LEVEL_LABEL[entry.graduation.nextLevel]}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/commerce/autonomy-board.tsx
+++ b/src/components/commerce/autonomy-board.tsx
@@ -101,10 +101,16 @@ export function AutonomyBoard() {
               onSet={(level) =>
                 setAutonomy.mutate({ agent: agent.agent, channel: data.channel, level })
               }
-              onGraduate={(level) => {
-                setAutonomy.mutate({ agent: agent.agent, channel: data.channel, level });
-                toast.success(`${AGENT_META[agent.agent]?.name ?? agent.agent} raised to ${LEVEL_LABEL[level]}`);
-              }}
+              onGraduate={(level) =>
+                setAutonomy.mutate(
+                  { agent: agent.agent, channel: data.channel, level },
+                  {
+                    onSuccess: () =>
+                      toast.success(`${AGENT_META[agent.agent]?.name ?? agent.agent} raised to ${LEVEL_LABEL[level]}`),
+                    onError: () => toast.error("Couldn't raise autonomy — please try again"),
+                  },
+                )
+              }
               onDismiss={() => dismiss.mutate({ agent: agent.agent, channel: data.channel })}
             />
           ))

--- a/src/hooks/use-commerce-autonomy.ts
+++ b/src/hooks/use-commerce-autonomy.ts
@@ -26,17 +26,25 @@ export interface AutonomyConfidence {
   updatedAt: string;
 }
 
+export interface GraduationInvite {
+  nextLevel: AutonomyLevel;
+}
+
 export interface AutonomyEntry {
   agent: string;
   channel: string;
   level: AutonomyLevel;
   guardrails: AutonomyGuardrails | null;
   confidence: AutonomyConfidence | null;
+  /** Set when the agent has EARNED a graduation to a higher level. */
+  graduation: GraduationInvite | null;
 }
 
 export interface AutonomyBoard {
   channel: string;
   agents: AutonomyEntry[];
+  /** Global execution halt — when true no agent can ship (proposals still work). */
+  killSwitch: boolean;
 }
 
 const AUTONOMY_KEY = "commerce-autonomy";
@@ -85,5 +93,53 @@ export function useSetAutonomy() {
     onSettled: () => {
       qc.invalidateQueries({ queryKey: key });
     },
+  });
+}
+
+/** Toggle the global execution kill switch (PUT /v1/commerce/settings). */
+export function useSetKillSwitch() {
+  const qc = useQueryClient();
+  const { org } = useAuth();
+  const key = [AUTONOMY_KEY, org?._id ?? null];
+  return useMutation<{ killSwitch: boolean }, Error, boolean>({
+    mutationFn: (killSwitch: boolean) =>
+      api.put<{ killSwitch: boolean }>("/v1/commerce/settings", { killSwitch }),
+    onMutate: async (killSwitch) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<AutonomyBoard>(key);
+      if (prev) qc.setQueryData<AutonomyBoard>(key, { ...prev, killSwitch });
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if ((ctx as { prev?: AutonomyBoard })?.prev) qc.setQueryData(key, (ctx as { prev: AutonomyBoard }).prev);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: key }),
+  });
+}
+
+/** Dismiss an agent's graduation invite (POST /v1/commerce/graduation/dismiss). */
+export function useDismissGraduation() {
+  const qc = useQueryClient();
+  const { org } = useAuth();
+  const key = [AUTONOMY_KEY, org?._id ?? null];
+  return useMutation<unknown, Error, { agent: string; channel: string }>({
+    mutationFn: ({ agent, channel }) =>
+      api.post("/v1/commerce/graduation/dismiss", { agent, channel }),
+    // Optimistically clear the invite so it disappears immediately.
+    onMutate: async ({ agent }) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<AutonomyBoard>(key);
+      if (prev) {
+        qc.setQueryData<AutonomyBoard>(key, {
+          ...prev,
+          agents: prev.agents.map((a) => (a.agent === agent ? { ...a, graduation: null } : a)),
+        });
+      }
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if ((ctx as { prev?: AutonomyBoard })?.prev) qc.setQueryData(key, (ctx as { prev: AutonomyBoard }).prev);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: key }),
   });
 }


### PR DESCRIPTION
## What

Final Phase 2 PR — wires the **P2.9 control plane** (api #846/#847) into the Autopilot **autonomy board**.

## Surface

- **`use-commerce-autonomy.ts`** — the board now carries `killSwitch` + per-agent `graduation`; adds `useSetKillSwitch` (optimistic) and `useDismissGraduation` (optimistic clear).
- **`autonomy-board.tsx`**:
  - **Kill switch** toggle in the header — red state when on ("execution is halted; proposals + drafts still work"). The merchant's emergency brake.
  - **Earned-graduation banner** per agent — *"X has earned more autonomy — raise it to Approve?"* with **Raise to <level>** (existing `setAutonomy` PUT) and **Not now** (`/graduation/dismiss`).
- **Merchant opts in — never auto-raised; default stays L1.**

## Verification (local)

- `npx eslint` ✅ · `npx tsc --noEmit` ✅

## Note

Surfacing explicit **execute / stage / revert** buttons on approved actions is a focused follow-up (needs a new "pending execution" actions-list surface). This PR delivers the safety + graduation control-plane UX; the execution engine is fully built + tested in api #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)