### PR TITLE
feat(linkedin): composer publishes as the Company Page by default

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/post-composer.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/post-composer.tsx
@@ -35,6 +35,7 @@ import {
   AtSign,
   CalendarClock,
   ChevronDown,
+  Building2,
   GalleryHorizontalEnd,
   Link2,
   ListChecks,
@@ -45,6 +46,7 @@ import {
   ShieldAlert,
   ShieldCheck,
   Sparkles,
+  User,
   Wand2,
   X,
 } from "lucide-react";
@@ -181,15 +183,15 @@ export function PostComposer({ identity, seedText }: Props) {
   const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
 
   // Author picker — discriminated union string keys for the Select.
-  // "person" → user's personal feed. "org:<id>" → that org page.
+  // "org:<id>" → that org page. "person" → user's personal feed.
+  // Pages come FIRST and are the default: the business publishes as
+  // its Company Page. The personal feed is only offered when the
+  // server says it's allowed (pageless fallback — /me's
+  // personalPostingAllowed; the publish routes enforce the same
+  // policy server-side) or when no page option could be built at all
+  // (missing org scope → the reconnect hint below guides the user).
   const authorOptions = useMemo(() => {
-    const opts: Array<{ value: string; label: string; sublabel?: string }> = [
-      {
-        value: "person",
-        label: identity.person.name ?? "My personal feed",
-        sublabel: "Personal feed",
-      },
-    ];
+    const opts: Array<{ value: string; label: string; sublabel?: string }> = [];
     const canPostAsOrg = identity.scopes.includes(HAS_ORG_SCOPE);
     if (canPostAsOrg) {
       for (const page of identity.pages) {
@@ -199,6 +201,13 @@ export function PostComposer({ identity, seedText }: Props) {
           sublabel: "Company page",
         });
       }
+    }
+    if ((identity.personalPostingAllowed ?? true) || opts.length === 0) {
+      opts.push({
+        value: "person",
+        label: identity.person.name ?? "My personal feed",
+        sublabel: "Personal feed",
+      });
     }
     return opts;
   }, [identity]);
@@ -719,25 +728,47 @@ export function PostComposer({ identity, seedText }: Props) {
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="li-author" className="text-xs uppercase tracking-wide text-muted-foreground">
-              Post as
+              Posting as
             </Label>
-            <Select value={authorKey} onValueChange={setAuthorKey}>
-              <SelectTrigger id="li-author">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {authorOptions.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    <span className="flex flex-col">
-                      <span>{opt.label}</span>
-                      {opt.sublabel && (
-                        <span className="text-xs text-muted-foreground">{opt.sublabel}</span>
-                      )}
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {authorOptions.length === 1 ? (
+              // Single allowed author (the mapped Company Page, or the
+              // pageless personal fallback) — nothing to choose, so show
+              // a locked identity chip instead of a one-item dropdown.
+              <div
+                id="li-author"
+                className="flex h-9 items-center gap-2 rounded-md border bg-muted/40 px-3 text-sm"
+              >
+                {authorOptions[0].value === "person" ? (
+                  <User className="size-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <Building2 className="size-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className="truncate font-medium">{authorOptions[0].label}</span>
+                {authorOptions[0].sublabel && (
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                    {authorOptions[0].sublabel}
+                  </span>
+                )}
+              </div>
+            ) : (
+              <Select value={authorKey} onValueChange={setAuthorKey}>
+                <SelectTrigger id="li-author">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {authorOptions.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      <span className="flex flex-col">
+                        <span>{opt.label}</span>
+                        {opt.sublabel && (
+                          <span className="text-xs text-muted-foreground">{opt.sublabel}</span>
+                        )}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             {!identity.scopes.includes(HAS_ORG_SCOPE) && identity.pages.length > 0 && (
               <p className="text-xs text-muted-foreground">
                 Reconnect LinkedIn to enable posting from your company pages.

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -80,6 +80,11 @@ export interface LinkedInIdentity {
     email?: string;
   };
   pages: LinkedInOrgPage[];
+  /** Personal-feed publishing is the pageless fallback only — false
+   *  whenever a Company Page is enabled on the connection (the
+   *  server rejects person authors on publish surfaces then). Absent
+   *  on older API deploys → treat as allowed. */
+  personalPostingAllowed?: boolean;
 }
 
 /** Hook DNA score. Tier badge:


### PR DESCRIPTION
## Problem

The composer always seeded **Post as <person>** as the first (and default) author option — a business workspace like quests.travel published to Vanshita's personal feed by default and showed an unnecessary person/page dropdown.

## Fix

- Pages first, pages default. The personal-feed option renders only when `GET /me` says `personalPostingAllowed` (pageless fallback) or when no page option could be built at all (missing `w_organization_social`, where the existing "Reconnect" hint guides the user). Legacy API responses without the flag keep old behavior.
- Exactly one allowed author → the dropdown collapses to a locked **"Posting as <page>"** chip (icon + page name) — nothing to choose.
- `LinkedInIdentity` type gains `personalPostingAllowed?: boolean`.

Server-side counterpart: travelxp/peakhour-api#927 (enforces Company-Page authorship on every publish surface, incl. scheduled posts).

Page **logo** in the chip is deferred to the connect-time page-mapping PR (logo capture needs provider-side hydration of organization media).

## Verification

`tsc --noEmit` clean, eslint clean, vitest 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)