### PR TITLE
feat(linkedin): post-connect Company Page selection prompt

### DIFF
--- a/src/app/(site)/dashboard/integrations/page.tsx
+++ b/src/app/(site)/dashboard/integrations/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/providers/auth-provider";
 import { useLocale } from "@/hooks/use-locale";
 import { api, ApiError, API_BASE_URL } from "@/lib/api";
@@ -1369,7 +1370,15 @@ function LinkedInContentPages({
   onChanged?: () => void;
 }) {
   const pages = Array.isArray(extra?.pages) ? extra.pages : [];
-  const [manageOpen, setManageOpen] = useState(false);
+  // Deep link from the post-connect "choose your Company Page" prompt
+  // (settings banner → /dashboard/integrations?manage_pages=1). Lazy
+  // initializer, not an effect: this card mounts only after the
+  // connections fetch resolves, so pages are already present — and
+  // closing the dialog must not re-open it.
+  const searchParams = useSearchParams();
+  const [manageOpen, setManageOpen] = useState(
+    () => searchParams?.get("manage_pages") === "1" && pages.length > 0,
+  );
 
   // The OAuth callback skips per-Page name hydration to redirect fast
   // (peakhour-api PR #247). Names land within ~1 min via a background

--- a/src/app/(site)/dashboard/settings/page.tsx
+++ b/src/app/(site)/dashboard/settings/page.tsx
@@ -104,6 +104,10 @@ function SettingsContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [justConnectedProvider, setJustConnectedProvider] = useState<string | null>(null);
+  // Set when the OAuth callback flags a multi-page LinkedIn connect
+  // (`select_page=1`): the connected member admins several Company
+  // Pages, and the auto-seeded default needs human confirmation.
+  const [selectPagePrompt, setSelectPagePrompt] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   // Raw context for a brand_mismatch block, so the user can dispute it ("request
   // a review"). Null unless the last connect was blocked as a wrong brand.
@@ -163,6 +167,7 @@ function SettingsContent() {
   useEffect(() => {
     if (searchParams?.get("integration") === "connected") {
       setJustConnectedProvider(searchParams.get("provider") ?? "");
+      setSelectPagePrompt(searchParams.get("select_page") === "1");
       // Refetch integration status everywhere immediately after a successful
       // OAuth. Otherwise the content/composer pages keep their cached
       // pre-connect state and show a stale "Connect" CTA — which invites a
@@ -216,6 +221,23 @@ function SettingsContent() {
         <div className="flex items-center gap-2 rounded-lg bg-green-500/10 border border-green-500/20 p-4 text-sm text-green-700 dark:text-green-400">
           <CheckCircle2 className="h-4 w-4 shrink-0" />
           {formatProviderName(justConnectedProvider)} connected successfully!
+        </div>
+      )}
+
+      {selectPagePrompt && (
+        <div className="flex flex-col gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-800 dark:text-amber-300">
+          <p className="font-medium">Which Company Page belongs to this business?</p>
+          <p>
+            Your LinkedIn account manages several Company Pages. Posts publish
+            as the page mapped to this business, so please confirm which page
+            that should be.
+          </p>
+          <Link
+            href="/dashboard/integrations?manage_pages=1"
+            className="w-fit font-medium underline underline-offset-2 hover:no-underline"
+          >
+            Choose your Company Page
+          </Link>
         </div>
       )}
 


### PR DESCRIPTION
## What

- Settings page: after a multi-page LinkedIn connect (callback appends `select_page=1` — api companion PR), show an amber "Which Company Page belongs to this business?" prompt under the green success banner, linking to `/dashboard/integrations?manage_pages=1`.
- Integrations page: `?manage_pages=1` auto-opens the existing Manage Pages dialog (lazy `useState` initializer — the card mounts after connections load, and closing the dialog doesn't re-open it).

Companion PRs: peakhour-api (redirect param) + peakhour-mongodb mig 188 (backfills explicit page capabilities on legacy connections).

## Verification

`tsc --noEmit` clean; eslint: only pre-existing master error remains (names-poll `setAttempts`); vitest 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)