### PR TITLE
feat(commerce): b2c pending-execution surface — Approve/Ship/Revert (A1.2)

### DIFF
--- a/src/components/commerce/autopilot.tsx
+++ b/src/components/commerce/autopilot.tsx
@@ -4,6 +4,7 @@ import { Store } from "lucide-react";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
+import { PendingExecutions } from "@/components/commerce/pending-executions";
 import { AutonomyBoard } from "@/components/commerce/autonomy-board";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
 
@@ -55,6 +56,13 @@ function CommerceAutopilotBody() {
               Approvals
             </h2>
             <CommerceNeedsYou />
+          </section>
+
+          <section aria-labelledby="ship-heading" className="mt-8">
+            <h2 id="ship-heading" className="mb-2 text-sm font-medium text-muted-foreground">
+              Ready to ship
+            </h2>
+            <PendingExecutions />
           </section>
 
           <section aria-labelledby="autonomy-heading" className="mt-8">

--- a/src/components/commerce/pending-executions.tsx
+++ b/src/components/commerce/pending-executions.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { PackageCheck, Zap, FileClock, Undo2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useLocale } from "@/hooks/use-locale";
+import { agentLabel } from "@/lib/commerce-agents";
+import { minorToMajor } from "@/lib/money";
+import {
+  useCommerceActions,
+  useApproveAction,
+  useExecuteAction,
+  useRevertAction,
+  type ActionableItem,
+} from "@/hooks/use-commerce-actions";
+
+/**
+ * Commerce → Autopilot "Ready to ship" surface — the b2c parity with the
+ * WordPress plugin's ship loop. Lists the actions a merchant can act on and
+ * routes each by ledger status:
+ *   proposed  → Approve (makes it shippable)
+ *   approved  → Ship it (executes for real, or stages advisory per the
+ *               capability matrix — the row shows which BEFORE the click)
+ *   executed / staged → Revert
+ * Every mutation is optimistic-free (the list refetches on settle); only the row
+ * in flight is disabled. Hides entirely when nothing is pending (the Autopilot
+ * page already shows the connect / autonomy context).
+ */
+export function PendingExecutions() {
+  const { data, isLoading, isError } = useCommerceActions();
+  const approve = useApproveAction();
+  const execute = useExecuteAction();
+  const revert = useRevertAction();
+
+  if (isError) return null;
+
+  const items = data?.items ?? [];
+  const pendingId =
+    (approve.isPending && approve.variables) ||
+    (execute.isPending && execute.variables) ||
+    (revert.isPending && revert.variables) ||
+    null;
+
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      <CardHeader className="flex flex-row items-center justify-between gap-2 border-b bg-muted/30 px-4 py-3">
+        <CardTitle className="text-base">Ready to ship</CardTitle>
+        {items.length > 0 && (
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold tabular-nums text-muted-foreground">
+            {items.length}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {isLoading ? (
+          <div className="divide-y">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="px-4 py-3">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-2 h-3 w-1/2" />
+              </div>
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center gap-1.5 px-4 py-10 text-center">
+            <PackageCheck className="size-7 text-emerald-500" />
+            <p className="text-sm font-medium">Nothing waiting to ship</p>
+            <p className="text-xs text-muted-foreground">
+              Approved actions and agent proposals show up here for you to ship or undo.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {items.map((item) => (
+              <ActionRow
+                key={item.id}
+                item={item}
+                busy={pendingId === item.id}
+                onApprove={() => approve.mutate(item.id)}
+                onExecute={() => execute.mutate(item.id)}
+                onRevert={() => revert.mutate(item.id)}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+const STATUS_TONE: Record<string, "secondary" | "outline"> = {
+  proposed: "outline",
+  approved: "secondary",
+  executed: "secondary",
+  staged: "outline",
+};
+
+function ActionRow({
+  item,
+  busy,
+  onApprove,
+  onExecute,
+  onRevert,
+}: {
+  item: ActionableItem;
+  busy: boolean;
+  onApprove: () => void;
+  onExecute: () => void;
+  onRevert: () => void;
+}) {
+  const { formatNumber } = useLocale();
+  const p = item.prediction;
+  const projected =
+    p && typeof p.valueMinor === "number" && p.currency
+      ? formatNumber(minorToMajor(p.valueMinor, p.currency), {
+          style: "currency",
+          currency: p.currency,
+          maximumFractionDigits: 0,
+        })
+      : null;
+
+  // For an approved action, the capability tells us whether shipping applies
+  // live or stages advisory — surface it honestly BEFORE the click.
+  const willStage = item.status === "approved" && item.capability?.mode !== "execute";
+
+  return (
+    <li className="px-4 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{item.title}</p>
+          <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+            <span>{agentLabel(item.agent)}</span>
+            {projected && (
+              <span className="font-medium text-emerald-600 dark:text-emerald-400">{projected}</span>
+            )}
+          </div>
+        </div>
+        <Badge variant={STATUS_TONE[item.status] ?? "outline"} className="shrink-0 capitalize">
+          {item.status}
+        </Badge>
+      </div>
+
+      {/* Honest capability note on an approved action that will only stage. */}
+      {willStage && item.capability && (
+        <p className="mt-1.5 flex items-start gap-1 text-xs text-amber-600 dark:text-amber-400">
+          <FileClock aria-hidden="true" className="mt-0.5 size-3 shrink-0" />
+          {item.capability.reason}
+        </p>
+      )}
+
+      <div className="mt-2.5 flex gap-2">
+        {item.status === "proposed" && (
+          <Button size="sm" disabled={busy} onClick={onApprove}>
+            Approve
+          </Button>
+        )}
+        {item.status === "approved" && (
+          <Button size="sm" disabled={busy} onClick={onExecute}>
+            {willStage ? (
+              <>
+                <FileClock aria-hidden="true" className="size-3.5" /> Stage
+              </>
+            ) : (
+              <>
+                <Zap aria-hidden="true" className="size-3.5" /> Ship it
+              </>
+            )}
+          </Button>
+        )}
+        {(item.status === "executed" || item.status === "staged") && (
+          <Button size="sm" variant="ghost" disabled={busy} onClick={onRevert}>
+            <Undo2 aria-hidden="true" className="size-3.5" /> Revert
+          </Button>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/hooks/use-commerce-actions.ts
+++ b/src/hooks/use-commerce-actions.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+import { ACTIVITY_KEY } from "@/hooks/use-commerce-activity";
+
+/**
+ * Commerce pending-execution surface (GET /v1/commerce/actions + approve /
+ * execute / revert, api A1.1). The b2c parity with the WordPress plugin's
+ * Autopilot ship loop: proposals → approve → ship (execute for real or stage
+ * advisory, per the capability matrix) → revert. Each row carries its RESOLVED
+ * capability so the UI knows whether "Ship it" applies live or stages before the
+ * click. Mutations invalidate the actions list, the activity digest, and the
+ * autonomy board (confidence can move on execution).
+ */
+
+export type CapabilityMode = "execute" | "stage" | "advisory" | "unavailable";
+
+export interface ActionablePrediction {
+  metric: string;
+  value?: number;
+  valueMinor?: number;
+  currency?: string;
+  confidence?: number;
+}
+
+export interface ActionableItem {
+  id: string;
+  agent: string;
+  title: string;
+  status: string;
+  sourceType: string | null;
+  prediction: ActionablePrediction | null;
+  at: string;
+  channel: string | null;
+  /** The resolved capability (execute vs stage + honest reason), or null for an
+   *  agent that performs no store write. */
+  capability: { mode: CapabilityMode; reason: string } | null;
+}
+
+export const ACTIONS_KEY = "commerce-actions";
+const AUTONOMY_KEY = "commerce-autonomy";
+
+/** The actions a merchant can act on — proposals to approve, approved to ship,
+ *  shipped to revert. Newest first. */
+export function useCommerceActions(
+  statuses: string[] = ["proposed", "approved", "executed", "staged"],
+) {
+  const { isAuthenticated, org } = useAuth();
+  const status = statuses.join(",");
+  return useQuery<{ items: ActionableItem[] }>({
+    queryKey: [ACTIONS_KEY, org?._id ?? null, status],
+    queryFn: () => api.get<{ items: ActionableItem[] }>(
+      `/v1/commerce/actions?status=${encodeURIComponent(status)}`,
+    ),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+function useInvalidateActions() {
+  const qc = useQueryClient();
+  const { org } = useAuth();
+  return () => {
+    const id = org?._id ?? null;
+    qc.invalidateQueries({ queryKey: [ACTIONS_KEY, id] });
+    qc.invalidateQueries({ queryKey: [ACTIVITY_KEY, id] });
+    qc.invalidateQueries({ queryKey: [AUTONOMY_KEY, id] });
+  };
+}
+
+/** Approve a proposed intent → approved (shippable). */
+export function useApproveAction() {
+  const invalidate = useInvalidateActions();
+  return useMutation<{ status: string }, ApiError, string>({
+    mutationFn: (id) => api.post<{ status: string }>(`/v1/commerce/actions/${id}/approve`, {}),
+    onSuccess: () => toast.success("Approved — ready to ship"),
+    onError: (e) => toast.error(e.message || "Couldn't approve this action"),
+    onSettled: () => invalidate(),
+  });
+}
+
+/** Ship an approved action — executes for real or stages advisory (per the
+ *  capability matrix); the server returns the resulting ledger status. */
+export function useExecuteAction() {
+  const invalidate = useInvalidateActions();
+  return useMutation<{ status: string }, ApiError, string>({
+    mutationFn: (id) => api.post<{ status: string }>(`/v1/commerce/actions/${id}/execute`, {}),
+    onSuccess: (res) => {
+      if (res.status === "executed") toast.success("Shipped — applied to your store");
+      else if (res.status === "staged")
+        toast.success("Staged", {
+          description: "Prepared as advisory — live apply isn't available on this channel yet.",
+        });
+      else if (res.status === "failed")
+        toast.error("Couldn't apply on the store", {
+          description: "Nothing was changed. Please try again shortly.",
+        });
+      else toast.success("Done");
+    },
+    onError: (e) => {
+      if (e.code === "AUTONOMY_DISABLED")
+        toast.error("Raise this agent to Approve (L2) before it can ship");
+      else if (e.code === "KILL_SWITCH")
+        toast.error("The kill switch is on — turn it off to ship actions");
+      else if (e.code === "GUARDRAIL") toast.error("A guardrail blocked this action");
+      else toast.error(e.message || "Couldn't ship this action");
+    },
+    onSettled: () => invalidate(),
+  });
+}
+
+/** Undo an executed or staged action (clears the real store change first). */
+export function useRevertAction() {
+  const invalidate = useInvalidateActions();
+  return useMutation<{ status: string }, ApiError, string>({
+    mutationFn: (id) => api.post<{ status: string }>(`/v1/commerce/actions/${id}/revert`, {}),
+    onSuccess: () => toast.success("Reverted"),
+    onError: (e) => toast.error(e.message || "Couldn't revert this action"),
+    onSettled: () => invalidate(),
+  });
+}

--- a/src/hooks/use-commerce-actions.ts
+++ b/src/hooks/use-commerce-actions.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/providers/auth-provider";
 import { ACTIVITY_KEY } from "@/hooks/use-commerce-activity";
+import { AUTONOMY_KEY } from "@/hooks/use-commerce-autonomy";
 
 /**
  * Commerce pending-execution surface (GET /v1/commerce/actions + approve /
@@ -41,7 +42,6 @@ export interface ActionableItem {
 }
 
 export const ACTIONS_KEY = "commerce-actions";
-const AUTONOMY_KEY = "commerce-autonomy";
 
 /** The actions a merchant can act on — proposals to approve, approved to ship,
  *  shipped to revert. Newest first. */

--- a/src/hooks/use-commerce-autonomy.ts
+++ b/src/hooks/use-commerce-autonomy.ts
@@ -47,7 +47,7 @@ export interface AutonomyBoard {
   killSwitch: boolean;
 }
 
-const AUTONOMY_KEY = "commerce-autonomy";
+export const AUTONOMY_KEY = "commerce-autonomy";
 
 export function useCommerceAutonomy() {
   const { isAuthenticated, org } = useAuth();


### PR DESCRIPTION
## A1.2 — b2c ship parity (Commerce completion, Phase A)

Closes the **biggest b2c gap**: the cockpit could propose/approve but never **ship** — no execute/stage/revert control existed anywhere. This brings b2c to parity with the WordPress plugin's Autopilot loop, consuming A1.1's routes + the capability matrix.

### What
- **`use-commerce-actions.ts`** — `useCommerceActions` (GET `/v1/commerce/actions`, the capability-enriched pending list) + `useApproveAction` / `useExecuteAction` / `useRevertAction`.
  - Execute **branches on the returned ledger status**: `executed` → "Shipped — applied to your store", `staged` → honest "Staged (advisory)", `failed` → "nothing was changed".
  - Maps the gate errors (`AUTONOMY_DISABLED` / `KILL_SWITCH` / `GUARDRAIL`) to friendly toasts.
  - Mutations invalidate actions + activity digest + autonomy board (confidence can move).
- **`pending-executions.tsx`** — the "Ready to ship" surface, routed by ledger status: `proposed → Approve`, `approved → Ship it / Stage`, `executed|staged → Revert`. An approved action that will only **stage** shows the matrix's honest reason **before** the click (folds in A0.3's write-surface degradation).
- Mounted on the **Autopilot page** between Approvals and Autonomy.

### Notes
- The read-side "Switching on" degradation is already honest server-side; this adds the **write-surface** honesty via per-action capability.
- Ship still gates on the dial (L2+) + guardrails + kill switch — an L1 store sees a clear "raise autonomy to ship" toast.

### Gate
b2c has no CI (Vercel ignored-build-step) — **`eslint` + `tsc --noEmit` clean**; double `/code-review high` is the gate.

Completes **Phase A** (foundation + parity) alongside A0.1/A0.2/A1.1. Next: **A2.1** (guardrail hardening).