### PR TITLE
fix(cms): remove dead AI use-case Delete button (deletion disabled server-side)

### DIFF
--- a/src/app/(site)/cms/ai-config/page.tsx
+++ b/src/app/(site)/cms/ai-config/page.tsx
@@ -35,7 +35,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Plus, Pencil, Trash2 } from "lucide-react";
+import { Plus, Pencil } from "lucide-react";
 import { formatDateTime } from "@/components/cms/ai/format";
 import { ModelSelect, ModelChainEditor } from "@/components/cms/model-select";
 
@@ -74,7 +74,6 @@ export default function AiConfigPage() {
   const { user } = useAuth();
   const role = user?.cmsRole as CmsRole;
   const canWrite = hasCmsRole(role, "ops");
-  const canDelete = hasCmsRole(role, "superadmin");
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<ConfigRow | null>(null);
   const [form, setForm] = useState<Partial<ConfigRow>>(EMPTY_FORM);
@@ -98,11 +97,6 @@ export default function AiConfigPage() {
       }
       setSheetOpen(false);
     },
-  });
-
-  const remove = useMutation({
-    mutationFn: (useCase: string) => api.delete(`/v1/cms/ai-config/${useCase}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["cms-ai-config"] }),
   });
 
   function open(row: ConfigRow | null) {
@@ -176,19 +170,6 @@ export default function AiConfigPage() {
                         {canWrite && (
                           <Button variant="ghost" size="icon" onClick={() => open(row)}>
                             <Pencil className="size-4" />
-                          </Button>
-                        )}
-                        {canDelete && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => {
-                              if (confirm(`Delete useCase '${row.useCase}'?`)) {
-                                remove.mutate(row.useCase);
-                              }
-                            }}
-                          >
-                            <Trash2 className="size-4" />
                           </Button>
                         )}
                       </div>
@@ -316,9 +297,9 @@ export default function AiConfigPage() {
             )}
           </Tabs>
 
-          {(upsert.isError || remove.isError) && (
+          {upsert.isError && (
             <p className="mt-4 text-sm text-red-600">
-              {((upsert.error || remove.error) as Error)?.message ||
+              {(upsert.error as Error)?.message ||
                 "Operation failed. You may not have the required CMS role."}
             </p>
           )}


### PR DESCRIPTION
Follow-up to travelxp/peakhour-api#749, flagged by that PR's review.

#749 permanently disabled `DELETE /v1/cms/ai-config/:useCase` (403 — a use-case may run in code and be priced into customers' Peaks). The CMS row-list Delete button (superadmin-gated) still fired it, and its only error surface was inside the edit Sheet — which is **closed** when deleting from the list — so the 403 failed **silently** (confirm → nothing happens → row stays).

Removes the dead affordance: the Delete button, the `remove` mutation, the `Trash2` import, and the `canDelete` role check; the shared error banner now references only `upsert`. A use-case is retired via **Edit → Active: false** (or `customerBillable: false`), per #749's guidance.

Verified: `tsc` clean, eslint 0 errors (net −1 warning), 62 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)