### PR TITLE
feat(nav): Insights pillar + upsell-visible gated pillars

### DIFF
--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -62,6 +62,7 @@ import {
   MessagesSquare,
   ShoppingBag,
   MapPin,
+  LineChart,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -71,6 +72,7 @@ import {
 } from "@/components/ui/collapsible";
 import { useMyTickets } from "@/hooks/use-feedback";
 import { useRunningJobCount } from "@/hooks/use-jobs";
+import { LockedNavItem } from "@/components/dashboard/locked-nav-item";
 
 interface NavItem {
   href: string;
@@ -84,6 +86,12 @@ interface NavItem {
    * Content/Growth items). Used to gate the Commerce pillar on `commerce.nav`.
    */
   feature?: string;
+  /**
+   * One-line value prop shown in the upgrade drawer when a `feature`-gated
+   * pillar is rendered locked (unentitled) instead of hidden. Ignored for
+   * ungated items. See LockedNavItem.
+   */
+  upsellTagline?: string;
   subItems?: { href: string; label: string; badge?: () => React.ReactNode }[];
 }
 
@@ -153,6 +161,8 @@ const NAV_GROUPS: NavGroup[] = [
         label: "Commerce",
         icon: ShoppingBag,
         feature: "commerce.nav",
+        upsellTagline:
+          "Autonomous merchandising, inventory and pricing across your storefronts.",
         subItems: [
           { href: "/dashboard/commerce", label: "Command Center" },
           { href: "/dashboard/commerce/channels", label: "Channels" },
@@ -173,6 +183,23 @@ const NAV_GROUPS: NavGroup[] = [
         label: "Presence",
         icon: MapPin,
         feature: "presence.nav",
+        upsellTagline:
+          "Own your Google Business Profile, listings and local reviews from one place.",
+      },
+      // Insights — GA4 + Search Console dashboards. Ungated (no `feature`):
+      // the pages self-gate on the relevant Google integration being
+      // connected, so the pillar stays discoverable for everyone and acts
+      // as the connect prompt. Previously these routes existed but were
+      // unreachable from the nav — only deep-linked from the Overview
+      // recommendations card / Ask Peakhour.
+      {
+        href: "/dashboard/insights/analytics",
+        label: "Insights",
+        icon: LineChart,
+        subItems: [
+          { href: "/dashboard/insights/analytics", label: "Web Analytics" },
+          { href: "/dashboard/insights/search-console", label: "Search Console" },
+        ],
       },
       { href: "/dashboard/inbox", label: "Inbox", icon: MessagesSquare },
       { href: "/dashboard/tasks", label: "Tasks", icon: ListChecks, badge: () => <RunningJobsBadge /> },
@@ -306,13 +333,25 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
               )}
               <SidebarGroupContent>
                 <SidebarMenu>
-                  {group.items
-                    .filter(
-                      (item) =>
-                        !item.feature ||
-                        Boolean(entitlements?.features?.includes(item.feature)),
-                    )
-                    .map((item) => {
+                  {group.items.map((item) => {
+                    // Gated pillar the org isn't entitled to → render it
+                    // locked with an upsell affordance instead of hiding it
+                    // (entitlements are resolved by now; the shell blocks on
+                    // isLoading above, so no locked-flash for entitled orgs).
+                    if (
+                      item.feature &&
+                      !entitlements?.features?.includes(item.feature)
+                    ) {
+                      return (
+                        <LockedNavItem
+                          key={item.href}
+                          icon={item.icon}
+                          label={item.label}
+                          featureKey={item.feature}
+                          tagline={item.upsellTagline}
+                        />
+                      );
+                    }
                     const Icon = item.icon;
                     const isActive = item.subItems
                       ? item.subItems.some((s) => pathname === s.href || pathname?.startsWith(s.href + "/"))

--- a/src/components/dashboard/locked-nav-item.tsx
+++ b/src/components/dashboard/locked-nav-item.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles, type LucideIcon } from "lucide-react";
+import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import { UpgradeDrawer } from "@/components/upgrade/upgrade-drawer";
+
+/**
+ * LockedNavItem — a top-level sidebar pillar the org is NOT entitled to,
+ * rendered visible-but-locked instead of hidden. Reversing the earlier
+ * "hide unentitled pillars" behaviour so gated pillars become an upsell
+ * surface: owners discover Commerce/Presence/etc. and can self-serve the
+ * upgrade rather than never learning the pillar exists.
+ *
+ * Unlike an entitled pillar it does NOT expand its sub-items or navigate.
+ * Clicking opens the upgrade drawer scoped to the pillar's `.nav` feature
+ * key (intent=plan_upgrade), so the waitlist/checkout copy and analytics
+ * are tagged to what the user reached for. Mirrors the FeatureGate "lock"
+ * affordance, applied at the nav level where FeatureGate isn't wired.
+ */
+export function LockedNavItem({
+  icon: Icon,
+  label,
+  featureKey,
+  tagline,
+}: {
+  icon: LucideIcon;
+  label: string;
+  /** cfg_features.key gating the pillar, e.g. "commerce.nav". */
+  featureKey: string;
+  tagline?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        tooltip={`${label} — upgrade to unlock`}
+        onClick={() => setOpen(true)}
+        className="text-sidebar-foreground/60"
+      >
+        <Icon />
+        <span>{label}</span>
+        <Sparkles className="ml-auto size-3.5 text-amber-500 dark:text-amber-400" />
+      </SidebarMenuButton>
+      <UpgradeDrawer
+        open={open}
+        onOpenChange={setOpen}
+        featureKey={featureKey}
+        featureName={label}
+        featureTagline={tagline}
+        intent="plan_upgrade"
+      />
+    </SidebarMenuItem>
+  );
+}

--- a/src/components/molecules/command-menu.tsx
+++ b/src/components/molecules/command-menu.tsx
@@ -21,6 +21,8 @@ import {
   Sparkles,
   Plug,
   Settings,
+  LineChart,
+  Search,
 } from "lucide-react";
 
 const PAGES = [
@@ -31,6 +33,8 @@ const PAGES = [
   { label: "Ads", href: "/dashboard/ads", icon: Megaphone, group: "Navigation" },
   { label: "Outcomes", href: "/dashboard/outcomes", icon: TrendingUp, group: "Navigation" },
   { label: "Optimizer", href: "/dashboard/optimizer", icon: Sparkles, group: "Navigation" },
+  { label: "Web Analytics", href: "/dashboard/insights/analytics", icon: LineChart, group: "Navigation" },
+  { label: "Search Console", href: "/dashboard/insights/search-console", icon: Search, group: "Navigation" },
   { label: "Integrations", href: "/dashboard/integrations", icon: Plug, group: "Settings" },
   { label: "Settings", href: "/dashboard/settings", icon: Settings, group: "Settings" },
 ] as const;


### PR DESCRIPTION
## What
Two customer-dashboard sidebar changes (peakhour-b2c):

1. **Insights pillar (new, missing menu item).** The GA4 (**Web Analytics**) and **Search Console** dashboards already exist at `/dashboard/insights/*` but were unreachable from the nav — only deep-linked from the Overview recommendations card / Ask Peakhour. Adds a top-level **Insights** pillar. Ungated: the pages self-gate on the relevant Google integration being connected, so the pillar stays discoverable and doubles as the connect prompt. Also added to the Cmd+K command menu.

2. **Gated pillars now upsell instead of hide.** Commerce + Presence previously vanished from the sidebar when the org wasn't entitled. They now render **locked-with-upsell** via the new `LockedNavItem`, which opens the `UpgradeDrawer` scoped to the pillar's `.nav` feature key (`intent=plan_upgrade`). Reverses the prior hide-filter so owners discover pillars and can self-serve the upgrade.

## Why
Per product direction: don't hide unentitled pillars — show them and upsell. Discovered while investigating why the *quests.travel* org (on `content_studio.free`) couldn't see Commerce/Analytics.

## Notes / safety
- Entitled orgs are unaffected — the shell blocks on `isLoading` before nav renders, so there's no locked-flash for entitled pillars.
- `tsc --noEmit` clean, ESLint clean on touched files.
- Separate follow-up (not in this PR): the *Quest Travels* org on `commerce_assistant.free` has **stale** `entitlements.features` (missing `commerce.nav` + siblings that the plan already grants post-migration 144) → needs an entitlements recompute, an ops/data action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)