### PR TITLE
feat(site): dedicated pillar pages /commerce…/presence (PR-4 relaunch)

### DIFF
--- a/src/app/(site)/commerce/page.tsx
+++ b/src/app/(site)/commerce/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PillarPage } from "@/components/marketing/pillar-page";
+
+export const metadata: Metadata = {
+  title: "Commerce — AI storefront assistant | Peakhour.ai",
+  description:
+    "An AI assistant that knows your whole catalog and sells on WhatsApp and your storefront, 24/7. Free plan included — no credit card.",
+};
+
+export default function CommercePillar() {
+  return <PillarPage slug="commerce" />;
+}

--- a/src/app/(site)/content/page.tsx
+++ b/src/app/(site)/content/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PillarPage } from "@/components/marketing/pillar-page";
+
+export const metadata: Metadata = {
+  title: "Content — AI writers in your voice | Peakhour.ai",
+  description:
+    "AI writers that publish in your brand voice — blogs, newsletters, socials — from your news desk to every channel. Free plan included — no credit card.",
+};
+
+export default function ContentPillar() {
+  return <PillarPage slug="content" />;
+}

--- a/src/app/(site)/growth/page.tsx
+++ b/src/app/(site)/growth/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PillarPage } from "@/components/marketing/pillar-page";
+
+export const metadata: Metadata = {
+  title: "Growth — ads & LinkedIn on autopilot | Peakhour.ai",
+  description:
+    "Campaigns drafted, leads captured, budgets optimized while you sleep. The Growth pillar runs acquisition for you. Free plan included — no credit card.",
+};
+
+export default function GrowthPillar() {
+  return <PillarPage slug="growth" />;
+}

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -47,8 +47,9 @@ export const metadata: Metadata = {
 
 /**
  * The five pillars are the product. This list is stable brand architecture
- * (mirrors cfg_products.pillar); the section ids back the header/footer
- * anchors (/#commerce …). Integrations below stay catalog-driven.
+ * (mirrors cfg_products.pillar); the section ids give each pillar an on-page
+ * anchor (the header/footer now link to the dedicated /commerce … pages).
+ * Integrations below stay catalog-driven.
  */
 const PILLARS = [
   {

--- a/src/app/(site)/presence/page.tsx
+++ b/src/app/(site)/presence/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PillarPage } from "@/components/marketing/pillar-page";
+
+export const metadata: Metadata = {
+  title: "Presence — own how you show up on Google | Peakhour.ai",
+  description:
+    "Your Google Business Profile — listings, hours, photos, and reviews — managed from one place, always current. Always free — no credit card.",
+};
+
+export default function PresencePillar() {
+  return <PillarPage slug="presence" />;
+}

--- a/src/app/(site)/support/page.tsx
+++ b/src/app/(site)/support/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PillarPage } from "@/components/marketing/pillar-page";
+
+export const metadata: Metadata = {
+  title: "Support — one AI inbox for every channel | Peakhour.ai",
+  description:
+    "WhatsApp, Instagram, email — one inbox. AI answers the routine and hands you what needs a human, with full context. Free plan included — no credit card.",
+};
+
+export default function SupportPillar() {
+  return <PillarPage slug="support" />;
+}

--- a/src/components/marketing/pillar-page.tsx
+++ b/src/components/marketing/pillar-page.tsx
@@ -28,15 +28,24 @@ export async function PillarPage({ slug }: { slug: PillarSlug }) {
         <section className="py-16 sm:py-24">
           <div className="mx-auto grid max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
             <div>
-              <p className="text-sm font-medium text-muted-foreground">
-                <Link href="/" className="transition-colors hover:text-brand">
-                  Platform
-                </Link>{" "}
-                <span aria-hidden className="opacity-40">
-                  ›
-                </span>{" "}
-                <span className="text-foreground">{pillar.name}</span>
-              </p>
+              <nav
+                aria-label="Breadcrumb"
+                className="text-sm font-medium text-muted-foreground"
+              >
+                <ol className="flex items-center gap-1.5">
+                  <li>
+                    <Link href="/" className="transition-colors hover:text-brand">
+                      Home
+                    </Link>
+                  </li>
+                  <li aria-hidden className="opacity-40">
+                    ›
+                  </li>
+                  <li aria-current="page" className="text-foreground">
+                    {pillar.name}
+                  </li>
+                </ol>
+              </nav>
               <span className="mt-5 inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
                 <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
                 {pillar.eyebrow}

--- a/src/components/marketing/pillar-page.tsx
+++ b/src/components/marketing/pillar-page.tsx
@@ -1,0 +1,198 @@
+import Link from "next/link";
+import { ArrowRight, Check } from "lucide-react";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+import { getPublicCatalog, signupCta } from "@/lib/catalog";
+import { PILLARS, PILLAR_ORDER, type PillarSlug } from "@/lib/pillars";
+
+/**
+ * Shared template for the five pillar marketing pages. Server component;
+ * content comes from lib/pillars.ts and the signup CTA from the live platform
+ * catalog (same resolver + fallback as the homepage), so the CTA can never
+ * disagree with the signup flow. Polish is CSS-only.
+ */
+export async function PillarPage({ slug }: { slug: PillarSlug }) {
+  const pillar = PILLARS[slug];
+  const Icon = pillar.icon;
+
+  const catalog = await getPublicCatalog();
+  const cta = signupCta(catalog?.platform?.signupMode ?? "open");
+
+  const others = PILLAR_ORDER.filter((s) => s !== slug).map((s) => PILLARS[s]);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main>
+        {/* Hero */}
+        <section className="py-16 sm:py-24">
+          <div className="mx-auto grid max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                <Link href="/" className="transition-colors hover:text-brand">
+                  Platform
+                </Link>{" "}
+                <span aria-hidden className="opacity-40">
+                  ›
+                </span>{" "}
+                <span className="text-foreground">{pillar.name}</span>
+              </p>
+              <span className="mt-5 inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+                <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+                {pillar.eyebrow}
+              </span>
+              <h1 className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
+                {pillar.headline}{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  {pillar.accent}
+                </span>
+              </h1>
+              <p className="mt-5 max-w-xl text-lg text-muted-foreground">
+                {pillar.lede}
+              </p>
+              <div className="mt-8 flex flex-wrap items-center gap-4">
+                {!cta.disabled && (
+                  <Link
+                    href={cta.href}
+                    className="group inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-6 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
+                  >
+                    {cta.label}
+                    <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
+                  </Link>
+                )}
+                <Link
+                  href="/pricing"
+                  className="inline-flex items-center rounded-xl border-2 px-6 py-3 text-sm font-bold transition-colors hover:border-brand hover:text-brand"
+                >
+                  See pricing
+                </Link>
+              </div>
+              <p className="mt-4 text-sm text-muted-foreground">
+                <span aria-hidden className="font-bold text-brand-label">
+                  ✓
+                </span>{" "}
+                {pillar.freeLabel} — no credit card
+              </p>
+            </div>
+
+            {/* "What you get back" — outcomes in a dark panel */}
+            <div className="overflow-hidden rounded-2xl border border-white/10 bg-zinc-900 p-6 text-zinc-100 shadow-2xl">
+              <div className="flex items-center gap-3">
+                <span className="flex size-11 items-center justify-center rounded-xl bg-brand-gradient shadow-inner">
+                  <Icon className="size-5 text-brand-contrast" strokeWidth={2} aria-hidden />
+                </span>
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-[0.18em] text-zinc-400">
+                    What you get back
+                  </p>
+                  <p className="text-lg font-bold">{pillar.name}</p>
+                </div>
+              </div>
+              <ul className="mt-5 flex flex-col gap-3">
+                {pillar.outcomes.map((outcome) => (
+                  <li key={outcome} className="flex gap-3 text-sm text-zinc-300">
+                    <Check className="mt-0.5 size-4 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                    {outcome}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* What it does — capabilities */}
+        <section className="border-t bg-muted/30 py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <div className="max-w-3xl">
+              <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+                <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+                What it does
+              </span>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                Everything the {pillar.name} pillar handles for you.
+              </h2>
+            </div>
+            <div className="mt-10 grid gap-4 md:grid-cols-3">
+              {pillar.features.map((feature) => (
+                <div
+                  key={feature.title}
+                  className="flex flex-col gap-3 rounded-2xl border bg-background p-6 transition-all hover:-translate-y-1 hover:border-foreground hover:shadow-xl"
+                >
+                  <div className="flex size-10 items-center justify-center rounded-xl bg-brand-soft">
+                    <Check className="size-5 text-brand-ink" strokeWidth={2.5} aria-hidden />
+                  </div>
+                  <h3 className="text-base font-bold tracking-tight">{feature.title}</h3>
+                  <p className="text-sm text-muted-foreground">{feature.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Part of the platform — cross-links to the other pillars */}
+        <section className="py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <div className="max-w-3xl">
+              <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+                <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+                One platform, five pillars
+              </span>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                {pillar.name} shares one brain with the rest.
+              </h2>
+              <p className="mt-3 text-muted-foreground">
+                Your catalog, your brand voice, your customers — every pillar
+                learns from the same place. Add the others when you&rsquo;re ready.
+              </p>
+            </div>
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {others.map((other) => {
+                const OtherIcon = other.icon;
+                return (
+                  <Link
+                    key={other.slug}
+                    href={`/${other.slug}`}
+                    className="group flex items-center gap-3 rounded-2xl border bg-background p-5 transition-all hover:-translate-y-1 hover:border-foreground hover:shadow-md"
+                  >
+                    <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-brand-gradient">
+                      <OtherIcon className="size-5 text-brand-contrast" strokeWidth={2} aria-hidden />
+                    </span>
+                    <span className="font-bold">{other.name}</span>
+                    <ArrowRight className="ml-auto size-4 text-muted-foreground transition-transform group-hover:translate-x-1" aria-hidden />
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        {/* Final CTA */}
+        <section className="pb-24">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl">
+              <h2 className="mx-auto max-w-2xl text-3xl font-extrabold tracking-tight text-pretty sm:text-4xl">
+                Try {pillar.name}{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  free.
+                </span>
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-zinc-400">
+                {pillar.freeLabel} — no credit card. Your first Peaks are on us.
+              </p>
+              {!cta.disabled && (
+                <Link
+                  href={cta.href}
+                  className="group mt-8 inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-7 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+                >
+                  {cta.label}
+                  <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
+                </Link>
+              )}
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -2,18 +2,16 @@ import Link from "next/link";
 import { SITE } from "@/lib/utils";
 import { PeakhourLogo } from "@/components/shared/peakhour-logo";
 
-// Grouped footer nav. Pillar links target homepage anchors until the dedicated
-// pillar pages ship (PR-5) — they resolve to the homepage until then (no 404).
-// Every non-anchor href below is a route that exists today.
+// Grouped footer nav. Every href below is a route that exists today.
 const FOOTER_GROUPS = [
   {
     heading: "Platform",
     links: [
-      { href: "/#commerce", label: "Commerce" },
-      { href: "/#content", label: "Content" },
-      { href: "/#growth", label: "Growth" },
-      { href: "/#support", label: "Support" },
-      { href: "/#presence", label: "Presence" },
+      { href: "/commerce", label: "Commerce" },
+      { href: "/content", label: "Content" },
+      { href: "/growth", label: "Growth" },
+      { href: "/support", label: "Support" },
+      { href: "/presence", label: "Presence" },
     ],
   },
   {

--- a/src/components/shared/header.tsx
+++ b/src/components/shared/header.tsx
@@ -6,15 +6,14 @@ import { usePathname } from "next/navigation";
 import { useAuth } from "@/providers/auth-provider";
 import { PeakhourLogo } from "@/components/shared/peakhour-logo";
 
-// The five pillars are the product. Links target homepage anchors until the
-// dedicated pillar pages ship (PR-5); before then they resolve to the homepage
-// (graceful — no 404). Pricing is a real route today.
+// The five pillars are the product — each has its own page. Pricing is a real
+// route today.
 const NAV_LINKS = [
-  { href: "/#commerce", label: "Commerce" },
-  { href: "/#content", label: "Content" },
-  { href: "/#growth", label: "Growth" },
-  { href: "/#support", label: "Support" },
-  { href: "/#presence", label: "Presence" },
+  { href: "/commerce", label: "Commerce" },
+  { href: "/content", label: "Content" },
+  { href: "/growth", label: "Growth" },
+  { href: "/support", label: "Support" },
+  { href: "/presence", label: "Presence" },
   { href: "/pricing", label: "Pricing" },
 ] as const;
 

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -19,7 +19,7 @@ export interface PillarFeature {
 }
 
 export interface PillarContent {
-  slug: string;
+  slug: PillarSlug;
   icon: LucideIcon;
   name: string;
   /** Small uppercase eyebrow. */
@@ -118,7 +118,7 @@ export const PILLARS: Record<PillarSlug, PillarContent> = {
     eyebrow: "The Growth pillar",
     headline: "Ads and LinkedIn",
     accent: "on autopilot.",
-    lede: "Campaigns drafted, audiences found, leads captured, budgets optimized — while you sleep. Growth runs the acquisition work a small team can't get to, and stops wasting spend on what isn't working.",
+    lede: "Campaigns drafted, audiences found, leads captured, budgets optimized — around the clock. Growth runs the acquisition work a small team can't get to, and stops wasting spend on what isn't working.",
     features: [
       {
         title: "LinkedIn growth engine",

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -1,0 +1,210 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  ShoppingBag,
+  PenLine,
+  TrendingUp,
+  MessageSquare,
+  MapPin,
+} from "lucide-react";
+
+/**
+ * Content model for the five pillar marketing pages (/commerce … /presence).
+ * Kept as data (not hardcoded JSX) so the pages stay a thin template and so
+ * PR-5 (next-intl) can extract these strings without touching layout. Mirrors
+ * cfg_products.pillar; the `slug` is the public route + the homepage anchor id.
+ */
+export interface PillarFeature {
+  title: string;
+  description: string;
+}
+
+export interface PillarContent {
+  slug: string;
+  icon: LucideIcon;
+  name: string;
+  /** Small uppercase eyebrow. */
+  eyebrow: string;
+  /** Headline lead; `accent` renders as the gold serif-italic flourish. */
+  headline: string;
+  accent: string;
+  lede: string;
+  /** "What it does" — the capabilities, 3 cards. */
+  features: PillarFeature[];
+  /** "How it helps" — outcome-framed, plain-language jobs done. */
+  outcomes: string[];
+  /** Whether the pillar's plan is free ("Free plan included" vs "Always free"). */
+  freeLabel: string;
+}
+
+export const PILLAR_ORDER = [
+  "commerce",
+  "content",
+  "growth",
+  "support",
+  "presence",
+] as const;
+
+export type PillarSlug = (typeof PILLAR_ORDER)[number];
+
+export const PILLARS: Record<PillarSlug, PillarContent> = {
+  commerce: {
+    slug: "commerce",
+    icon: ShoppingBag,
+    name: "Commerce",
+    eyebrow: "The Commerce pillar",
+    headline: "An AI storefront assistant that",
+    accent: "sells while you sleep.",
+    lede: "It knows your whole catalog and answers shoppers on WhatsApp and your storefront in real time — accurate prices, live stock, in their language — turning questions into orders 24/7.",
+    features: [
+      {
+        title: "Catalog always in sync",
+        description:
+          "Products, prices, and stock pull automatically from Shopify and WooCommerce. The AI always answers from live data — no stale info, no wrong prices.",
+      },
+      {
+        title: "WhatsApp & storefront chat",
+        description:
+          "Shoppers ask on your WhatsApp number or your site. AI replies instantly, reserves items, and shares a checkout link — zero agent time.",
+      },
+      {
+        title: "Inventory intelligence",
+        description:
+          "See what shoppers ask for most, spot the sizes selling out, and get nudged to restock before you lose the sale.",
+      },
+    ],
+    outcomes: [
+      "Recover the late-night sales you miss when no one's online to reply.",
+      "Cut the repetitive “is this in stock / my size?” questions off your plate.",
+      "Know which products to reorder before they sell out.",
+    ],
+    freeLabel: "Free plan included",
+  },
+  content: {
+    slug: "content",
+    icon: PenLine,
+    name: "Content",
+    eyebrow: "The Content pillar",
+    headline: "AI writers that publish",
+    accent: "in your voice.",
+    lede: "From your news desk to every channel — blogs, newsletters, socials — Peakhour drafts on-brand content you approve in a tap, then publishes it. No more staring at a blank page.",
+    features: [
+      {
+        title: "Brand-voice AI writers",
+        description:
+          "The AI learns how your brand sounds from your existing content and writes new posts, articles, and emails that match it.",
+      },
+      {
+        title: "News-driven ideas",
+        description:
+          "A news desk surfaces what's trending in your world and turns it into ready-to-approve content ideas, so you're never short of something to say.",
+      },
+      {
+        title: "Multi-format publishing",
+        description:
+          "One idea becomes a blog post, a newsletter, and a week of social posts — each formatted natively for its channel.",
+      },
+    ],
+    outcomes: [
+      "Turn one idea into a week of content instead of a blank calendar.",
+      "Stay consistent across channels without hiring a content team.",
+      "Publish on-brand every time — the AI keeps your voice, you keep approval.",
+    ],
+    freeLabel: "Free plan included",
+  },
+  growth: {
+    slug: "growth",
+    icon: TrendingUp,
+    name: "Growth",
+    eyebrow: "The Growth pillar",
+    headline: "Ads and LinkedIn",
+    accent: "on autopilot.",
+    lede: "Campaigns drafted, audiences found, leads captured, budgets optimized — while you sleep. Growth runs the acquisition work a small team can't get to, and stops wasting spend on what isn't working.",
+    features: [
+      {
+        title: "LinkedIn growth engine",
+        description:
+          "Post as your brand, engage the right audiences, and turn conversations into a lead pipeline — without living in the feed.",
+      },
+      {
+        title: "Ad campaigns + optimizer",
+        description:
+          "Draft platform-native campaigns, launch them, and let the AI pause underperformers and double down on winners hourly.",
+      },
+      {
+        title: "Lead inbox",
+        description:
+          "Every lead from every channel lands in one inbox, enriched and ready — so nothing slips through the cracks.",
+      },
+    ],
+    outcomes: [
+      "Stop burning ad budget on what isn't converting.",
+      "Find shoppers who look like your best customers, automatically.",
+      "Capture and follow up on every lead — no manual chasing.",
+    ],
+    freeLabel: "Free plan included",
+  },
+  support: {
+    slug: "support",
+    icon: MessageSquare,
+    name: "Support",
+    eyebrow: "The Support pillar",
+    headline: "One inbox for every channel,",
+    accent: "answered.",
+    lede: "WhatsApp, Instagram, email — all in one place. AI answers the routine questions with full context and hands you only the ones that need a human, so support never runs your day.",
+    features: [
+      {
+        title: "Omnichannel inbox",
+        description:
+          "Every conversation from every channel in one thread-per-customer view — no more tab-switching to keep up.",
+      },
+      {
+        title: "AI-drafted replies",
+        description:
+          "The AI drafts accurate answers grounded in your catalog and policies; you approve, edit, or let it send the easy ones.",
+      },
+      {
+        title: "Human handoff",
+        description:
+          "When something needs you, it hands over with the full history — so you step in already knowing the context.",
+      },
+    ],
+    outcomes: [
+      "Clear the routine “where's my order?” questions without lifting a finger.",
+      "Never leave a customer waiting, even after hours.",
+      "Step in only for the conversations that actually need you.",
+    ],
+    freeLabel: "Free plan included",
+  },
+  presence: {
+    slug: "presence",
+    icon: MapPin,
+    name: "Presence",
+    eyebrow: "The Presence pillar",
+    headline: "Own how you show up",
+    accent: "on Google.",
+    lede: "Your Google Business Profile — listings, hours, photos, and reviews — managed from one place, always current. So when someone searches nearby, you're the one they find and trust.",
+    features: [
+      {
+        title: "Google Business Profile",
+        description:
+          "Keep your listing accurate everywhere — hours, contact, categories, photos — updated from one dashboard.",
+      },
+      {
+        title: "Review management",
+        description:
+          "Every review surfaced and replied to, with AI-drafted responses in your voice, so your rating keeps climbing.",
+      },
+      {
+        title: "Listing health",
+        description:
+          "Spot what's missing or out of date before it costs you a customer — and fix it in a tap.",
+      },
+    ],
+    outcomes: [
+      "Be the business that shows up first for “near me” searches.",
+      "Never let a review go unanswered and drag your rating down.",
+      "Keep every listing detail current without the busywork.",
+    ],
+    freeLabel: "Always free",
+  },
+};


### PR DESCRIPTION
## PR-4 of the marketing-site relaunch — pillar pages

Adds the five dedicated pillar pages behind the nav, **repositioned as platform pillars** (not the old Commerce-only framing).

### Structure
- **`lib/pillars.ts`** — content model + per-pillar data. Kept as data (not JSX) so PR-5 `next-intl` extracts strings without touching layout. Mirrors `cfg_products.pillar`; `slug` = route + homepage anchor id.
- **`components/marketing/pillar-page.tsx`** — shared server-component template: hero + "what you get back" dark outcomes panel, capabilities grid, **cross-links to the other four pillars** (internal-linking mesh for SEO), dark final CTA. CTA uses the live catalog `signupCta` (+ fallback) — same as homepage, so it can't disagree with the signup flow.
- **`(site)/{commerce,content,growth,support,presence}/page.tsx`** — thin routes, each with its own SEO `metadata`.

### Nav
Header + footer Platform links now point at the real `/commerce … /presence` pages (were `/#commerce` homepage anchors from PR-2). **The anchors this replaces resolved to the homepage; these are now real pages — no 404s.**

### Verification
`eslint` clean · `tsc --noEmit` clean. Reuses PR-1/PR-3 tokens (`brand-label` eyebrows for AA, `brand-gradient`, `zinc-900` dark panels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)