### PR TITLE
feat(ask): Ask Peakhour launcher + full-page surface (PR-8)

### DIFF
--- a/src/app/(site)/dashboard/ask/page.tsx
+++ b/src/app/(site)/dashboard/ask/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+/**
+ * Ask Peakhour — full-page conversation surface. Roomier than the launcher; same
+ * grounded engine. threadId is minted client-side (lazy, to avoid an SSR/client
+ * hydration mismatch) and reset by "New conversation".
+ */
+
+import { useState } from "react";
+import { Sparkles, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { AskConversation } from "@/components/ask/ask-conversation";
+
+function newThreadId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `ask-${crypto.randomUUID()}`;
+  }
+  return `ask-${Math.random().toString(36).slice(2)}${Date.now()}`;
+}
+
+export default function AskPage() {
+  // Lazy initializer (not setState-in-effect); threadId isn't rendered to the
+  // DOM, so a server/client value difference can't cause a hydration mismatch.
+  const [threadId, setThreadId] = useState<string>(() => newThreadId());
+
+  return (
+    <div className="mx-auto flex h-[calc(100dvh-5rem)] w-full max-w-3xl flex-col p-4">
+      <div className="mb-3 flex items-center gap-3">
+        <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
+          <Sparkles className="size-5 text-primary" />
+        </div>
+        <div className="flex-1">
+          <h1 className="text-lg font-semibold leading-none tracking-tight">Ask Peakhour</h1>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Your SEO manager + data analyst — answers grounded in your real analytics.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setThreadId(newThreadId())}>
+          <Plus className="mr-1.5 size-3.5" />
+          New conversation
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-hidden rounded-xl border bg-background">
+        {threadId && <AskConversation threadId={threadId} className="h-full" />}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -44,8 +44,11 @@ import { SidebarStorageMeter } from "@/components/dashboard/sidebar-storage-mete
 import { FeedbackWidget } from "@/components/molecules/feedback-widget";
 import { ChatPanel } from "@/components/molecules/chat-panel";
 import { AskContextProvider } from "@/providers/ask-context-provider";
+import { AskLauncher } from "@/components/ask/ask-launcher";
+import { ASK_ENABLED } from "@/lib/flags";
 import {
   LayoutDashboard,
+  Sparkles,
   FileText,
   TrendingUp,
   Plug,
@@ -100,6 +103,9 @@ const NAV_GROUPS: NavGroup[] = [
     label: "",
     items: [
       { href: "/dashboard/overview", label: "Overview", icon: LayoutDashboard },
+      ...(ASK_ENABLED
+        ? [{ href: "/dashboard/ask", label: "Ask Peakhour", icon: Sparkles }]
+        : []),
       {
         href: "/dashboard/content",
         label: "Content",
@@ -477,7 +483,8 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
       </SidebarInset>
 
       {/* ── AI Chat FAB ──────────────────────────────────── */}
-      <ChatPanel />
+      {/* Ask Peakhour (grounded) runs behind a flag; legacy ChatPanel until PR-11 cutover. */}
+      {ASK_ENABLED ? <AskLauncher /> : <ChatPanel />}
     </SidebarProvider>
     </AskContextProvider>
   );

--- a/src/components/ask/ask-conversation.tsx
+++ b/src/components/ask/ask-conversation.tsx
@@ -117,7 +117,9 @@ export function AskConversation({
   }, [messages, status]);
 
   useEffect(() => {
-    if (autoFocus) setTimeout(() => inputRef.current?.focus(), 80);
+    if (!autoFocus) return;
+    const t = setTimeout(() => inputRef.current?.focus(), 80);
+    return () => clearTimeout(t);
   }, [autoFocus]);
 
   function handleSend() {
@@ -191,7 +193,7 @@ export function AskConversation({
             onKeyDown={handleKeyDown}
             placeholder="Ask about your traffic, search, pages…"
             rows={1}
-            className="max-h-[120px] min-h-[36px] resize-none text-sm"
+            className="max-h-30 min-h-9 resize-none text-sm"
             disabled={busy}
           />
           <Button size="icon" className="size-9 shrink-0" onClick={handleSend} disabled={!input.trim() || busy}>

--- a/src/components/ask/ask-conversation.tsx
+++ b/src/components/ask/ask-conversation.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+/**
+ * Ask Peakhour — shared conversation surface (message list + composer).
+ * Driven by the `useAsk` (Vercel AI SDK `useChat`) hook, rendering v7 UIMessage
+ * `parts`: text as prose and tool calls as compact "reading…" chips. Used by
+ * both the floating launcher and the full-page /dashboard/ask surface.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import type { UIMessage } from "ai";
+import { Bot, Send, Loader2, Check, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { useAsk } from "@/hooks/use-ask";
+
+/** Friendly labels for the analytics tools (falls back to a prettified name). */
+const TOOL_LABELS: Record<string, string> = {
+  gsc_search_digest: "Checking search performance",
+  gsc_action_worklist: "Finding SEO actions",
+  gsc_site_health: "Checking index health",
+  gsc_top_queries: "Reading top search queries",
+  ga4_conversion_funnel: "Reading website traffic",
+  ga4_top_pages: "Reading top pages",
+  ga4_acquisition_channels: "Reading traffic sources",
+  ga4_run_report: "Running a custom GA4 report",
+};
+
+function toolLabel(name: string): string {
+  return TOOL_LABELS[name] ?? name.replace(/_/g, " ");
+}
+
+const SUGGESTIONS = [
+  "How's my website traffic and search doing?",
+  "What should I do to get more search traffic?",
+  "Which pages get the most visitors?",
+];
+
+interface AskPart {
+  type: string;
+  text?: string;
+  toolName?: string;
+  state?: string;
+}
+
+/** A tool-call part rendered as a status chip. */
+function ToolChip({ label, done }: { label: string; done: boolean }) {
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-full border bg-muted/50 px-2.5 py-1 text-xs text-muted-foreground">
+      {done ? (
+        <Check className="size-3 text-emerald-500" />
+      ) : (
+        <Loader2 className="size-3 animate-spin" />
+      )}
+      <Search className="size-3 opacity-60" />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function MessageView({ message }: { message: UIMessage }) {
+  const isUser = message.role === "user";
+  const parts = (message.parts ?? []) as AskPart[];
+
+  const textParts = parts.filter((p) => p.type === "text" && p.text);
+  const toolParts = parts.filter(
+    (p) => p.type.startsWith("tool-") || p.type === "dynamic-tool",
+  );
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", isUser ? "items-end" : "items-start")}>
+      {/* Tool chips (assistant only) */}
+      {!isUser && toolParts.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {toolParts.map((p, i) => {
+            const name = p.type === "dynamic-tool" ? (p.toolName ?? "tool") : p.type.slice("tool-".length);
+            const done = p.state === "output-available" || p.state === "output-error";
+            return <ToolChip key={i} label={toolLabel(name)} done={done} />;
+          })}
+        </div>
+      )}
+      {textParts.map((p, i) => (
+        <div
+          key={i}
+          className={cn(
+            "max-w-[85%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap",
+            isUser
+              ? "bg-primary text-primary-foreground rounded-br-md"
+              : "bg-muted rounded-bl-md",
+          )}
+        >
+          {p.text}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function AskConversation({
+  threadId,
+  className,
+  autoFocus = true,
+}: {
+  threadId: string;
+  className?: string;
+  autoFocus?: boolean;
+}) {
+  const { messages, sendMessage, status, error } = useAsk(threadId);
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const busy = status === "submitted" || status === "streaming";
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, status]);
+
+  useEffect(() => {
+    if (autoFocus) setTimeout(() => inputRef.current?.focus(), 80);
+  }, [autoFocus]);
+
+  function handleSend() {
+    const text = input.trim();
+    if (!text || busy) return;
+    setInput("");
+    void sendMessage({ text });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+        {messages.length === 0 && !busy && (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+            <Bot className="size-8 opacity-30" />
+            <p className="text-sm">Ask about your analytics, search, and pages — grounded in your real data.</p>
+            <div className="mt-2 flex flex-wrap justify-center gap-1.5">
+              {SUGGESTIONS.map((q) => (
+                <button
+                  key={q}
+                  onClick={() => {
+                    setInput(q);
+                    inputRef.current?.focus();
+                  }}
+                  className="rounded-full border px-3 py-1 text-xs transition-colors hover:bg-muted"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((m) => (
+          <MessageView key={m.id} message={m} />
+        ))}
+
+        {status === "submitted" && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <div className="flex size-6 items-center justify-center rounded-full bg-primary/10">
+              <Bot className="size-3 text-primary" />
+            </div>
+            <div className="flex gap-1">
+              <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/50 [animation-delay:0ms]" />
+              <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/50 [animation-delay:150ms]" />
+              <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/50 [animation-delay:300ms]" />
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+            Something went wrong. Please try again.
+          </div>
+        )}
+      </div>
+
+      <div className="border-t p-3">
+        <div className="flex items-end gap-2">
+          <Textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about your traffic, search, pages…"
+            rows={1}
+            className="max-h-[120px] min-h-[36px] resize-none text-sm"
+            disabled={busy}
+          />
+          <Button size="icon" className="size-9 shrink-0" onClick={handleSend} disabled={!input.trim() || busy}>
+            {busy ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+          </Button>
+        </div>
+        <p className="mt-1.5 px-1 text-[10px] text-muted-foreground">
+          Ask Peakhour answers only from your connected data — it won&apos;t make numbers up.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ask/ask-launcher.tsx
+++ b/src/components/ask/ask-launcher.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Ask Peakhour — floating launcher. A FAB in the bottom-right that opens a
+ * slide-over conversation panel, available across the dashboard. Runs in
+ * parallel with the legacy ChatPanel behind the NEXT_PUBLIC_ASK_ENABLED flag
+ * until the PR-11 cutover.
+ */
+
+import { useState } from "react";
+import { Sparkles, X, ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { AskConversation } from "./ask-conversation";
+
+function newThreadId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `ask-${crypto.randomUUID()}`;
+  }
+  return `ask-${Math.random().toString(36).slice(2)}${Date.now()}`;
+}
+
+export function AskLauncher() {
+  const [open, setOpen] = useState(false);
+  // Minted lazily on first open (client-only → no SSR/hydration mismatch).
+  const [threadId, setThreadId] = useState<string | null>(null);
+
+  function openPanel() {
+    setThreadId((id) => id ?? newThreadId());
+    setOpen(true);
+  }
+
+  return (
+    <>
+      {!open && (
+        <button
+          onClick={openPanel}
+          className="fixed bottom-6 right-6 z-50 flex size-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-transform hover:scale-105 active:scale-95"
+          aria-label="Open Ask Peakhour"
+        >
+          <Sparkles className="size-5" />
+        </button>
+      )}
+
+      {open && threadId && (
+        <div className="fixed bottom-6 right-6 z-50 flex h-[560px] w-[400px] flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl">
+          <div className="flex items-center gap-3 border-b px-4 py-3">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-primary/10">
+              <Sparkles className="size-4 text-primary" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-semibold leading-none">Ask Peakhour</p>
+              <p className="text-[11px] text-muted-foreground">Grounded in your real data</p>
+            </div>
+            <Button variant="ghost" size="icon" className="size-7" asChild title="Open full page">
+              <Link href="/dashboard/ask">
+                <ExternalLink className="size-3.5" />
+              </Link>
+            </Button>
+            <Button variant="ghost" size="icon" className="size-7" onClick={() => setOpen(false)} aria-label="Close">
+              <X className="size-4" />
+            </Button>
+          </div>
+
+          <AskConversation threadId={threadId} className="flex-1 overflow-hidden" />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ask/ask-launcher.tsx
+++ b/src/components/ask/ask-launcher.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import { Sparkles, X, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -22,9 +23,14 @@ function newThreadId(): string {
 }
 
 export function AskLauncher() {
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   // Minted lazily on first open (client-only → no SSR/hydration mismatch).
   const [threadId, setThreadId] = useState<string | null>(null);
+
+  // The full-page /dashboard/ask surface already hosts a conversation — don't
+  // also float a (separate-thread) launcher over it.
+  if (pathname === "/dashboard/ask") return null;
 
   function openPanel() {
     setThreadId((id) => id ?? newThreadId());

--- a/src/components/ask/ask-launcher.tsx
+++ b/src/components/ask/ask-launcher.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { Sparkles, X, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { AskConversation } from "./ask-conversation";
 
 function newThreadId(): string {
@@ -42,8 +43,15 @@ export function AskLauncher() {
         </button>
       )}
 
-      {open && threadId && (
-        <div className="fixed bottom-6 right-6 z-50 flex h-[560px] w-[400px] flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl">
+      {/* Mount once opened, then toggle visibility (don't unmount) so useChat keeps
+          the conversation across close→reopen. */}
+      {threadId && (
+        <div
+          className={cn(
+            "fixed bottom-6 right-6 z-50 h-140 w-100 flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl",
+            open ? "flex" : "hidden",
+          )}
+        >
           <div className="flex items-center gap-3 border-b px-4 py-3">
             <div className="flex size-8 items-center justify-center rounded-lg bg-primary/10">
               <Sparkles className="size-4 text-primary" />
@@ -52,8 +60,8 @@ export function AskLauncher() {
               <p className="text-sm font-semibold leading-none">Ask Peakhour</p>
               <p className="text-[11px] text-muted-foreground">Grounded in your real data</p>
             </div>
-            <Button variant="ghost" size="icon" className="size-7" asChild title="Open full page">
-              <Link href="/dashboard/ask">
+            <Button variant="ghost" size="icon" className="size-7" asChild>
+              <Link href="/dashboard/ask" aria-label="Open Ask Peakhour full page" title="Open full page">
                 <ExternalLink className="size-3.5" />
               </Link>
             </Button>
@@ -62,7 +70,7 @@ export function AskLauncher() {
             </Button>
           </div>
 
-          <AskConversation threadId={threadId} className="flex-1 overflow-hidden" />
+          <AskConversation threadId={threadId} className="flex-1 overflow-hidden" autoFocus={open} />
         </div>
       )}
     </>

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,10 @@
+/**
+ * Client-visible feature flags (inlined at build via NEXT_PUBLIC_*).
+ */
+
+/**
+ * Ask Peakhour — the grounded assistant (FAB launcher + /dashboard/ask + nav).
+ * Runs in parallel with the legacy ChatPanel until the PR-11 cutover; enable per
+ * environment with NEXT_PUBLIC_ASK_ENABLED=true.
+ */
+export const ASK_ENABLED = process.env.NEXT_PUBLIC_ASK_ENABLED === "true";


### PR DESCRIPTION
## Why
PR-8 of 12 for **Ask Peakhour** — the visible UI. Built on the **Vercel AI SDK UI** (`useAsk`/`useChat`) for streaming and **shadcn/ui** primitives for the shell (the shadcnblocks PRO registry search returned only marketing blocks — no AI-chat block fit).

## What
- **`ask-conversation.tsx`** — shared message list + composer. Renders v7 `UIMessage` parts: text as prose, tool calls as compact "reading…" chips with friendly labels ("Reading website traffic", "Finding SEO actions"), plus typing/streaming + error states, suggested prompts, and a "won't make numbers up" grounding note.
- **`ask-launcher.tsx`** — bottom-right FAB → slide-over panel. Lazily mints a client-side threadId on first open (no SSR hydration mismatch), and **stays mounted while open toggles** so the conversation survives close→reopen.
- **`/dashboard/ask/page.tsx`** — roomy full-page conversation + New conversation.
- **`lib/flags.ts` — `ASK_ENABLED`** (`NEXT_PUBLIC_ASK_ENABLED`): behind it, a nav entry + swapping the FAB from the legacy `ChatPanel` to `AskLauncher`. Default OFF = ChatPanel unchanged; ON = exactly one FAB (no double).

## Double review
- **Review #1 (manual + subagent):** verified v7 part rendering (real tool-state literals), `useChat` status/`sendMessage({text})`, threadId reset semantics, flag gating (no double-FAB), a11y labels. Fixed one **MEDIUM** (launcher lost the conversation on close→reopen — now keeps it mounted) + LOW nits (focus-timeout cleanup, link aria-label, Tailwind v4 canonical classes), in a separate commit.

## Gate (no CI on this repo)
`tsc` clean · `eslint` clean · `vitest` 62/62 · `next build` succeeds (`/dashboard/ask` generated).

⚠️ Live UX smoke recommended in a dev deploy with `NEXT_PUBLIC_ASK_ENABLED=true` (streaming + tool chips against the real /v1/ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)