### PR TITLE
feat(site): v3 shell — five-pillar nav + gold CTA + grouped footer (PR-2 relaunch)

### DIFF
--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -2,40 +2,93 @@ import Link from "next/link";
 import { SITE } from "@/lib/utils";
 import { PeakhourLogo } from "@/components/shared/peakhour-logo";
 
-const FOOTER_LINKS = [
-  { href: "/peaks", label: "Peaks" },
-  { href: "/contact", label: "Contact" },
-  { href: "/privacy-policy", label: "Privacy Policy" },
-  { href: "/terms", label: "Terms of Service" },
-  { href: "/cookie-policy", label: "Cookie Policy" },
-  { href: "/data-deletion", label: "Data Deletion" },
+// Grouped footer nav. Pillar links target homepage anchors until the dedicated
+// pillar pages ship (PR-5) — they resolve to the homepage until then (no 404).
+// Every non-anchor href below is a route that exists today.
+const FOOTER_GROUPS = [
+  {
+    heading: "Platform",
+    links: [
+      { href: "/#commerce", label: "Commerce" },
+      { href: "/#content", label: "Content" },
+      { href: "/#growth", label: "Growth" },
+      { href: "/#support", label: "Support" },
+      { href: "/#presence", label: "Presence" },
+    ],
+  },
+  {
+    heading: "Product",
+    links: [
+      { href: "/pricing", label: "Pricing" },
+      { href: "/peaks", label: "Peaks" },
+      { href: "/contact", label: "Contact" },
+    ],
+  },
+  {
+    heading: "Legal",
+    links: [
+      { href: "/privacy-policy", label: "Privacy Policy" },
+      { href: "/terms", label: "Terms of Service" },
+      { href: "/cookie-policy", label: "Cookie Policy" },
+      { href: "/data-deletion", label: "Data Deletion" },
+    ],
+  },
 ] as const;
 
 export function Footer() {
   return (
     <footer className="border-t bg-muted/30">
-      <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
-        <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
-          <Link href="/" className="flex items-center" aria-label="Peakhour.ai home">
-            <PeakhourLogo className="h-7 w-auto" />
-          </Link>
+      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
+        <div className="flex flex-col gap-10 md:flex-row md:justify-between">
+          {/* Brand */}
+          <div className="max-w-xs">
+            <Link
+              href="/"
+              className="flex items-center"
+              aria-label="Peakhour.ai home"
+            >
+              <PeakhourLogo className="h-7 w-auto" />
+            </Link>
+            <p className="mt-4 text-sm text-muted-foreground">
+              The AI business platform for growing brands. Five pillars, one
+              brain, free to start.
+            </p>
+            <span
+              className="mt-4 inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold text-muted-foreground"
+              title="Available in English; more languages coming"
+            >
+              <span aria-hidden="true">🌐</span> English
+              <span className="font-normal">· more soon</span>
+            </span>
+          </div>
 
-          <nav className="flex items-center gap-6">
-            {FOOTER_LINKS.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {link.label}
-              </Link>
+          {/* Link groups */}
+          <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 md:gap-14">
+            {FOOTER_GROUPS.map((group) => (
+              <nav key={group.heading} aria-label={group.heading}>
+                <p className="text-xs font-semibold uppercase tracking-wider text-foreground">
+                  {group.heading}
+                </p>
+                <ul className="mt-4 flex flex-col gap-2.5">
+                  {group.links.map((link) => (
+                    <li key={link.href}>
+                      <Link
+                        href={link.href}
+                        className="text-sm text-muted-foreground transition-colors hover:text-brand"
+                      >
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
             ))}
-          </nav>
+          </div>
         </div>
 
-        <div className="mt-8 border-t pt-6 text-center text-xs text-muted-foreground">
-          {SITE.name} &copy; {new Date().getFullYear()}. AI-powered marketing
-          for growing businesses.
+        <div className="mt-10 border-t pt-6 text-center text-xs text-muted-foreground">
+          {SITE.name} &copy; {new Date().getFullYear()}. The AI business platform
+          for growing brands.
         </div>
       </div>
     </footer>

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -87,8 +87,7 @@ export function Footer() {
         </div>
 
         <div className="mt-10 border-t pt-6 text-center text-xs text-muted-foreground">
-          {SITE.name} &copy; {new Date().getFullYear()}. The AI business platform
-          for growing brands.
+          {SITE.name} &copy; {new Date().getFullYear()}. All rights reserved.
         </div>
       </div>
     </footer>

--- a/src/components/shared/header.tsx
+++ b/src/components/shared/header.tsx
@@ -25,13 +25,13 @@ const navLinkClass =
 // Gold-gradient primary CTA — self-contained so it doesn't fight the shadcn
 // Button variant's background. Near-black ink (--brand-contrast) on molten gold.
 const ctaClass =
-  "inline-flex items-center justify-center rounded-md bg-brand-gradient px-4 py-2 text-sm font-semibold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5";
+  "inline-flex items-center justify-center rounded-md bg-brand-gradient px-4 py-2 text-sm font-semibold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2";
 
 /**
  * @param minimal When true, renders only the brand lockup — no marketing nav
- *   (Features/Pricing), no auth CTAs, no mobile menu. Used on the public
- *   legal pages, which are reachable pre-launch (through the coming-soon gate
- *   allowlist) where those links would point at gated/non-existent routes.
+ *   (the five pillars + Pricing), no auth CTAs, no mobile menu. Used on the
+ *   public legal pages, which are reachable pre-launch (through the coming-soon
+ *   gate allowlist) where those links would point at gated/non-existent routes.
  */
 export function Header({ minimal = false }: { minimal?: boolean } = {}) {
   const pathname = usePathname();
@@ -60,8 +60,9 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
 
         {!minimal && !isAuthPage && (
           <>
-            {/* Desktop nav */}
-            <nav className="hidden items-center gap-6 md:flex">
+            {/* Desktop nav — collapses to the mobile menu below lg so the six
+                items + auth cluster never crowd on small laptops/tablets. */}
+            <nav aria-label="Primary" className="hidden items-center gap-6 lg:flex">
               {NAV_LINKS.map((link) => (
                 <Link key={link.href} href={link.href} className={navLinkClass}>
                   {link.label}
@@ -79,7 +80,7 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
           ) : !isAuthPage ? (
             <>
               {/* Desktop CTA */}
-              <div className="hidden items-center gap-4 md:flex">
+              <div className="hidden items-center gap-4 lg:flex">
                 <span
                   className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold text-muted-foreground"
                   title="Available in English; more languages coming"
@@ -101,7 +102,7 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
               <button
                 type="button"
                 onClick={() => setMenuOpen(!menuOpen)}
-                className="flex h-9 w-9 items-center justify-center rounded-md border md:hidden"
+                className="flex h-9 w-9 items-center justify-center rounded-md border lg:hidden"
                 aria-label={menuOpen ? "Close menu" : "Open menu"}
                 aria-expanded={menuOpen}
                 aria-controls="mobile-nav"
@@ -129,8 +130,8 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
 
       {/* Mobile nav panel */}
       {!minimal && !isAuthPage && menuOpen && (
-        <div id="mobile-nav" className="border-t bg-background px-4 pb-4 pt-2 md:hidden">
-          <nav className="flex flex-col gap-3">
+        <div id="mobile-nav" className="border-t bg-background px-4 pb-4 pt-2 lg:hidden">
+          <nav aria-label="Primary" className="flex flex-col gap-3">
             {NAV_LINKS.map((link) => (
               <Link
                 key={link.href}
@@ -141,7 +142,14 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
                 {link.label}
               </Link>
             ))}
-            <div className="mt-2 flex flex-col gap-2 border-t pt-3">
+            <div className="mt-2 flex flex-col items-start gap-3 border-t pt-3">
+              <span
+                className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold text-muted-foreground"
+                title="Available in English; more languages coming"
+              >
+                <span aria-hidden="true">🌐</span> English
+                <span className="font-normal">· more soon</span>
+              </span>
               {!isLoading && isAuthenticated ? (
                 <>
                   <Link

--- a/src/components/shared/header.tsx
+++ b/src/components/shared/header.tsx
@@ -3,16 +3,29 @@
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Button } from "@/components/ui/button";
 import { useAuth } from "@/providers/auth-provider";
 import { PeakhourLogo } from "@/components/shared/peakhour-logo";
 
+// The five pillars are the product. Links target homepage anchors until the
+// dedicated pillar pages ship (PR-5); before then they resolve to the homepage
+// (graceful — no 404). Pricing is a real route today.
 const NAV_LINKS = [
-  { href: "/#features", label: "Features" },
-  { href: "/#how-it-works", label: "How it works" },
-  { href: "/pricing", label: "Plans" },
-  { href: "/peaks", label: "Peaks" },
+  { href: "/#commerce", label: "Commerce" },
+  { href: "/#content", label: "Content" },
+  { href: "/#growth", label: "Growth" },
+  { href: "/#support", label: "Support" },
+  { href: "/#presence", label: "Presence" },
+  { href: "/pricing", label: "Pricing" },
 ] as const;
+
+// Nav link with a gold underline that wipes in on hover/focus.
+const navLinkClass =
+  "relative text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground after:absolute after:-bottom-1 after:left-0 after:h-0.5 after:w-0 after:rounded-full after:bg-brand after:transition-all after:duration-300 hover:after:w-full focus-visible:after:w-full";
+
+// Gold-gradient primary CTA — self-contained so it doesn't fight the shadcn
+// Button variant's background. Near-black ink (--brand-contrast) on molten gold.
+const ctaClass =
+  "inline-flex items-center justify-center rounded-md bg-brand-gradient px-4 py-2 text-sm font-semibold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5";
 
 /**
  * @param minimal When true, renders only the brand lockup — no marketing nav
@@ -50,11 +63,7 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
             {/* Desktop nav */}
             <nav className="hidden items-center gap-6 md:flex">
               {NAV_LINKS.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                >
+                <Link key={link.href} href={link.href} className={navLinkClass}>
                   {link.label}
                 </Link>
               ))}
@@ -70,16 +79,22 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
           ) : !isAuthPage ? (
             <>
               {/* Desktop CTA */}
-              <div className="hidden items-center gap-3 md:flex">
+              <div className="hidden items-center gap-4 md:flex">
+                <span
+                  className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold text-muted-foreground"
+                  title="Available in English; more languages coming"
+                >
+                  <span aria-hidden="true">🌐</span> EN
+                </span>
                 <Link
                   href="/auth"
-                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
                 >
                   Sign in
                 </Link>
-                <Button asChild size="sm">
-                  <Link href="/auth">Get started free</Link>
-                </Button>
+                <Link href="/auth" className={ctaClass}>
+                  Start free
+                </Link>
               </div>
 
               {/* Mobile menu button */}
@@ -152,11 +167,13 @@ export function Header({ minimal = false }: { minimal?: boolean } = {}) {
                   >
                     Sign in
                   </Link>
-                  <Button asChild size="sm">
-                    <Link href="/auth" onClick={() => setMenuOpen(false)}>
-                      Get started free
-                    </Link>
-                  </Button>
+                  <Link
+                    href="/auth"
+                    onClick={() => setMenuOpen(false)}
+                    className={ctaClass}
+                  >
+                    Start free
+                  </Link>
                 </>
               )}
             </div>


### PR DESCRIPTION
## PR-2 of the marketing-site relaunch program

Restyles the shared **Header** and **Footer** to the approved v3 look — the first PRs to visually consume the PR-1 brand tokens.

### Header
- Nav = the **five pillars** (Commerce / Content / Growth / Support / Presence) + Pricing, with a gold underline that wipes in on hover/focus.
- Primary CTA → **molten-gold gradient** (`bg-brand-gradient` + `text-brand-contrast`), relabeled "Start free".
- Adds an **EN language chip** (i18n signal for PR-3).
- **Preserved unchanged:** all auth-aware logic, `minimal` mode, mobile menu, `UserMenu`, dashboard/onboarding suppression. Removed the now-unused `Button` import.

### Footer
- Brand lockup + platform tagline + language chip, and a **grouped nav** (Platform / Product / Legal) replacing the flat row.

### Production-safety
- Pillar links target homepage anchors (`/#commerce` …) until the dedicated pillar pages ship in **PR-5**; until then they resolve to the homepage — **no 404s on master**. Every non-anchor href is a route that exists today.

### Verification
- `eslint` clean · `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)