### PR TITLE
feat(site): SEO hardening — sitemap, robots, OG, canonical + How-it-works (PR-6 relaunch)

### DIFF
--- a/src/app/(site)/commerce/page.tsx
+++ b/src/app/(site)/commerce/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seo";
 import { PillarPage } from "@/components/marketing/pillar-page";
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Commerce — AI storefront assistant | Peakhour.ai",
   description:
     "An AI assistant that knows your whole catalog and sells on WhatsApp and your storefront, 24/7. Free plan included — no credit card.",
-};
+  path: "/commerce",
+});
 
 export default function CommercePillar() {
   return <PillarPage slug="commerce" />;

--- a/src/app/(site)/content/page.tsx
+++ b/src/app/(site)/content/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seo";
 import { PillarPage } from "@/components/marketing/pillar-page";
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Content — AI writers in your voice | Peakhour.ai",
   description:
     "AI writers that publish in your brand voice — blogs, newsletters, socials — from your news desk to every channel. Free plan included — no credit card.",
-};
+  path: "/content",
+});
 
 export default function ContentPillar() {
   return <PillarPage slug="content" />;

--- a/src/app/(site)/growth/page.tsx
+++ b/src/app/(site)/growth/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seo";
 import { PillarPage } from "@/components/marketing/pillar-page";
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Growth — ads & LinkedIn on autopilot | Peakhour.ai",
   description:
-    "Campaigns drafted, leads captured, budgets optimized while you sleep. The Growth pillar runs acquisition for you. Free plan included — no credit card.",
-};
+    "Campaigns drafted, leads captured, budgets optimized around the clock. The Growth pillar runs acquisition for you. Free plan included — no credit card.",
+  path: "/growth",
+});
 
 export default function GrowthPillar() {
   return <PillarPage slug="growth" />;

--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -4,6 +4,7 @@ import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 import { pageMetadata } from "@/lib/seo";
 import { getPublicCatalog, signupCta } from "@/lib/catalog";
+import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
 
 export const metadata = pageMetadata({
   title: "How it works — live in minutes, not quarters | Peakhour.ai",
@@ -11,33 +12,6 @@ export const metadata = pageMetadata({
     "Connect what you have, approve the plan, then let Peakhour run and learn. Grounded in your real catalog and content — never guessed from your name.",
   path: "/how-it-works",
 });
-
-const STEPS = [
-  {
-    step: "1",
-    title: "Connect what you have",
-    description:
-      "Shopify, WordPress, WooCommerce, WhatsApp, LinkedIn, Google — one click each. Peakhour reads your real catalog and content, never guesses from your name.",
-    detail:
-      "Everything the AI does is grounded in your actual products, prices, and past content — so it's right from day one, not generic.",
-  },
-  {
-    step: "2",
-    title: "Approve the plan",
-    description:
-      "AI drafts your brand voice, content calendar, and assistant behavior. You review and approve — nothing ships without your say-so, until you say otherwise.",
-    detail:
-      "You stay in control. Approve, edit, or hand back. Autonomy is a dial you turn up as trust grows, not a switch you flip on day one.",
-  },
-  {
-    step: "3",
-    title: "Let it run, watch it learn",
-    description:
-      "Pillars work daily and report in plain language. Every approval teaches the AI your taste; autonomy grows as trust does.",
-    detail:
-      "Week one it drafts and asks. By month three it knows your bestsellers, your voice, and your customers' questions — and needs you less.",
-  },
-] as const;
 
 export default async function HowItWorks() {
   const catalog = await getPublicCatalog();
@@ -69,7 +43,7 @@ export default async function HowItWorks() {
 
         <section className="border-t bg-muted/30 py-20">
           <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 sm:px-6">
-            {STEPS.map((s) => (
+            {HOW_IT_WORKS_STEPS.map((s) => (
               <div
                 key={s.step}
                 className="grid gap-6 rounded-2xl border bg-background p-7 transition-all hover:border-foreground hover:shadow-xl sm:grid-cols-[auto_1fr]"
@@ -106,7 +80,7 @@ export default async function HowItWorks() {
                   className="group mt-8 inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-7 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
                 >
                   {cta.label}
-                  <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
+                  <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" aria-hidden />
                 </Link>
               )}
             </div>

--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+import { pageMetadata } from "@/lib/seo";
+import { getPublicCatalog, signupCta } from "@/lib/catalog";
+
+export const metadata = pageMetadata({
+  title: "How it works — live in minutes, not quarters | Peakhour.ai",
+  description:
+    "Connect what you have, approve the plan, then let Peakhour run and learn. Grounded in your real catalog and content — never guessed from your name.",
+  path: "/how-it-works",
+});
+
+const STEPS = [
+  {
+    step: "1",
+    title: "Connect what you have",
+    description:
+      "Shopify, WordPress, WooCommerce, WhatsApp, LinkedIn, Google — one click each. Peakhour reads your real catalog and content, never guesses from your name.",
+    detail:
+      "Everything the AI does is grounded in your actual products, prices, and past content — so it's right from day one, not generic.",
+  },
+  {
+    step: "2",
+    title: "Approve the plan",
+    description:
+      "AI drafts your brand voice, content calendar, and assistant behavior. You review and approve — nothing ships without your say-so, until you say otherwise.",
+    detail:
+      "You stay in control. Approve, edit, or hand back. Autonomy is a dial you turn up as trust grows, not a switch you flip on day one.",
+  },
+  {
+    step: "3",
+    title: "Let it run, watch it learn",
+    description:
+      "Pillars work daily and report in plain language. Every approval teaches the AI your taste; autonomy grows as trust does.",
+    detail:
+      "Week one it drafts and asks. By month three it knows your bestsellers, your voice, and your customers' questions — and needs you less.",
+  },
+] as const;
+
+export default async function HowItWorks() {
+  const catalog = await getPublicCatalog();
+  const cta = signupCta(catalog?.platform?.signupMode ?? "open");
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main>
+        <section className="py-16 sm:py-24">
+          <div className="mx-auto max-w-3xl px-4 text-center sm:px-6">
+            <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+              <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+              How it works
+            </span>
+            <h1 className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
+              Live in minutes,{" "}
+              <span className="font-serif font-normal italic text-brand-gradient">
+                not quarters.
+              </span>
+            </h1>
+            <p className="mx-auto mt-5 max-w-xl text-lg text-muted-foreground">
+              No lengthy setup, no agency onboarding. Connect your tools, approve
+              the plan, and Peakhour starts working — grounded in your real
+              business from the first minute.
+            </p>
+          </div>
+        </section>
+
+        <section className="border-t bg-muted/30 py-20">
+          <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 sm:px-6">
+            {STEPS.map((s) => (
+              <div
+                key={s.step}
+                className="grid gap-6 rounded-2xl border bg-background p-7 transition-all hover:border-foreground hover:shadow-xl sm:grid-cols-[auto_1fr]"
+              >
+                <div className="font-serif text-5xl font-normal italic text-brand-gradient">
+                  {s.step}
+                </div>
+                <div>
+                  <h2 className="text-xl font-bold tracking-tight">{s.title}</h2>
+                  <p className="mt-2 text-muted-foreground">{s.description}</p>
+                  <p className="mt-3 text-sm text-muted-foreground/80">{s.detail}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="pb-24 pt-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl">
+              <h2 className="mx-auto max-w-2xl text-3xl font-extrabold tracking-tight text-pretty sm:text-4xl">
+                See it work on{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  your business.
+                </span>
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-zinc-400">
+                A free plan on every pillar. No credit card. Your first Peaks are
+                on us.
+              </p>
+              {!cta.disabled && (
+                <Link
+                  href={cta.href}
+                  className="group mt-8 inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-7 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+                >
+                  {cta.label}
+                  <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
+                </Link>
+              )}
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Space_Grotesk, Fraunces } from "next/font/google";
 import { connection } from "next/server";
 import { getLocale } from "next-intl/server";
+import { SITE } from "@/lib/utils";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { QueryProvider } from "@/providers/query-provider";
 import { AuthProvider } from "@/providers/auth-provider";
@@ -41,10 +42,34 @@ const fraunces = Fraunces({
   display: "swap",
 });
 
+const DEFAULT_TITLE = "Peakhour.ai — The AI business platform for growing brands";
+const DEFAULT_DESCRIPTION =
+  "Five AI pillars — Commerce, Content, Growth, Support, Presence — that sell, publish, advertise, answer, and get you found. A free plan on every pillar. No credit card.";
+
 export const metadata: Metadata = {
-  title: "Peakhour.ai — Agentic AI Marketing Platform",
-  description:
-    "Peakhour.ai is an agentic AI marketing platform: autonomous AI agents analyze your content, create campaigns, and optimize performance across every channel — around the clock.",
+  metadataBase: new URL(SITE.url),
+  title: DEFAULT_TITLE,
+  description: DEFAULT_DESCRIPTION,
+  applicationName: SITE.name,
+  alternates: {
+    canonical: "/",
+    // hreflang-ready: English-only today (self-referencing). Add locales here
+    // alongside messages/<locale>.json when languages grow.
+    languages: { en: "/" },
+  },
+  openGraph: {
+    type: "website",
+    siteName: SITE.name,
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+    url: "/",
+    locale: "en",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+  },
 };
 
 /**

--- a/src/app/(site)/opengraph-image.tsx
+++ b/src/app/(site)/opengraph-image.tsx
@@ -1,9 +1,10 @@
 import { ImageResponse } from "next/og";
+import { SITE } from "@/lib/utils";
 
 // Shared social-share image for the marketing surface. Text-only + inline
 // styles (Satori has no Tailwind and finicky gradient-text support), so we use
 // a solid gold accent on a dark ground — reliable across renderers.
-export const alt = "Peakhour.ai — The AI business platform for growing brands";
+export const alt = `${SITE.name} — ${SITE.tagline}`;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -33,7 +34,7 @@ export default function OpengraphImage() {
 
         <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
           <div style={{ display: "flex", fontSize: 68, fontWeight: 800, lineHeight: 1.05, letterSpacing: -1.5, maxWidth: 900 }}>
-            The AI business platform for growing brands
+            {SITE.tagline}
           </div>
           <div style={{ display: "flex", fontSize: 30, color: "#b9b2a2" }}>
             Five pillars. One platform. A free plan on every one.

--- a/src/app/(site)/opengraph-image.tsx
+++ b/src/app/(site)/opengraph-image.tsx
@@ -1,0 +1,55 @@
+import { ImageResponse } from "next/og";
+
+// Shared social-share image for the marketing surface. Text-only + inline
+// styles (Satori has no Tailwind and finicky gradient-text support), so we use
+// a solid gold accent on a dark ground — reliable across renderers.
+export const alt = "Peakhour.ai — The AI business platform for growing brands";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const GOLD = "#f0a821";
+const INK = "#0b0a08";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: `radial-gradient(1000px 500px at 80% -10%, rgba(240,168,33,0.18), transparent 60%), ${INK}`,
+          color: "#f7f4ec",
+          padding: "72px 80px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline", fontSize: 40, fontWeight: 800 }}>
+          <span>Peakhour</span>
+          <span style={{ color: GOLD }}>.ai</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          <div style={{ display: "flex", fontSize: 68, fontWeight: 800, lineHeight: 1.05, letterSpacing: -1.5, maxWidth: 900 }}>
+            The AI business platform for growing brands
+          </div>
+          <div style={{ display: "flex", fontSize: 30, color: "#b9b2a2" }}>
+            Five pillars. One platform. A free plan on every one.
+          </div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div style={{ display: "flex", fontSize: 26, fontWeight: 700, color: GOLD }}>
+            Commerce · Content · Growth · Support · Presence
+          </div>
+          <div style={{ display: "flex", fontSize: 24, color: "#b9b2a2" }}>
+            No credit card
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import {
   ArrowRight,
@@ -16,6 +15,7 @@ import {
 } from "lucide-react";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
+import { pageMetadata } from "@/lib/seo";
 import {
   getPublicCatalog,
   dedupePublicIntegrations,
@@ -39,11 +39,12 @@ import {
   TwitterIcon,
 } from "@/components/ui/brand-icons";
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Peakhour.ai — The AI business platform for growing brands",
   description:
     "Five AI pillars — Commerce, Content, Growth, Support, Presence — that sell, publish, advertise, answer, and get you found. A free plan on every pillar. No credit card.",
-};
+  path: "/",
+});
 
 /**
  * The five pillars are the product. This list is stable brand architecture

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
 import { pageMetadata } from "@/lib/seo";
+import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
 import {
   getPublicCatalog,
   dedupePublicIntegrations,
@@ -124,26 +125,8 @@ const FREE_POINTS = [
   },
 ] as const;
 
-const STEPS = [
-  {
-    step: "1",
-    title: "Connect what you have",
-    description:
-      "Shopify, WordPress, WooCommerce, WhatsApp, LinkedIn, Google — one click each. Peakhour reads your real catalog and content, never guesses from your name.",
-  },
-  {
-    step: "2",
-    title: "Approve the plan",
-    description:
-      "AI drafts your brand voice, content calendar, and assistant behavior. You review and approve — nothing ships without your say-so, until you say otherwise.",
-  },
-  {
-    step: "3",
-    title: "Let it run, watch it learn",
-    description:
-      "Pillars work daily and report in plain language. Every approval teaches the AI your taste; autonomy grows as trust does.",
-  },
-] as const;
+// Shared with the standalone /how-it-works page (single source of truth).
+const STEPS = HOW_IT_WORKS_STEPS;
 
 // Static fallback for the integrations strip when the catalog API is
 // unreachable — mirrors the resolved shape so the section never hard-fails.

--- a/src/app/(site)/presence/page.tsx
+++ b/src/app/(site)/presence/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seo";
 import { PillarPage } from "@/components/marketing/pillar-page";
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Presence — own how you show up on Google | Peakhour.ai",
   description:
     "Your Google Business Profile — listings, hours, photos, and reviews — managed from one place, always current. Always free — no credit card.",
-};
+  path: "/presence",
+});
 
 export default function PresencePillar() {
   return <PillarPage slug="presence" />;

--- a/src/app/(site)/support/page.tsx
+++ b/src/app/(site)/support/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seo";
 import { PillarPage } from "@/components/marketing/pillar-page";
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Support — one AI inbox for every channel | Peakhour.ai",
   description:
     "WhatsApp, Instagram, email — one inbox. AI answers the routine and hands you what needs a human, with full context. Free plan included — no credit card.",
-};
+  path: "/support",
+});
 
 export default function SupportPillar() {
   return <PillarPage slug="support" />;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { SITE } from "@/lib/utils";
+
+/**
+ * robots.txt — allow the public marketing site, disallow the gated app and
+ * auth surfaces (they must never be indexed), and point crawlers at the
+ * sitemap. Absolute sitemap URL from SITE.url.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const base = SITE.url.replace(/\/$/, "");
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/dashboard/", "/onboarding/", "/auth", "/cms/", "/api/", "/claim/", "/reconnect/"],
+    },
+    sitemap: `${base}/sitemap.xml`,
+    host: base,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+import { SITE } from "@/lib/utils";
+import { PILLAR_ORDER } from "@/lib/pillars";
+
+/**
+ * Marketing sitemap. Lists only public, indexable marketing routes — not the
+ * gated app (dashboard/onboarding/auth/cms), which must stay out of the index.
+ * Absolute URLs are built from SITE.url (env-overridable).
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = SITE.url.replace(/\/$/, "");
+
+  const staticPaths: {
+    path: string;
+    priority: number;
+    changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+  }[] = [
+    { path: "/", priority: 1.0, changeFrequency: "weekly" },
+    { path: "/pricing", priority: 0.9, changeFrequency: "weekly" },
+    { path: "/peaks", priority: 0.7, changeFrequency: "monthly" },
+    { path: "/how-it-works", priority: 0.7, changeFrequency: "monthly" },
+    { path: "/contact", priority: 0.5, changeFrequency: "yearly" },
+    { path: "/privacy-policy", priority: 0.3, changeFrequency: "yearly" },
+    { path: "/terms", priority: 0.3, changeFrequency: "yearly" },
+    { path: "/cookie-policy", priority: 0.3, changeFrequency: "yearly" },
+  ];
+
+  const pillarPaths = PILLAR_ORDER.map((slug) => ({
+    path: `/${slug}`,
+    priority: 0.8,
+    changeFrequency: "weekly" as const,
+  }));
+
+  return [...staticPaths, ...pillarPaths].map(
+    ({ path, priority, changeFrequency }) => ({
+      url: `${base}${path}`,
+      changeFrequency,
+      priority,
+    }),
+  );
+}

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -19,6 +19,7 @@ const FOOTER_GROUPS = [
     links: [
       { href: "/pricing", label: "Pricing" },
       { href: "/peaks", label: "Peaks" },
+      { href: "/how-it-works", label: "How it works" },
       { href: "/contact", label: "Contact" },
     ],
   },

--- a/src/lib/how-it-works.ts
+++ b/src/lib/how-it-works.ts
@@ -1,0 +1,32 @@
+/**
+ * The three onboarding steps — single source of truth shared by the homepage
+ * "How it works" section and the standalone /how-it-works page. The homepage
+ * uses step/title/description; the standalone page additionally renders
+ * `detail`. Keeping one array prevents the two surfaces from drifting.
+ */
+export const HOW_IT_WORKS_STEPS = [
+  {
+    step: "1",
+    title: "Connect what you have",
+    description:
+      "Shopify, WordPress, WooCommerce, WhatsApp, LinkedIn, Google — one click each. Peakhour reads your real catalog and content, never guesses from your name.",
+    detail:
+      "Everything the AI does is grounded in your actual products, prices, and past content — so it's right from day one, not generic.",
+  },
+  {
+    step: "2",
+    title: "Approve the plan",
+    description:
+      "AI drafts your brand voice, content calendar, and assistant behavior. You review and approve — nothing ships without your say-so, until you say otherwise.",
+    detail:
+      "You stay in control. Approve, edit, or hand back. Autonomy is a dial you turn up as trust grows, not a switch you flip on day one.",
+  },
+  {
+    step: "3",
+    title: "Let it run, watch it learn",
+    description:
+      "Pillars work daily and report in plain language. Every approval teaches the AI your taste; autonomy grows as trust does.",
+    detail:
+      "Week one it drafts and asks. By month three it knows your bestsellers, your voice, and your customers' questions — and needs you less.",
+  },
+] as const;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { SITE } from "@/lib/utils";
 
 /**
  * Build per-page metadata with a canonical URL + OpenGraph + Twitter card from
@@ -21,6 +22,9 @@ export function pageMetadata({
     alternates: { canonical: path },
     openGraph: {
       type: "website",
+      // Next replaces (not deep-merges) openGraph per page, so siteName must be
+      // repeated here or og:site_name is dropped on every page using this.
+      siteName: SITE.name,
       title,
       description,
       url: path,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+
+/**
+ * Build per-page metadata with a canonical URL + OpenGraph + Twitter card from
+ * a title/description/path. Paths are relative; metadataBase (set on the root
+ * layout) resolves them to absolute URLs. Keeps every marketing page's SEO
+ * consistent without repeating the OG/twitter/alternates block per route.
+ */
+export function pageMetadata({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}): Metadata {
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      type: "website",
+      title,
+      description,
+      url: path,
+      locale: "en",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,6 +8,10 @@ export function cn(...inputs: ClassValue[]) {
 /** Shared site / legal metadata — single source of truth */
 export const SITE = {
   name: "Peakhour.ai",
+  /** Canonical public origin — drives metadataBase, sitemap, robots, OG URLs.
+   *  Override per-env with NEXT_PUBLIC_SITE_URL; defaults to production. */
+  url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://peakhour.ai",
+  tagline: "The AI business platform for growing brands",
   legalLastUpdated: "June 1, 2026",
   /** Operating legal entity (data controller / data fiduciary). */
   company: {


### PR DESCRIPTION
## PR-6 of the marketing-site relaunch — SEO hardening + polish

Makes the site properly indexable and shareable, and adds the standalone How-it-works page.

### SEO infrastructure
- **`SITE.url`** (env `NEXT_PUBLIC_SITE_URL`, prod fallback `https://peakhour.ai`) as the canonical origin; `SITE.tagline` added.
- **`app/sitemap.ts`** — marketing routes only (home, 5 pillars, pricing, peaks, how-it-works, legal). The gated app is excluded from the index.
- **`app/robots.ts`** — allow marketing, **disallow** dashboard/onboarding/auth/cms/api/claim/reconnect, plus sitemap + host.
- **Root metadata** — `metadataBase`, refreshed default title/description (platform positioning replaces the stale "Agentic AI Marketing Platform" copy), default OpenGraph + Twitter, **hreflang-ready** `alternates` (`en` self-ref).
- **`lib/seo.ts`** — `pageMetadata()` helper (canonical + OG + Twitter), wired into the homepage and all five pillar routes for correct **per-page** cards.
- **`(site)/opengraph-image.tsx`** — branded 1200×630 social image via `next/og`.

### Content
- **`/how-it-works`** — standalone page (3 grounded steps + detail) with a footer link.

### Verification
`eslint` + `tsc` clean, and a **full `next build` (exit 0)** generating `/sitemap.xml`, `/robots.txt`, and the OG image route (the real gate for build-generated routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)