### PR TITLE
feat(growth): Ads Manager MVP + Boost-to-Campaign (G1)

### DIFF
--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -1,22 +1,395 @@
-import { Megaphone } from "lucide-react";
+"use client";
 
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api";
+import {
+  linkedInAdsApi,
+  type ManagedCampaign,
+  type ManagedCampaignStatus,
+} from "@/lib/api/linkedin-ads";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { EmptyState } from "@/components/molecules/empty-state";
+import { Archive, Megaphone, Pause, Play, RefreshCw, Rocket } from "lucide-react";
+
+/**
+ * Ads Manager (G1 MVP) — the Growth pillar's first live surface.
+ *
+ * Lists the business's MANAGED campaigns (Peakhour-created via
+ * Boost-to-Campaign / the WhatsApp BOOST workflow — all born as
+ * non-serving LinkedIn drafts) with live performance, and owns the one
+ * spend-enabling action in the product: Activate, behind an explicit
+ * confirm. Campaigns created directly in LinkedIn's own Campaign
+ * Manager are out of scope here (no import yet).
+ */
+
+interface ApiIntegration {
+  provider: string;
+  connected?: boolean;
+  status?: string;
+}
+
+const STATUS_BADGE: Record<ManagedCampaignStatus, string> = {
+  draft: "bg-muted text-muted-foreground",
+  review: "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200",
+  active: "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200",
+  paused: "bg-orange-100 text-orange-900 dark:bg-orange-950 dark:text-orange-200",
+  completed: "bg-sky-100 text-sky-900 dark:bg-sky-950 dark:text-sky-200",
+  archived: "bg-muted/60 text-muted-foreground",
+};
+
+function formatMoney(value: number | undefined, currency?: string): string {
+  if (typeof value !== "number") return "—";
+  const rounded = Math.round(value * 100) / 100;
+  return currency ? `${currency} ${rounded}` : String(rounded);
+}
 
 export default function AdsPage() {
+  const integrations = useQuery({
+    queryKey: ["content-hub-integrations"],
+    queryFn: () =>
+      api.get<{ integrations: ApiIntegration[] }>("/v1/integrations"),
+    staleTime: 30_000,
+  });
+
+  const adsConnection = useMemo(
+    () => integrations.data?.integrations.find((i) => i.provider === "linkedin_ads"),
+    [integrations.data],
+  );
+  const isConnected =
+    adsConnection?.connected === true || adsConnection?.status === "needs_reauth";
+
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-bold">Ad Campaigns</h2>
         <p className="text-muted-foreground">
-          AI-generated ads reaching your ideal customers
+          Boost your proven LinkedIn posts into campaigns — created as
+          non-spending drafts you activate when ready
         </p>
       </div>
 
-      <EmptyState
-        icon={Megaphone}
-        title="Coming Soon"
-        description="The AI will analyze your best content, generate ad creatives, and deploy them to your connected platforms — all automatically."
-      />
+      {integrations.isLoading ? (
+        <Card>
+          <CardContent className="space-y-3 p-6">
+            <Skeleton className="h-5 w-1/3" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-24 w-full" />
+          </CardContent>
+        </Card>
+      ) : !isConnected ? (
+        <EmptyState
+          icon={Megaphone}
+          title="Connect LinkedIn Ads to get started"
+          description="Connect your LinkedIn ad account, then boost your best organic posts into campaigns from the Content → LinkedIn → Boost tab. Campaigns are created as drafts — nothing spends until you activate it."
+          action={{ label: "Connect LinkedIn Ads", href: "/dashboard/integrations" }}
+        />
+      ) : (
+        <CampaignsPanel />
+      )}
     </div>
+  );
+}
+
+function CampaignsPanel() {
+  const queryClient = useQueryClient();
+  const campaigns = useQuery({
+    queryKey: ["linkedin-managed-campaigns"],
+    queryFn: () => linkedInAdsApi.managedCampaigns(),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+
+  if (campaigns.isLoading) {
+    return (
+      <Card>
+        <CardContent className="space-y-2 p-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (campaigns.isError) {
+    const err = campaigns.error;
+    const needsReauth = err instanceof ApiError && err.code === "NEEDS_REAUTH";
+    return (
+      <EmptyState
+        icon={RefreshCw}
+        title={needsReauth ? "LinkedIn Ads needs a reconnect" : "Couldn't load campaigns"}
+        description={
+          needsReauth
+            ? "Your LinkedIn Ads connection went stale. Reconnect to manage campaigns."
+            : "Try refreshing in a moment. If the problem persists, check your LinkedIn Ads connection."
+        }
+        action={
+          needsReauth
+            ? { label: "Reconnect", href: "/dashboard/integrations" }
+            : undefined
+        }
+      />
+    );
+  }
+
+  const rows = campaigns.data?.campaigns ?? [];
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        icon={Rocket}
+        title="No campaigns yet"
+        description="Head to the Boost tab on your LinkedIn content hub — we rank your recent posts by boost-worthiness, and one click turns the winner into a draft campaign."
+        action={{ label: "See boost-worthy posts", href: "/dashboard/content/linkedin" }}
+      />
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-base font-semibold leading-none">Managed campaigns</h3>
+          <Badge
+            variant="outline"
+            className="text-[10px] uppercase tracking-wide"
+            title="Campaigns Peakhour created from your organic posts. All start as non-spending LinkedIn drafts; Activate is the only action that starts spend."
+          >
+            Draft-first
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Campaign</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Daily budget</TableHead>
+              <TableHead className="text-right">Spent</TableHead>
+              <TableHead className="text-right">Impressions</TableHead>
+              <TableHead className="text-right">Clicks</TableHead>
+              <TableHead className="text-right">CTR</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((c) => (
+              <CampaignRow key={c._id} campaign={c} onChanged={invalidate} />
+            ))}
+          </TableBody>
+        </Table>
+        <p className="mt-3 border-t pt-2 text-[11px] text-muted-foreground">
+          Campaigns are created in LinkedIn as drafts under a paused group —
+          they cannot spend until you activate them. Finish audience targeting
+          in LinkedIn Campaign Manager before activating; the protective
+          monitor auto-pauses any campaign that reaches its total budget.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CampaignRow({
+  campaign,
+  onChanged,
+}: {
+  campaign: ManagedCampaign;
+  onChanged: () => void;
+}) {
+  const [confirmActivate, setConfirmActivate] = useState(false);
+
+  const status = useMutation({
+    mutationFn: (next: "active" | "paused" | "archived") =>
+      linkedInAdsApi.setStatus(campaign._id, next),
+    onSuccess: (_data, next) => {
+      toast.success(
+        next === "active"
+          ? "Campaign activated — LinkedIn will start delivery once its review passes."
+          : next === "paused"
+            ? "Campaign paused."
+            : "Campaign archived.",
+      );
+      onChanged();
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.code === "NEEDS_REAUTH") {
+        toast.error("LinkedIn Ads needs a reconnect before changing campaigns.");
+      } else if (err instanceof ApiError && err.code === "INVALID_TRANSITION") {
+        toast.error("That status change isn't possible from the campaign's current state.");
+      } else {
+        toast.error("Couldn't update the campaign. Try again in a moment.");
+      }
+    },
+  });
+
+  const sync = useMutation({
+    mutationFn: () => linkedInAdsApi.syncCampaign(campaign._id),
+    onSuccess: () => {
+      toast.success("Campaign metrics refreshed.");
+      onChanged();
+    },
+    onError: () => toast.error("Couldn't refresh metrics right now."),
+  });
+
+  const busy = status.isPending || sync.isPending;
+  const perf = campaign.performance;
+  const canActivate = ["draft", "review", "paused"].includes(campaign.status);
+  const canPause = campaign.status === "active";
+  const canArchive = !["archived"].includes(campaign.status);
+  const canSync = Boolean(campaign.platformCampaignId);
+
+  return (
+    <TableRow>
+      <TableCell className="max-w-[260px]">
+        <p className="truncate text-sm font-medium" title={campaign.name}>
+          {campaign.name}
+        </p>
+        {campaign.schedule?.durationDays ? (
+          <p className="text-[11px] text-muted-foreground">
+            {campaign.schedule.durationDays}-day flight
+          </p>
+        ) : null}
+      </TableCell>
+      <TableCell>
+        <span
+          className={`inline-flex rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${STATUS_BADGE[campaign.status] ?? STATUS_BADGE.draft}`}
+        >
+          {campaign.status}
+        </span>
+      </TableCell>
+      <TableCell className="text-right text-sm tabular-nums">
+        {formatMoney(campaign.budget?.daily, campaign.currency)}
+      </TableCell>
+      <TableCell className="text-right text-sm tabular-nums">
+        {formatMoney(campaign.budget?.spent ?? perf?.spend, campaign.currency)}
+      </TableCell>
+      <TableCell className="text-right text-sm tabular-nums">
+        {perf ? perf.impressions.toLocaleString() : "—"}
+      </TableCell>
+      <TableCell className="text-right text-sm tabular-nums">
+        {perf ? perf.clicks.toLocaleString() : "—"}
+      </TableCell>
+      <TableCell className="text-right text-sm tabular-nums">
+        {perf ? `${(perf.ctr * 100).toFixed(2)}%` : "—"}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center justify-end gap-1">
+          {canSync ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2"
+              disabled={busy}
+              title="Refresh live metrics from LinkedIn"
+              onClick={() => sync.mutate()}
+            >
+              <RefreshCw className={`size-3 ${sync.isPending ? "animate-spin" : ""}`} />
+            </Button>
+          ) : null}
+          {canActivate ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="default"
+              className="h-7 px-2 text-xs"
+              disabled={busy}
+              title="Activate — this is the step that starts real ad spend"
+              onClick={() => setConfirmActivate(true)}
+            >
+              <Play className="mr-1 size-3" />
+              Activate
+            </Button>
+          ) : null}
+          {canPause ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              disabled={busy}
+              onClick={() => status.mutate("paused")}
+            >
+              <Pause className="mr-1 size-3" />
+              Pause
+            </Button>
+          ) : null}
+          {canArchive ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2"
+              disabled={busy}
+              title="Archive campaign"
+              onClick={() => status.mutate("archived")}
+            >
+              <Archive className="size-3" />
+            </Button>
+          ) : null}
+        </div>
+
+        <AlertDialog open={confirmActivate} onOpenChange={setConfirmActivate}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Start spending on this campaign?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Activating &ldquo;{campaign.name}&rdquo; un-pauses its LinkedIn
+                campaign group and submits the campaign for delivery at{" "}
+                <span className="font-medium">
+                  {formatMoney(campaign.budget?.daily, campaign.currency)}/day
+                </span>
+                {typeof campaign.budget?.total === "number" ? (
+                  <>
+                    {" "}
+                    (up to {formatMoney(campaign.budget.total, campaign.currency)}{" "}
+                    total — we auto-pause at that cap)
+                  </>
+                ) : null}
+                . Make sure its audience targeting is finished in LinkedIn
+                Campaign Manager first.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Not yet</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  setConfirmActivate(false);
+                  status.mutate("active");
+                }}
+              >
+                Activate &amp; start spend
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -131,7 +131,8 @@ export default function AdsPage() {
                 <span>
                   Your LinkedIn Ads connection is{" "}
                   <span className="font-medium">stale</span>. Reconnect to
-                  boost posts or change campaigns — the list below still works.
+                  boost posts, sync metrics, or change campaigns — the list
+                  below still works.
                 </span>
                 <a
                   href="/dashboard/integrations"
@@ -174,22 +175,12 @@ function CampaignsPanel() {
   }
 
   if (campaigns.isError) {
-    const err = campaigns.error;
-    const needsReauth = err instanceof ApiError && err.code === "NEEDS_REAUTH";
+    // The list is a pure local read — no reauth special case exists.
     return (
       <EmptyState
         icon={RefreshCw}
-        title={needsReauth ? "LinkedIn Ads needs a reconnect" : "Couldn't load campaigns"}
-        description={
-          needsReauth
-            ? "Your LinkedIn Ads connection went stale. Reconnect to manage campaigns."
-            : "Try refreshing in a moment. If the problem persists, check your LinkedIn Ads connection."
-        }
-        action={
-          needsReauth
-            ? { label: "Reconnect", href: "/dashboard/integrations" }
-            : undefined
-        }
+        title="Couldn't load campaigns"
+        description="Try refreshing in a moment. If the problem persists, check your LinkedIn Ads connection."
       />
     );
   }
@@ -314,6 +305,8 @@ function CampaignRow({
             onClick: () => { window.location.href = "/dashboard/integrations"; },
           },
         });
+      } else if (code === "RATE_LIMITED") {
+        toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
       } else {
         toast.error("Couldn't refresh metrics right now.");
       }
@@ -326,7 +319,12 @@ function CampaignRow({
     ["draft", "review", "paused"].includes(campaign.status) &&
     Boolean(campaign.platformCampaignId && campaign.platformCampaignGroupId);
   const canPause = campaign.status === "active";
-  const canArchive = !["archived"].includes(campaign.status);
+  // Rows without a platform campaign (WhatsApp-approval "review"
+  // markers) are workflow-owned: the server 409s NO_PLATFORM_ID on any
+  // status change, so offering actions would only produce dead-end
+  // errors. They resolve via the WhatsApp flow (or expire to archived).
+  const canArchive =
+    !["archived"].includes(campaign.status) && Boolean(campaign.platformCampaignId);
   const canSync = Boolean(campaign.platformCampaignId);
 
   return (
@@ -429,7 +427,8 @@ function CampaignRow({
               <AlertDialogDescription>
                 Archiving &ldquo;{campaign.name}&rdquo; stops it permanently on
                 LinkedIn{campaign.status === "active" ? " (it is currently active)" : ""} —
-                archived campaigns can&apos;t be reactivated.
+                archived campaigns can&apos;t be reactivated here or in Campaign
+                Manager.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -62,6 +62,17 @@ const STATUS_BADGE: Record<ManagedCampaignStatus, string> = {
 
 function formatMoney(value: number | undefined, currency?: string): string {
   if (typeof value !== "number") return "—";
+  if (currency) {
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency,
+        maximumFractionDigits: 2,
+      }).format(value);
+    } catch {
+      // Unknown ISO code — fall through to the plain render.
+    }
+  }
   const rounded = Math.round(value * 100) / 100;
   return currency ? `${currency} ${rounded}` : String(rounded);
 }
@@ -99,6 +110,12 @@ export default function AdsPage() {
             <Skeleton className="h-24 w-full" />
           </CardContent>
         </Card>
+      ) : integrations.isError ? (
+        <EmptyState
+          icon={RefreshCw}
+          title="Couldn't check your connections"
+          description="We couldn't load your integration status just now. Refresh in a moment — your campaigns are unaffected."
+        />
       ) : !isConnected ? (
         <EmptyState
           icon={Megaphone}
@@ -107,7 +124,26 @@ export default function AdsPage() {
           action={{ label: "Connect LinkedIn Ads", href: "/dashboard/integrations" }}
         />
       ) : (
-        <CampaignsPanel />
+        <>
+          {adsConnection?.status === "needs_reauth" ? (
+            <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-900 dark:bg-amber-950/30">
+              <CardContent className="flex items-center justify-between gap-4 p-4 text-sm">
+                <span>
+                  Your LinkedIn Ads connection is{" "}
+                  <span className="font-medium">stale</span>. Reconnect to
+                  boost posts or change campaigns — the list below still works.
+                </span>
+                <a
+                  href="/dashboard/integrations"
+                  className="font-medium text-amber-900 underline underline-offset-4 dark:text-amber-200"
+                >
+                  Reconnect
+                </a>
+              </CardContent>
+            </Card>
+          ) : null}
+          <CampaignsPanel />
+        </>
       )}
     </div>
   );
@@ -223,6 +259,7 @@ function CampaignRow({
   onChanged: () => void;
 }) {
   const [confirmActivate, setConfirmActivate] = useState(false);
+  const [confirmArchive, setConfirmArchive] = useState(false);
 
   const status = useMutation({
     mutationFn: (next: "active" | "paused" | "archived") =>
@@ -238,10 +275,24 @@ function CampaignRow({
       onChanged();
     },
     onError: (err) => {
-      if (err instanceof ApiError && err.code === "NEEDS_REAUTH") {
-        toast.error("LinkedIn Ads needs a reconnect before changing campaigns.");
-      } else if (err instanceof ApiError && err.code === "INVALID_TRANSITION") {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "NEEDS_REAUTH" || code === "NOT_CONNECTED") {
+        toast.error("LinkedIn Ads needs a reconnect before changing campaigns.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => { window.location.href = "/dashboard/integrations"; },
+          },
+        });
+      } else if (code === "INVALID_TRANSITION") {
         toast.error("That status change isn't possible from the campaign's current state.");
+        // The row is by definition stale — resync the table.
+        onChanged();
+      } else if (code === "NO_PLATFORM_ID" || code === "VALIDATION_GROUP_ID_REQUIRED") {
+        toast.error(
+          "This campaign is missing its LinkedIn identity and can't be changed from here — contact support.",
+        );
+      } else if (code === "RATE_LIMITED") {
+        toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
       } else {
         toast.error("Couldn't update the campaign. Try again in a moment.");
       }
@@ -254,12 +305,26 @@ function CampaignRow({
       toast.success("Campaign metrics refreshed.");
       onChanged();
     },
-    onError: () => toast.error("Couldn't refresh metrics right now."),
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "NEEDS_REAUTH" || code === "NOT_CONNECTED") {
+        toast.error("LinkedIn Ads needs a reconnect before syncing metrics.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => { window.location.href = "/dashboard/integrations"; },
+          },
+        });
+      } else {
+        toast.error("Couldn't refresh metrics right now.");
+      }
+    },
   });
 
   const busy = status.isPending || sync.isPending;
   const perf = campaign.performance;
-  const canActivate = ["draft", "review", "paused"].includes(campaign.status);
+  const canActivate =
+    ["draft", "review", "paused"].includes(campaign.status) &&
+    Boolean(campaign.platformCampaignId && campaign.platformCampaignGroupId);
   const canPause = campaign.status === "active";
   const canArchive = !["archived"].includes(campaign.status);
   const canSync = Boolean(campaign.platformCampaignId);
@@ -308,6 +373,7 @@ function CampaignRow({
               className="h-7 px-2"
               disabled={busy}
               title="Refresh live metrics from LinkedIn"
+              aria-label="Refresh live metrics from LinkedIn"
               onClick={() => sync.mutate()}
             >
               <RefreshCw className={`size-3 ${sync.isPending ? "animate-spin" : ""}`} />
@@ -347,13 +413,38 @@ function CampaignRow({
               variant="ghost"
               className="h-7 px-2"
               disabled={busy}
-              title="Archive campaign"
-              onClick={() => status.mutate("archived")}
+              title="Archive campaign (permanent)"
+              aria-label="Archive campaign (permanent)"
+              onClick={() => setConfirmArchive(true)}
             >
               <Archive className="size-3" />
             </Button>
           ) : null}
         </div>
+
+        <AlertDialog open={confirmArchive} onOpenChange={setConfirmArchive}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Archive this campaign?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Archiving &ldquo;{campaign.name}&rdquo; stops it permanently on
+                LinkedIn{campaign.status === "active" ? " (it is currently active)" : ""} —
+                archived campaigns can&apos;t be reactivated.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Keep it</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  setConfirmArchive(false);
+                  status.mutate("archived");
+                }}
+              >
+                Archive permanently
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         <AlertDialog open={confirmActivate} onOpenChange={setConfirmActivate}>
           <AlertDialogContent>

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import {
+  linkedInAdsApi,
+  type BoostObjective,
+} from "@/lib/api/linkedin-ads";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Rocket } from "lucide-react";
+
+/**
+ * Boost-to-Campaign dialog (G1) — turns a ranked organic post into a
+ * REAL LinkedIn campaign via POST /v1/linkedin/ads/boost.
+ *
+ * Safety framing baked into the copy: the campaign is created as a
+ * LinkedIn DRAFT under a paused group. Nothing spends from this dialog
+ * — activation (the one spend-enabling action) lives in the Ads
+ * Manager behind its own confirm.
+ */
+
+const OBJECTIVES: Array<{ value: BoostObjective; label: string }> = [
+  { value: "engagement", label: "Engagement (boost the post)" },
+  { value: "brand_awareness", label: "Brand awareness" },
+  { value: "website_traffic", label: "Website traffic" },
+  { value: "lead_generation", label: "Lead generation" },
+];
+
+export function BoostCampaignDialog({
+  open,
+  onOpenChange,
+  postUrn,
+  defaultName,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  postUrn: string;
+  defaultName: string;
+}) {
+  const [name, setName] = useState(defaultName);
+  const [objective, setObjective] = useState<BoostObjective>("engagement");
+  const [dailyBudget, setDailyBudget] = useState("10");
+  const [currencyCode, setCurrencyCode] = useState("USD");
+  const [durationDays, setDurationDays] = useState("14");
+
+  const boost = useMutation({
+    mutationFn: () =>
+      linkedInAdsApi.boost({
+        postUrn,
+        name: name.trim(),
+        objective,
+        dailyBudget: Number(dailyBudget),
+        currencyCode: currencyCode.trim().toUpperCase(),
+        durationDays: Math.round(Number(durationDays)),
+      }),
+    onSuccess: () => {
+      onOpenChange(false);
+      toast.success("Draft campaign created on LinkedIn.", {
+        description:
+          "It won't spend until you activate it. Finish targeting, then activate from the Ads Manager.",
+        action: {
+          label: "Open Ads Manager",
+          onClick: () => {
+            window.location.href = "/dashboard/ads";
+          },
+        },
+      });
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.code === "CURRENCY_MISMATCH") {
+        toast.error(err.message || "Use your ad account's billing currency.");
+      } else if (err instanceof ApiError && err.code === "NOT_CONNECTED") {
+        toast.error("Connect LinkedIn Ads first (Integrations page).");
+      } else if (err instanceof ApiError && err.code === "NEEDS_REAUTH") {
+        toast.error("LinkedIn Ads needs a reconnect before boosting.");
+      } else {
+        toast.error("Couldn't create the campaign. Try again in a moment.");
+      }
+    },
+  });
+
+  const budgetNumber = Number(dailyBudget);
+  const durationNumber = Number(durationDays);
+  const valid =
+    name.trim().length > 0 &&
+    Number.isFinite(budgetNumber) &&
+    budgetNumber > 0 &&
+    /^[A-Za-z]{3}$/.test(currencyCode.trim()) &&
+    Number.isFinite(durationNumber) &&
+    durationNumber >= 1 &&
+    durationNumber <= 366;
+
+  const total =
+    valid && Number.isFinite(budgetNumber * durationNumber)
+      ? Math.round(budgetNumber * durationNumber * 100) / 100
+      : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Rocket className="size-4" />
+            Boost this post
+          </DialogTitle>
+          <DialogDescription>
+            Creates a LinkedIn campaign sponsoring this post — as a{" "}
+            <span className="font-medium">non-spending draft</span>. You finish
+            audience targeting and activate it from the Ads Manager; only that
+            activation starts spend.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="boost-name">Campaign name</Label>
+            <Input
+              id="boost-name"
+              value={name}
+              maxLength={256}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Objective</Label>
+            <Select
+              value={objective}
+              onValueChange={(v) => setObjective(v as BoostObjective)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {OBJECTIVES.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="boost-budget">Daily budget</Label>
+              <Input
+                id="boost-budget"
+                type="number"
+                min={1}
+                step="1"
+                value={dailyBudget}
+                onChange={(e) => setDailyBudget(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="boost-currency">Currency</Label>
+              <Input
+                id="boost-currency"
+                value={currencyCode}
+                maxLength={3}
+                onChange={(e) => setCurrencyCode(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="boost-days">Days</Label>
+              <Input
+                id="boost-days"
+                type="number"
+                min={1}
+                max={366}
+                step="1"
+                value={durationDays}
+                onChange={(e) => setDurationDays(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <p className="text-[11px] text-muted-foreground">
+            Currency must match your LinkedIn ad account&apos;s billing
+            currency.
+            {total !== null ? (
+              <>
+                {" "}
+                Planned cap:{" "}
+                <span className="font-medium">
+                  {currencyCode.toUpperCase()} {total}
+                </span>{" "}
+                — the monitor auto-pauses the campaign when spend reaches it.
+              </>
+            ) : null}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={boost.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => boost.mutate()}
+            disabled={!valid || boost.isPending}
+          >
+            {boost.isPending ? "Creating…" : "Create draft campaign"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -62,6 +62,10 @@ export function BoostCampaignDialog({
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
+  // Latched after PERSIST_FAILED: the draft EXISTS on LinkedIn, so a
+  // resubmit would duplicate it — the button stays disabled for this
+  // dialog instance.
+  const [terminal, setTerminal] = useState(false);
 
   // Round ONCE up front so validation, the displayed cap, and the
   // payload can never disagree (typing "14.7" must not show a x14.7
@@ -114,9 +118,21 @@ export function BoostCampaignDialog({
           (err as ApiError).message || "Use your ad account's billing currency.",
         );
       } else if (code === "NOT_CONNECTED") {
-        toast.error("Connect LinkedIn Ads first (Integrations page).");
+        // Also the code a STALE (needs_reauth) connection produces —
+        // the server only uses active connections.
+        toast.error("Connect (or reconnect) LinkedIn Ads first.", {
+          action: {
+            label: "Integrations",
+            onClick: () => { window.location.href = "/dashboard/integrations"; },
+          },
+        });
       } else if (code === "NEEDS_REAUTH") {
-        toast.error("LinkedIn Ads needs a reconnect before boosting.");
+        toast.error("LinkedIn Ads needs a reconnect before boosting.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => { window.location.href = "/dashboard/integrations"; },
+          },
+        });
       } else if (code === "NO_AD_ACCOUNT") {
         toast.error(
           "Your LinkedIn Ads connection has no ad account — reconnect it, or create an ad account in LinkedIn Campaign Manager first.",
@@ -125,6 +141,7 @@ export function BoostCampaignDialog({
         toast.error("Pick a business first, then boost.");
       } else if (code === "PERSIST_FAILED") {
         // The draft DOES exist on LinkedIn — retrying would duplicate it.
+        setTerminal(true);
         toast.error(
           (err as ApiError).message ||
             "The campaign was created on LinkedIn but couldn't be saved here — contact support (don't retry).",
@@ -143,7 +160,15 @@ export function BoostCampaignDialog({
       : null;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // No dismissal mid-flight: closing + reopening while the POST
+        // is in flight would allow a concurrent duplicate boost.
+        if (!next && boost.isPending) return;
+        onOpenChange(next);
+      }}
+    >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -252,9 +277,9 @@ export function BoostCampaignDialog({
           <Button
             type="button"
             onClick={() => boost.mutate()}
-            disabled={!valid || boost.isPending}
+            disabled={!valid || boost.isPending || terminal}
           >
-            {boost.isPending ? "Creating…" : "Create draft campaign"}
+            {boost.isPending ? "Creating…" : terminal ? "Created — see support note" : "Create draft campaign"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
 import {
@@ -56,11 +56,30 @@ export function BoostCampaignDialog({
   postUrn: string;
   defaultName: string;
 }) {
+  const queryClient = useQueryClient();
   const [name, setName] = useState(defaultName);
   const [objective, setObjective] = useState<BoostObjective>("engagement");
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
+
+  // Round ONCE up front so validation, the displayed cap, and the
+  // payload can never disagree (typing "14.7" must not show a x14.7
+  // cap while the server stores x15).
+  const budgetNumber = Number(dailyBudget);
+  const durationNumber = Math.round(Number(durationDays));
+  /** Fat-finger ceiling for a daily spend input — the server accepts
+   *  any positive number, so the UI is the sanity gate. */
+  const MAX_DAILY_BUDGET = 1_000_000;
+  const valid =
+    name.trim().length > 0 &&
+    Number.isFinite(budgetNumber) &&
+    budgetNumber > 0 &&
+    budgetNumber <= MAX_DAILY_BUDGET &&
+    /^[A-Za-z]{3}$/.test(currencyCode.trim()) &&
+    Number.isFinite(durationNumber) &&
+    durationNumber >= 1 &&
+    durationNumber <= 366;
 
   const boost = useMutation({
     mutationFn: () =>
@@ -68,11 +87,14 @@ export function BoostCampaignDialog({
         postUrn,
         name: name.trim(),
         objective,
-        dailyBudget: Number(dailyBudget),
+        dailyBudget: budgetNumber,
         currencyCode: currencyCode.trim().toUpperCase(),
-        durationDays: Math.round(Number(durationDays)),
+        durationDays: durationNumber,
       }),
     onSuccess: () => {
+      // The Ads Manager list must show the new campaign even within
+      // its staleTime window.
+      queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
       onOpenChange(false);
       toast.success("Draft campaign created on LinkedIn.", {
         description:
@@ -86,28 +108,34 @@ export function BoostCampaignDialog({
       });
     },
     onError: (err) => {
-      if (err instanceof ApiError && err.code === "CURRENCY_MISMATCH") {
-        toast.error(err.message || "Use your ad account's billing currency.");
-      } else if (err instanceof ApiError && err.code === "NOT_CONNECTED") {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "CURRENCY_MISMATCH") {
+        toast.error(
+          (err as ApiError).message || "Use your ad account's billing currency.",
+        );
+      } else if (code === "NOT_CONNECTED") {
         toast.error("Connect LinkedIn Ads first (Integrations page).");
-      } else if (err instanceof ApiError && err.code === "NEEDS_REAUTH") {
+      } else if (code === "NEEDS_REAUTH") {
         toast.error("LinkedIn Ads needs a reconnect before boosting.");
+      } else if (code === "NO_AD_ACCOUNT") {
+        toast.error(
+          "Your LinkedIn Ads connection has no ad account — reconnect it, or create an ad account in LinkedIn Campaign Manager first.",
+        );
+      } else if (code === "FORBIDDEN") {
+        toast.error("Pick a business first, then boost.");
+      } else if (code === "PERSIST_FAILED") {
+        // The draft DOES exist on LinkedIn — retrying would duplicate it.
+        toast.error(
+          (err as ApiError).message ||
+            "The campaign was created on LinkedIn but couldn't be saved here — contact support (don't retry).",
+        );
+      } else if (code === "RATE_LIMITED") {
+        toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
       } else {
         toast.error("Couldn't create the campaign. Try again in a moment.");
       }
     },
   });
-
-  const budgetNumber = Number(dailyBudget);
-  const durationNumber = Number(durationDays);
-  const valid =
-    name.trim().length > 0 &&
-    Number.isFinite(budgetNumber) &&
-    budgetNumber > 0 &&
-    /^[A-Za-z]{3}$/.test(currencyCode.trim()) &&
-    Number.isFinite(durationNumber) &&
-    durationNumber >= 1 &&
-    durationNumber <= 366;
 
   const total =
     valid && Number.isFinite(budgetNumber * durationNumber)
@@ -142,12 +170,12 @@ export function BoostCampaignDialog({
           </div>
 
           <div className="space-y-1.5">
-            <Label>Objective</Label>
+            <Label htmlFor="boost-objective">Objective</Label>
             <Select
               value={objective}
               onValueChange={(v) => setObjective(v as BoostObjective)}
             >
-              <SelectTrigger>
+              <SelectTrigger id="boost-objective">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -167,6 +195,7 @@ export function BoostCampaignDialog({
                 id="boost-budget"
                 type="number"
                 min={1}
+                max={MAX_DAILY_BUDGET}
                 step="1"
                 value={dailyBudget}
                 onChange={(e) => setDailyBudget(e.target.value)}

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-candidates-panel.tsx
@@ -20,17 +20,16 @@ import {
   linkedInContentApi,
   type BoostCandidate,
 } from "@/lib/api/linkedin-content";
+import { BoostCampaignDialog } from "./boost-campaign-dialog";
 import { RetentionFootnote } from "./retention-footnote";
 
 /**
  * BoostCandidatesPanel — ranks the business's recently-published
  * LinkedIn posts by boost-worthiness and surfaces the top N.
  *
- * The "Boost this post" button is intentionally disabled with a
- * "coming soon" tooltip — autonomous ad-spend ships in workstream
- * D6 (Autonomous Ad Engine). Today the panel is a recommendation
- * surface: it tells the user *which* posts deserve the budget, but
- * the actual campaign creation is one PR away.
+ * The "Boost" button opens the Boost-to-Campaign dialog (G1): one
+ * click turns the ranked post into a REAL LinkedIn campaign — created
+ * as a non-spending draft the user activates from the Ads Manager.
  *
  * Lazy-mounted from the LinkedIn dashboard tabs (same pattern as
  * AudiencePanel) so the boost-candidates query doesn't fire on
@@ -235,6 +234,7 @@ function BoostCandidateRow({
   candidate: BoostCandidate;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [boostOpen, setBoostOpen] = useState(false);
   const ActorIcon = candidate.authorType === "org" ? Building2 : User;
 
   return (
@@ -323,13 +323,21 @@ function BoostCandidateRow({
           type="button"
           size="sm"
           variant="default"
-          disabled
           className="h-7 text-xs"
-          title="Coming soon — autonomous ad-spend deployment ships in the Ad Engine workstream. For now this surface tells you which posts deserve the budget."
+          title="Turn this post into a LinkedIn campaign — created as a non-spending draft you activate from the Ads Manager."
+          onClick={() => setBoostOpen(true)}
         >
           <Rocket className="mr-1 size-3" />
           Boost
         </Button>
+        {boostOpen ? (
+          <BoostCampaignDialog
+            open={boostOpen}
+            onOpenChange={setBoostOpen}
+            postUrn={candidate.linkedInPostUrn}
+            defaultName={`Boost: ${candidate.hookExcerpt.slice(0, 80)}`}
+          />
+        ) : null}
       </div>
     </li>
   );

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -45,7 +45,10 @@ export interface ManagedCampaign {
   /** Organic post this campaign sponsors (Boost-to-Campaign). */
   sourcePostUrn?: string;
   name: string;
-  objective?: BoostObjective;
+  /** zCampaignObjective — typed to the boost set today; rows written by
+   *  other producers may carry values outside it, so treat unknown
+   *  strings as display-only rather than exhaustive-matching. */
+  objective?: BoostObjective | (string & {});
   status: ManagedCampaignStatus;
   /** ISO-4217 — matches the ad account's billing currency. */
   currency?: string;
@@ -56,9 +59,14 @@ export interface ManagedCampaign {
     endsAt?: string;
     durationDays?: number;
   };
+  /** Platform creative URN ids attached at boost time. */
+  linkedCreativeUrns?: string[];
   performance?: ManagedCampaignPerformance;
   createdAt: string;
   updatedAt?: string;
+  /** Audit ids (hex) — present on rows created via the routes. */
+  createdById?: string;
+  updatedById?: string;
 }
 
 export interface BoostCampaignInput {

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -1,0 +1,109 @@
+import { api } from "@/lib/api";
+
+/**
+ * LinkedIn Ads Manager client (G1) — the MANAGED campaign surface.
+ *
+ * These endpoints operate on Peakhour's own `ad_campaigns` rows (the
+ * execution-loop spine), not raw LinkedIn ids: /boost creates the real
+ * LinkedIn campaign group + campaign + creative via the api-side ads
+ * adapter — always in LinkedIn's NON-SERVING draft state. The only
+ * spend-enabling action anywhere is `setStatus(id, "active")`, which
+ * the UI gates behind an explicit confirm.
+ */
+
+export type ManagedCampaignStatus =
+  | "draft"
+  | "review"
+  | "active"
+  | "paused"
+  | "completed"
+  | "archived";
+
+export type BoostObjective =
+  | "engagement"
+  | "brand_awareness"
+  | "website_traffic"
+  | "lead_generation";
+
+export interface ManagedCampaignPerformance {
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  spend: number;
+  ctr: number;
+  cpc?: number;
+  cpa?: number;
+  lastUpdated?: string;
+}
+
+export interface ManagedCampaign {
+  _id: string;
+  platform: string;
+  platformCampaignId?: string;
+  platformCampaignGroupId?: string;
+  adAccountId?: string;
+  /** Organic post this campaign sponsors (Boost-to-Campaign). */
+  sourcePostUrn?: string;
+  name: string;
+  objective?: BoostObjective;
+  status: ManagedCampaignStatus;
+  /** ISO-4217 — matches the ad account's billing currency. */
+  currency?: string;
+  budget?: { daily?: number; total?: number; spent: number };
+  schedule?: {
+    launchedAt?: string;
+    activatedAt?: string;
+    endsAt?: string;
+    durationDays?: number;
+  };
+  performance?: ManagedCampaignPerformance;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface BoostCampaignInput {
+  /** LinkedIn share/ugcPost URN of the organic post to sponsor. */
+  postUrn: string;
+  name: string;
+  objective: BoostObjective;
+  dailyBudget: number;
+  /** Must match the ad account's billing currency — the server rejects
+   *  a mismatch with code CURRENCY_MISMATCH naming the expected code. */
+  currencyCode: string;
+  durationDays: number;
+}
+
+export const linkedInAdsApi = {
+  /** Local managed campaigns for the active business (newest first). */
+  managedCampaigns: () =>
+    api.get<{ campaigns: ManagedCampaign[] }>(
+      "/v1/linkedin/ads/managed-campaigns",
+    ),
+
+  /**
+   * Boost-to-Campaign: sponsor an existing organic post. Creates the
+   * REAL LinkedIn artefacts as a non-serving draft (group PAUSED +
+   * campaign DRAFT + creative PAUSED) and persists the managed row.
+   * Nothing spends until the campaign is explicitly activated.
+   */
+  boost: (body: BoostCampaignInput) =>
+    api.post<{ campaign: ManagedCampaign }>("/v1/linkedin/ads/boost", body),
+
+  /** Pull live analytics into the row; returns fresh performance. */
+  syncCampaign: (id: string) =>
+    api.post<{ performance: ManagedCampaignPerformance }>(
+      `/v1/linkedin/ads/managed-campaigns/${id}/sync`,
+    ),
+
+  /**
+   * Activate / pause / archive — platform first, then locally.
+   * "active" is the ONLY call that can start spend; callers must gate
+   * it behind an explicit user confirm. Invalid transitions 409 with
+   * code INVALID_TRANSITION.
+   */
+  setStatus: (id: string, status: "active" | "paused" | "archived") =>
+    api.patch<{ campaignId: string; status: string }>(
+      `/v1/linkedin/ads/managed-campaigns/${id}/status`,
+      { status },
+    ),
+};


### PR DESCRIPTION
## Summary
The Growth pillar's first live surface (G1 of the approved plan):

- **/dashboard/ads** — Ads Manager MVP: managed campaigns table (status chips, daily/total budget in the ad account currency, spent, impressions/clicks/CTR), per-row **Sync** (live metrics), **Activate** (explicit spend confirm), **Pause**, **Archive**. Connection-gated on `linkedin_ads`.
- **Boost-to-Campaign** — the boost-candidates panel's Boost button is live: dialog → `POST /v1/linkedin/ads/boost` → real LinkedIn campaign as a **non-spending draft** (group PAUSED + campaign DRAFT). Success toast deep-links to the Ads Manager.
- New `lib/api/linkedin-ads.ts` typed client.

Spend-safety UX contract: drafts everywhere by default; the ONLY spend-enabling action is Activate behind a confirm that states daily rate, total cap, and the monitor's auto-pause at that cap.

## Dependencies
peakhour-api **#920** (managed routes + ads adapter). Merge order: api #920 → this.

## Review
Round 1 in progress (manual + subagent). `tsc --noEmit` + eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)