### PR TITLE
feat(analytics): "Explain this" Tier-2 card on both dashboards (Phase 4c-3)

### DIFF
--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -28,6 +28,7 @@ import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { useSetAskEntityIds } from "@/providers/ask-context-provider";
 import { ASK_ENABLED } from "@/lib/flags";
 import { TrendChart } from "@/components/ui/trend-chart";
+import { ExplainCard } from "@/components/dashboard/explain-card";
 import {
   useAnalyticsInsights,
   ANALYTICS_INSIGHTS_KEY,
@@ -425,6 +426,9 @@ function AnalyticsData({
           )}
         </Card>
       )}
+
+      {/* ── Tier-2 "Explain this" (user-triggered, Peaks-metered) ── */}
+      <ExplainCard surface="ga4" resource={data.property} />
 
       {/* ── Funnel top-line ── */}
       {/* Totals over the funnel window (30d). We deliberately DON'T show a WoW

--- a/src/app/(site)/dashboard/insights/search-console/page.tsx
+++ b/src/app/(site)/dashboard/insights/search-console/page.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { TrendChart } from "@/components/ui/trend-chart";
+import { ExplainCard } from "@/components/dashboard/explain-card";
 import { useSetAskEntityIds } from "@/providers/ask-context-provider";
 
 // ── Types (mirror peakhour-api search-insights service) ─────────────────────
@@ -414,6 +415,9 @@ export default function SearchConsoleInsightsPage() {
                   </CardContent>
                 </Card>
               )}
+
+              {/* ── Tier-2 "Explain this" (user-triggered, Peaks-metered) ── */}
+              <ExplainCard surface="gsc" resource={data.siteUrl} />
 
               {/* ── Clicks trend ── */}
               {data.trend && data.trend.length > 0 && (

--- a/src/components/dashboard/explain-card.tsx
+++ b/src/components/dashboard/explain-card.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Sparkles, RefreshCw, Loader2, Lightbulb, Zap } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api";
+import { useExplain, type ExplainSurface, type ExplainNarration } from "@/hooks/use-explain";
+
+/** Sentiment → left-accent colour for the narration card. */
+const ACCENT: Record<ExplainNarration["sentiment"], string> = {
+  positive: "border-l-emerald-500",
+  neutral: "border-l-muted-foreground/40",
+  concern: "border-l-amber-500",
+};
+
+/**
+ * The user-triggered, Peaks-metered Tier-2 "Explain this" card. Deterministic
+ * Tier-1 always renders above it; this is the optional plain-English gloss the
+ * owner opts into. Renders nothing when there's no week-over-week comparison to
+ * explain (the Tier-1 "not enough history" banner covers that state).
+ */
+export function ExplainCard({ surface, resource }: { surface: ExplainSurface; resource?: string }) {
+  const { query, generate } = useExplain(surface, resource);
+  const [outOfPeaks, setOutOfPeaks] = useState(false);
+
+  const data = query.data;
+  // Nothing to explain yet (first week / not connected / still syncing) — stay
+  // out of the way; the deterministic dashboard already speaks to those states.
+  if (query.isLoading || !data || !data.available) return null;
+
+  const narration = data.narration;
+  const pending = generate.isPending;
+
+  const run = (refresh: boolean) => {
+    setOutOfPeaks(false);
+    generate.mutate(
+      { refresh },
+      {
+        onError: (err) => {
+          // Peaks hard cap (requireUnderFairUse → 429) — meter, don't paywall:
+          // show an honest top-up nudge, never a raw error.
+          if (err instanceof ApiError && (err.code === "CREDITS_EXHAUSTED" || err.status === 429)) {
+            setOutOfPeaks(true);
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <Card className={narration ? `border-l-4 ${ACCENT[narration.sentiment]}` : undefined}>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Explain this
+          </CardTitle>
+          {narration && (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={pending}
+              onClick={() => run(true)}
+              title={data.stale ? "The data has moved on — refresh the explanation" : "Regenerate"}
+            >
+              <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${pending ? "animate-spin" : ""}`} />
+              {data.stale ? "Refresh" : "Regenerate"}
+            </Button>
+          )}
+        </div>
+        {narration && data.stale && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Your numbers have changed since this was written.
+          </p>
+        )}
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {outOfPeaks ? (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/40">
+            <span className="text-amber-900 dark:text-amber-200">
+              You&apos;re out of Peaks for now — top up to generate more explanations.
+            </span>
+            <Button asChild size="sm" variant="outline">
+              <Link href="/dashboard/peaks">
+                <Zap className="mr-1.5 h-3.5 w-3.5" />
+                Peaks
+              </Link>
+            </Button>
+          </div>
+        ) : !narration ? (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Turn this week&apos;s numbers into plain English — what changed, and what to do next.
+            </p>
+            <Button size="sm" disabled={pending} onClick={() => run(false)}>
+              {pending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Sparkles className="mr-2 h-4 w-4" />
+              )}
+              Explain this week
+            </Button>
+            <p className="text-xs text-muted-foreground">Uses 1 Peak.</p>
+          </div>
+        ) : (
+          <>
+            <p className="text-sm font-semibold">{narration.headline}</p>
+            <ul className="space-y-1.5">
+              {narration.lines.map((line, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" aria-hidden />
+                  {line}
+                </li>
+              ))}
+            </ul>
+            {narration.nextAction && (
+              <div className="flex items-start gap-2 rounded-md bg-muted/50 p-2.5 text-sm">
+                <Lightbulb className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                <span>
+                  <span className="font-medium">Do this: </span>
+                  {narration.nextAction}
+                </span>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/explain-card.tsx
+++ b/src/components/dashboard/explain-card.tsx
@@ -2,11 +2,17 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { toast } from "sonner";
 import { Sparkles, RefreshCw, Loader2, Lightbulb, Zap } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/api";
+import { useCreditsBalance, useCreditsRateCard, getCapStatus } from "@/hooks/use-credits";
 import { useExplain, type ExplainSurface, type ExplainNarration } from "@/hooks/use-explain";
+
+/** The billable useCase (cfg_ai_models, mongodb migration 164) — used to read
+ *  the true per-generation cost off the rate card. */
+const EXPLAIN_USE_CASE = "metrics_translate_dashboard";
 
 /** Sentiment → left-accent colour for the narration card. */
 const ACCENT: Record<ExplainNarration["sentiment"], string> = {
@@ -23,7 +29,10 @@ const ACCENT: Record<ExplainNarration["sentiment"], string> = {
  */
 export function ExplainCard({ surface, resource }: { surface: ExplainSurface; resource?: string }) {
   const { query, generate } = useExplain(surface, resource);
+  const { data: balance } = useCreditsBalance();
+  const { data: rateCard } = useCreditsRateCard();
   const [outOfPeaks, setOutOfPeaks] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const data = query.data;
   // Nothing to explain yet (first week / not connected / still syncing) — stay
@@ -32,17 +41,32 @@ export function ExplainCard({ surface, resource }: { surface: ExplainSurface; re
 
   const narration = data.narration;
   const pending = generate.isPending;
+  // Pre-flight: don't let the click fail into a 429 if we already know they're
+  // capped (also shows the nudge proactively, not just reactively).
+  const hardCapped = getCapStatus(balance) === "hard" || outOfPeaks;
+
+  // True cost from the rate card (creditMultiplier), NOT a hard-coded guess — the
+  // price lives in cfg_ai_models and ops can retune it. Falls back to unit-less
+  // copy rather than a wrong number while the card loads.
+  const cost = rateCard?.useCases.find((u) => u.useCase === EXPLAIN_USE_CASE)?.creditMultiplier;
+  const costLabel = cost ? `Uses about ${cost} Peaks.` : "Uses Peaks.";
 
   const run = (refresh: boolean) => {
-    setOutOfPeaks(false);
+    if (hardCapped) return;
+    setErrorMsg(null);
     generate.mutate(
       { refresh },
       {
         onError: (err) => {
           // Peaks hard cap (requireUnderFairUse → 429) — meter, don't paywall:
-          // show an honest top-up nudge, never a raw error.
+          // an honest top-up nudge, never a raw error.
           if (err instanceof ApiError && (err.code === "CREDITS_EXHAUSTED" || err.status === 429)) {
             setOutOfPeaks(true);
+          } else {
+            // Any other failure (model hiccup / network) — surface it, don't
+            // leave the user staring at a reset button with no feedback.
+            setErrorMsg("Couldn't generate that explanation — please try again.");
+            toast.error("Couldn't generate the explanation. Please try again.");
           }
         },
       },
@@ -61,9 +85,13 @@ export function ExplainCard({ surface, resource }: { surface: ExplainSurface; re
             <Button
               size="sm"
               variant="ghost"
-              disabled={pending}
+              disabled={pending || hardCapped}
               onClick={() => run(true)}
-              title={data.stale ? "The data has moved on — refresh the explanation" : "Regenerate"}
+              title={
+                data.stale
+                  ? `The data has moved on — refresh the explanation (${costLabel})`
+                  : `Regenerate (${costLabel})`
+              }
             >
               <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${pending ? "animate-spin" : ""}`} />
               {data.stale ? "Refresh" : "Regenerate"}
@@ -78,7 +106,8 @@ export function ExplainCard({ surface, resource }: { surface: ExplainSurface; re
       </CardHeader>
 
       <CardContent className="space-y-3">
-        {outOfPeaks ? (
+        {/* Additive banners — never replace the narration/button below. */}
+        {hardCapped && (
           <div className="flex items-center justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/40">
             <span className="text-amber-900 dark:text-amber-200">
               You&apos;re out of Peaks for now — top up to generate more explanations.
@@ -90,12 +119,19 @@ export function ExplainCard({ surface, resource }: { surface: ExplainSurface; re
               </Link>
             </Button>
           </div>
-        ) : !narration ? (
+        )}
+        {errorMsg && (
+          <p className="rounded-md border border-red-300 bg-red-50 p-2.5 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            {errorMsg}
+          </p>
+        )}
+
+        {!narration ? (
           <div className="space-y-2">
             <p className="text-sm text-muted-foreground">
               Turn this week&apos;s numbers into plain English — what changed, and what to do next.
             </p>
-            <Button size="sm" disabled={pending} onClick={() => run(false)}>
+            <Button size="sm" disabled={pending || hardCapped} onClick={() => run(false)}>
               {pending ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               ) : (
@@ -103,7 +139,7 @@ export function ExplainCard({ surface, resource }: { surface: ExplainSurface; re
               )}
               Explain this week
             </Button>
-            <p className="text-xs text-muted-foreground">Uses 1 Peak.</p>
+            <p className="text-xs text-muted-foreground">{costLabel}</p>
           </div>
         ) : (
           <>
@@ -125,6 +161,9 @@ export function ExplainCard({ surface, resource }: { surface: ExplainSurface; re
                 </span>
               </div>
             )}
+            <p className="text-xs text-muted-foreground">
+              {cost ? `Regenerating uses about ${cost} more Peaks.` : "Regenerating spends Peaks again."}
+            </p>
           </>
         )}
       </CardContent>

--- a/src/hooks/use-explain.ts
+++ b/src/hooks/use-explain.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+export type ExplainSurface = "ga4" | "gsc";
+
+export interface ExplainNarration {
+  headline: string;
+  lines: string[];
+  sentiment: "positive" | "neutral" | "concern";
+  nextAction?: string;
+}
+
+export interface ExplainResponse {
+  /** True when there's a week-over-week digest worth narrating. */
+  available: boolean;
+  reason?: string;
+  narration: ExplainNarration | null;
+  cached: boolean;
+  stale?: boolean;
+}
+
+const BASE: Record<ExplainSurface, string> = {
+  ga4: "analytics-insights",
+  gsc: "search-insights",
+};
+const PARAM: Record<ExplainSurface, string> = { ga4: "propertyId", gsc: "siteUrl" };
+
+function path(surface: ExplainSurface, resource: string | undefined, refresh: boolean): string {
+  const params = new URLSearchParams();
+  if (resource) params.set(PARAM[surface], resource);
+  if (refresh) params.set("refresh", "1");
+  const qs = params.toString();
+  return `/v1/content/${BASE[surface]}/explain${qs ? `?${qs}` : ""}`;
+}
+
+/**
+ * The user-triggered Tier-2 "Explain this" narration for a dashboard surface.
+ * GET reads the cached narration (never spends); `generate` POSTs to create or
+ * refresh it (spends one Peak, gated server-side by fair-use). Query key is
+ * scoped by business + surface + property so switching either re-reads.
+ */
+export function useExplain(surface: ExplainSurface, resource: string | undefined, enabled = true) {
+  const { business } = useAuth();
+  const qc = useQueryClient();
+  const key = ["explain", surface, business?._id ?? "none", resource ?? "default"];
+
+  const query = useQuery({
+    queryKey: key,
+    queryFn: () => api.get<ExplainResponse>(path(surface, resource, false)),
+    enabled: enabled && Boolean(business?._id),
+    refetchOnWindowFocus: false,
+  });
+
+  const generate = useMutation({
+    mutationFn: (opts?: { refresh?: boolean }) =>
+      api.post<ExplainResponse>(path(surface, resource, opts?.refresh ?? false), {}),
+    // Write the fresh narration straight into the GET cache so the card updates
+    // without a second round-trip.
+    onSuccess: (data) => qc.setQueryData(key, data),
+  });
+
+  return { query, generate };
+}


### PR DESCRIPTION
## Phase 4c-3 — the "Explain this" card (final piece of the initiative)

The b2c half of the user-triggered, Peaks-metered narrator, on both dashboards. Consumes the endpoints from api#877. Deterministic Tier-1 always renders; this is the optional plain-English gloss the owner opts into.

- **`hooks/use-explain.ts`** — GET reads the cached narration (**never spends**); `generate` POSTs to create/refresh (spends 1 Peak, server-gated by `requireUnderFairUse`). Business+surface+property-scoped key; `onSuccess` writes the fresh narration into the GET cache (no second round-trip).
- **`components/dashboard/explain-card.tsx`** — renders **nothing** until there's a week-over-week digest to explain (`available:false` → the Tier-1 "not enough history" banner covers that). Otherwise: an "Explain this week" button → a card with headline + lines + **sentiment left-accent** + a "Do this" nextAction; a **Refresh** when `stale`; "Uses 1 Peak." The button is **disabled while pending** (mitigates the concurrent double-charge window). A **429 `CREDITS_EXHAUSTED`** renders an honest "out of Peaks — top up" nudge to `/dashboard/peaks` (never a raw error — meter, not paywall).
- Wired into both the **GA4** (`surface="ga4"`) and **GSC** (`surface="gsc"`) dashboards, below the digest banner.

### Verification
- `tsc` + `eslint` clean; `next build` compiles; `vitest` green (62).
- ⚠️ Runtime render static-only-verified (no connected dev tenant to auth against). The endpoint contract is API-verified (#877, DB-tested incl. the cache-hit no-AI path). Happy to seed a dev tenant + screenshot if you want a visual pass.

### This completes the analytics-insight-dashboards initiative through Phase 4
Reader → service → GA4 digest → route → trend series → dashboards → Explain-this (cache + billing + endpoint + card). Remaining: **Phase 5** (the 8 dead GA4 skills — loud-loader fix, then implement/stop-seeding), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)