### PR TITLE
feat(site): [...slug] renderer for CMS marketing pages (MP-2b)

### DIFF
--- a/src/app/(site)/[...slug]/page.tsx
+++ b/src/app/(site)/[...slug]/page.tsx
@@ -2,13 +2,27 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
-import { PageBlocks } from "@/components/marketing/page-blocks";
+import { PageBlocks, hasHeroBlock } from "@/components/marketing/page-blocks";
 import {
   getMarketingPage,
   type MarketingPage,
   type FaqBlock,
 } from "@/lib/marketing-pages";
 import { SITE } from "@/lib/utils";
+
+/**
+ * Escape a JSON string for safe embedding inside a <script> element. JSON.stringify
+ * does NOT escape "<", so a value containing "</script>" would break out of the
+ * ld+json block — the classic JSON-LD XSS. Escaping "<", ">", "&" closes it.
+ */
+function safeJsonLd(obj: Record<string, unknown>): string {
+  // Escape "<" (plus ">" and "&") so a value containing "</script>" cannot
+  // break out of the <script type="application/ld+json"> element (JSON-LD XSS).
+  return JSON.stringify(obj).replace(
+    /[<>&]/g,
+    (ch) => String.fromCharCode(92) + "u00" + ch.charCodeAt(0).toString(16),
+  );
+}
 
 /**
  * Catch-all renderer for CMS-authored marketing pages (Pages Manager, MP-2b).
@@ -109,10 +123,13 @@ export default async function MarketingCatchAll({
         <script
           key={i}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
+          dangerouslySetInnerHTML={{ __html: safeJsonLd(graph) }}
         />
       ))}
       <main>
+        {/* Guarantee exactly one h1: a hero block renders it; if the page has
+            none (e.g. a rich_text-only article), supply a visually-hidden h1. */}
+        {!hasHeroBlock(page.blocks) && <h1 className="sr-only">{page.seo.title}</h1>}
         <PageBlocks blocks={page.blocks} />
       </main>
       <Footer />

--- a/src/app/(site)/[...slug]/page.tsx
+++ b/src/app/(site)/[...slug]/page.tsx
@@ -1,0 +1,121 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Header } from "@/components/shared/header";
+import { Footer } from "@/components/shared/footer";
+import { PageBlocks } from "@/components/marketing/page-blocks";
+import {
+  getMarketingPage,
+  type MarketingPage,
+  type FaqBlock,
+} from "@/lib/marketing-pages";
+import { SITE } from "@/lib/utils";
+
+/**
+ * Catch-all renderer for CMS-authored marketing pages (Pages Manager, MP-2b).
+ *
+ * A REQUIRED catch-all (`[...slug]`, one-or-more segments) so it never collides
+ * with the homepage (`/`) or the explicit spine routes (`/commerce`, `/pricing`,
+ * …) — Next resolves explicit segments before this. Any remaining path is
+ * looked up in mkt_pages via the render API; a miss → notFound() (real 404).
+ * English-only today (locale fixed to "en").
+ */
+
+const LOCALE = "en";
+
+function slugFromParams(slug: string[]): string {
+  return slug.join("/");
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const path = slugFromParams(slug);
+  const page = await getMarketingPage(path, LOCALE);
+  if (!page) return {}; // notFound() runs in the component
+
+  const canonicalPath = page.seo.canonicalPath ?? `/${path}`;
+  return {
+    title: page.seo.title,
+    description: page.seo.description,
+    alternates: { canonical: canonicalPath },
+    robots: page.seo.noindex ? { index: false, follow: true } : undefined,
+    openGraph: {
+      type: "website",
+      siteName: SITE.name,
+      title: page.seo.title,
+      description: page.seo.description,
+      url: canonicalPath,
+      locale: LOCALE,
+      ...(page.seo.ogImageUrl ? { images: [{ url: page.seo.ogImageUrl }] } : {}),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: page.seo.title,
+      description: page.seo.description,
+    },
+  };
+}
+
+/** Build JSON-LD for the page — WebPage/Article, plus FAQPage from faq blocks. */
+function jsonLd(page: MarketingPage, url: string): Record<string, unknown>[] {
+  const graphs: Record<string, unknown>[] = [];
+  const base = {
+    "@context": "https://schema.org",
+    name: page.seo.title,
+    description: page.seo.description,
+    url,
+  };
+  if (page.seo.schemaType === "article") {
+    graphs.push({ ...base, "@type": "Article", headline: page.seo.title });
+  } else {
+    graphs.push({ ...base, "@type": "WebPage" });
+  }
+
+  const faqBlocks = page.blocks.filter((b): b is FaqBlock => b.type === "faq");
+  const faqItems = faqBlocks.flatMap((b) => b.items);
+  if (faqItems.length > 0) {
+    graphs.push({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: faqItems.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: { "@type": "Answer", text: item.answer },
+      })),
+    });
+  }
+  return graphs;
+}
+
+export default async function MarketingCatchAll({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>;
+}) {
+  const { slug } = await params;
+  const path = slugFromParams(slug);
+  const page = await getMarketingPage(path, LOCALE);
+  if (!page) notFound();
+
+  const url = `${SITE.url.replace(/\/$/, "")}/${path}`;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      {jsonLd(page, url).map((graph, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
+        />
+      ))}
+      <main>
+        <PageBlocks blocks={page.blocks} />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,15 @@
 import type { MetadataRoute } from "next";
 import { SITE } from "@/lib/utils";
 import { PILLAR_ORDER } from "@/lib/pillars";
+import { getMarketingSitemapEntries } from "@/lib/marketing-pages";
 
 /**
- * Marketing sitemap. Lists only public, indexable marketing routes — not the
- * gated app (dashboard/onboarding/auth/cms), which must stay out of the index.
- * Absolute URLs are built from SITE.url (env-overridable).
+ * Marketing sitemap. Lists the public, indexable code routes AND the
+ * CMS-authored pages from the Pages Manager (mkt_pages) — never the gated app
+ * (dashboard/onboarding/auth/cms), which stays out of the index. The API
+ * already excludes noindex + draft pages. Absolute URLs from SITE.url.
  */
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const base = SITE.url.replace(/\/$/, "");
 
   const staticPaths: {
@@ -31,11 +33,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "weekly" as const,
   }));
 
-  return [...staticPaths, ...pillarPaths].map(
+  const codeEntries: MetadataRoute.Sitemap = [...staticPaths, ...pillarPaths].map(
     ({ path, priority, changeFrequency }) => ({
       url: `${base}${path}`,
       changeFrequency,
       priority,
     }),
   );
+
+  // CMS-authored pages (Pages Manager). Degrades to [] if the API is down.
+  const cmsEntries: MetadataRoute.Sitemap = (await getMarketingSitemapEntries()).map(
+    (entry) => ({
+      url: `${base}/${entry.slug}`,
+      lastModified: entry.updatedAt ? new Date(entry.updatedAt) : undefined,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    }),
+  );
+
+  return [...codeEntries, ...cmsEntries];
 }

--- a/src/components/marketing/page-blocks.tsx
+++ b/src/components/marketing/page-blocks.tsx
@@ -38,13 +38,27 @@ function Eyebrow({ children }: { children: React.ReactNode }) {
 const ctaClass =
   "group inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-6 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2";
 
-function Hero({ b }: { b: HeroBlock }) {
+/**
+ * Guard CMS/AI-authored URLs before rendering into href/src. Allows only a
+ * leading-"/" relative path or an absolute http(s) URL — blocks javascript:,
+ * data:, vbscript:, etc. (stored-XSS defence-in-depth). Returns null when
+ * unsafe so callers can drop the link/image.
+ */
+function safeHref(h: string | undefined): string | null {
+  if (!h) return null;
+  return h.startsWith("/") || /^https?:\/\//i.test(h) ? h : null;
+}
+
+function Hero({ b, asH1 = true }: { b: HeroBlock; asH1?: boolean }) {
+  const Heading = asH1 ? "h1" : "h2";
+  const cta = safeHref(b.ctaHref);
+  const img = safeHref(b.imageUrl);
   return (
     <section className="py-16 sm:py-24">
       <div className="mx-auto grid max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
         <div>
           {b.eyebrow && <Eyebrow>{b.eyebrow}</Eyebrow>}
-          <h1 className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
+          <Heading className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
             {b.headline}
             {b.accent && (
               <>
@@ -54,21 +68,21 @@ function Hero({ b }: { b: HeroBlock }) {
                 </span>
               </>
             )}
-          </h1>
+          </Heading>
           {b.lede && <p className="mt-5 max-w-xl text-lg text-muted-foreground">{b.lede}</p>}
-          {b.ctaLabel && b.ctaHref && (
+          {b.ctaLabel && cta && (
             <div className="mt-8">
-              <Link href={b.ctaHref} className={ctaClass}>
+              <Link href={cta} className={ctaClass}>
                 {b.ctaLabel}
                 <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" aria-hidden />
               </Link>
             </div>
           )}
         </div>
-        {b.imageUrl && (
+        {img && (
           // eslint-disable-next-line @next/next/no-img-element
           <img
-            src={b.imageUrl}
+            src={img}
             alt={b.imageAlt ?? ""}
             className="w-full rounded-2xl border object-cover shadow-xl"
           />
@@ -87,8 +101,8 @@ function PainPoints({ b }: { b: PainPointsBlock }) {
           {b.intro && <p className="mt-3 text-muted-foreground">{b.intro}</p>}
         </div>
         <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {b.items.map((item) => (
-            <div key={item.title} className="rounded-2xl border bg-background p-6">
+          {b.items.map((item, i) => (
+            <div key={`${item.title}-${i}`} className="rounded-2xl border bg-background p-6">
               <p className="font-bold">{item.title}</p>
               <p className="mt-2 text-sm text-muted-foreground">{item.body}</p>
             </div>
@@ -107,9 +121,9 @@ function PillarOutcomes({ b }: { b: PillarOutcomesBlock }) {
           {b.heading}
         </h2>
         <div className="mt-10 flex flex-col gap-3">
-          {b.items.map((item) => (
+          {b.items.map((item, i) => (
             <div
-              key={item.pillar}
+              key={`${item.pillar}-${i}`}
               className="grid gap-3 rounded-2xl border bg-background p-6 sm:grid-cols-[150px_1fr]"
             >
               <span className="font-bold capitalize">{item.pillar}</span>
@@ -132,8 +146,8 @@ function LearnsWithYou({ b }: { b: LearnsWithYouBlock }) {
           </h2>
           {b.body && <p className="mt-4 max-w-2xl text-zinc-400">{b.body}</p>}
           <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            {b.timeline.map((t) => (
-              <div key={t.when} className="border-l-2 border-brand/40 pl-4">
+            {b.timeline.map((t, i) => (
+              <div key={`${t.when}-${i}`} className="border-l-2 border-brand/40 pl-4">
                 <div className="font-serif text-lg italic text-brand">{t.when}</div>
                 <div className="mt-2 text-sm text-zinc-400">{t.what}</div>
               </div>
@@ -156,8 +170,8 @@ function FeatureGrid({ b }: { b: FeatureGridBlock }) {
           {b.heading}
         </h2>
         <div className="mt-10 grid gap-4 md:grid-cols-3">
-          {b.features.map((f) => (
-            <div key={f.title} className="rounded-2xl border bg-background p-6">
+          {b.features.map((f, i) => (
+            <div key={`${f.title}-${i}`} className="rounded-2xl border bg-background p-6">
               <div className="flex size-10 items-center justify-center rounded-xl bg-brand-soft">
                 <Check className="size-5 text-brand-ink" strokeWidth={2.5} aria-hidden />
               </div>
@@ -186,8 +200,8 @@ function Cta({ b }: { b: CtaBlock }) {
             )}
           </h2>
           {b.body && <p className="mx-auto mt-4 max-w-xl text-zinc-400">{b.body}</p>}
-          {b.ctaLabel && b.ctaHref && (
-            <Link href={b.ctaHref} className={`${ctaClass} mt-8 focus-visible:ring-offset-zinc-900`}>
+          {b.ctaLabel && safeHref(b.ctaHref) && (
+            <Link href={safeHref(b.ctaHref)!} className={`${ctaClass} mt-8 focus-visible:ring-offset-zinc-900`}>
               {b.ctaLabel}
               <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" aria-hidden />
             </Link>
@@ -207,16 +221,20 @@ function CrossLinks({ b }: { b: CrossLinksBlock }) {
           {b.intro && <p className="mt-3 text-muted-foreground">{b.intro}</p>}
         </div>
         <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {b.links.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              className="group flex items-center gap-3 rounded-2xl border bg-background p-5 transition-all hover:-translate-y-1 hover:border-foreground hover:shadow-md"
-            >
-              <span className="font-bold">{l.label}</span>
-              <ArrowRight className="ml-auto size-4 text-muted-foreground transition-transform group-hover:translate-x-1" aria-hidden />
-            </Link>
-          ))}
+          {b.links.map((l, i) => {
+            const href = safeHref(l.href);
+            if (!href) return null;
+            return (
+              <Link
+                key={`${l.href}-${i}`}
+                href={href}
+                className="group flex items-center gap-3 rounded-2xl border bg-background p-5 transition-all hover:-translate-y-1 hover:border-foreground hover:shadow-md"
+              >
+                <span className="font-bold">{l.label}</span>
+                <ArrowRight className="ml-auto size-4 text-muted-foreground transition-transform group-hover:translate-x-1" aria-hidden />
+              </Link>
+            );
+          })}
         </div>
       </div>
     </section>
@@ -251,12 +269,12 @@ function Faq({ b }: { b: FaqBlock }) {
           <h2 className="text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">{b.heading}</h2>
         )}
         <div className="mt-8 flex flex-col gap-3">
-          {b.items.map((item) => (
+          {b.items.map((item, i) => (
             <details
-              key={item.question}
+              key={`${item.question}-${i}`}
               className="group rounded-2xl border bg-background p-5 [&_summary]:cursor-pointer"
             >
-              <summary className="flex items-center justify-between font-bold marker:content-none">
+              <summary className="flex items-center justify-between font-bold list-none marker:content-none [&::-webkit-details-marker]:hidden">
                 {item.question}
                 <span className="text-brand transition-transform group-open:rotate-45" aria-hidden>+</span>
               </summary>
@@ -270,11 +288,19 @@ function Faq({ b }: { b: FaqBlock }) {
 }
 
 function Media({ b }: { b: MediaBlock }) {
+  const img = safeHref(b.imageUrl);
+  if (!img) return null;
   return (
     <section className="py-12">
       <figure className="mx-auto max-w-4xl px-4 sm:px-6">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={b.imageUrl} alt={b.alt} className="w-full rounded-2xl border shadow-md" />
+        <img
+          src={img}
+          alt={b.alt}
+          loading="lazy"
+          decoding="async"
+          className="w-full rounded-2xl border shadow-md"
+        />
         {b.caption && (
           <figcaption className="mt-3 text-center text-sm text-muted-foreground">{b.caption}</figcaption>
         )}
@@ -283,10 +309,15 @@ function Media({ b }: { b: MediaBlock }) {
   );
 }
 
-function renderBlock(block: PageBlock, index: number): React.ReactNode {
+function renderBlock(
+  block: PageBlock,
+  index: number,
+  firstHeroIndex: number,
+): React.ReactNode {
   switch (block.type) {
     case "hero":
-      return <Hero key={index} b={block} />;
+      // Exactly one h1 per page: the first hero is the h1, any later hero an h2.
+      return <Hero key={index} b={block} asH1={index === firstHeroIndex} />;
     case "pain_points":
       return <PainPoints key={index} b={block} />;
     case "pillar_outcomes":
@@ -310,6 +341,12 @@ function renderBlock(block: PageBlock, index: number): React.ReactNode {
   }
 }
 
+/** True when the page has no hero block — the caller must supply an h1. */
+export function hasHeroBlock(blocks: PageBlock[]): boolean {
+  return blocks.some((b) => b.type === "hero");
+}
+
 export function PageBlocks({ blocks }: { blocks: PageBlock[] }) {
-  return <>{blocks.map((block, i) => renderBlock(block, i))}</>;
+  const firstHeroIndex = blocks.findIndex((b) => b.type === "hero");
+  return <>{blocks.map((block, i) => renderBlock(block, i, firstHeroIndex))}</>;
 }

--- a/src/components/marketing/page-blocks.tsx
+++ b/src/components/marketing/page-blocks.tsx
@@ -1,0 +1,315 @@
+import Link from "next/link";
+import DOMPurify from "isomorphic-dompurify";
+import { ArrowRight, Check } from "lucide-react";
+import type {
+  PageBlock,
+  HeroBlock,
+  PainPointsBlock,
+  PillarOutcomesBlock,
+  LearnsWithYouBlock,
+  FeatureGridBlock,
+  CtaBlock,
+  CrossLinksBlock,
+  RichTextBlock,
+  FaqBlock,
+  MediaBlock,
+} from "@/lib/marketing-pages";
+
+/**
+ * Renders the content-as-data blocks of a marketing page (MP-2b) into the v3
+ * marketing design system. Server component. Every block type in mkt_pages'
+ * union has a renderer here; rich_text HTML is sanitised with DOMPurify before
+ * render (the schema marks it app-sanitised — this is that layer).
+ */
+
+const eyebrow = (
+  <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+);
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+      {eyebrow}
+      {children}
+    </span>
+  );
+}
+
+const ctaClass =
+  "group inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-6 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2";
+
+function Hero({ b }: { b: HeroBlock }) {
+  return (
+    <section className="py-16 sm:py-24">
+      <div className="mx-auto grid max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <div>
+          {b.eyebrow && <Eyebrow>{b.eyebrow}</Eyebrow>}
+          <h1 className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
+            {b.headline}
+            {b.accent && (
+              <>
+                {" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  {b.accent}
+                </span>
+              </>
+            )}
+          </h1>
+          {b.lede && <p className="mt-5 max-w-xl text-lg text-muted-foreground">{b.lede}</p>}
+          {b.ctaLabel && b.ctaHref && (
+            <div className="mt-8">
+              <Link href={b.ctaHref} className={ctaClass}>
+                {b.ctaLabel}
+                <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" aria-hidden />
+              </Link>
+            </div>
+          )}
+        </div>
+        {b.imageUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={b.imageUrl}
+            alt={b.imageAlt ?? ""}
+            className="w-full rounded-2xl border object-cover shadow-xl"
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function PainPoints({ b }: { b: PainPointsBlock }) {
+  return (
+    <section className="border-t bg-muted/30 py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-3xl">
+          <h2 className="text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">{b.heading}</h2>
+          {b.intro && <p className="mt-3 text-muted-foreground">{b.intro}</p>}
+        </div>
+        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {b.items.map((item) => (
+            <div key={item.title} className="rounded-2xl border bg-background p-6">
+              <p className="font-bold">{item.title}</p>
+              <p className="mt-2 text-sm text-muted-foreground">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PillarOutcomes({ b }: { b: PillarOutcomesBlock }) {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <h2 className="max-w-3xl text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+          {b.heading}
+        </h2>
+        <div className="mt-10 flex flex-col gap-3">
+          {b.items.map((item) => (
+            <div
+              key={item.pillar}
+              className="grid gap-3 rounded-2xl border bg-background p-6 sm:grid-cols-[150px_1fr]"
+            >
+              <span className="font-bold capitalize">{item.pillar}</span>
+              <span className="text-muted-foreground">{item.outcome}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LearnsWithYou({ b }: { b: LearnsWithYouBlock }) {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 p-8 text-zinc-100 shadow-2xl lg:p-12">
+          <h2 className="max-w-2xl text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+            {b.heading}
+          </h2>
+          {b.body && <p className="mt-4 max-w-2xl text-zinc-400">{b.body}</p>}
+          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {b.timeline.map((t) => (
+              <div key={t.when} className="border-l-2 border-brand/40 pl-4">
+                <div className="font-serif text-lg italic text-brand">{t.when}</div>
+                <div className="mt-2 text-sm text-zinc-400">{t.what}</div>
+              </div>
+            ))}
+          </div>
+          {b.footnote && (
+            <p className="mt-8 border-t border-white/10 pt-6 text-sm text-zinc-400">{b.footnote}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FeatureGrid({ b }: { b: FeatureGridBlock }) {
+  return (
+    <section className="border-t bg-muted/30 py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <h2 className="max-w-3xl text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+          {b.heading}
+        </h2>
+        <div className="mt-10 grid gap-4 md:grid-cols-3">
+          {b.features.map((f) => (
+            <div key={f.title} className="rounded-2xl border bg-background p-6">
+              <div className="flex size-10 items-center justify-center rounded-xl bg-brand-soft">
+                <Check className="size-5 text-brand-ink" strokeWidth={2.5} aria-hidden />
+              </div>
+              <h3 className="mt-3 text-base font-bold tracking-tight">{f.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{f.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Cta({ b }: { b: CtaBlock }) {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl">
+          <h2 className="mx-auto max-w-2xl text-3xl font-extrabold tracking-tight text-pretty sm:text-4xl">
+            {b.headline}
+            {b.accent && (
+              <>
+                {" "}
+                <span className="font-serif font-normal italic text-brand-gradient">{b.accent}</span>
+              </>
+            )}
+          </h2>
+          {b.body && <p className="mx-auto mt-4 max-w-xl text-zinc-400">{b.body}</p>}
+          {b.ctaLabel && b.ctaHref && (
+            <Link href={b.ctaHref} className={`${ctaClass} mt-8 focus-visible:ring-offset-zinc-900`}>
+              {b.ctaLabel}
+              <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" aria-hidden />
+            </Link>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CrossLinks({ b }: { b: CrossLinksBlock }) {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-3xl">
+          <h2 className="text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">{b.heading}</h2>
+          {b.intro && <p className="mt-3 text-muted-foreground">{b.intro}</p>}
+        </div>
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {b.links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="group flex items-center gap-3 rounded-2xl border bg-background p-5 transition-all hover:-translate-y-1 hover:border-foreground hover:shadow-md"
+            >
+              <span className="font-bold">{l.label}</span>
+              <ArrowRight className="ml-auto size-4 text-muted-foreground transition-transform group-hover:translate-x-1" aria-hidden />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function RichText({ b }: { b: RichTextBlock }) {
+  const clean = DOMPurify.sanitize(b.html);
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6">
+        {b.heading && (
+          <h2 className="mb-6 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+            {b.heading}
+          </h2>
+        )}
+        <div
+          className="prose prose-zinc max-w-none dark:prose-invert"
+          // Sanitised above with DOMPurify.
+          dangerouslySetInnerHTML={{ __html: clean }}
+        />
+      </div>
+    </section>
+  );
+}
+
+function Faq({ b }: { b: FaqBlock }) {
+  return (
+    <section className="border-t bg-muted/30 py-20">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6">
+        {b.heading && (
+          <h2 className="text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">{b.heading}</h2>
+        )}
+        <div className="mt-8 flex flex-col gap-3">
+          {b.items.map((item) => (
+            <details
+              key={item.question}
+              className="group rounded-2xl border bg-background p-5 [&_summary]:cursor-pointer"
+            >
+              <summary className="flex items-center justify-between font-bold marker:content-none">
+                {item.question}
+                <span className="text-brand transition-transform group-open:rotate-45" aria-hidden>+</span>
+              </summary>
+              <p className="mt-3 text-sm text-muted-foreground">{item.answer}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Media({ b }: { b: MediaBlock }) {
+  return (
+    <section className="py-12">
+      <figure className="mx-auto max-w-4xl px-4 sm:px-6">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={b.imageUrl} alt={b.alt} className="w-full rounded-2xl border shadow-md" />
+        {b.caption && (
+          <figcaption className="mt-3 text-center text-sm text-muted-foreground">{b.caption}</figcaption>
+        )}
+      </figure>
+    </section>
+  );
+}
+
+function renderBlock(block: PageBlock, index: number): React.ReactNode {
+  switch (block.type) {
+    case "hero":
+      return <Hero key={index} b={block} />;
+    case "pain_points":
+      return <PainPoints key={index} b={block} />;
+    case "pillar_outcomes":
+      return <PillarOutcomes key={index} b={block} />;
+    case "learns_with_you":
+      return <LearnsWithYou key={index} b={block} />;
+    case "feature_grid":
+      return <FeatureGrid key={index} b={block} />;
+    case "cta":
+      return <Cta key={index} b={block} />;
+    case "cross_links":
+      return <CrossLinks key={index} b={block} />;
+    case "rich_text":
+      return <RichText key={index} b={block} />;
+    case "faq":
+      return <Faq key={index} b={block} />;
+    case "media":
+      return <Media key={index} b={block} />;
+    default:
+      return null;
+  }
+}
+
+export function PageBlocks({ blocks }: { blocks: PageBlock[] }) {
+  return <>{blocks.map((block, i) => renderBlock(block, i))}</>;
+}

--- a/src/lib/marketing-pages.ts
+++ b/src/lib/marketing-pages.ts
@@ -1,0 +1,162 @@
+/**
+ * Server-side client for the Pages Manager render API (peakhour-api
+ * /v1/marketing/pages — MP-2a). Fetches published marketing pages as
+ * content-as-data blocks for the `[[...slug]]` catch-all renderer.
+ *
+ * Cached with a revalidate window + tags so a CMS publish can push a fresh
+ * render via revalidateTag("mkt-pages") / revalidateTag(`mkt-page:${slug}`)
+ * (MP-3). The (site) layout forces dynamic rendering for the CSP nonce, so the
+ * *page* is SSR'd per request; this fetch's data cache is the ISR-equivalent.
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+const REVALIDATE_SECONDS = 300;
+
+// ── Block content model (mirrors mkt_pages.zod.ts / the API projection) ──────
+export interface HeroBlock {
+  type: "hero";
+  eyebrow?: string;
+  headline: string;
+  accent?: string;
+  lede?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  imageUrl?: string;
+  imageAlt?: string;
+}
+export interface PainPointsBlock {
+  type: "pain_points";
+  heading: string;
+  intro?: string;
+  items: { title: string; body: string }[];
+}
+export interface PillarOutcomesBlock {
+  type: "pillar_outcomes";
+  heading: string;
+  items: { pillar: string; outcome: string }[];
+}
+export interface LearnsWithYouBlock {
+  type: "learns_with_you";
+  heading: string;
+  body?: string;
+  timeline: { when: string; what: string }[];
+  footnote?: string;
+}
+export interface FeatureGridBlock {
+  type: "feature_grid";
+  heading: string;
+  features: { title: string; description: string }[];
+}
+export interface CtaBlock {
+  type: "cta";
+  headline: string;
+  accent?: string;
+  body?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+}
+export interface CrossLinksBlock {
+  type: "cross_links";
+  heading: string;
+  intro?: string;
+  links: { label: string; href: string }[];
+}
+export interface RichTextBlock {
+  type: "rich_text";
+  heading?: string;
+  html: string;
+}
+export interface FaqBlock {
+  type: "faq";
+  heading?: string;
+  items: { question: string; answer: string }[];
+}
+export interface MediaBlock {
+  type: "media";
+  imageUrl: string;
+  alt: string;
+  caption?: string;
+}
+
+export type PageBlock =
+  | HeroBlock
+  | PainPointsBlock
+  | PillarOutcomesBlock
+  | LearnsWithYouBlock
+  | FeatureGridBlock
+  | CtaBlock
+  | CrossLinksBlock
+  | RichTextBlock
+  | FaqBlock
+  | MediaBlock;
+
+export interface MarketingPageSeo {
+  title: string;
+  description: string;
+  ogImageUrl?: string;
+  canonicalPath?: string;
+  schemaType?: "web_page" | "article" | "faq_page";
+  noindex?: boolean;
+}
+
+export interface MarketingPage {
+  slug: string;
+  locale: string;
+  kind: string;
+  taxonomy: { industry?: string; persona?: string; pillar?: string };
+  seo: MarketingPageSeo;
+  blocks: PageBlock[];
+  translationGroupId?: string;
+  publishedAt?: string;
+  updatedAt?: string;
+}
+
+export interface MarketingSitemapEntry {
+  slug: string;
+  locale: string;
+  updatedAt?: string;
+}
+
+/**
+ * Fetch a published page by slug (path may be multi-segment) + locale. Returns
+ * null when unconfigured, 404 (no published page), or on any error — the
+ * caller renders notFound().
+ */
+export async function getMarketingPage(
+  slug: string,
+  locale = "en",
+): Promise<MarketingPage | null> {
+  if (!API_URL) return null;
+  try {
+    const res = await fetch(
+      `${API_URL}/v1/marketing/pages/${encodeURI(slug)}?locale=${encodeURIComponent(locale)}`,
+      {
+        next: {
+          revalidate: REVALIDATE_SECONDS,
+          tags: ["mkt-pages", `mkt-page:${slug}`],
+        },
+      },
+    );
+    if (!res.ok) return null;
+    const json = (await res.json()) as { ok?: boolean; data?: MarketingPage };
+    if (!json.ok || !json.data) return null;
+    return json.data;
+  } catch {
+    return null;
+  }
+}
+
+/** Published pages for the sitemap; [] on any failure (sitemap degrades). */
+export async function getMarketingSitemapEntries(): Promise<MarketingSitemapEntry[]> {
+  if (!API_URL) return [];
+  try {
+    const res = await fetch(`${API_URL}/v1/marketing/pages`, {
+      next: { revalidate: REVALIDATE_SECONDS, tags: ["mkt-pages"] },
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as { ok?: boolean; data?: { pages?: MarketingSitemapEntry[] } };
+    return json.ok && json.data?.pages ? json.data.pages : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/marketing-pages.ts
+++ b/src/lib/marketing-pages.ts
@@ -1,7 +1,7 @@
 /**
  * Server-side client for the Pages Manager render API (peakhour-api
  * /v1/marketing/pages — MP-2a). Fetches published marketing pages as
- * content-as-data blocks for the `[[...slug]]` catch-all renderer.
+ * content-as-data blocks for the `[...slug]` catch-all renderer.
  *
  * Cached with a revalidate window + tags so a CMS publish can push a fresh
  * render via revalidateTag("mkt-pages") / revalidateTag(`mkt-page:${slug}`)
@@ -127,9 +127,12 @@ export async function getMarketingPage(
   locale = "en",
 ): Promise<MarketingPage | null> {
   if (!API_URL) return null;
+  // Encode each path segment (keeps "/" separators, but escapes ? # & etc. so a
+  // slug segment can't inject into the API query string).
+  const encodedSlug = slug.split("/").map(encodeURIComponent).join("/");
   try {
     const res = await fetch(
-      `${API_URL}/v1/marketing/pages/${encodeURI(slug)}?locale=${encodeURIComponent(locale)}`,
+      `${API_URL}/v1/marketing/pages/${encodedSlug}?locale=${encodeURIComponent(locale)}`,
       {
         next: {
           revalidate: REVALIDATE_SECONDS,


### PR DESCRIPTION
## MP-2b — the b2c renderer (completes MP-2)

Renders the Pages Manager pages (`mkt_pages`) on the public site. With MP-2a's API, a DB-authored page now appears **live** end-to-end.

### What's here
- **`lib/marketing-pages.ts`** — typed page/block model + `getMarketingPage(slug, locale)` and `getMarketingSitemapEntries()`, fetching the MP-2a API with a revalidate window + **cache tags** (`mkt-pages` / `mkt-page:<slug>`) so a CMS publish can push a fresh render via `revalidateTag` (MP-3).
- **`components/marketing/page-blocks.tsx`** — renders all **10 block types** into the v3 design system. `rich_text` HTML is **sanitised with isomorphic-dompurify** before render (the schema's "app-sanitised" layer; addresses the MP-2a XSS flag).
- **`(site)/[...slug]/page.tsx`** — **required** catch-all (never collides with `/` or the explicit spine routes — Next resolves those first). `generateMetadata` builds canonical/OG/Twitter + `robots(noindex)` from `seo`; a miss → `notFound()` (real 404); emits **JSON-LD** (WebPage/Article + **FAQPage** derived from `faq` blocks — the AEO wedge).
- **`sitemap.ts`** — now async, appends the published CMS pages (API already excludes noindex/draft); degrades to code routes if the API is down.

### Verification
`eslint` + `tsc` clean, and a **full `next build` (exit 0)** — `/[...slug]` compiles and **coexists with `/commerce`, `/pricing`, and the homepage** (no route conflict), sitemap builds.

Next: MP-3 (CMS Website section) → MP-4 (AI authoring) → MP-5 (seed pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)