### PR TITLE
feat(growth): audience targeting editor in the Ads Manager (G1)

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
+++ b/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
@@ -169,14 +169,21 @@ function FacetPicker({
         onChange={(e) => setSearch(e.target.value)}
         autoComplete="off"
         disabled={atCap}
-        role="combobox"
-        aria-expanded={active && options.length > 0}
-        aria-controls={listId}
         aria-required={facet.required ? true : undefined}
       />
-      <div aria-live="polite">
-        {active && !atCap ? (
-          results.isLoading ? (
+      {/* Plain filtered list on purpose — a full APG combobox
+          (aria-activedescendant + arrow-key nav) is a follow-up; a
+          half-declared combobox role misleads screen readers worse
+          than honest Tab-reachable buttons. Status line is the only
+          live region so result sets aren't announced wholesale. */}
+      {active && !atCap ? (
+        <>
+          <p aria-live="polite" className="sr-only">
+            {results.isLoading
+              ? "Searching"
+              : `${options.length} result${options.length === 1 ? "" : "s"}`}
+          </p>
+          {results.isLoading ? (
             <p className="text-xs text-muted-foreground">Searching…</p>
           ) : results.isError ? (
             <p className="text-xs text-muted-foreground">
@@ -187,9 +194,9 @@ function FacetPicker({
           ) : options.length === 0 ? (
             <p className="text-xs text-muted-foreground">No matches.</p>
           ) : (
-            <ul id={listId} role="listbox" className="max-h-36 overflow-y-auto rounded-md border text-sm">
+            <ul id={listId} className="max-h-36 overflow-y-auto rounded-md border text-sm">
               {options.map((e) => (
-                <li key={e.urn} role="option" aria-selected={false}>
+                <li key={e.urn}>
                   <button
                     type="button"
                     className="w-full px-2 py-1.5 text-left hover:bg-muted focus:bg-muted"
@@ -203,9 +210,9 @@ function FacetPicker({
                 </li>
               ))}
             </ul>
-          )
-        ) : null}
-      </div>
+          )}
+        </>
+      ) : null}
     </div>
   );
 }
@@ -221,8 +228,15 @@ export function TargetingDialog({
 }) {
   const queryClient = useQueryClient();
   const existing = editorTargeting(campaign.targeting);
-  const [facets, setFacets] = useState<TargetingFacets>(existing?.facets ?? {});
-  const [labels, setLabels] = useState<Record<string, string>>(existing?.labels ?? {});
+  // Facets + labels live in ONE state object so a single updater
+  // decides accept/reject atomically — two separate setStates let a
+  // same-render double-click add an orphan label past the server's
+  // 250-entry bound.
+  const [selection, setSelection] = useState<{
+    facets: TargetingFacets;
+    labels: Record<string, string>;
+  }>({ facets: existing?.facets ?? {}, labels: existing?.labels ?? {} });
+  const { facets, labels } = selection;
 
   const save = useMutation({
     mutationFn: () => linkedInAdsApi.setTargeting(campaign._id, facets, labels),
@@ -257,6 +271,21 @@ export function TargetingDialog({
         );
         // Either way the row is stale — resync.
         queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+      } else if (code === "TARGETING_PERSIST_FAILED") {
+        // Qualified success: LinkedIn HAS the audience; only our local
+        // mirror failed. Close, resync, and pass on the server's
+        // retry-is-safe guidance — leaving the dialog open would show
+        // "no audience" for a campaign whose platform audience is set.
+        queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+        onOpenChange(false);
+        toast.warning(
+          (err as ApiError).message ||
+            "Targeting was applied on LinkedIn but couldn't be saved locally — apply again to refresh the display.",
+        );
+      } else if (err instanceof ApiError && err.status === 400 && err.message) {
+        // Platform-rejected entity (the api deliberately 400s
+        // provider_4xx here as user-fixable) — the message names it.
+        toast.error(err.message);
       } else {
         toast.error("Couldn't apply targeting. Try again in a moment.");
       }
@@ -264,26 +293,26 @@ export function TargetingDialog({
   });
 
   const addEntity = (key: TargetingFacetKey) => (entity: TargetingEntity) => {
-    setFacets((prev) => {
-      const current = prev[key] ?? [];
+    setSelection((prev) => {
+      const current = prev.facets[key] ?? [];
       // Dedupe + server cap guard (a rapid double-click can beat the
-      // options filter's re-render).
+      // options filter's re-render). Reject = neither facet NOR label
+      // changes.
       if (current.includes(entity.urn) || current.length >= MAX_PER_FACET) return prev;
-      return { ...prev, [key]: [...current, entity.urn] };
+      return {
+        facets: { ...prev.facets, [key]: [...current, entity.urn] },
+        labels: { ...prev.labels, [entity.urn]: entity.name },
+      };
     });
-    setLabels((prev) => ({ ...prev, [entity.urn]: entity.name }));
   };
   const removeEntity = (key: TargetingFacetKey) => (urn: string) => {
-    setFacets((prev) => ({
-      ...prev,
-      [key]: (prev[key] ?? []).filter((u) => u !== urn),
-    }));
-    // Prune the label too — orphaned entries would otherwise persist
-    // and accumulate across edit sessions.
-    setLabels((prev) => {
-      const rest = { ...prev };
-      delete rest[urn];
-      return rest;
+    setSelection((prev) => {
+      const labels = { ...prev.labels };
+      delete labels[urn];
+      return {
+        facets: { ...prev.facets, [key]: (prev.facets[key] ?? []).filter((u) => u !== urn) },
+        labels,
+      };
     });
   };
 
@@ -306,7 +335,9 @@ export function TargetingDialog({
           <DialogDescription>
             Who should see &ldquo;{campaign.name}&rdquo;? LinkedIn requires at
             least one location; entities within a facet broaden the audience,
-            facets narrow it. Applying targeting never starts spend.
+            facets narrow it. Applying targeting never starts spend — but it
+            REPLACES the campaign&apos;s whole audience, including anything set
+            directly in LinkedIn Campaign Manager.
           </DialogDescription>
         </DialogHeader>
 
@@ -332,14 +363,20 @@ export function TargetingDialog({
           >
             Cancel
           </Button>
-          <Button
-            type="button"
-            onClick={() => save.mutate()}
-            disabled={!valid || save.isPending}
-            title={valid ? undefined : "Pick at least one location"}
-          >
-            {save.isPending ? "Applying…" : "Apply targeting"}
-          </Button>
+          <div className="flex flex-col items-end gap-1">
+            {!valid ? (
+              <p className="text-[11px] text-muted-foreground">
+                Pick at least one location to apply.
+              </p>
+            ) : null}
+            <Button
+              type="button"
+              onClick={() => save.mutate()}
+              disabled={!valid || save.isPending}
+            >
+              {save.isPending ? "Applying…" : "Apply targeting"}
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
+++ b/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import {
+  linkedInAdsApi,
+  type ManagedCampaign,
+  type CampaignTargeting,
+  type TargetingEntity,
+  type TargetingFacetKey,
+  type TargetingFacets,
+} from "@/lib/api/linkedin-ads";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Target, X } from "lucide-react";
+
+/**
+ * TargetingDialog — the facet-targeting editor that closes the G1
+ * activation gap: pick locations (required) + optional industries /
+ * seniorities / job titles / company sizes via LinkedIn's facet
+ * typeahead, and apply them to the draft campaign without leaving
+ * Peakhour. Applying targeting can never start spend.
+ *
+ * Facet URNs mirror the api's TARGETING_FACETS map; selections are
+ * sent as simple per-facet URN lists and redisplayed from the row's
+ * stored `targeting.facets` + `labels`.
+ */
+
+const FACETS: Array<{
+  key: TargetingFacetKey;
+  facetUrn: string;
+  label: string;
+  placeholder: string;
+  required?: boolean;
+}> = [
+  {
+    key: "locations",
+    facetUrn: "urn:li:adTargetingFacet:locations",
+    label: "Locations (required)",
+    placeholder: "Search countries, regions, cities…",
+    required: true,
+  },
+  {
+    key: "industries",
+    facetUrn: "urn:li:adTargetingFacet:industries",
+    label: "Industries",
+    placeholder: "Search industries…",
+  },
+  {
+    key: "seniorities",
+    facetUrn: "urn:li:adTargetingFacet:seniorities",
+    label: "Seniorities",
+    placeholder: "Search seniorities…",
+  },
+  {
+    key: "titles",
+    facetUrn: "urn:li:adTargetingFacet:titles",
+    label: "Job titles",
+    placeholder: "Search job titles…",
+  },
+  {
+    key: "staffCountRanges",
+    facetUrn: "urn:li:adTargetingFacet:staffCountRanges",
+    label: "Company size",
+    placeholder: "Search company-size ranges…",
+  },
+];
+
+/** Feature-detect editor-shaped targeting on a row (legacy rows carry
+ *  a free-form object from the AI workflow instead). */
+function editorTargeting(t: ManagedCampaign["targeting"]): CampaignTargeting | null {
+  if (t && typeof t === "object" && "facets" in t) return t as CampaignTargeting;
+  return null;
+}
+
+/** Debounce a string value. */
+function useDebounced(value: string, ms: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+function FacetPicker({
+  facet,
+  selected,
+  labels,
+  onAdd,
+  onRemove,
+}: {
+  facet: (typeof FACETS)[number];
+  selected: string[];
+  labels: Record<string, string>;
+  onAdd: (entity: TargetingEntity) => void;
+  onRemove: (urn: string) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const query = useDebounced(search.trim(), 350);
+
+  const results = useQuery({
+    queryKey: ["linkedin-targeting-entities", facet.facetUrn, query],
+    queryFn: () => linkedInAdsApi.targetingEntities(facet.facetUrn, query),
+    enabled: query.length >= 2,
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+
+  const options = useMemo(
+    () =>
+      (results.data?.entities ?? [])
+        .filter((e) => e.urn && !selected.includes(e.urn))
+        .slice(0, 8),
+    [results.data, selected],
+  );
+
+  const inputId = `targeting-${facet.key}`;
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={inputId}>{facet.label}</Label>
+      {selected.length > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {selected.map((urn) => (
+            <Badge key={urn} variant="secondary" className="gap-1 pr-1 text-xs font-normal">
+              {labels[urn] ?? urn}
+              <button
+                type="button"
+                aria-label={`Remove ${labels[urn] ?? urn}`}
+                className="rounded-sm p-0.5 hover:bg-muted-foreground/20"
+                onClick={() => onRemove(urn)}
+              >
+                <X className="size-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+      <Input
+        id={inputId}
+        value={search}
+        placeholder={facet.placeholder}
+        onChange={(e) => setSearch(e.target.value)}
+        autoComplete="off"
+      />
+      {query.length >= 2 ? (
+        results.isLoading ? (
+          <p className="text-xs text-muted-foreground">Searching…</p>
+        ) : results.isError ? (
+          <p className="text-xs text-muted-foreground">
+            Couldn&apos;t search LinkedIn right now — try again in a moment.
+          </p>
+        ) : options.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No matches.</p>
+        ) : (
+          <ul className="max-h-36 overflow-y-auto rounded-md border text-sm">
+            {options.map((e) => (
+              <li key={e.urn}>
+                <button
+                  type="button"
+                  className="w-full px-2 py-1.5 text-left hover:bg-muted"
+                  onClick={() => {
+                    onAdd(e);
+                    setSearch("");
+                  }}
+                >
+                  {e.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+export function TargetingDialog({
+  open,
+  onOpenChange,
+  campaign,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  campaign: ManagedCampaign;
+}) {
+  const queryClient = useQueryClient();
+  const existing = editorTargeting(campaign.targeting);
+  const [facets, setFacets] = useState<TargetingFacets>(existing?.facets ?? {});
+  const [labels, setLabels] = useState<Record<string, string>>(existing?.labels ?? {});
+
+  const save = useMutation({
+    mutationFn: () => linkedInAdsApi.setTargeting(campaign._id, facets, labels),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+      onOpenChange(false);
+      toast.success("Audience targeting applied.", {
+        description:
+          campaign.status === "active"
+            ? "LinkedIn will re-review the campaign with the new audience."
+            : "The draft now carries its audience — activate it when you're ready.",
+      });
+    },
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "NEEDS_REAUTH" || code === "NOT_CONNECTED") {
+        toast.error("LinkedIn Ads needs a reconnect before updating targeting.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => { window.location.href = "/dashboard/integrations"; },
+          },
+        });
+      } else if (code === "VALIDATION_ERROR") {
+        toast.error((err as ApiError).message || "Check the targeting selection.");
+      } else if (code === "RATE_LIMITED") {
+        toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
+      } else if (code === "INVALID_TRANSITION") {
+        toast.error("This campaign can no longer be retargeted.");
+      } else {
+        toast.error("Couldn't apply targeting. Try again in a moment.");
+      }
+    },
+  });
+
+  const addEntity = (key: TargetingFacetKey) => (entity: TargetingEntity) => {
+    setFacets((prev) => ({
+      ...prev,
+      [key]: [...(prev[key] ?? []), entity.urn],
+    }));
+    setLabels((prev) => ({ ...prev, [entity.urn]: entity.name }));
+  };
+  const removeEntity = (key: TargetingFacetKey) => (urn: string) => {
+    setFacets((prev) => ({
+      ...prev,
+      [key]: (prev[key] ?? []).filter((u) => u !== urn),
+    }));
+  };
+
+  const valid = (facets.locations?.length ?? 0) > 0;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && save.isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Target className="size-4" />
+            Audience targeting
+          </DialogTitle>
+          <DialogDescription>
+            Who should see &ldquo;{campaign.name}&rdquo;? LinkedIn requires at
+            least one location; entities within a facet broaden the audience,
+            facets narrow it. Applying targeting never starts spend.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[55vh] space-y-4 overflow-y-auto pr-1">
+          {FACETS.map((f) => (
+            <FacetPicker
+              key={f.key}
+              facet={f}
+              selected={facets[f.key] ?? []}
+              labels={labels}
+              onAdd={addEntity(f.key)}
+              onRemove={removeEntity(f.key)}
+            />
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={save.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => save.mutate()}
+            disabled={!valid || save.isPending}
+            title={valid ? undefined : "Pick at least one location"}
+          >
+            {save.isPending ? "Applying…" : "Apply targeting"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
+++ b/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
@@ -38,12 +38,18 @@ import { Target, X } from "lucide-react";
  * stored `targeting.facets` + `labels`.
  */
 
+/** Server-enforced bound (TargetingBody zod: max 50 per facet). */
+const MAX_PER_FACET = 50;
+
 const FACETS: Array<{
   key: TargetingFacetKey;
   facetUrn: string;
   label: string;
   placeholder: string;
   required?: boolean;
+  /** Small fixed facets (seniorities, company size) list all values
+   *  up front instead of forcing a guess-the-keyword typeahead. */
+  listAll?: boolean;
 }> = [
   {
     key: "locations",
@@ -62,7 +68,8 @@ const FACETS: Array<{
     key: "seniorities",
     facetUrn: "urn:li:adTargetingFacet:seniorities",
     label: "Seniorities",
-    placeholder: "Search seniorities…",
+    placeholder: "Filter seniorities…",
+    listAll: true,
   },
   {
     key: "titles",
@@ -74,13 +81,14 @@ const FACETS: Array<{
     key: "staffCountRanges",
     facetUrn: "urn:li:adTargetingFacet:staffCountRanges",
     label: "Company size",
-    placeholder: "Search company-size ranges…",
+    placeholder: "Filter ranges…",
+    listAll: true,
   },
 ];
 
 /** Feature-detect editor-shaped targeting on a row (legacy rows carry
  *  a free-form object from the AI workflow instead). */
-function editorTargeting(t: ManagedCampaign["targeting"]): CampaignTargeting | null {
+export function editorTargeting(t: ManagedCampaign["targeting"]): CampaignTargeting | null {
   if (t && typeof t === "object" && "facets" in t) return t as CampaignTargeting;
   return null;
 }
@@ -110,24 +118,30 @@ function FacetPicker({
 }) {
   const [search, setSearch] = useState("");
   const query = useDebounced(search.trim(), 350);
+  // listAll facets fetch the full (small) entity list once and filter
+  // client-side; typeahead facets search server-side from 2 chars.
+  const serverQuery = facet.listAll ? "" : query;
+  const active = facet.listAll || query.length >= 2;
 
   const results = useQuery({
-    queryKey: ["linkedin-targeting-entities", facet.facetUrn, query],
-    queryFn: () => linkedInAdsApi.targetingEntities(facet.facetUrn, query),
-    enabled: query.length >= 2,
+    queryKey: ["linkedin-targeting-entities", facet.facetUrn, serverQuery],
+    queryFn: () => linkedInAdsApi.targetingEntities(facet.facetUrn, serverQuery || undefined),
+    enabled: active,
     staleTime: 5 * 60_000,
     retry: 1,
   });
 
-  const options = useMemo(
-    () =>
-      (results.data?.entities ?? [])
-        .filter((e) => e.urn && !selected.includes(e.urn))
-        .slice(0, 8),
-    [results.data, selected],
-  );
+  const atCap = selected.length >= MAX_PER_FACET;
+  const options = useMemo(() => {
+    const needle = facet.listAll ? query.toLowerCase() : "";
+    return (results.data?.entities ?? [])
+      .filter((e) => e.urn && !selected.includes(e.urn))
+      .filter((e) => (needle ? e.name.toLowerCase().includes(needle) : true))
+      .slice(0, facet.listAll ? 12 : 8);
+  }, [results.data, selected, facet.listAll, query]);
 
   const inputId = `targeting-${facet.key}`;
+  const listId = `targeting-${facet.key}-options`;
   return (
     <div className="space-y-1.5">
       <Label htmlFor={inputId}>{facet.label}</Label>
@@ -151,38 +165,47 @@ function FacetPicker({
       <Input
         id={inputId}
         value={search}
-        placeholder={facet.placeholder}
+        placeholder={atCap ? `Limit of ${MAX_PER_FACET} reached` : facet.placeholder}
         onChange={(e) => setSearch(e.target.value)}
         autoComplete="off"
+        disabled={atCap}
+        role="combobox"
+        aria-expanded={active && options.length > 0}
+        aria-controls={listId}
+        aria-required={facet.required ? true : undefined}
       />
-      {query.length >= 2 ? (
-        results.isLoading ? (
-          <p className="text-xs text-muted-foreground">Searching…</p>
-        ) : results.isError ? (
-          <p className="text-xs text-muted-foreground">
-            Couldn&apos;t search LinkedIn right now — try again in a moment.
-          </p>
-        ) : options.length === 0 ? (
-          <p className="text-xs text-muted-foreground">No matches.</p>
-        ) : (
-          <ul className="max-h-36 overflow-y-auto rounded-md border text-sm">
-            {options.map((e) => (
-              <li key={e.urn}>
-                <button
-                  type="button"
-                  className="w-full px-2 py-1.5 text-left hover:bg-muted"
-                  onClick={() => {
-                    onAdd(e);
-                    setSearch("");
-                  }}
-                >
-                  {e.name}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )
-      ) : null}
+      <div aria-live="polite">
+        {active && !atCap ? (
+          results.isLoading ? (
+            <p className="text-xs text-muted-foreground">Searching…</p>
+          ) : results.isError ? (
+            <p className="text-xs text-muted-foreground">
+              Couldn&apos;t reach LinkedIn — if your LinkedIn Ads connection is
+              stale, reconnect it from Integrations; otherwise try again in a
+              moment.
+            </p>
+          ) : options.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No matches.</p>
+          ) : (
+            <ul id={listId} role="listbox" className="max-h-36 overflow-y-auto rounded-md border text-sm">
+              {options.map((e) => (
+                <li key={e.urn} role="option" aria-selected={false}>
+                  <button
+                    type="button"
+                    className="w-full px-2 py-1.5 text-left hover:bg-muted focus:bg-muted"
+                    onClick={() => {
+                      onAdd(e);
+                      if (!facet.listAll) setSearch("");
+                    }}
+                  >
+                    {e.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -226,8 +249,14 @@ export function TargetingDialog({
         toast.error((err as ApiError).message || "Check the targeting selection.");
       } else if (code === "RATE_LIMITED") {
         toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
-      } else if (code === "INVALID_TRANSITION") {
-        toast.error("This campaign can no longer be retargeted.");
+      } else if (code === "INVALID_TRANSITION" || code === "NO_PLATFORM_ID") {
+        toast.error(
+          code === "NO_PLATFORM_ID"
+            ? "This campaign has no LinkedIn identity to target — refresh the list."
+            : "This campaign can no longer be retargeted.",
+        );
+        // Either way the row is stale — resync.
+        queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
       } else {
         toast.error("Couldn't apply targeting. Try again in a moment.");
       }
@@ -235,10 +264,13 @@ export function TargetingDialog({
   });
 
   const addEntity = (key: TargetingFacetKey) => (entity: TargetingEntity) => {
-    setFacets((prev) => ({
-      ...prev,
-      [key]: [...(prev[key] ?? []), entity.urn],
-    }));
+    setFacets((prev) => {
+      const current = prev[key] ?? [];
+      // Dedupe + server cap guard (a rapid double-click can beat the
+      // options filter's re-render).
+      if (current.includes(entity.urn) || current.length >= MAX_PER_FACET) return prev;
+      return { ...prev, [key]: [...current, entity.urn] };
+    });
     setLabels((prev) => ({ ...prev, [entity.urn]: entity.name }));
   };
   const removeEntity = (key: TargetingFacetKey) => (urn: string) => {
@@ -246,6 +278,13 @@ export function TargetingDialog({
       ...prev,
       [key]: (prev[key] ?? []).filter((u) => u !== urn),
     }));
+    // Prune the label too — orphaned entries would otherwise persist
+    // and accumulate across edit sessions.
+    setLabels((prev) => {
+      const rest = { ...prev };
+      delete rest[urn];
+      return rest;
+    });
   };
 
   const valid = (facets.locations?.length ?? 0) > 0;

--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -33,8 +33,7 @@ import {
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { Archive, Megaphone, Pause, Play, RefreshCw, Rocket, Target } from "lucide-react";
-import { TargetingDialog } from "./_components/targeting-dialog";
-import { type CampaignTargeting } from "@/lib/api/linkedin-ads";
+import { TargetingDialog, editorTargeting } from "./_components/targeting-dialog";
 
 /**
  * Ads Manager (G1 MVP) — the Growth pillar's first live surface.
@@ -235,9 +234,9 @@ function CampaignsPanel() {
         </Table>
         <p className="mt-3 border-t pt-2 text-[11px] text-muted-foreground">
           Campaigns are created in LinkedIn as drafts under a paused group —
-          they cannot spend until you activate them. Finish audience targeting
-          in LinkedIn Campaign Manager before activating; the protective
-          monitor auto-pauses any campaign that reaches its total budget.
+          they cannot spend until you activate them. Set the audience with the
+          Audience button before activating; the protective monitor
+          auto-pauses any campaign that reaches its total budget.
         </p>
       </CardContent>
     </Card>
@@ -333,12 +332,9 @@ function CampaignRow({
     Boolean(campaign.platformCampaignId) &&
     !["archived", "completed"].includes(campaign.status);
   // Editor-shaped targeting (workflow rows carry a legacy free-form
-  // object instead — feature-detect).
-  const targeting =
-    campaign.targeting && typeof campaign.targeting === "object" && "facets" in campaign.targeting
-      ? (campaign.targeting as CampaignTargeting)
-      : null;
-  const hasAudience = (targeting?.facets?.locations?.length ?? 0) > 0;
+  // object instead — feature-detected by the shared helper).
+  const hasAudience =
+    (editorTargeting(campaign.targeting)?.facets?.locations?.length ?? 0) > 0;
 
   return (
     <TableRow>

--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -32,7 +32,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { Archive, Megaphone, Pause, Play, RefreshCw, Rocket } from "lucide-react";
+import { Archive, Megaphone, Pause, Play, RefreshCw, Rocket, Target } from "lucide-react";
+import { TargetingDialog } from "./_components/targeting-dialog";
+import { type CampaignTargeting } from "@/lib/api/linkedin-ads";
 
 /**
  * Ads Manager (G1 MVP) — the Growth pillar's first live surface.
@@ -251,6 +253,7 @@ function CampaignRow({
 }) {
   const [confirmActivate, setConfirmActivate] = useState(false);
   const [confirmArchive, setConfirmArchive] = useState(false);
+  const [targetingOpen, setTargetingOpen] = useState(false);
 
   const status = useMutation({
     mutationFn: (next: "active" | "paused" | "archived") =>
@@ -326,6 +329,16 @@ function CampaignRow({
   const canArchive =
     !["archived"].includes(campaign.status) && Boolean(campaign.platformCampaignId);
   const canSync = Boolean(campaign.platformCampaignId);
+  const canTarget =
+    Boolean(campaign.platformCampaignId) &&
+    !["archived", "completed"].includes(campaign.status);
+  // Editor-shaped targeting (workflow rows carry a legacy free-form
+  // object instead — feature-detect).
+  const targeting =
+    campaign.targeting && typeof campaign.targeting === "object" && "facets" in campaign.targeting
+      ? (campaign.targeting as CampaignTargeting)
+      : null;
+  const hasAudience = (targeting?.facets?.locations?.length ?? 0) > 0;
 
   return (
     <TableRow>
@@ -377,6 +390,20 @@ function CampaignRow({
               <RefreshCw className={`size-3 ${sync.isPending ? "animate-spin" : ""}`} />
             </Button>
           ) : null}
+          {canTarget ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              disabled={busy}
+              title={hasAudience ? "Edit audience targeting" : "Set audience targeting (required before the campaign can serve)"}
+              onClick={() => setTargetingOpen(true)}
+            >
+              <Target className="mr-1 size-3" />
+              {hasAudience ? "Audience" : "Set audience"}
+            </Button>
+          ) : null}
           {canActivate ? (
             <Button
               type="button"
@@ -420,6 +447,14 @@ function CampaignRow({
           ) : null}
         </div>
 
+        {targetingOpen ? (
+          <TargetingDialog
+            open={targetingOpen}
+            onOpenChange={setTargetingOpen}
+            campaign={campaign}
+          />
+        ) : null}
+
         <AlertDialog open={confirmArchive} onOpenChange={setConfirmArchive}>
           <AlertDialogContent>
             <AlertDialogHeader>
@@ -462,8 +497,10 @@ function CampaignRow({
                     total — we auto-pause at that cap)
                   </>
                 ) : null}
-                . Make sure its audience targeting is finished in LinkedIn
-                Campaign Manager first.
+                .{" "}
+                {hasAudience
+                  ? "Its audience is set — LinkedIn will review, then deliver."
+                  : "No audience is set yet — use the Audience button first, or LinkedIn will reject delivery."}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -36,6 +36,34 @@ export interface ManagedCampaignPerformance {
   lastUpdated?: string;
 }
 
+/** Facet keys the targeting editor exposes — mirror the api's
+ *  TARGETING_FACETS (helpers/linkedin-ad-targeting.ts). */
+export type TargetingFacetKey =
+  | "locations"
+  | "industries"
+  | "seniorities"
+  | "titles"
+  | "staffCountRanges";
+
+export type TargetingFacets = Partial<Record<TargetingFacetKey, string[]>> & {
+  locations?: string[];
+};
+
+export interface TargetingEntity {
+  urn: string;
+  facetUrn: string;
+  name: string;
+}
+
+/** Stored targeting selection on a managed row (set via setTargeting). */
+export interface CampaignTargeting {
+  facets?: TargetingFacets;
+  /** URN → display name, for chip redisplay. */
+  labels?: Record<string, string>;
+  criteria?: Record<string, unknown>;
+  appliedAt?: string;
+}
+
 export interface ManagedCampaign {
   _id: string;
   platform: string;
@@ -61,6 +89,10 @@ export interface ManagedCampaign {
   };
   /** Platform creative URN ids attached at boost time. */
   linkedCreativeUrns?: string[];
+  /** Audience selection. Rows written by the boost/workflow paths may
+   *  carry a legacy free-form object here instead — always feature-
+   *  detect `targeting.facets` before treating it as editor state. */
+  targeting?: CampaignTargeting | Record<string, unknown>;
   performance?: ManagedCampaignPerformance;
   createdAt: string;
   updatedAt?: string;
@@ -113,5 +145,27 @@ export const linkedInAdsApi = {
     api.patch<{ campaignId: string; status: string }>(
       `/v1/linkedin/ads/managed-campaigns/${id}/status`,
       { status },
+    ),
+
+  /** Facet-entity discovery within one LinkedIn targeting facet.
+   *  With `query` it typeaheads; without, lists the full facet
+   *  (sensible only for small facets like seniorities). */
+  targetingEntities: (facetUrn: string, query?: string) => {
+    const qs = new URLSearchParams({ facet: facetUrn });
+    if (query) qs.set("query", query);
+    return api.get<{ entities: TargetingEntity[] }>(
+      `/v1/linkedin/ads/targeting/entities?${qs.toString()}`,
+    );
+  },
+
+  /**
+   * Replace a campaign's audience targeting (platform first, then the
+   * local row). Locations required — the server 400s without one.
+   * Cannot start spend; an ACTIVE campaign re-enters LinkedIn review.
+   */
+  setTargeting: (id: string, facets: TargetingFacets, labels?: Record<string, string>) =>
+    api.patch<{ campaignId: string; facets: TargetingFacets }>(
+      `/v1/linkedin/ads/managed-campaigns/${id}/targeting`,
+      { facets, ...(labels ? { labels } : {}) },
     ),
 };

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -45,9 +45,10 @@ export type TargetingFacetKey =
   | "titles"
   | "staffCountRanges";
 
-export type TargetingFacets = Partial<Record<TargetingFacetKey, string[]>> & {
-  locations?: string[];
-};
+/** Per-facet entity-URN lists. `locations` is required at APPLY time
+ *  (server 400s without one) but optional in the type so partial
+ *  editor state is representable. */
+export type TargetingFacets = Partial<Record<TargetingFacetKey, string[]>>;
 
 export interface TargetingEntity {
   urn: string;


### PR DESCRIPTION
## Summary
Per-row **Audience** button in the Ads Manager opens the targeting editor: locations (required) + industries / seniorities / job titles / company size. Big facets typeahead LinkedIn live (debounced); small fixed facets (seniorities, company size) list all values. Selections apply via the new `PATCH /managed-campaigns/:id/targeting` — platform first, chips redisplayed from stored facets+labels.

Applying targeting never starts spend; the Activate confirm now states honestly whether an audience is set instead of pointing users at LinkedIn Campaign Manager.

## Review
Round 1 done (manual + subagent, 14 findings fixed: list-all facets, 50-cap mirroring, combobox/listbox a11y, label pruning, stale-copy fix).

Depends on peakhour-api `feat/growth-g1-campaign-targeting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)