### PR TITLE
feat(dev): document ask-weekly-digest + wa-outcome-billing crons

### DIFF
--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -342,10 +342,15 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       const d = asRecord(data);
       if (!d) return null;
       const targets = num(d.targets);
-      if (targets === 0) return "No businesses were due a digest.";
+      // targets counts businesses DUE a digest, so 0 covers two very different
+      // cases: nobody has connected analytics, or everyone was digested inside
+      // the 6-day guard window. Don't claim which.
+      if (targets === 0) return "Nothing to send — no business is due a digest right now.";
       const sent = num(d.sent);
       const parts = [`${sent} ${plural(sent, "digest")} sent`];
-      // skipped = quiet-hours / no-metrics / already-digested this week.
+      // skipped = connected but no metrics worth a brief yet (still syncing, or
+      // no period comparison). It is NOT a re-send skip — businesses digested
+      // inside the guard window are excluded by the query and never counted here.
       if (num(d.skipped) > 0) parts.push(`${num(d.skipped)} skipped`);
       if (num(d.errors) > 0) parts.push(`${num(d.errors)} failed`);
       // budgetHit means the run stopped early on wall-clock, not that it

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -333,6 +333,48 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       return "X ad metrics refreshed.";
     },
   },
+  "ask-weekly-digest": {
+    label: "Send weekly digest",
+    frequency: "Runs weekly (Monday 6:00 AM UTC)",
+    description:
+      "Sends each business owner their weekly performance digest — plain-English headline, what moved, and one suggested next step — over WhatsApp, falling back to in-app.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return null;
+      const targets = num(d.targets);
+      if (targets === 0) return "No businesses were due a digest.";
+      const sent = num(d.sent);
+      const parts = [`${sent} ${plural(sent, "digest")} sent`];
+      // skipped = quiet-hours / no-metrics / already-digested this week.
+      if (num(d.skipped) > 0) parts.push(`${num(d.skipped)} skipped`);
+      if (num(d.errors) > 0) parts.push(`${num(d.errors)} failed`);
+      // budgetHit means the run stopped early on wall-clock, not that it
+      // finished the queue — say so, or the count reads as complete.
+      const tail = d.budgetHit === true ? " Time budget reached — the rest roll over to the next run." : "";
+      return `${parts.join(", ")}.${tail}`;
+    },
+  },
+  "wa-outcome-billing": {
+    label: "Bill resolved chats",
+    frequency: "Runs every 3 hours",
+    description:
+      "Reviews WhatsApp conversations that have gone quiet, works out which ones actually reached an outcome (resolved, lead qualified, appointment booked), and charges Peaks once per outcome. Ongoing chat turns are always free.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return null;
+      const scanned = num(d.scanned);
+      if (scanned === 0) return "No quiet conversations to review yet.";
+      const billed = num(d.billed);
+      const parts = [
+        billed === 0
+          ? `${scanned} ${plural(scanned, "conversation")} reviewed — none reached a billable outcome`
+          : `${billed} of ${scanned} ${plural(scanned, "conversation")} billed`,
+      ];
+      if (num(d.humanTakeover) > 0) parts.push(`${num(d.humanTakeover)} handed to a human`);
+      if (num(d.errors) > 0) parts.push(`${num(d.errors)} failed`);
+      return `${parts.join(", ")}.`;
+    },
+  },
 };
 
 /** Fallback for a cron name not yet documented in CRON_METADATA. The UI


### PR DESCRIPTION
Phase 0 of the [GA4 + Search Console insight dashboards plan](https://github.com/travelxp/peakhour-mongodb/blob/master/docs/idea/analytics-insights-dashboards-plan.md). UI-copy only — no behaviour change.

## Depends on travelxp/peakhour-api#868 — merge that first

Until the api PR lands, `POST /v1/dev/cron/:name` 404s for both names and these buttons don't work. (`wa-outcome-billing`'s button is *already* rendered on `dashboard/content/whatsapp/analytics` and *already* 404ing today — the api PR is what actually fixes it.)

## What changed

Both crons are now dev-triggerable api-side, so give them friendly labels, tooltips and summarizers instead of the `"Run <name>"` fallback.

Summarizers are written against the handlers' **actual** return shapes, read from source rather than assumed:

- `ask-weekly-digest` → `{ targets, sent, skipped, errors, budgetHit }`
- `wa-outcome-billing` → `{ scanned, humanTakeover, billed, none, errors, byOutcome, durationMs }` (`OutcomeRunStats`)

`budgetHit` is surfaced explicitly — the run stops on wall-clock without finishing the queue, so a bare "N sent" would read as complete when it isn't.

## Second commit — review finding

Adversarial review caught the `skipped` comment claiming *"quiet-hours / no-metrics / already-digested this week"*. Only no-metrics was real: there is no quiet-hours logic, and the already-digested guard **did not exist at all** until the paired api fix added it. The comment documented protection that wasn't there — which is precisely how the next reader would have missed the re-send bug that review found.

Also reworded the `targets === 0` line. *"No businesses were due a digest"* implied a healthy no-op, but 0 covers both "nobody has connected analytics" and "everyone was digested inside the guard window". It no longer claims which.

## Verification

- `tsc --noEmit` clean.
- Exercised both summarizers against the real return shapes: pluralization correct at n=1 ("1 digest sent", "1 of 1 conversation billed"), `budgetHit` disclosed, zero-states read honestly.
- Resilience: empty body, malformed JSON, missing `data`, `data: null`, and wrong-typed `data` all return `null` → generic toast, never a throw. Matches the file's documented contract.

Sample output:

```
ask-weekly-digest    "Nothing to send — no business is due a digest right now."
ask-weekly-digest    "12 digests sent."
ask-weekly-digest    "41 digests sent, 2 skipped, 1 failed. Time budget reached — the rest roll over to the next run."
wa-outcome-billing   "No quiet conversations to review yet."
wa-outcome-billing   "3 of 9 conversations billed, 1 handed to a human."
wa-outcome-billing   "4 conversations reviewed — none reached a billable outcome."
```

## Note

5 pre-existing whitelisted crons still render with the fallback label (`fx-rates`, `meta-token-keepalive`, `media-overage-snapshot`, `shopify-deadstock-score`, `shopify-voice-card-learn`). Left alone here to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)