### PR TITLE
fix(content): preference-aware dates on LinkedIn feed + X cards

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/feed-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/feed-panel.tsx
@@ -29,6 +29,7 @@ import {
   type LinkedInFeedResponse,
 } from "@/lib/api/linkedin-content";
 import { RetentionFootnote } from "./retention-footnote";
+import { useLocale } from "@/hooks/use-locale";
 
 /** LinkedIn's comment body cap. */
 const COMMENT_MAX_LEN = 1250;
@@ -165,6 +166,7 @@ export function FeedPanel() {
 
 function FeedRow({ post }: { post: LinkedInFeedPost }) {
   const url = linkedInPostUrl(post.linkedInPostId);
+  const { formatRelativeTime } = useLocale();
   const [commenting, setCommenting] = useState(false);
   // Comment as the post's own author (your member feed, or the page that
   // published it). We can only build a valid author URN when we know the
@@ -386,20 +388,6 @@ function formatCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
-}
-
-function formatRelativeTime(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return "";
-  const diffMs = Date.now() - then;
-  const mins = Math.round(diffMs / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.round(hrs / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString();
 }
 
 // ── Sub-components ────────────────────────────────────────

--- a/src/app/(site)/dashboard/content/x/_components/mentions-list.tsx
+++ b/src/app/(site)/dashboard/content/x/_components/mentions-list.tsx
@@ -33,7 +33,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { formatDate } from "@/lib/locale";
+import { useLocale } from "@/hooks/use-locale";
 import {
   xApi,
   type XMention,
@@ -246,6 +246,7 @@ function MentionCard({
   markPending: boolean;
   onReply: () => void;
 }) {
+  const { formatDate } = useLocale();
   const m = mention.metrics;
   const isUnread = !mention.readAt;
   const handle = mention.author.handle ?? mention.author.id;
@@ -267,7 +268,7 @@ function MentionCard({
                 </Badge>
               )}
               <span>·</span>
-              <span>{formatDate(mention.mentionedAt, null)}</span>
+              <span>{formatDate(mention.mentionedAt)}</span>
               {isUnread && (
                 <Badge variant="default" className="text-xs h-4 px-1.5">
                   New

--- a/src/app/(site)/dashboard/content/x/_components/tweet-card.tsx
+++ b/src/app/(site)/dashboard/content/x/_components/tweet-card.tsx
@@ -21,7 +21,7 @@ import {
   Sparkles,
   Loader2,
 } from "lucide-react";
-import { formatDate } from "@/lib/locale";
+import { useLocale } from "@/hooks/use-locale";
 import { xApi, type XTweet } from "@/lib/api/x";
 import { ApiError } from "@/lib/api";
 
@@ -38,6 +38,7 @@ export interface TweetCardProps {
 }
 
 export function TweetCard({ tweet, onRepurpose, repurposing }: TweetCardProps) {
+  const { formatDate } = useLocale();
   const queryClient = useQueryClient();
   const del = useMutation({
     mutationFn: () => xApi.deleteTweet(tweet.id),
@@ -99,7 +100,7 @@ export function TweetCard({ tweet, onRepurpose, repurposing }: TweetCardProps) {
         </div>
 
         <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>{formatDate(tweet.createdAt, null)}</span>
+          <span>{formatDate(tweet.createdAt)}</span>
           {m && (
             <div className="flex items-center gap-3">
               <Metric icon={Heart} label="Likes" value={m.likeCount} />

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -173,12 +173,20 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
         upserted += num(rr.postsUpserted);
         fetched += num(rr.postsFetched);
       }
-      if (num(d.synced) === 0 && num(d.failed) > 0)
+      const failed = num(d.failed);
+      if (num(d.synced) === 0 && failed > 0)
         return "LinkedIn sync didn't complete — please reconnect and try again.";
+      // A failed business among healthy ones (e.g. its token was
+      // revoked) must not read as all-good.
+      const failedSuffix =
+        failed > 0
+          ? ` ${failed} ${plural(failed, "account")} need${failed === 1 ? "s" : ""} reconnecting.`
+          : "";
       if (upserted > 0)
-        return `${upserted} ${plural(upserted, "post")} synced successfully.`;
-      if (fetched > 0) return "LinkedIn synced — your posts are already up to date.";
-      return "LinkedIn synced — no new posts in range yet.";
+        return `${upserted} ${plural(upserted, "post")} synced successfully.${failedSuffix}`;
+      if (fetched > 0)
+        return `LinkedIn synced — your posts are already up to date.${failedSuffix}`;
+      return `LinkedIn synced — no new posts in range yet.${failedSuffix}`;
     },
   },
   "linkedin-retention-cleanup": {


### PR DESCRIPTION
## Problem

- LinkedIn feed panel ([feed-panel.tsx](src/app/(site)/dashboard/content/linkedin/_components/feed-panel.tsx)) had a file-local `formatRelativeTime` that falls back to raw `toLocaleDateString()` for posts older than 30 days → quests.travel saw "6/4/2026" on every post, ignoring the `dateFormat` user preference.
- `TweetCard` / `MentionCard` imported the canonical `formatDate` but passed `prefs = null` — preference silently discarded.
- The `linkedin-post-sync` Cron Toolbar toast only said "please reconnect" when **every** business failed; one revoked-token business among healthy ones still read as success.

## Fix

- Feed panel now uses `useLocale()`'s `formatRelativeTime` (Intl relative time, preference-formatted fallback) — same pattern as `attention-bell.tsx`.
- `TweetCard` / `MentionCard` use `useLocale()`'s bound `formatDate`.
- Sync toast appends `"N accounts need reconnecting."` to success variants when any business failed. Pairs with travelxp/peakhour-api#926 (revoked tokens now report `status: "failed"`).

## Verification

`tsc --noEmit` clean, eslint clean on changed files, vitest 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)