### PR TITLE
feat(billing): checkout tax labels + seller entity + IN GSTIN gate (Phase 6)

### DIFF
--- a/src/components/upgrade/payment-modal.tsx
+++ b/src/components/upgrade/payment-modal.tsx
@@ -5,24 +5,47 @@ import { loadStripe, type Stripe } from "@stripe/stripe-js";
 import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js";
 import { toast } from "sonner";
 
+import { api } from "@/lib/api";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 /**
  * On-site payment overlay for native subscription checkout. The API's
- * /v1/billing/checkout returns a { gateway, embed } payload; this renders the
- * matching gateway's native surface:
+ * /v1/billing/checkout returns a { gateway, embed, summary } payload; this
+ * renders the matching gateway's native surface:
  *   • stripe   → embedded Checkout mounted INSIDE our modal (desktop) /
  *                bottom sheet (mobile).
  *   • razorpay → Razorpay Checkout.js overlay (its own full-screen surface).
  *   • payu     → PayU Bolt overlay (its own surface).
- * Only Stripe renders inside our shell; Razorpay/PayU bring their own overlays,
- * so for those we just launch the SDK and render nothing.
+ * The buyer-facing `summary` (seller entity + tax label, Phase 6) renders above
+ * the Stripe iframe and — for India — in a pre-overlay step that also offers
+ * optional GSTIN capture (input credit) before the Razorpay surface opens.
  */
 
+/** Buyer-facing checkout summary from the api — the tax label is derived from
+ *  the SAME plan flag that stamps the charge, so copy and money always agree. */
+export interface CheckoutSummary {
+  tier: string;
+  amount: number;
+  currency: string;
+  interval: "month" | "year";
+  buyerCountry: string;
+  taxIncluded: boolean;
+  taxLabel: string;
+  sellerName: string;
+  sellerCountry: string | null;
+  merchantOfRecord: "self" | "stripe";
+}
+
 export type CheckoutResult =
-  | { gateway: "stripe"; embed: { kind: "stripe"; clientSecret: string; publishableKey: string } }
+  | {
+      gateway: "stripe";
+      embed: { kind: "stripe"; clientSecret: string; publishableKey: string };
+      summary?: CheckoutSummary;
+    }
   | {
       gateway: "razorpay";
       embed: {
@@ -31,8 +54,13 @@ export type CheckoutResult =
         keyId: string;
         prefill?: { name?: string; email?: string };
       };
+      summary?: CheckoutSummary;
     }
-  | { gateway: "payu"; embed: { kind: "payu"; action: string; params: Record<string, string> } };
+  | {
+      gateway: "payu";
+      embed: { kind: "payu"; action: string; params: Record<string, string> };
+      summary?: CheckoutSummary;
+    };
 
 declare global {
   interface Window {
@@ -61,6 +89,26 @@ function loadScript(src: string, id: string): Promise<void> {
   });
 }
 
+function SummaryLine({ summary }: { summary: CheckoutSummary }) {
+  return (
+    <div className="rounded-xl border bg-muted/40 px-4 py-3 text-sm">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-medium truncate">{summary.tier}</span>
+        <span className="font-semibold whitespace-nowrap">
+          {summary.currency} {summary.amount}/{summary.interval === "year" ? "yr" : "mo"}
+        </span>
+      </div>
+      <div className="text-muted-foreground mt-1 flex flex-wrap items-baseline justify-between gap-x-3 text-xs">
+        <span>{summary.taxLabel}</span>
+        <span>
+          Sold by {summary.sellerName}
+          {summary.sellerCountry ? ` (${summary.sellerCountry})` : ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 interface PaymentModalProps {
   checkout: CheckoutResult | null;
   onOpenChange: (open: boolean) => void;
@@ -72,7 +120,13 @@ interface PaymentModalProps {
 export function PaymentModal({ checkout, onOpenChange, onSuccess }: PaymentModalProps) {
   if (!checkout) return null;
   if (checkout.gateway === "stripe") {
-    return <StripeEmbedded embed={checkout.embed} onOpenChange={onOpenChange} />;
+    return (
+      <StripeEmbedded
+        embed={checkout.embed}
+        summary={checkout.summary}
+        onOpenChange={onOpenChange}
+      />
+    );
   }
   return (
     <GatewayLauncher checkout={checkout} onOpenChange={onOpenChange} onSuccess={onSuccess} />
@@ -83,9 +137,11 @@ export function PaymentModal({ checkout, onOpenChange, onSuccess }: PaymentModal
 
 function StripeEmbedded({
   embed,
+  summary,
   onOpenChange,
 }: {
   embed: Extract<CheckoutResult, { gateway: "stripe" }>["embed"];
+  summary?: CheckoutSummary;
   onOpenChange: (open: boolean) => void;
 }) {
   const isMobile = useIsMobile();
@@ -117,9 +173,16 @@ function StripeEmbedded({
   if (invalid || !mounted) return null;
 
   const body = (
-    <EmbeddedCheckoutProvider stripe={stripePromise} options={options}>
-      <EmbeddedCheckout />
-    </EmbeddedCheckoutProvider>
+    <>
+      {summary ? (
+        <div className="px-1 pb-3">
+          <SummaryLine summary={summary} />
+        </div>
+      ) : null}
+      <EmbeddedCheckoutProvider stripe={stripePromise} options={options}>
+        <EmbeddedCheckout />
+      </EmbeddedCheckoutProvider>
+    </>
   );
 
   if (isMobile) {
@@ -159,6 +222,8 @@ function StripeEmbedded({
 const RAZORPAY_SRC = "https://checkout.razorpay.com/v1/checkout.js";
 const PAYU_BOLT_SRC = "https://jssdk.payu.in/bolt/bolt.min.js";
 
+const GSTIN_RE = /^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z][0-9A-Z]Z[0-9A-Z]$/;
+
 function GatewayLauncher({
   checkout,
   onOpenChange,
@@ -168,11 +233,39 @@ function GatewayLauncher({
   onOpenChange: (open: boolean) => void;
   onSuccess?: () => void;
 }) {
+  const summary = checkout.summary;
+  // India self-MoR: offer optional GSTIN capture (buyer input credit on the GST
+  // invoice) BEFORE handing off to the gateway overlay. Skipping is fine — the
+  // field also lives in Settings → Billing. Non-IN goes straight to the overlay.
+  const needsGstGate = summary?.buyerCountry === "IN" && summary.merchantOfRecord === "self";
+  const [gate, setGate] = useState<"checking" | "prompt" | "launch">(
+    needsGstGate ? "checking" : "launch",
+  );
+  const [gstin, setGstin] = useState("");
+  const [savingGstin, setSavingGstin] = useState(false);
+
+  useEffect(() => {
+    if (!needsGstGate) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await api.get<{ billingProfile?: { gstin?: string } }>("/v1/billing/profile");
+        if (cancelled) return;
+        setGate(r?.billingProfile?.gstin ? "launch" : "prompt");
+      } catch {
+        if (!cancelled) setGate("launch"); // never block payment on the profile read
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [needsGstGate]);
+
   // Guard so the overlay is launched exactly once per checkout payload.
   const launched = useRef(false);
 
   useEffect(() => {
-    if (launched.current) return;
+    if (gate !== "launch" || launched.current) return;
     launched.current = true;
 
     (async () => {
@@ -184,7 +277,10 @@ function GatewayLauncher({
           const rzp = new window.Razorpay({
             key: keyId,
             subscription_id: subscriptionId,
-            name: "Peakhour",
+            // Seller identity is data-driven from the billing entity's invoice
+            // branding (Phase 6) — never hardcoded.
+            name: summary?.sellerName || "Peakhour",
+            ...(summary ? { description: `${summary.tier} — ${summary.taxLabel}` } : {}),
             ...(prefill ? { prefill } : {}),
             handler: () => {
               onSuccess?.();
@@ -213,8 +309,65 @@ function GatewayLauncher({
         onOpenChange(false);
       }
     })();
-  }, [checkout, onOpenChange, onSuccess]);
+  }, [gate, checkout, onOpenChange, onSuccess, summary]);
 
-  // The gateway renders its own overlay; nothing for us to draw.
+  const continueToPayment = async () => {
+    const value = gstin.trim().toUpperCase();
+    if (value) {
+      if (!GSTIN_RE.test(value)) {
+        toast.error("That GSTIN doesn't look right — it's 15 characters, e.g. 22AAAAA0000A1Z5");
+        return;
+      }
+      setSavingGstin(true);
+      try {
+        // Merge-PUT: only touches gstin (+ derives place of supply from it).
+        await api.put("/v1/billing/profile", { gstin: value, placeOfSupplyState: value.slice(0, 2) });
+      } catch {
+        toast.error("Couldn't save the GSTIN — you can add it later in Settings → Billing.");
+      } finally {
+        setSavingGstin(false);
+      }
+    }
+    setGate("launch");
+  };
+
+  if (gate === "prompt" && summary) {
+    return (
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Complete your purchase</DialogTitle>
+          </DialogHeader>
+          <SummaryLine summary={summary} />
+          <div className="space-y-1">
+            <label htmlFor="checkout-gstin" className="text-xs font-medium text-muted-foreground">
+              GSTIN (optional — for your input tax credit)
+            </label>
+            <Input
+              id="checkout-gstin"
+              value={gstin}
+              placeholder="22AAAAA0000A1Z5"
+              onChange={(e) => setGstin(e.target.value)}
+            />
+            <p className="text-muted-foreground text-xs">
+              Businesses: add your GSTIN so it prints on your tax invoice. You can also add it later
+              in Settings → Billing.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setGate("launch")} disabled={savingGstin}>
+              Skip
+            </Button>
+            <Button onClick={continueToPayment} disabled={savingGstin}>
+              {savingGstin ? "Saving…" : "Continue to payment"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // The gateway renders its own overlay; nothing for us to draw while checking
+  // or once launched.
   return null;
 }

--- a/src/components/upgrade/payment-modal.tsx
+++ b/src/components/upgrade/payment-modal.tsx
@@ -29,6 +29,8 @@ import { Input } from "@/components/ui/input";
  *  the SAME plan flag that stamps the charge, so copy and money always agree. */
 export interface CheckoutSummary {
   tier: string;
+  /** Human plan name (cfg_plans.name) — always prefer over the machine key. */
+  tierLabel?: string;
   amount: number;
   currency: string;
   interval: "month" | "year";
@@ -93,7 +95,7 @@ function SummaryLine({ summary }: { summary: CheckoutSummary }) {
   return (
     <div className="rounded-xl border bg-muted/40 px-4 py-3 text-sm">
       <div className="flex items-baseline justify-between gap-3">
-        <span className="font-medium truncate">{summary.tier}</span>
+        <span className="font-medium truncate">{summary.tierLabel || summary.tier}</span>
         <span className="font-semibold whitespace-nowrap">
           {summary.currency} {summary.amount}/{summary.interval === "year" ? "yr" : "mo"}
         </span>
@@ -280,7 +282,7 @@ function GatewayLauncher({
             // Seller identity is data-driven from the billing entity's invoice
             // branding (Phase 6) — never hardcoded.
             name: summary?.sellerName || "Peakhour",
-            ...(summary ? { description: `${summary.tier} — ${summary.taxLabel}` } : {}),
+            ...(summary ? { description: `${summary.tierLabel || summary.tier} — ${summary.taxLabel}` } : {}),
             ...(prefill ? { prefill } : {}),
             handler: () => {
               onSuccess?.();
@@ -334,7 +336,7 @@ function GatewayLauncher({
   if (gate === "prompt" && summary) {
     return (
       <Dialog open onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-md">
+        <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Complete your purchase</DialogTitle>
           </DialogHeader>
@@ -348,6 +350,9 @@ function GatewayLauncher({
               value={gstin}
               placeholder="22AAAAA0000A1Z5"
               onChange={(e) => setGstin(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void continueToPayment();
+              }}
             />
             <p className="text-muted-foreground text-xs">
               Businesses: add your GSTIN so it prints on your tax invoice. You can also add it later
@@ -367,7 +372,22 @@ function GatewayLauncher({
     );
   }
 
-  // The gateway renders its own overlay; nothing for us to draw while checking
-  // or once launched.
+  if (gate === "checking") {
+    // Never render "nothing" while the profile read is in flight — a dead click
+    // invites a re-click that would mint a second gateway subscription.
+    return (
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Preparing payment…</DialogTitle>
+          </DialogHeader>
+          {summary ? <SummaryLine summary={summary} /> : null}
+          <p className="text-muted-foreground text-sm">One moment — opening the secure payment window.</p>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // The gateway renders its own overlay; nothing for us to draw once launched.
   return null;
 }


### PR DESCRIPTION
Companion to peakhour-api#911. Renders the checkout `summary` (price, tax label, seller entity) above the Stripe embedded checkout; Razorpay overlay branding becomes data-driven from cfg_billing_entities invoice branding; India self-MoR buyers get an optional GSTIN step (validated, merge-PUT, auto place-of-supply from the GSTIN state code) before the gateway overlay opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)