### PR TITLE
feat(growth): G3 slice 2 companion — consumer copy + composer cadence note

### DIFF
--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -45,6 +45,14 @@ const TYPE_LABEL: Record<OptimizerProposal["type"], string> = {
   audience_emphasis: "Audience emphasis",
 };
 
+/** Which engine surface consumes each LIVE non-budget type — used in the
+ *  approve-toast so the promise matches the actual consumer. */
+const CONSUMER_SURFACE: Partial<Record<OptimizerProposal["type"], string>> = {
+  hook_weighting: "draft generation",
+  posting_cadence: "schedule recommendation",
+  boost_threshold: "boost ranking",
+};
+
 const STATUS_BADGE: Record<ProposalStatus, string> = {
   proposed: "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200",
   approved: "bg-sky-100 text-sky-900 dark:bg-sky-950 dark:text-sky-200",
@@ -358,11 +366,13 @@ function ProposalRow({
       } else if (res.status === "failed") {
         toast.error(res.failReason || "This proposal can't be applied — see the reason on the card.");
       } else if (res.status === "approved") {
-        // Non-budget types are consumed by the engine (boost ranking,
-        // draft generation, schedule recommendations) on their next
-        // run — the card flips to "applied" when that happens.
+        // Per-type honesty: only types with a LIVE consumer may promise
+        // application. audience_emphasis has no consumer wired yet —
+        // its card stays "approved" until that ships, so say so.
         toast.success(
-          "Approved — the engine applies it on its next run (boost ranking, drafts, or scheduling).",
+          proposal.type === "audience_emphasis"
+            ? "Approved and recorded — audience emphasis is picked up when its consumer ships."
+            : `Approved — the engine applies it on its next ${CONSUMER_SURFACE[proposal.type] ?? "run"}.`,
         );
       } else {
         toast.success("Dismissed.");

--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -358,9 +358,12 @@ function ProposalRow({
       } else if (res.status === "failed") {
         toast.error(res.failReason || "This proposal can't be applied — see the reason on the card.");
       } else if (res.status === "approved") {
-        // Honest: recorded for the engine; consumption lands in a
-        // follow-up — no fake "it's live" claim.
-        toast.success("Approved and recorded — the engine picks this up as its consumers ship.");
+        // Non-budget types are consumed by the engine (boost ranking,
+        // draft generation, schedule recommendations) on their next
+        // run — the card flips to "applied" when that happens.
+        toast.success(
+          "Approved — the engine applies it on its next run (boost ranking, drafts, or scheduling).",
+        );
       } else {
         toast.success("Dismissed.");
       }

--- a/src/components/scheduler/schedule-confirm-card.tsx
+++ b/src/components/scheduler/schedule-confirm-card.tsx
@@ -10,7 +10,7 @@
  * ("shifted +90m for cross-channel min-spacing").
  */
 
-import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { CheckCircle2, AlertCircle, Loader2, Sparkles } from "lucide-react";
 import { ChannelIconCompact } from "@/components/ui/channel-icon";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
@@ -108,6 +108,21 @@ export function ScheduleConfirmCard({
             </li>
           ))}
         </ul>
+
+        {preview.cadenceAdjustment && (
+          <div className="flex items-start gap-2 rounded-md border border-primary/20 bg-background px-3 py-2 text-xs text-muted-foreground">
+            <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+            <div className="min-w-0">
+              <span className="font-medium text-foreground">
+                Your weekly optimizer suggests:
+              </span>{" "}
+              {preview.cadenceAdjustment.summary}
+              <span className="block text-[11px]">
+                {preview.cadenceAdjustment.expectedEffect}
+              </span>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/lib/scheduler/types.ts
+++ b/src/lib/scheduler/types.ts
@@ -239,6 +239,10 @@ export interface PreviewTimeResponse {
     scheduledAtUtc: string | null;
     audit: string[];
   }[];
+  /** Present when the preview includes LinkedIn and the business has an
+   *  approved/applied `posting_cadence` adjustment from the weekly
+   *  optimizer (G3) — surfaced so cadence guidance steers scheduling. */
+  cadenceAdjustment?: { summary: string; expectedEffect: string };
 }
 
 export interface ListPlansResponse {


### PR DESCRIPTION
Pairs with travelxp/peakhour-api#924. Optimizer approve-toast updated (consumers now exist — no more 'recorded ... as its consumers ship'), and the scheduler confirm card renders the optional cadenceAdjustment surfaced by POST /v1/scheduler/preview-time. Additive optional field — safe (and intended) to merge BEFORE the api PR so the note renders from the first flip. Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)