### PR TITLE
feat(billing): plan-picker on Settings>Billing (replaces mailto)

### DIFF
--- a/src/app/(site)/dashboard/settings/billing/page.tsx
+++ b/src/app/(site)/dashboard/settings/billing/page.tsx
@@ -18,6 +18,8 @@ import { featureLabel } from "@/lib/pricing";
 import { useQueryClient } from "@tanstack/react-query";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { TaxAndInvoices } from "@/components/settings-tax-invoices";
+import { UpgradePlanDialog } from "@/components/upgrade/upgrade-plan-dialog";
+import { useState } from "react";
 
 // Mirrors the navbar PlanBadge tier accents so plan presentation stays
 // consistent across surfaces.
@@ -38,6 +40,7 @@ export default function BillingPage() {
   const { formatDate } = useLocale();
   const { data: details, isLoading } = useDashboardOrg();
   const extend = useExtendTrial();
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
 
   const cronToolbar = (
     <CronToolbar
@@ -146,8 +149,12 @@ export default function BillingPage() {
                   {extend.isPending ? "Extending…" : "Extend trial 7 days"}
                 </Button>
               ) : null}
-              <Button variant="outline" size="sm" asChild>
-                <a href="mailto:hello@peakhour.ai">Upgrade plan</a>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setUpgradeOpen(true)}
+              >
+                Upgrade plan
               </Button>
             </div>
           </div>
@@ -256,6 +263,14 @@ export default function BillingPage() {
         {/* Tax details + self-issued invoices */}
         <TaxAndInvoices />
       </div>
+
+      <UpgradePlanDialog
+        open={upgradeOpen}
+        onOpenChange={setUpgradeOpen}
+        onPurchased={() =>
+          queryClient.invalidateQueries({ queryKey: ["/v1/dashboard/org"] })
+        }
+      />
     </div>
   );
 }

--- a/src/components/upgrade/upgrade-plan-dialog.tsx
+++ b/src/components/upgrade/upgrade-plan-dialog.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Check, Loader2, Sparkles } from "lucide-react";
+import { api } from "@/lib/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PaymentModal, type CheckoutResult } from "./payment-modal";
+
+/**
+ * UpgradePlanDialog — the plan-picker that replaces the old mailto on
+ * Settings › Billing. Lists the purchasable plans (GET /v1/billing/plans,
+ * priced in the buyer's own currency by the server), lets the user pick one,
+ * then POSTs /v1/billing/checkout and hands the returned gateway payload to
+ * PaymentModal — which renders Stripe/Razorpay/PayU on-site. The gateway is
+ * chosen server-side from the org's country, so there's nothing region-
+ * specific here.
+ */
+
+interface PurchasablePlan {
+  tier: string;
+  name: string;
+  tagline?: string;
+  products: string[];
+  amount: number;
+  yearly: number | null;
+  currency: string;
+  interval: "month";
+  trialDays: number;
+  taxIncluded: boolean;
+  recommended: boolean;
+  isCurrent: boolean;
+}
+interface PlansResponse {
+  country: string;
+  purchasable: boolean;
+  plans: PurchasablePlan[];
+}
+
+function formatPrice(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount}`;
+  }
+}
+
+export function UpgradePlanDialog({
+  open,
+  onOpenChange,
+  onPurchased,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  /** Fired after a successful payment so the host can refresh billing state. */
+  onPurchased?: () => void;
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [checkout, setCheckout] = useState<CheckoutResult | null>(null);
+
+  const plansQ = useQuery({
+    queryKey: ["billing-plans"],
+    queryFn: () => api.get<PlansResponse>("/v1/billing/plans"),
+    enabled: open,
+    refetchOnWindowFocus: false,
+  });
+
+  const checkoutMut = useMutation({
+    mutationFn: (tier: string) =>
+      api.post<CheckoutResult>("/v1/billing/checkout", { tier }),
+    onSuccess: (res) => setCheckout(res),
+    onError: (e: Error) => toast.error(e.message ?? "Couldn't start checkout"),
+  });
+
+  const plans = plansQ.data?.plans ?? [];
+  const purchasable = plansQ.data?.purchasable ?? true;
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Choose a plan</DialogTitle>
+            <DialogDescription>
+              {purchasable
+                ? "Pick a plan to upgrade — you'll pay securely on the next step."
+                : "Payments aren't available in your country yet. We'll let you know as soon as they are."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {plansQ.isLoading ? (
+            <div className="flex justify-center py-10">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : plansQ.isError ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Couldn&apos;t load plans. Please try again.
+            </p>
+          ) : plans.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No plans available right now.
+            </p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {plans.map((p) => {
+                const active = selected === p.tier;
+                const disabled = p.isCurrent || !purchasable;
+                return (
+                  <button
+                    key={p.tier}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => setSelected(p.tier)}
+                    className={cn(
+                      "relative rounded-lg border p-4 text-left transition",
+                      active
+                        ? "border-primary ring-1 ring-primary"
+                        : "hover:border-foreground/30",
+                      disabled && "cursor-not-allowed opacity-60",
+                    )}
+                  >
+                    {p.recommended && (
+                      <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                        <Sparkles className="size-3" />
+                        Popular
+                      </span>
+                    )}
+                    <div className="font-medium">{p.name}</div>
+                    {p.tagline && (
+                      <div className="mt-0.5 text-xs text-muted-foreground">
+                        {p.tagline}
+                      </div>
+                    )}
+                    <div className="mt-2 text-lg font-semibold">
+                      {formatPrice(p.amount, p.currency)}
+                      <span className="text-xs font-normal text-muted-foreground">
+                        /mo
+                      </span>
+                    </div>
+                    {p.trialDays > 0 && (
+                      <div className="text-xs text-emerald-600 dark:text-emerald-400">
+                        {p.trialDays}-day free trial
+                      </div>
+                    )}
+                    {p.isCurrent && (
+                      <span className="mt-2 inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                        Current plan
+                      </span>
+                    )}
+                    {active && !disabled && (
+                      <Check className="absolute bottom-3 right-3 size-4 text-primary" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!selected || !purchasable || checkoutMut.isPending}
+              onClick={() => selected && checkoutMut.mutate(selected)}
+            >
+              {checkoutMut.isPending ? "Starting…" : "Continue to payment"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <PaymentModal
+        checkout={checkout}
+        onOpenChange={(o) => {
+          if (!o) setCheckout(null);
+        }}
+        onSuccess={() => {
+          setCheckout(null);
+          onOpenChange(false);
+          onPurchased?.();
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Why
Settings › Billing → **Upgrade plan** was a `mailto:hello@peakhour.ai`. That fit the waitlist era; now it should open a real payment page.

## What
- **`UpgradePlanDialog`** (new) — lists purchasable plans from `GET /v1/billing/plans` (priced in the buyer's currency, resolved server-side), user picks one → `POST /v1/billing/checkout` → hands the returned gateway payload to the **existing `PaymentModal`** (Stripe embedded / Razorpay / PayU on-site). The gateway is chosen **server-side** from the org's country, so there's nothing region-specific in the UI. Current tiers render disabled; a not-yet-live country disables buying with a clear message.
- **`billing/page.tsx`** — the `mailto` becomes a button that opens the dialog; org state refreshes on a successful purchase.

## Dependencies / rollout
- **Depends on peakhour-api [#917](https://github.com/travelxp/peakhour-api/pull/917)** (`GET /v1/billing/plans`). Merge + deploy that to devapi first.
- To actually transact in dev, **devapi (Vercel) needs the gateway env creds** — Stripe + Razorpay **test** keys (present in local `.env`; confirm they're set in Vercel dev). Until then `/v1/billing/checkout` returns `503 billing-not-configured`.

## Verify
- `tsc` + ESLint clean.
- Plans endpoint returns real per-country pricing (verified on the api PR). Full pay round-trip (checkout → gateway overlay → webhook → entitlement recompute) needs a browser session on devapi after both PRs deploy + creds — tracked as the manual dev-verification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)