### PR TITLE
feat(growth): Optimizer page goes live — weekly adjustments board (G3)

### DIFF
--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -14,6 +14,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { Check, ChevronDown, ChevronUp, Play, Sparkles, X } from "lucide-react";
 
@@ -27,6 +29,11 @@ import { Check, ChevronDown, ChevronUp, Play, Sparkles, X } from "lucide-react";
  * (approved / applied / failed with the reason) — never a fake
  * success.
  */
+
+/** Channel display names — runs are platform-stamped; never hardcode
+ *  the channel in copy (channel-common surface). */
+const PLATFORM_LABEL: Record<string, string> = { linkedin: "LinkedIn" };
+const platformLabel = (p: string) => PLATFORM_LABEL[p] ?? p;
 
 const TYPE_LABEL: Record<OptimizerProposal["type"], string> = {
   hook_weighting: "Hook style",
@@ -46,7 +53,9 @@ const STATUS_BADGE: Record<ProposalStatus, string> = {
 
 function weekLabel(iso: string): string {
   const d = new Date(iso);
-  return `Week of ${d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" })}`;
+  // weekStart is Monday 00:00 UTC — format in UTC or UTC-negative
+  // timezones render the previous Sunday.
+  return `Week of ${d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" })}`;
 }
 
 export function AdjustmentsBoard() {
@@ -57,9 +66,30 @@ export function AdjustmentsBoard() {
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });
+  const settings = useQuery({
+    queryKey: ["growth-settings"],
+    queryFn: () => growthApi.settings(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["growth-adjustments"] });
+
+  const optimizerEnabled = settings.data?.settings.optimizerEnabled === true;
+
+  const toggle = useMutation({
+    mutationFn: (enabled: boolean) => growthApi.updateSettings({ optimizerEnabled: enabled }),
+    onSuccess: (res) => {
+      queryClient.setQueryData(["growth-settings"], res);
+      toast.success(
+        res.settings.optimizerEnabled
+          ? "Optimizer enabled — it reviews this business every Monday. Run the first review whenever you like."
+          : "Optimizer disabled — no further weekly reviews.",
+      );
+    },
+    onError: () => toast.error("Couldn't update the optimizer setting. Try again in a moment."),
+  });
 
   const runNow = useMutation({
     mutationFn: () => growthApi.runNow(),
@@ -79,7 +109,13 @@ export function AdjustmentsBoard() {
         toast.info("Nothing to analyse yet — publish posts or run campaigns first.");
       }
     },
-    onError: () => toast.error("Couldn't run the optimizer. Try again in a moment."),
+    onError: (err) => {
+      if (err instanceof ApiError && err.code === "FORBIDDEN") {
+        toast.error("Pick a business first, then run the review.");
+      } else {
+        toast.error("Couldn't run the optimizer. Try again in a moment.");
+      }
+    },
   });
 
   if (runs.isLoading) {
@@ -108,29 +144,50 @@ export function AdjustmentsBoard() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm text-muted-foreground">
-          Weekly review of your organic + paid outcomes — at most three
-          small, evidence-backed proposals. You decide; nothing applies
-          itself.
-        </p>
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          disabled={runNow.isPending}
-          onClick={() => runNow.mutate()}
-        >
-          <Play className="mr-1 size-3" />
-          {runNow.isPending ? "Reviewing…" : "Run this week's review"}
-        </Button>
-      </div>
+      <Card>
+        <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
+          <div className="flex items-center gap-3">
+            <Switch
+              id="optimizer-enabled"
+              checked={optimizerEnabled}
+              disabled={settings.isLoading || toggle.isPending}
+              onCheckedChange={(v) => toggle.mutate(v)}
+            />
+            <Label htmlFor="optimizer-enabled" className="text-sm">
+              {optimizerEnabled
+                ? "Weekly reviews are ON — every Monday for this business."
+                : "Weekly reviews are OFF — enable to get Monday reviews."}
+            </Label>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={runNow.isPending || !optimizerEnabled}
+            title={optimizerEnabled ? undefined : "Enable the optimizer first"}
+            onClick={() => runNow.mutate()}
+          >
+            <Play className="mr-1 size-3" />
+            {runNow.isPending ? "Reviewing…" : "Run this week's review"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <p className="text-sm text-muted-foreground">
+        Weekly review of your organic + paid outcomes — at most three
+        small, evidence-backed proposals. You decide; nothing applies
+        itself.
+      </p>
 
       {rows.length === 0 ? (
         <EmptyState
           icon={Sparkles}
           title="No reviews yet"
-          description="The optimizer runs every Monday for enabled businesses — or run this week's review now. It needs some published posts or campaigns to analyse."
+          description={
+            optimizerEnabled
+              ? "Run this week's review now, or wait for Monday. It needs some published posts or campaigns to analyse."
+              : "Turn the optimizer on above to get a review every Monday — at most three small proposals, and you decide every one."
+          }
         />
       ) : (
         rows.map((run) => <RunCard key={run._id} run={run} onChanged={invalidate} />)
@@ -163,7 +220,13 @@ function RunCard({ run, onChanged }: { run: OptimizerRun; onChanged: () => void 
           </p>
         ) : (
           run.proposals.map((p) => (
-            <ProposalRow key={p.id} runId={run._id} proposal={p} onChanged={onChanged} />
+            <ProposalRow
+              key={p.id}
+              runId={run._id}
+              platform={run.platform}
+              proposal={p}
+              onChanged={onChanged}
+            />
           ))
         )}
       </CardContent>
@@ -173,34 +236,60 @@ function RunCard({ run, onChanged }: { run: OptimizerRun; onChanged: () => void 
 
 function ProposalRow({
   runId,
+  platform,
   proposal,
   onChanged,
 }: {
   runId: string;
+  platform: string;
   proposal: OptimizerProposal;
   onChanged: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const platformName = platformLabel(platform);
 
   const decide = useMutation({
     mutationFn: (decision: "approve" | "dismiss") =>
       growthApi.decide(runId, proposal.id, decision),
     onSuccess: (res) => {
       if (res.status === "applied") {
-        toast.success("Approved and applied — the budget change is live on LinkedIn.");
+        toast.success(`Approved and applied — the budget change is live on ${platformName}.`);
+      } else if (res.status === "retryable") {
+        // The proposal reverted to proposed — fixable, decide again.
+        toast.warning(
+          res.failReason
+            ? `Couldn't apply it yet: ${res.failReason}. Fix that and approve again.`
+            : "Couldn't apply it yet — fix the cause and approve again.",
+        );
       } else if (res.status === "failed") {
-        toast.error(res.failReason || "Approved, but applying it failed — see the proposal for why.");
+        toast.error(res.failReason || "This proposal can't be applied — see the reason on the card.");
       } else if (res.status === "approved") {
-        toast.success("Approved — the engine will fold this into how it works for you.");
+        // Honest: recorded for the engine; consumption lands in a
+        // follow-up — no fake "it's live" claim.
+        toast.success("Approved and recorded — the engine picks this up as its consumers ship.");
       } else {
         toast.success("Dismissed.");
       }
       onChanged();
     },
     onError: (err) => {
-      if (err instanceof ApiError && err.code === "ALREADY_DECIDED") {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "ALREADY_DECIDED") {
         toast.info("This proposal was already decided — refreshing.");
         onChanged();
+      } else if (code === "NEEDS_REAUTH") {
+        toast.error(`${platformName} Ads needs a reconnect before applying budget changes.`, {
+          action: {
+            label: "Reconnect",
+            onClick: () => { window.location.href = "/dashboard/integrations"; },
+          },
+        });
+        onChanged();
+      } else if (code === "NOT_FOUND") {
+        toast.error("This proposal no longer exists — refreshing.");
+        onChanged();
+      } else if (code === "FORBIDDEN") {
+        toast.error("Pick a business first.");
       } else {
         toast.error("Couldn't record the decision. Try again in a moment.");
       }
@@ -224,20 +313,24 @@ function ProposalRow({
             </Badge>
           </div>
           <p className="text-sm font-medium">{proposal.summary}</p>
-          {proposal.status === "failed" && proposal.failReason ? (
-            <p className="text-xs text-red-700 dark:text-red-300">{proposal.failReason}</p>
+          {proposal.failReason && (proposal.status === "failed" || proposal.status === "proposed") ? (
+            <p className="text-xs text-red-700 dark:text-red-300">
+              {proposal.status === "proposed" ? "Last attempt: " : ""}
+              {proposal.failReason}
+            </p>
           ) : null}
           <button
             type="button"
             className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:underline"
             aria-expanded={expanded}
+            aria-controls={`proposal-detail-${proposal.id}`}
             onClick={() => setExpanded((v) => !v)}
           >
             {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
             {expanded ? "Hide the numbers" : "See the numbers behind it"}
           </button>
           {expanded ? (
-            <div className="space-y-1.5 rounded-md bg-muted/30 p-2 text-xs">
+            <div id={`proposal-detail-${proposal.id}`} className="space-y-1.5 rounded-md bg-muted/30 p-2 text-xs">
               <div>
                 <p className="font-medium">Evidence</p>
                 <ul className="list-disc pl-4 text-muted-foreground">
@@ -267,7 +360,7 @@ function ProposalRow({
               disabled={decide.isPending}
               title={
                 proposal.type === "budget_resplit"
-                  ? "Approve — applies the budget change on LinkedIn (guarded: never an increase beyond your envelope)"
+                  ? `Approve — applies the budget change on ${platformName} (guarded: never an increase beyond your envelope)`
                   : "Approve this adjustment"
               }
               onClick={() => decide.mutate("approve")}

--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
 import {
   growthApi,
+  type GrowthSettings,
   type OptimizerProposal,
   type OptimizerRun,
   type ProposalStatus,
@@ -16,6 +17,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { Check, ChevronDown, ChevronUp, Play, Sparkles, X } from "lucide-react";
 
@@ -103,6 +105,8 @@ export function AdjustmentsBoard() {
         invalidate();
       } else if (res.reason === "already_ran") {
         toast.info("This week's review already ran — it runs once per week.");
+        // The cron may have created it after our list was cached.
+        invalidate();
       } else if (res.reason === "optimizer_disabled") {
         toast.info("The optimizer isn't enabled for this business yet.");
       } else {
@@ -145,31 +149,52 @@ export function AdjustmentsBoard() {
   return (
     <div className="space-y-4">
       <Card>
-        <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
-          <div className="flex items-center gap-3">
-            <Switch
-              id="optimizer-enabled"
-              checked={optimizerEnabled}
-              disabled={settings.isLoading || toggle.isPending}
-              onCheckedChange={(v) => toggle.mutate(v)}
+        <CardContent className="space-y-3 p-4">
+          {settings.isError ? (
+            // Honest failure: NEVER render a confident OFF state from a
+            // failed read — the business may well be opted in and
+            // running.
+            <p className="text-sm text-muted-foreground">
+              Couldn&apos;t load the optimizer settings just now — the state
+              shown may be wrong. Refresh in a moment; scheduled reviews
+              are unaffected.
+            </p>
+          ) : (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="optimizer-enabled"
+                  checked={optimizerEnabled}
+                  disabled={settings.isLoading || toggle.isPending}
+                  onCheckedChange={(v) => toggle.mutate(v)}
+                />
+                <Label htmlFor="optimizer-enabled" className="text-sm">
+                  {settings.isLoading
+                    ? "Checking optimizer status…"
+                    : optimizerEnabled
+                      ? "Weekly reviews are ON — every Monday for this business."
+                      : "Weekly reviews are OFF — enable to get Monday reviews."}
+                </Label>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={runNow.isPending || !optimizerEnabled}
+                title={optimizerEnabled ? undefined : "Enable the optimizer first"}
+                onClick={() => runNow.mutate()}
+              >
+                <Play aria-hidden="true" className="mr-1 size-3" />
+                {runNow.isPending ? "Reviewing…" : "Run this week's review"}
+              </Button>
+            </div>
+          )}
+          {!settings.isError && optimizerEnabled ? (
+            <EnvelopeEditor
+              current={settings.data?.settings.weeklyBudgetEnvelope}
+              onSaved={(res) => queryClient.setQueryData(["growth-settings"], res)}
             />
-            <Label htmlFor="optimizer-enabled" className="text-sm">
-              {optimizerEnabled
-                ? "Weekly reviews are ON — every Monday for this business."
-                : "Weekly reviews are OFF — enable to get Monday reviews."}
-            </Label>
-          </div>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={runNow.isPending || !optimizerEnabled}
-            title={optimizerEnabled ? undefined : "Enable the optimizer first"}
-            onClick={() => runNow.mutate()}
-          >
-            <Play className="mr-1 size-3" />
-            {runNow.isPending ? "Reviewing…" : "Run this week's review"}
-          </Button>
+          ) : null}
         </CardContent>
       </Card>
 
@@ -192,6 +217,75 @@ export function AdjustmentsBoard() {
       ) : (
         rows.map((run) => <RunCard key={run._id} run={run} onChanged={invalidate} />)
       )}
+    </div>
+  );
+}
+
+/**
+ * Weekly budget envelope editor — the cap that makes budget INCREASES
+ * approvable (without one, re-splits may only decrease; the api guard
+ * says so and points here). Blank + Save clears the envelope.
+ */
+function EnvelopeEditor({
+  current,
+  onSaved,
+}: {
+  current: number | undefined;
+  onSaved: (settings: { settings: GrowthSettings }) => void;
+}) {
+  const [value, setValue] = useState(current !== undefined ? String(current) : "");
+
+  const save = useMutation({
+    mutationFn: () => {
+      const trimmed = value.trim();
+      return growthApi.updateSettings({
+        weeklyBudgetEnvelope: trimmed === "" ? null : Number(trimmed),
+      });
+    },
+    onSuccess: (res) => {
+      onSaved(res);
+      toast.success(
+        typeof res.settings.weeklyBudgetEnvelope === "number"
+          ? `Weekly budget cap set to ${res.settings.weeklyBudgetEnvelope}. Budget increases can now be approved up to it.`
+          : "Weekly budget cap cleared — budget re-splits may only decrease.",
+      );
+    },
+    onError: () => toast.error("Couldn't save the budget cap. Try again in a moment."),
+  });
+
+  const trimmed = value.trim();
+  const numeric = Number(trimmed);
+  const valid = trimmed === "" || (Number.isFinite(numeric) && numeric >= 0);
+  const dirty = trimmed !== (current !== undefined ? String(current) : "");
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+      <Label htmlFor="weekly-envelope" className="text-xs text-muted-foreground">
+        Weekly budget cap (ad-account currency)
+      </Label>
+      <Input
+        id="weekly-envelope"
+        type="number"
+        min={0}
+        value={value}
+        placeholder="none — increases blocked"
+        className="h-7 w-44 text-xs"
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="h-7 px-2 text-xs"
+        disabled={!valid || !dirty || save.isPending}
+        onClick={() => save.mutate()}
+      >
+        {save.isPending ? "Saving…" : "Save"}
+      </Button>
+      <span className="text-[11px] text-muted-foreground">
+        Approved budget increases must fit under this cap; without one,
+        re-splits may only decrease.
+      </span>
     </div>
   );
 }
@@ -326,7 +420,11 @@ function ProposalRow({
             aria-controls={`proposal-detail-${proposal.id}`}
             onClick={() => setExpanded((v) => !v)}
           >
-            {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+            {expanded ? (
+              <ChevronUp aria-hidden="true" className="size-3" />
+            ) : (
+              <ChevronDown aria-hidden="true" className="size-3" />
+            )}
             {expanded ? "Hide the numbers" : "See the numbers behind it"}
           </button>
           {expanded ? (
@@ -365,7 +463,7 @@ function ProposalRow({
               }
               onClick={() => decide.mutate("approve")}
             >
-              <Check className="mr-1 size-3" />
+              <Check aria-hidden="true" className="mr-1 size-3" />
               Approve
             </Button>
             <Button
@@ -376,7 +474,7 @@ function ProposalRow({
               disabled={decide.isPending}
               onClick={() => decide.mutate("dismiss")}
             >
-              <X className="mr-1 size-3" />
+              <X aria-hidden="true" className="mr-1 size-3" />
               Dismiss
             </Button>
           </div>

--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import {
+  growthApi,
+  type OptimizerProposal,
+  type OptimizerRun,
+  type ProposalStatus,
+} from "@/lib/api/growth";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { Check, ChevronDown, ChevronUp, Play, Sparkles, X } from "lucide-react";
+
+/**
+ * AdjustmentsBoard — the weekly optimizer's proposal review surface
+ * (G3, autonomy L0/L1: every decision is a human's).
+ *
+ * Honesty rules baked in: quiet weeks render the optimizer's own
+ * "not enough signal" note; inputsDigest shows exactly what a run
+ * looked at; a budget approval reports what ACTUALLY happened
+ * (approved / applied / failed with the reason) — never a fake
+ * success.
+ */
+
+const TYPE_LABEL: Record<OptimizerProposal["type"], string> = {
+  hook_weighting: "Hook style",
+  posting_cadence: "Posting cadence",
+  budget_resplit: "Budget re-split",
+  boost_threshold: "Boost threshold",
+  audience_emphasis: "Audience emphasis",
+};
+
+const STATUS_BADGE: Record<ProposalStatus, string> = {
+  proposed: "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200",
+  approved: "bg-sky-100 text-sky-900 dark:bg-sky-950 dark:text-sky-200",
+  applied: "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200",
+  dismissed: "bg-muted/60 text-muted-foreground",
+  failed: "bg-red-100 text-red-900 dark:bg-red-950 dark:text-red-200",
+};
+
+function weekLabel(iso: string): string {
+  const d = new Date(iso);
+  return `Week of ${d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" })}`;
+}
+
+export function AdjustmentsBoard() {
+  const queryClient = useQueryClient();
+  const runs = useQuery({
+    queryKey: ["growth-adjustments"],
+    queryFn: () => growthApi.adjustments(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["growth-adjustments"] });
+
+  const runNow = useMutation({
+    mutationFn: () => growthApi.runNow(),
+    onSuccess: (res) => {
+      if (res.created) {
+        toast.success(
+          res.proposalCount > 0
+            ? `Optimizer reviewed the week — ${res.proposalCount} proposal${res.proposalCount === 1 ? "" : "s"} to decide.`
+            : "Optimizer reviewed the week — nothing worth changing (a quiet week is a valid result).",
+        );
+        invalidate();
+      } else if (res.reason === "already_ran") {
+        toast.info("This week's review already ran — it runs once per week.");
+      } else if (res.reason === "optimizer_disabled") {
+        toast.info("The optimizer isn't enabled for this business yet.");
+      } else {
+        toast.info("Nothing to analyse yet — publish posts or run campaigns first.");
+      }
+    },
+    onError: () => toast.error("Couldn't run the optimizer. Try again in a moment."),
+  });
+
+  if (runs.isLoading) {
+    return (
+      <Card>
+        <CardContent className="space-y-3 p-6">
+          <Skeleton className="h-5 w-1/3" />
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (runs.isError) {
+    return (
+      <EmptyState
+        icon={Sparkles}
+        title="Couldn't load optimizer reviews"
+        description="Try refreshing in a moment."
+      />
+    );
+  }
+
+  const rows = runs.data?.runs ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Weekly review of your organic + paid outcomes — at most three
+          small, evidence-backed proposals. You decide; nothing applies
+          itself.
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={runNow.isPending}
+          onClick={() => runNow.mutate()}
+        >
+          <Play className="mr-1 size-3" />
+          {runNow.isPending ? "Reviewing…" : "Run this week's review"}
+        </Button>
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyState
+          icon={Sparkles}
+          title="No reviews yet"
+          description="The optimizer runs every Monday for enabled businesses — or run this week's review now. It needs some published posts or campaigns to analyse."
+        />
+      ) : (
+        rows.map((run) => <RunCard key={run._id} run={run} onChanged={invalidate} />)
+      )}
+    </div>
+  );
+}
+
+function RunCard({ run, onChanged }: { run: OptimizerRun; onChanged: () => void }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-base font-semibold leading-none">{weekLabel(run.weekStart)}</h3>
+          {run.inputsDigest ? (
+            <span className="text-[11px] text-muted-foreground">
+              Looked at {run.inputsDigest.organicPosts} post
+              {run.inputsDigest.organicPosts === 1 ? "" : "s"} ·{" "}
+              {run.inputsDigest.campaignsAnalysed} campaign
+              {run.inputsDigest.campaignsAnalysed === 1 ? "" : "s"} ·{" "}
+              {run.inputsDigest.windowDays}-day window
+            </span>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 pt-0">
+        {run.proposals.length === 0 ? (
+          <p className="rounded-md border border-dashed bg-muted/20 px-3 py-3 text-sm text-muted-foreground">
+            {run.noAdjustmentReason || "Nothing worth changing this week."}
+          </p>
+        ) : (
+          run.proposals.map((p) => (
+            <ProposalRow key={p.id} runId={run._id} proposal={p} onChanged={onChanged} />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ProposalRow({
+  runId,
+  proposal,
+  onChanged,
+}: {
+  runId: string;
+  proposal: OptimizerProposal;
+  onChanged: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const decide = useMutation({
+    mutationFn: (decision: "approve" | "dismiss") =>
+      growthApi.decide(runId, proposal.id, decision),
+    onSuccess: (res) => {
+      if (res.status === "applied") {
+        toast.success("Approved and applied — the budget change is live on LinkedIn.");
+      } else if (res.status === "failed") {
+        toast.error(res.failReason || "Approved, but applying it failed — see the proposal for why.");
+      } else if (res.status === "approved") {
+        toast.success("Approved — the engine will fold this into how it works for you.");
+      } else {
+        toast.success("Dismissed.");
+      }
+      onChanged();
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.code === "ALREADY_DECIDED") {
+        toast.info("This proposal was already decided — refreshing.");
+        onChanged();
+      } else {
+        toast.error("Couldn't record the decision. Try again in a moment.");
+      }
+    },
+  });
+
+  const open = proposal.status === "proposed";
+
+  return (
+    <div className="rounded-md border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${STATUS_BADGE[proposal.status]}`}
+            >
+              {proposal.status}
+            </span>
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              {TYPE_LABEL[proposal.type] ?? proposal.type}
+            </Badge>
+          </div>
+          <p className="text-sm font-medium">{proposal.summary}</p>
+          {proposal.status === "failed" && proposal.failReason ? (
+            <p className="text-xs text-red-700 dark:text-red-300">{proposal.failReason}</p>
+          ) : null}
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:underline"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+            {expanded ? "Hide the numbers" : "See the numbers behind it"}
+          </button>
+          {expanded ? (
+            <div className="space-y-1.5 rounded-md bg-muted/30 p-2 text-xs">
+              <div>
+                <p className="font-medium">Evidence</p>
+                <ul className="list-disc pl-4 text-muted-foreground">
+                  {proposal.evidence.map((e, i) => (
+                    <li key={i}>{e}</li>
+                  ))}
+                </ul>
+              </div>
+              <p>
+                <span className="font-medium">Expected effect:</span>{" "}
+                <span className="text-muted-foreground">{proposal.expectedEffect}</span>
+              </p>
+              <p>
+                <span className="font-medium">Rollback if:</span>{" "}
+                <span className="text-muted-foreground">{proposal.rollbackCondition}</span>
+              </p>
+            </div>
+          ) : null}
+        </div>
+        {open ? (
+          <div className="flex shrink-0 gap-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="default"
+              className="h-7 px-2 text-xs"
+              disabled={decide.isPending}
+              title={
+                proposal.type === "budget_resplit"
+                  ? "Approve — applies the budget change on LinkedIn (guarded: never an increase beyond your envelope)"
+                  : "Approve this adjustment"
+              }
+              onClick={() => decide.mutate("approve")}
+            >
+              <Check className="mr-1 size-3" />
+              Approve
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-xs"
+              disabled={decide.isPending}
+              onClick={() => decide.mutate("dismiss")}
+            >
+              <X className="mr-1 size-3" />
+              Dismiss
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/optimizer/page.tsx
+++ b/src/app/(site)/dashboard/optimizer/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Sparkles, Target, TrendingUp, Zap, type LucideIcon } from "lucide-react";
+import { Target, TrendingUp, Zap, type LucideIcon } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { AdjustmentsBoard } from "./_components/adjustments-board";
 
 const FEATURE_KEY = "growth.optimizer";
 const FEATURE_NAME = "Optimizer";
@@ -38,7 +39,7 @@ const PILLARS: Pillar[] = [
 export default function OptimizerPage() {
   return (
     <div className="space-y-6">
-      <CronToolbar crons={["outcome-backfill", "per-stream-effectiveness-rollup"]} />
+      <CronToolbar crons={["growth-optimizer", "outcome-backfill", "per-stream-effectiveness-rollup"]} />
       <div>
         <h2 className="text-2xl font-bold tracking-tight">Optimizer</h2>
         <p className="text-muted-foreground">
@@ -53,21 +54,10 @@ export default function OptimizerPage() {
         mode="hide"
         fallback={<OptimizerWaitlistCard />}
       >
-        {/* Unlocked branch — only reachable once an org has
-            growth.optimizer entitled (today: nobody, since the
-            feature is on no plan). Until the live agent ships, we
-            render the same pillar preview + a reservation banner so
-            entitled orgs see something stable instead of an empty
-            page. */}
-        <OptimizerPreview />
-        <Card>
-          <CardContent className="flex items-center gap-3 py-5 text-sm">
-            <Sparkles aria-hidden="true" className="size-4 text-amber-600 dark:text-amber-400 shrink-0" />
-            <span className="text-muted-foreground">
-              Access reserved on your account. Live agents roll out as each Phase ships — you&apos;ll see them appear here automatically.
-            </span>
-          </CardContent>
-        </Card>
+        {/* Unlocked branch (G3): the live weekly-review board. Every
+            proposal is a human decision at today's autonomy ceiling
+            (L0/L1) — the board and its copy say so explicitly. */}
+        <AdjustmentsBoard />
       </FeatureGate>
     </div>
   );

--- a/src/app/(site)/dashboard/optimizer/page.tsx
+++ b/src/app/(site)/dashboard/optimizer/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { UpgradeButton } from "@/components/upgrade/upgrade-button";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { useQueryClient } from "@tanstack/react-query";
 import { AdjustmentsBoard } from "./_components/adjustments-board";
 
 const FEATURE_KEY = "growth.optimizer";
@@ -37,13 +38,23 @@ const PILLARS: Pillar[] = [
 ];
 
 export default function OptimizerPage() {
+  const queryClient = useQueryClient();
   return (
     <div className="space-y-6">
-      <CronToolbar crons={["growth-optimizer", "outcome-backfill", "per-stream-effectiveness-rollup"]} />
+      <CronToolbar
+        crons={["growth-optimizer", "outcome-backfill", "per-stream-effectiveness-rollup"]}
+        onTriggered={() =>
+          queryClient.invalidateQueries({ queryKey: ["growth-adjustments"] })
+        }
+      />
       <div>
         <h2 className="text-2xl font-bold tracking-tight">Optimizer</h2>
+        {/* Honest at today's autonomy ceiling (L0/L1): it proposes,
+            you decide. The autonomous framing stays on the locked-
+            state marketing card, not above the live board. */}
         <p className="text-muted-foreground">
-          An autonomous teammate for paid + organic — running the dials so you don&apos;t have to.
+          A weekly teammate for paid + organic — it brings you the
+          evidence and the dials; you make the calls.
         </p>
       </div>
 

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -298,6 +298,18 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Generates new posts from any recurring schedule rules you've set up.",
   },
+  "growth-optimizer": {
+    label: "Run weekly growth review",
+    frequency: "Runs Mondays 03:00 UTC",
+    description:
+      "Reviews each opted-in business's week of posts and campaigns and proposes up to three small, evidence-backed adjustments for approval.",
+    summarize: (data) => {
+      const d = data as { businesses?: number; created?: number; skipped?: number; failed?: number } | null;
+      if (!d || typeof d.businesses !== "number") return null;
+      const msg = `${d.created ?? 0} review${(d.created ?? 0) === 1 ? "" : "s"} created across ${d.businesses} business${d.businesses === 1 ? "" : "es"} (${d.skipped ?? 0} already done, ${d.failed ?? 0} failed).`;
+      return (d.failed ?? 0) > 0 ? { message: msg, level: "warning" } : msg;
+    },
+  },
   "outcome-backfill": {
     label: "Backfill post outcomes",
     frequency: "Runs every hour",

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -304,10 +304,13 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Reviews each opted-in business's week of posts and campaigns and proposes up to three small, evidence-backed adjustments for approval.",
     summarize: (data) => {
-      const d = data as { businesses?: number; created?: number; skipped?: number; failed?: number } | null;
+      const d = data as {
+        businesses?: number; created?: number; skipped?: number; failed?: number; truncated?: boolean;
+      } | null;
       if (!d || typeof d.businesses !== "number") return null;
-      const msg = `${d.created ?? 0} review${(d.created ?? 0) === 1 ? "" : "s"} created across ${d.businesses} business${d.businesses === 1 ? "" : "es"} (${d.skipped ?? 0} already done, ${d.failed ?? 0} failed).`;
-      return (d.failed ?? 0) > 0 ? { message: msg, level: "warning" } : msg;
+      let msg = `${d.created ?? 0} review${(d.created ?? 0) === 1 ? "" : "s"} created across ${d.businesses} business${d.businesses === 1 ? "" : "es"} (${d.skipped ?? 0} already done, ${d.failed ?? 0} failed).`;
+      if (d.truncated) msg += " More businesses pending — trigger again to continue.";
+      return (d.failed ?? 0) > 0 || d.truncated ? { message: msg, level: "warning" } : msg;
     },
   },
   "outcome-backfill": {

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -20,6 +20,17 @@ export type ProposalType =
 
 export type ProposalStatus = "proposed" | "approved" | "dismissed" | "applied" | "failed";
 
+/** Decision outcomes the decide endpoint reports. `retryable` = the
+ *  apply failed for a FIXABLE reason and the proposal was reverted to
+ *  `proposed` — fix the cause (reconnect / envelope) and decide again. */
+export type DecisionStatus = "approved" | "dismissed" | "applied" | "failed" | "retryable";
+
+export interface GrowthSettings {
+  optimizerEnabled?: boolean;
+  autonomyLevel?: number;
+  weeklyBudgetEnvelope?: number;
+}
+
 export interface OptimizerProposal {
   id: string;
   type: ProposalType;
@@ -60,9 +71,17 @@ export const growthApi = {
 
   /** Human decision on one proposal. Approving a budget_resplit also
    *  attempts the guarded platform apply — the response's status says
-   *  what actually happened (approved / applied / failed). */
+   *  what ACTUALLY happened (approved / applied / failed / retryable).
+   *  Reauth failures arrive as 409 NEEDS_REAUTH instead. */
   decide: (runId: string, proposalId: string, decision: "approve" | "dismiss") =>
-    api.post<{ ok: true; status: ProposalStatus; failReason?: string }>(
+    api.post<{ ok: true; status: DecisionStatus; failReason?: string }>(
       `/v1/growth/adjustments/${runId}/proposals/${proposalId}/${decision}`,
     ),
+
+  /** Per-business growth settings (the optimizer opt-in lives here). */
+  settings: () => api.get<{ settings: GrowthSettings }>("/v1/growth/settings"),
+
+  /** Self-serve optimizer opt-in / weekly budget envelope. */
+  updateSettings: (patch: { optimizerEnabled?: boolean; weeklyBudgetEnvelope?: number | null }) =>
+    api.patch<{ settings: GrowthSettings }>("/v1/growth/settings", patch),
 };

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -1,0 +1,68 @@
+import { api } from "@/lib/api";
+
+/**
+ * Growth-engine client (G3) — the channel-common /v1/growth surface.
+ *
+ * Weekly optimizer runs land as `opt_adjustments` rows: at most 3
+ * SMALL, CONSERVATIVE proposals per week, each with evidence, expected
+ * effect, and a rollback condition. Humans decide here (autonomy
+ * L0/L1); only an approved budget_resplit ever touches the platform,
+ * behind the api's no-increase-without-envelope guard. Nothing on this
+ * surface can create campaigns or start spend.
+ */
+
+export type ProposalType =
+  | "hook_weighting"
+  | "posting_cadence"
+  | "budget_resplit"
+  | "boost_threshold"
+  | "audience_emphasis";
+
+export type ProposalStatus = "proposed" | "approved" | "dismissed" | "applied" | "failed";
+
+export interface OptimizerProposal {
+  id: string;
+  type: ProposalType;
+  summary: string;
+  evidence: string[];
+  expectedEffect: string;
+  rollbackCondition: string;
+  autoApplicable: boolean;
+  params?: Record<string, unknown>;
+  status: ProposalStatus;
+  decidedAt?: string;
+  appliedAt?: string;
+  failReason?: string;
+}
+
+export interface OptimizerRun {
+  _id: string;
+  platform: string;
+  weekStart: string;
+  proposals: OptimizerProposal[];
+  noAdjustmentReason?: string;
+  inputsDigest?: { organicPosts: number; campaignsAnalysed: number; windowDays: number };
+  createdAt: string;
+}
+
+export type RunNowResult =
+  | { created: false; reason: "already_ran" | "optimizer_disabled" | "no_data" }
+  | { created: true; runId: string; proposalCount: number };
+
+export const growthApi = {
+  /** Recent weekly optimizer runs (newest first, up to 12). */
+  adjustments: () => api.get<{ runs: OptimizerRun[] }>("/v1/growth/adjustments"),
+
+  /** Run the optimizer now for the active business. Idempotent per ISO
+   *  week; typed no-op reasons (already_ran / optimizer_disabled /
+   *  no_data) come back as 200s, not errors. */
+  runNow: () => api.post<RunNowResult>("/v1/growth/adjustments/run"),
+
+  /** Human decision on one proposal. Approving a budget_resplit also
+   *  attempts the guarded platform apply — the response's status says
+   *  what actually happened (approved / applied / failed). */
+  decide: (runId: string, proposalId: string, decision: "approve" | "dismiss") =>
+    api.post<{ ok: true; status: ProposalStatus; failReason?: string }>(
+      `/v1/growth/adjustments/${runId}/proposals/${proposalId}/${decision}`,
+    ),
+};


### PR DESCRIPTION
## Summary
`/dashboard/optimizer`'s unlocked branch becomes the real G3 surface: weekly optimizer runs with per-proposal **Approve / Dismiss**, expandable evidence/effect/rollback, honest quiet-week notes and coverage digests, and an idempotent "Run this week's review". Waitlist fallback for un-entitled users unchanged.

Autonomy L0/L1 is explicit: nothing applies itself; a budget-re-split approval reports applied/failed truthfully.

## Dependencies
peakhour-api **#923** (routes + service). Merge order: #923 → #404 (mongodb) → this.

## Review
Round 1 in progress. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)