### PR TITLE
feat(ask): make the Analytics page live + Ask deep-links (PR-9)

### DIFF
--- a/src/app/(site)/dashboard/ask/page.tsx
+++ b/src/app/(site)/dashboard/ask/page.tsx
@@ -3,10 +3,12 @@
 /**
  * Ask Peakhour — full-page conversation surface. Roomier than the launcher; same
  * grounded engine. threadId is minted client-side (lazy, to avoid an SSR/client
- * hydration mismatch) and reset by "New conversation".
+ * hydration mismatch) and reset by "New conversation". Supports a `?q=` deep-link
+ * to seed the composer (e.g. "Ask about this" from the Analytics page).
  */
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { Sparkles, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AskConversation } from "@/components/ask/ask-conversation";
@@ -18,7 +20,9 @@ function newThreadId(): string {
   return `ask-${Math.random().toString(36).slice(2)}${Date.now()}`;
 }
 
-export default function AskPage() {
+function AskPageInner() {
+  const searchParams = useSearchParams();
+  const initialInput = searchParams.get("q") ?? undefined;
   // Lazy initializer (not setState-in-effect); threadId isn't rendered to the
   // DOM, so a server/client value difference can't cause a hydration mismatch.
   const [threadId, setThreadId] = useState<string>(() => newThreadId());
@@ -42,8 +46,19 @@ export default function AskPage() {
       </div>
 
       <div className="flex-1 overflow-hidden rounded-xl border bg-background">
-        {threadId && <AskConversation threadId={threadId} className="h-full" />}
+        {/* useChat resets on threadId change, so no key needed; initialInput seeds
+            the composer once from the ?q deep-link. */}
+        <AskConversation threadId={threadId} className="h-full" initialInput={initialInput} />
       </div>
     </div>
+  );
+}
+
+export default function AskPage() {
+  // useSearchParams requires a Suspense boundary in the App Router.
+  return (
+    <Suspense fallback={null}>
+      <AskPageInner />
+    </Suspense>
   );
 }

--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -8,8 +8,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { LineChart, RefreshCw, ExternalLink, AlertTriangle, ArrowRight } from "lucide-react";
+import { LineChart, RefreshCw, ExternalLink, AlertTriangle, ArrowRight, Sparkles } from "lucide-react";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { useSetAskEntityIds } from "@/providers/ask-context-provider";
+import { ASK_ENABLED } from "@/lib/flags";
 
 interface ConnectionStatus {
   provider: string;
@@ -73,6 +75,11 @@ export default function AnalyticsInsightsPage() {
   const properties = capQ.data?.account?.extra?.properties ?? [];
   const selectedPropertyId = (capQ.data?.capabilities as Record<string, unknown> | undefined)
     ?.propertyId as string | undefined;
+
+  // Publish the selected GA4 property so Ask Peakhour on this page pre-scopes its
+  // tools to it (removed on unmount). Hook is called unconditionally (before any
+  // early return) per the rules of hooks.
+  useSetAskEntityIds({ propertyId: selectedPropertyId });
 
   // See search-console/page.tsx for the rationale: "error" still shows
   // the connected card so the user can retry; "expired" prompts reconnect.
@@ -220,19 +227,46 @@ export default function AnalyticsInsightsPage() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Funnel + top pages</CardTitle>
-              <p className="text-xs text-muted-foreground">
-                Each sync writes funnel totals + top-25 pages + acquisition channels to <code>ana_performance_snapshots</code> with platform=&quot;google_analytics&quot;. Funnel-chart UI ships in a follow-up.
-              </p>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Run a sync above, then the GA4 skills (ga4_funnel_analysis, ga4_top_pages_brief, etc.) become active in their respective agents.
-              </p>
-            </CardContent>
-          </Card>
+          {ASK_ENABLED ? (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Sparkles className="size-4 text-primary" />
+                  Ask Peakhour about your analytics
+                </CardTitle>
+                <p className="text-xs text-muted-foreground">
+                  Ask in plain language — answers are grounded in this property&apos;s real GA4 + Search Console
+                  data (no made-up numbers).
+                </p>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {[
+                  "How's my website traffic and search doing?",
+                  "What should I do to get more search traffic?",
+                  "Which pages get the most visitors?",
+                ].map((q) => (
+                  <Button key={q} asChild variant="outline" size="sm">
+                    <Link href={`/dashboard/ask?q=${encodeURIComponent(q)}`}>{q}</Link>
+                  </Button>
+                ))}
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Funnel + top pages</CardTitle>
+                <p className="text-xs text-muted-foreground">
+                  Each sync writes funnel totals + top-25 pages + acquisition channels to{" "}
+                  <code>ana_performance_snapshots</code> (platform=&quot;google_analytics&quot;).
+                </p>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Run a sync above to keep your analytics fresh.
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </>
       )}
     </div>

--- a/src/app/(site)/dashboard/overview/page.tsx
+++ b/src/app/(site)/dashboard/overview/page.tsx
@@ -34,6 +34,7 @@ import { DiscoveryProgressStrip } from "@/components/dashboard/discovery-progres
 import { FootprintReviewCard } from "@/components/dashboard/footprint-review-card";
 import { RecommendationsCard } from "@/components/dashboard/recommendations-card";
 import { BrandMirrorCard } from "@/components/dashboard/brand-mirror-card";
+import { AskCard } from "@/components/dashboard/ask-card";
 
 interface DashboardStats {
   content: {
@@ -163,6 +164,9 @@ export default function OverviewPage() {
       {/* "What we understand about you" — the Brand Mirror. Self-fetching;
           renders nothing until there is understanding to reflect. */}
       <BrandMirrorCard />
+
+      {/* Ask Peakhour entry point (self-hides unless the flag is on). */}
+      <AskCard />
 
       {isError && (
         <div

--- a/src/components/ask/ask-conversation.tsx
+++ b/src/components/ask/ask-conversation.tsx
@@ -101,13 +101,16 @@ export function AskConversation({
   threadId,
   className,
   autoFocus = true,
+  initialInput,
 }: {
   threadId: string;
   className?: string;
   autoFocus?: boolean;
+  /** Seed the composer (e.g. from an "Ask about this" deep-link). */
+  initialInput?: string;
 }) {
   const { messages, sendMessage, status, error } = useAsk(threadId);
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState(initialInput ?? "");
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const busy = status === "submitted" || status === "streaming";

--- a/src/components/dashboard/ask-card.tsx
+++ b/src/components/dashboard/ask-card.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * Ask Peakhour entry-point card for the dashboard Overview. Self-hides unless
+ * the ASK_ENABLED flag is on (parallel with the legacy chat until PR-11 cutover).
+ */
+
+import Link from "next/link";
+import { Sparkles, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ASK_ENABLED } from "@/lib/flags";
+
+export function AskCard() {
+  if (!ASK_ENABLED) return null;
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
+            <Sparkles className="size-5 text-primary" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold">Ask Peakhour</p>
+            <p className="text-xs text-muted-foreground">
+              Ask about your traffic, search, and pages — grounded in your real data, never made up.
+            </p>
+          </div>
+        </div>
+        <Button asChild size="sm" className="shrink-0">
+          <Link href="/dashboard/ask">
+            Ask a question
+            <ArrowRight className="ml-1.5 size-3.5" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Why
PR-9 of 12 for **Ask Peakhour** — turns the dead Analytics page ("funnel-chart ships later") into a real, actionable entry into the grounded assistant.

## What
- **Analytics page** (`insights/analytics`): publishes the selected GA4 `propertyId` via `useSetAskEntityIds` so Ask on this page pre-scopes its tools to that property; replaces the placeholder with an **"Ask Peakhour about your analytics"** card of suggested questions that deep-link to `/dashboard/ask?q=…` (flag-gated; the old info card shows when the flag is off).
- **`/dashboard/ask`**: reads the `?q` deep-link (`useSearchParams`, Suspense-wrapped per App Router) and seeds the composer; `AskConversation` gains an optional `initialInput`.
- **Overview**: a self-hiding `AskCard` entry point (renders only when `ASK_ENABLED`).

## Double review
- **Review #1 (manual + subagent):** clean, no defects. Verified rules-of-hooks (`useSetAskEntityIds` before the early return), no effect loop / correct publish-clear-on-unmount, Suspense-wrapped `useSearchParams`, `initialInput` seeds once (no re-seed / no "New conversation" breakage), `encodeURIComponent` + React-escaped rendering (no XSS), flag gating both branches, and Overview placement.

## Gate (no CI on this repo)
`tsc` clean · `eslint` clean · `vitest` 62/62 · `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)