### PR TITLE
feat(ask): b2c AI SDK v7 + page-context provider + useAsk hook (PR-7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "peakhour-b2c",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^4.0.32",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -19,6 +20,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.100.2",
         "@tanstack/react-table": "^8.21.3",
+        "ai": "^7.0.29",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -52,6 +54,90 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^6",
         "vitest": "^4.1.7"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.21.tgz",
+      "integrity": "sha512-GafyeyHFDKJjdtbyhCQ0aC2FORdyE56IxK45EZ1JLO1iVdg8XqEU3bwnRzI0+5S1XHV7W2qQsxkZnGYPbsFiXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.14.tgz",
+      "integrity": "sha512-Vf2THTWylnOiPUZgPEzTcbin+6pIBKMdJnDNAMHD0u+upNoO5747HMMFUJJnNNjk8eroAPomaVmF0w8gadA4WA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.10.tgz",
+      "integrity": "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.32.tgz",
+      "integrity": "sha512-H1tu1C5XoY1fh14Q4ABS1ljPx+H/y20MqJrUhATW5jjdAqOyyAy0rFl2qj5BC9uhFMtM+NkxEUOEPB5qeQLDQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.14",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "ai": "7.0.29",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5663,6 +5749,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
@@ -5776,6 +5871,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5821,6 +5922,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.29.tgz",
+      "integrity": "sha512-q+A+skhl6SyjWliU6W7zNYgDUrEk5SbNrCc5vt4S9n6+n6e7jSorDmu51hlhjDOsS7VwzWGCgbWFvvT3iomtvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.21",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.10"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -8528,10 +8646,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -10357,6 +10474,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12392,7 +12515,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -14092,6 +14214,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -14140,6 +14275,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@ai-sdk/react": "^4.0.32",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -25,6 +26,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.100.2",
     "@tanstack/react-table": "^8.21.3",
+    "ai": "^7.0.29",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -43,6 +43,7 @@ import { CommandMenu } from "@/components/molecules/command-menu";
 import { SidebarStorageMeter } from "@/components/dashboard/sidebar-storage-meter";
 import { FeedbackWidget } from "@/components/molecules/feedback-widget";
 import { ChatPanel } from "@/components/molecules/chat-panel";
+import { AskContextProvider } from "@/providers/ask-context-provider";
 import {
   LayoutDashboard,
   FileText,
@@ -247,6 +248,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
     : user?.email?.[0]?.toUpperCase() || "?";
 
   return (
+    <AskContextProvider>
     <SidebarProvider>
       <Sidebar collapsible="icon" variant="sidebar">
         {/* ── Header: Logo + Switchers ──────────────────────── */}
@@ -477,5 +479,6 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
       {/* ── AI Chat FAB ──────────────────────────────────── */}
       <ChatPanel />
     </SidebarProvider>
+    </AskContextProvider>
   );
 }

--- a/src/hooks/use-ask-threads.ts
+++ b/src/hooks/use-ask-threads.ts
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * Ask Peakhour — thread history hooks. Read-only helpers over the /v1/ask thread
+ * endpoints, scoped server-side to the current operator.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export interface AskThreadSummary {
+  threadId: string;
+  title: string | null;
+  updatedAt: string;
+  lastPageContext: { routeKey?: string } | null;
+}
+
+export interface AskThreadDetail {
+  threadId: string;
+  title: string | null;
+  messages: unknown[];
+  lastPageContext: { routeKey?: string } | null;
+}
+
+/** The operator's recent Ask threads in the current business (metadata only). */
+export function useAskThreads() {
+  return useQuery({
+    queryKey: ["ask-threads"],
+    queryFn: () => api.get<{ threads: AskThreadSummary[] }>("/v1/ask/threads"),
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** One thread's full transcript. Disabled until a threadId is provided. */
+export function useAskThread(threadId: string | null) {
+  return useQuery({
+    queryKey: ["ask-thread", threadId],
+    queryFn: () => api.get<AskThreadDetail>(`/v1/ask/threads/${threadId}`),
+    enabled: Boolean(threadId),
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/hooks/use-ask.ts
+++ b/src/hooks/use-ask.ts
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * Ask Peakhour — streaming chat hook.
+ *
+ * Thin wrapper over the Vercel AI SDK `useChat` pointed at the Hono `/v1/ask`
+ * route. Sends cookies (`credentials: "include"`) + the `X-CSRF-Token` header the
+ * API's csrfGuard requires, and injects the latest page context into each turn's
+ * body so the server activates the right engines.
+ */
+
+import { useMemo } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import { API_BASE_URL, getCsrfToken } from "@/lib/api";
+import { useAskContext } from "@/providers/ask-context-provider";
+
+export function useAsk(threadId: string) {
+  const { getPageContext } = useAskContext();
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: `${API_BASE_URL}/v1/ask`,
+        credentials: "include",
+        // csrfGuard rejects non-GET without this header; fetched from the shared
+        // cached token (same one ApiClient uses).
+        headers: async () => {
+          const token = await getCsrfToken();
+          const h: Record<string, string> = {};
+          if (token) h["X-CSRF-Token"] = token;
+          return h;
+        },
+        // Shape the request body to the /v1/ask contract: the client thread id,
+        // the UIMessage[] transcript, and the current page context.
+        prepareSendMessagesRequest: ({ messages, id }) => ({
+          body: { id, messages, context: getPageContext() },
+        }),
+      }),
+    [getPageContext],
+  );
+
+  return useChat({ id: threadId, transport });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,41 +11,50 @@ let csrfToken: string | null = null;
 let csrfFetchPromise: Promise<string | null> | null = null;
 let refreshPromise: Promise<boolean> | null = null;
 
+/**
+ * Fetch a CSRF token from the server (cached, with dedup guard). Exported so
+ * non-ApiClient callers — e.g. the Ask Peakhour `useChat` transport, which POSTs
+ * directly to /v1/ask and must set `X-CSRF-Token` itself — reuse the same cache.
+ */
+export async function getCsrfToken(): Promise<string | null> {
+  if (csrfToken) return csrfToken;
+
+  // Deduplicate concurrent fetches
+  if (!csrfFetchPromise) {
+    csrfFetchPromise = (async () => {
+      try {
+        const res = await fetch(`${API_URL}/v1/auth/csrf/token`, {
+          credentials: "include",
+        });
+        const json = await res.json();
+        if (json.ok && json.data?.csrf_token) {
+          csrfToken = json.data.csrf_token;
+          return csrfToken;
+        }
+      } catch {
+        // CSRF token fetch is best-effort
+      }
+      return null;
+    })();
+  }
+
+  try {
+    return await csrfFetchPromise;
+  } finally {
+    csrfFetchPromise = null;
+  }
+}
+
+/** Clear the cached CSRF token (e.g. after a CSRF rejection). */
+export function clearCsrfToken(): void {
+  csrfToken = null;
+}
+
 class ApiClient {
   private baseUrl: string;
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
-  }
-
-  /** Fetch a CSRF token from the server (cached, with dedup guard) */
-  private async getCsrfToken(): Promise<string | null> {
-    if (csrfToken) return csrfToken;
-
-    // Deduplicate concurrent fetches
-    if (!csrfFetchPromise) {
-      csrfFetchPromise = (async () => {
-        try {
-          const res = await fetch(`${this.baseUrl}/v1/auth/csrf/token`, {
-            credentials: "include",
-          });
-          const json = await res.json();
-          if (json.ok && json.data?.csrf_token) {
-            csrfToken = json.data.csrf_token;
-            return csrfToken;
-          }
-        } catch {
-          // CSRF token fetch is best-effort
-        }
-        return null;
-      })();
-    }
-
-    try {
-      return await csrfFetchPromise;
-    } finally {
-      csrfFetchPromise = null;
-    }
   }
 
   async request<T>(path: string, options: FetchOptions = {}): Promise<T> {
@@ -87,7 +96,7 @@ class ApiClient {
 
     // Add CSRF token for state-changing requests
     if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
-      const token = await this.getCsrfToken();
+      const token = await getCsrfToken();
       if (token) {
         headers["X-CSRF-Token"] = token;
       }
@@ -120,8 +129,8 @@ class ApiClient {
         (error.code === "CSRF_INVALID" || error.code === "CSRF_MISSING") &&
         method !== "GET"
       ) {
-        csrfToken = null;
-        const retryToken = await this.getCsrfToken();
+        clearCsrfToken();
+        const retryToken = await getCsrfToken();
         if (retryToken) {
           headers["X-CSRF-Token"] = retryToken;
           const retryRes = await fetch(url, {
@@ -262,7 +271,7 @@ class ApiClient {
       throw new ApiError("CONFIG_ERROR", "NEXT_PUBLIC_API_URL is not configured", 0);
     }
     const headers: Record<string, string> = {};
-    const token = await this.getCsrfToken();
+    const token = await getCsrfToken();
     if (token) headers["X-CSRF-Token"] = token;
 
     const doFetch = () =>
@@ -302,7 +311,7 @@ class ApiClient {
     const headers: Record<string, string> = {};
     if (body) headers["Content-Type"] = "application/json";
 
-    const token = await this.getCsrfToken();
+    const token = await getCsrfToken();
     if (token) headers["X-CSRF-Token"] = token;
 
     const fetchOpts: RequestInit = {
@@ -321,8 +330,8 @@ class ApiClient {
         | null;
       const code = errJson?.error?.code;
       if (code === "CSRF_INVALID" || code === "CSRF_MISSING") {
-        csrfToken = null;
-        const retryToken = await this.getCsrfToken();
+        clearCsrfToken();
+        const retryToken = await getCsrfToken();
         if (retryToken) {
           (fetchOpts.headers as Record<string, string>)["X-CSRF-Token"] = retryToken;
           res = await fetch(`${this.baseUrl}${path}`, fetchOpts);

--- a/src/providers/ask-context-provider.tsx
+++ b/src/providers/ask-context-provider.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * Ask Peakhour — page-context provider.
+ *
+ * Exposes the current page as a normalized `AskPageContext` (routeKey + path +
+ * optional entity ids) that the `useAsk` transport sends with every turn, so the
+ * server activates the right engines and pre-scopes tools. Pages publish their
+ * own entity ids (e.g. the selected GA4 propertyId) via `useSetAskEntityIds`.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+
+export interface AskPageContext {
+  routeKey: string;
+  path?: string;
+  title?: string;
+  entityIds?: Record<string, string>;
+}
+
+interface AskContextValue {
+  /** Read the latest page context (used by the transport at send time). */
+  getPageContext: () => AskPageContext;
+  setEntityIds: (ids: Record<string, string | undefined>) => void;
+}
+
+const AskCtx = createContext<AskContextValue | null>(null);
+
+/**
+ * Normalize a dashboard pathname to a routeKey the server's engine registry
+ * matches on: "/dashboard/insights/analytics" → "insights.analytics",
+ * "/dashboard/overview" → "overview", "/dashboard" → "dashboard".
+ */
+export function routeKeyFromPath(pathname: string): string {
+  const parts = pathname.split("/").filter(Boolean);
+  const idx = parts.indexOf("dashboard");
+  const rest = idx >= 0 ? parts.slice(idx + 1) : parts;
+  if (rest.length === 0) return "dashboard";
+  // Drop dynamic-id-looking trailing segments so routeKeys stay stable.
+  return rest.join(".");
+}
+
+export function AskContextProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [entityIds, setEntityIdsState] = useState<Record<string, string>>({});
+
+  // Refs so getPageContext (called by the transport at send time, not on render)
+  // always reads the freshest path + entity ids without re-creating the transport.
+  // Updated in effects (React 19 forbids writing refs during render).
+  const pathRef = useRef(pathname);
+  const entityRef = useRef(entityIds);
+  useEffect(() => {
+    pathRef.current = pathname;
+  }, [pathname]);
+  useEffect(() => {
+    entityRef.current = entityIds;
+  }, [entityIds]);
+
+  const setEntityIds = useCallback((ids: Record<string, string | undefined>) => {
+    setEntityIdsState((prev) => {
+      const next = { ...prev };
+      for (const [k, v] of Object.entries(ids)) {
+        if (v === undefined || v === "") delete next[k];
+        else next[k] = v;
+      }
+      return next;
+    });
+  }, []);
+
+  const getPageContext = useCallback((): AskPageContext => {
+    const path = pathRef.current;
+    const ids = entityRef.current;
+    return {
+      routeKey: routeKeyFromPath(path),
+      path,
+      ...(Object.keys(ids).length > 0 ? { entityIds: { ...ids } } : {}),
+    };
+  }, []);
+
+  const value = useMemo(() => ({ getPageContext, setEntityIds }), [getPageContext, setEntityIds]);
+  return <AskCtx.Provider value={value}>{children}</AskCtx.Provider>;
+}
+
+export function useAskContext(): AskContextValue {
+  const ctx = useContext(AskCtx);
+  if (!ctx) throw new Error("useAskContext must be used within <AskContextProvider>");
+  return ctx;
+}
+
+/**
+ * Publish this page's entity ids to Ask while the component is mounted, and
+ * remove exactly those keys on unmount (so it can't clobber another publisher).
+ * e.g. the Analytics page: `useSetAskEntityIds({ propertyId, siteUrl })`.
+ */
+export function useSetAskEntityIds(ids: Record<string, string | undefined>) {
+  const { setEntityIds } = useAskContext();
+  const key = JSON.stringify(ids);
+  useEffect(() => {
+    setEntityIds(ids);
+    return () => {
+      const cleared: Record<string, undefined> = {};
+      for (const k of Object.keys(ids)) cleared[k] = undefined;
+      setEntityIds(cleared);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, setEntityIds]);
+}

--- a/src/providers/ask-context-provider.tsx
+++ b/src/providers/ask-context-provider.tsx
@@ -36,17 +36,21 @@ interface AskContextValue {
 
 const AskCtx = createContext<AskContextValue | null>(null);
 
+/** ObjectId (24 hex) | UUID | numeric id — dynamic route segments to drop. */
+const ID_SEGMENT = /^(?:[0-9a-fA-F]{24}|[0-9a-fA-F]{8}-[0-9a-fA-F-]{27}|\d+)$/;
+
 /**
- * Normalize a dashboard pathname to a routeKey the server's engine registry
- * matches on: "/dashboard/insights/analytics" → "insights.analytics",
- * "/dashboard/overview" → "overview", "/dashboard" → "dashboard".
+ * Normalize a dashboard pathname to a stable routeKey the server's engine
+ * registry matches on: "/dashboard/insights/analytics" → "insights.analytics",
+ * "/dashboard/overview" → "overview", "/dashboard" → "dashboard". Dynamic id
+ * segments are stripped so per-entity detail pages don't explode the routeKey
+ * space: "/dashboard/strategist/6650ab…" → "strategist".
  */
 export function routeKeyFromPath(pathname: string): string {
   const parts = pathname.split("/").filter(Boolean);
   const idx = parts.indexOf("dashboard");
-  const rest = idx >= 0 ? parts.slice(idx + 1) : parts;
+  const rest = (idx >= 0 ? parts.slice(idx + 1) : parts).filter((seg) => !ID_SEGMENT.test(seg));
   if (rest.length === 0) return "dashboard";
-  // Drop dynamic-id-looking trailing segments so routeKeys stay stable.
   return rest.join(".");
 }
 
@@ -99,8 +103,9 @@ export function useAskContext(): AskContextValue {
 
 /**
  * Publish this page's entity ids to Ask while the component is mounted, and
- * remove exactly those keys on unmount (so it can't clobber another publisher).
- * e.g. the Analytics page: `useSetAskEntityIds({ propertyId, siteUrl })`.
+ * remove those keys on unmount. Removal is by key NAME, so use surface-unique
+ * keys (propertyId, siteUrl, ideaId…) — two publishers sharing a key name can
+ * step on each other. e.g. the Analytics page: `useSetAskEntityIds({ propertyId, siteUrl })`.
  */
 export function useSetAskEntityIds(ids: Record<string, string | undefined>) {
   const { setEntityIds } = useAskContext();


### PR DESCRIPTION
## Why
PR-7 of 12 for **Ask Peakhour** — the frontend foundation. No visible UI yet (the FAB + full page land in PR-8); this wires the streaming client, page-context, and thread hooks the UI will consume.

## What
- **Deps:** `ai@^7.0.29` + `@ai-sdk/react@^4.0.32` (same major as the API's v7 UI-message-stream protocol).
- **`lib/api.ts`:** extracted the CSRF fetch into an exported `getCsrfToken()`/`clearCsrfToken()` (single source; `ApiClient` delegates) so the `useChat` transport can set the `X-CSRF-Token` header `csrfGuard` requires. No behavior change for existing callers.
- **`providers/ask-context-provider.tsx`:** exposes the current page as a normalized `AskPageContext` — `routeKey` from the pathname (`/dashboard/insights/analytics` → `insights.analytics`, dynamic id segments stripped) + optional entity ids. `useSetAskEntityIds` lets a page publish its ids (e.g. selected GA4 `propertyId`). Refs synced in effects (React 19-safe) so the transport stays stable across navigation. Mounted in the dashboard layout.
- **`hooks/use-ask.ts`:** `useChat` over `DefaultChatTransport` → `/v1/ask`, `credentials:"include"` + CSRF header, injects live page context into each turn.
- **`hooks/use-ask-threads.ts`:** react-query read hooks for the thread list + one transcript.

## Double review
- **Review #1 (manual + subagent):** verified the CSRF refactor (no dangling `this.getCsrfToken`, cache shared, `API_URL`≡singleton `baseUrl`), transport config against the installed `@ai-sdk/react@4`/`ai@7` types (headers async fn + CSRF still sent, credentials applied, memo stable), effect-based refs (no send-time staleness), and layout wrap safety. Fixed one **Medium** in a separate commit: `routeKeyFromPath` now actually strips dynamic id segments (was a latent routeKey explosion on detail pages).

## Gate (no CI on this repo)
`tsc` clean · `eslint` clean · `vitest` **62/62** · `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)