### PR TITLE
fix(analytics): GA4 property picker persists + honest cron toast

### DIFF
--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -95,6 +95,24 @@ export default function AnalyticsInsightsPage() {
     onError: (e: Error) => toast.error(e.message ?? "Sync failed"),
   });
 
+  // Persist the chosen GA4 property to the connection (config.propertyId) —
+  // the field the hourly performance-sync actually reads. Without this the
+  // picker only ever changed a read-time query override, so the cron stayed
+  // blind and the dashboard showed nothing. On success we kick a sync so data
+  // for the newly-selected property lands right away.
+  const setPropertyMut = useMutation({
+    mutationFn: (propertyId: string) =>
+      api.put("/v1/integrations/google_analytics/ga4-property", { propertyId }),
+    onSuccess: () => {
+      toast.success("Property selected — syncing analytics now");
+      qc.invalidateQueries({ queryKey: ["integration-cap"] });
+      qc.invalidateQueries({ queryKey: [ANALYTICS_INSIGHTS_KEY] });
+      syncMut.mutate();
+    },
+    onError: (e: Error) =>
+      toast.error(e.message ?? "Could not select property"),
+  });
+
   const status = statusQ.data;
   const properties = capQ.data?.account?.extra?.properties ?? [];
   const selectedPropertyId = (capQ.data?.capabilities as Record<string, unknown> | undefined)
@@ -227,29 +245,47 @@ export default function AnalyticsInsightsPage() {
                   </p>
                 ) : (
                   <ul className="space-y-1">
-                    {properties.map((p) => (
-                      <li
-                        key={p.propertyId}
-                        className="flex items-center justify-between rounded border px-2 py-1"
-                      >
-                        <div>
-                          <span className="font-medium">{p.displayName}</span>
-                          <span className="ml-2 font-mono text-xs text-muted-foreground">
-                            {p.propertyId}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {p.currencyCode && (
-                            <Badge variant="outline" className="text-xs">
-                              {p.currencyCode}
-                            </Badge>
-                          )}
-                          {selectedPropertyId === p.propertyId && (
-                            <Badge className="text-xs">Active</Badge>
-                          )}
-                        </div>
-                      </li>
-                    ))}
+                    {properties.map((p) => {
+                      const isActive = selectedPropertyId === p.propertyId;
+                      const isSetting =
+                        setPropertyMut.isPending &&
+                        setPropertyMut.variables === p.propertyId;
+                      return (
+                        <li
+                          key={p.propertyId}
+                          className="flex items-center justify-between rounded border px-2 py-1"
+                        >
+                          <div>
+                            <span className="font-medium">{p.displayName}</span>
+                            <span className="ml-2 font-mono text-xs text-muted-foreground">
+                              {p.propertyId}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {p.currencyCode && (
+                              <Badge variant="outline" className="text-xs">
+                                {p.currencyCode}
+                              </Badge>
+                            )}
+                            {isActive ? (
+                              <Badge className="text-xs">Active</Badge>
+                            ) : (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-6 px-2 text-xs"
+                                disabled={setPropertyMut.isPending}
+                                onClick={() =>
+                                  setPropertyMut.mutate(p.propertyId)
+                                }
+                              >
+                                {isSetting ? "Selecting…" : "Use this"}
+                              </Button>
+                            )}
+                          </div>
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </div>

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -29,13 +29,21 @@
  *                   reads keep the intent obvious.
  */
 
+/** A summarizer may return a bare string (shown as a success toast) or an
+ *  object that also carries a severity — use `level: "warning"` when the run
+ *  technically succeeded (HTTP 2xx) but did nothing useful, e.g. a sync that
+ *  skipped every connection because none is finished being set up. Without
+ *  this a no-op reads as a green success, which is what made "sync ran, toast
+ *  green, still no data" so confusing. */
+export type CronSummary = string | { message: string; level?: "success" | "warning" };
+
 export interface CronMetadata {
   label: string;
   frequency: string;
   description: string;
-  /** Maps the parsed cron `data` payload to a friendly one-line success
-   *  message, or null to fall back to the generic toast. */
-  summarize?: (data: unknown) => string | null;
+  /** Maps the parsed cron `data` payload to a friendly one-line message
+   *  (optionally with a severity), or null to fall back to the generic toast. */
+  summarize?: (data: unknown) => CronSummary | null;
 }
 
 export const CRON_METADATA: Record<string, CronMetadata> = {
@@ -114,13 +122,37 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       const total = num(overall.connectionsTotal);
       if (total === 0) return "Performance refreshed — no connected platforms yet.";
       if (num(overall.errors) > 0)
-        return "Performance refreshed, but some platforms reported errors.";
+        return {
+          message: "Performance refreshed, but some platforms reported errors.",
+          level: "warning",
+        };
+      const notConfigured = num(overall.notConfigured);
       const run = num(overall.connectionsRun);
-      if (run > 0)
-        return `Performance refreshed across ${run} ${plural(run, "connection")}.`;
+      // Ran but every connection that ran was incomplete (e.g. GA4 with no
+      // property selected) — a 2xx no-op. Warn, and point at the fix, so this
+      // stops masquerading as a healthy sync.
+      if (notConfigured > 0 && notConfigured >= run) {
+        return {
+          message:
+            "Nothing synced — pick a GA4 property (and connect Search Console) above, then refresh.",
+          level: "warning",
+        };
+      }
+      if (run > 0) {
+        const base = `Performance refreshed across ${run} ${plural(run, "connection")}.`;
+        return notConfigured > 0
+          ? {
+              message: `${base} ${notConfigured} still ${notConfigured === 1 ? "needs" : "need"} setup.`,
+              level: "warning",
+            }
+          : base;
+      }
       // total > 0 but nothing ran → every connection was lock-skipped,
       // i.e. a refresh is already in progress (not "up to date").
-      return "A performance refresh is already running — check back shortly.";
+      return {
+        message: "A performance refresh is already running — check back shortly.",
+        level: "warning",
+      };
     },
   },
   "linkedin-post-sync": {
@@ -429,13 +461,21 @@ function plural(count: number, noun: string): string {
  * generic "<label> complete") whenever there's no summarizer, the body
  * isn't parseable, or the summarizer opts out. Never throws.
  */
-export function summarizeCronBody(cron: string, body: string): string | null {
+export function summarizeCronBody(
+  cron: string,
+  body: string,
+): { message: string; level: "success" | "warning" } | null {
   const summarize = CRON_METADATA[cron]?.summarize;
   if (!summarize || !body) return null;
   try {
     const parsed = JSON.parse(body) as unknown;
     const data = asRecord(parsed)?.data;
-    return summarize(data);
+    const result = summarize(data);
+    if (result == null) return null;
+    // Normalize the bare-string form to a success-level object.
+    return typeof result === "string"
+      ? { message: result, level: "success" }
+      : { message: result.message, level: result.level ?? "success" };
   } catch {
     // Malformed / truncated body — defer to the generic toast.
     return null;

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -92,13 +92,20 @@ export function CronToolbar({ crons, onTriggered }: Props) {
     try {
       const res = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, {});
       if (res.ok) {
-        // Show a clean, user-facing success line — never the raw cron
-        // JSON. The per-cron summarizer turns the response payload into
-        // something like "12 posts synced successfully."; absent one, we
-        // fall back to a generic "<label> complete". The raw body + timing
-        // still go to the dev console for debugging.
+        // Show a clean, user-facing line — never the raw cron JSON. The
+        // per-cron summarizer turns the response payload into something like
+        // "12 posts synced successfully."; absent one, we fall back to a
+        // generic "<label> complete". A summarizer can flag `level:"warning"`
+        // for a 2xx run that did nothing useful (e.g. a sync that skipped
+        // every connection because none is configured) so a no-op stops
+        // reading as a green success. The raw body + timing still go to the
+        // dev console for debugging.
         const summary = summarizeCronBody(cron, res.body);
-        toast.success(summary ?? `${meta.label} complete`);
+        if (summary?.level === "warning") {
+          toast.warning(summary.message);
+        } else {
+          toast.success(summary?.message ?? `${meta.label} complete`);
+        }
         if (res.body) {
           console.debug(
             `[CronToolbar] ${cron} ok in ${res.durationMs}ms:`,


### PR DESCRIPTION
## Why
Pairs with **peakhour-api #916**. Fixes "GA4 connected, **Refresh performance** green, dashboard empty" (repro'd on *quests.travel* dev).

The GA4 property list on the analytics page was **display-only** — a user could see the property but had no way to select it, so `config.propertyId` (what the sync cron reads) never got set. And the CronToolbar showed a **green success** toast for a 2xx no-op.

## Changes
- **`insights/analytics/page.tsx`** — each GA4 property row gets a **"Use this"** action that `PUT`s `/v1/integrations/google_analytics/ga4-property` (the new api route) to persist `config.propertyId`, then kicks a sync so data lands right away. The already-selected property still shows the **Active** badge.
- **`cron-metadata.ts`** — summarizers may now return `{ message, level }`. `performance-sync` returns `level:"warning"` when the run skipped every connection for missing setup (no GA4 property / no GSC site), pointing the user at the fix.
- **`cron-toolbar.tsx`** — a `warning`-level summary renders `toast.warning`, so a no-op stops reading as green.

## Verify
- `tsc --noEmit` + ESLint clean on touched files.
- End-to-end confirmed via the api side: persisting the property → sync wrote 824 GA4 snapshots for the dev org; the dashboard renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)