### PR TITLE
feat(pages): customer segment picker for Generate pages

### DIFF
--- a/src/app/(site)/dashboard/pages/components/generate-pages-dialog.tsx
+++ b/src/app/(site)/dashboard/pages/components/generate-pages-dialog.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Plus, Sparkles, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * GeneratePagesDialog — the owner defines which landing pages to create by giving
+ * one or more "topics" (an audience + an optional focus note). Each topic becomes a
+ * generation segment sent to POST /v1/content/web-pages/generate.
+ *
+ * Design notes:
+ *   • Copy is deliberately non-technical (owner-facing) — no "segment", "pillar", or
+ *     collection names. A "topic" == one page target.
+ *   • Follows the RejectReasonDialog idiom: controlled open, inner body mounted only
+ *     while open (so state resets on close with no useEffect), and dialog dismissal
+ *     is blocked while a submit is in flight.
+ *   • Seed-default preserved: submitting with NO topics filled sends `undefined`
+ *     (segments omitted). The internal platform org falls back to its seed set; a
+ *     customer gets SEGMENTS_REQUIRED, which the caller surfaces as an inline hint.
+ */
+
+// Mirror the API's zSegment caps (peakhour-api web-pages.ts) so the form can never
+// round-trip to a 400. Kebab keys are derived + capped at 64; labels/summary here.
+const MAX_TOPICS = 4;
+const AUDIENCE_MAX = 200;
+const FOCUS_MAX = 1000;
+const KEY_MAX = 64;
+
+/** One page topic as the owner enters it. */
+interface Topic {
+  /** Human audience/industry label, e.g. "Cafés & restaurants" → industryLabel. */
+  audience: string;
+  /** Optional free-text focus → segmentSummary. */
+  focus: string;
+}
+
+/** The segment shape POST /generate accepts (subset we send). */
+export interface GenerateSegmentInput {
+  industry: string;
+  industryLabel: string;
+  segmentSummary?: string;
+}
+
+/** Lowercase kebab key from a human label: anything that is not a-z0-9 (spaces,
+ *  punctuation, non-ASCII/accented letters) collapses to "-", then trim + cap. Empty
+ *  when the label has no ASCII alphanumerics (caller filters those out). The key is an
+ *  internal axis only — the human label is kept verbatim for the prompt. */
+function slugify(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, KEY_MAX)
+    .replace(/-+$/g, ""); // in case the slice landed on a trailing hyphen
+}
+
+const emptyTopic = (): Topic => ({ audience: "", focus: "" });
+
+/** Map filled topics → segments. A topic counts only if its audience slugifies to a
+ *  non-empty key (that key is the page's required `industry` axis). */
+function toSegments(topics: Topic[]): GenerateSegmentInput[] {
+  const segments: GenerateSegmentInput[] = [];
+  for (const t of topics) {
+    const label = t.audience.trim();
+    const industry = slugify(label);
+    if (!industry) continue;
+    const focus = t.focus.trim();
+    segments.push({
+      industry,
+      industryLabel: label.slice(0, AUDIENCE_MAX),
+      ...(focus ? { segmentSummary: focus.slice(0, FOCUS_MAX) } : {}),
+    });
+  }
+  return segments;
+}
+
+export interface GeneratePagesDialogProps {
+  /** Controlled open state — the parent already tracks it (header button + empty
+   *  state both open the same dialog). */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Runs the generation. Resolve to close the dialog; throw to keep it open and
+   *  surface the error inline (SEGMENTS_REQUIRED becomes a "name a topic" hint).
+   *  `segments` is undefined when the owner submitted no topics (seed-default path). */
+  onGenerate: (segments?: GenerateSegmentInput[]) => Promise<void>;
+}
+
+export function GeneratePagesDialog({ open, onOpenChange, onGenerate }: GeneratePagesDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? <GeneratePagesDialogBody onGenerate={onGenerate} onClose={() => onOpenChange(false)} /> : null}
+    </Dialog>
+  );
+}
+
+function GeneratePagesDialogBody({
+  onGenerate,
+  onClose,
+}: {
+  onGenerate: GeneratePagesDialogProps["onGenerate"];
+  onClose: () => void;
+}) {
+  const [topics, setTopics] = useState<Topic[]>([emptyTopic()]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const segments = toSegments(topics);
+  // Any audience text typed at all — used to distinguish "left it all blank on
+  // purpose" (allowed → seed-default) from "typed something that didn't count".
+  const anyAudienceTyped = topics.some((t) => t.audience.trim().length > 0);
+  // Typed an audience but none produced a usable key (e.g. only punctuation/emoji).
+  const typedButUnusable = anyAudienceTyped && segments.length === 0;
+
+  function update(i: number, patch: Partial<Topic>) {
+    setError(null);
+    setTopics((prev) => prev.map((t, idx) => (idx === i ? { ...t, ...patch } : t)));
+  }
+  function addTopic() {
+    setError(null);
+    setTopics((prev) => (prev.length >= MAX_TOPICS ? prev : [...prev, emptyTopic()]));
+  }
+  function removeTopic(i: number) {
+    setError(null);
+    setTopics((prev) => (prev.length <= 1 ? prev : prev.filter((_, idx) => idx !== i)));
+  }
+
+  async function handleSubmit() {
+    if (submitting || typedButUnusable) return;
+    // No usable topics → seed-default path (send undefined). Otherwise send segments.
+    const payload = segments.length > 0 ? segments : undefined;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onGenerate(payload);
+      onClose();
+    } catch (e) {
+      // Turn the API's SEGMENTS_REQUIRED into an inline hint rather than a toast:
+      // it means this (non-platform) business must name at least one topic.
+      const code = (e as { code?: string } | null)?.code;
+      if (code === "SEGMENTS_REQUIRED") {
+        setError("Add at least one topic — tell us who your pages should be for.");
+      } else {
+        setError(e instanceof Error ? e.message : "Couldn't start generating. Please try again.");
+      }
+      setSubmitting(false);
+    }
+  }
+
+  const block = (e: { preventDefault: () => void }) => {
+    if (submitting) e.preventDefault();
+  };
+
+  return (
+    <DialogContent
+      className="sm:max-w-lg"
+      onEscapeKeyDown={block}
+      onPointerDownOutside={block}
+      onInteractOutside={block}
+    >
+      <DialogHeader>
+        <DialogTitle>Generate pages</DialogTitle>
+        <DialogDescription>
+          Tell us who your pages should be for and we&apos;ll write a landing page for each. You
+          review every page before anything goes live.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        {topics.map((t, i) => (
+          <div key={i} className="rounded-lg border p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-semibold text-muted-foreground">Topic {i + 1}</span>
+              {topics.length > 1 && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-6"
+                  disabled={submitting}
+                  onClick={() => removeTopic(i)}
+                  aria-label={`Remove topic ${i + 1}`}
+                >
+                  <X className="size-4" aria-hidden="true" />
+                </Button>
+              )}
+            </div>
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor={`audience-${i}`}>Who are these pages for?</Label>
+                <Input
+                  id={`audience-${i}`}
+                  value={t.audience}
+                  maxLength={AUDIENCE_MAX}
+                  disabled={submitting}
+                  placeholder="e.g. Cafés & restaurants"
+                  onChange={(e) => update(i, { audience: e.target.value })}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor={`focus-${i}`}>
+                  What should they focus on? <span className="text-muted-foreground">(optional)</span>
+                </Label>
+                <Textarea
+                  id={`focus-${i}`}
+                  value={t.focus}
+                  maxLength={FOCUS_MAX}
+                  disabled={submitting}
+                  rows={2}
+                  placeholder="e.g. Getting more table bookings from nearby customers"
+                  onChange={(e) => update(i, { focus: e.target.value })}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+
+        {topics.length < MAX_TOPICS && (
+          <Button type="button" variant="outline" size="sm" disabled={submitting} onClick={addTopic}>
+            <Plus className="size-4" aria-hidden="true" />
+            Add another topic
+          </Button>
+        )}
+
+        {(error || typedButUnusable) && (
+          <p className="text-sm text-destructive" role="alert">
+            {error ?? "Please use letters or numbers to describe who a topic is for."}
+          </p>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" type="button" disabled={submitting} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="button" disabled={submitting || typedButUnusable} onClick={handleSubmit}>
+          {submitting ? (
+            <>
+              <Loader2 className="mr-1.5 size-4 animate-spin" />
+              Writing pages…
+            </>
+          ) : (
+            <>
+              <Sparkles className="size-4" aria-hidden="true" />
+              {segments.length > 0
+                ? `Generate ${segments.length} page${segments.length !== 1 ? "s" : ""}`
+                : "Generate pages"}
+            </>
+          )}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/src/app/(site)/dashboard/pages/components/generate-pages-dialog.tsx
+++ b/src/app/(site)/dashboard/pages/components/generate-pages-dialog.tsx
@@ -14,6 +14,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { ApiError } from "@/lib/api";
+import type { GenerateSegmentInput } from "@/hooks/use-web-pages";
 
 /**
  * GeneratePagesDialog — the owner defines which landing pages to create by giving
@@ -44,13 +46,6 @@ interface Topic {
   audience: string;
   /** Optional free-text focus → segmentSummary. */
   focus: string;
-}
-
-/** The segment shape POST /generate accepts (subset we send). */
-export interface GenerateSegmentInput {
-  industry: string;
-  industryLabel: string;
-  segmentSummary?: string;
 }
 
 /** Lowercase kebab key from a human label: anything that is not a-z0-9 (spaces,
@@ -117,23 +112,37 @@ function GeneratePagesDialogBody({
   const [error, setError] = useState<string | null>(null);
 
   const segments = toSegments(topics);
-  // Any audience text typed at all — used to distinguish "left it all blank on
-  // purpose" (allowed → seed-default) from "typed something that didn't count".
-  const anyAudienceTyped = topics.some((t) => t.audience.trim().length > 0);
-  // Typed an audience but none produced a usable key (e.g. only punctuation/emoji).
-  const typedButUnusable = anyAudienceTyped && segments.length === 0;
+  // How many topics the owner actually typed an audience into.
+  const typedAudiences = topics.filter((t) => t.audience.trim().length > 0).length;
+  // Typed at least one audience but NONE produced a usable key (e.g. only
+  // punctuation/emoji) → block: submitting would misleadingly seed-default.
+  const typedButUnusable = typedAudiences > 0 && segments.length === 0;
+  // Some usable, some not — the unusable ones are dropped; warn so it isn't silent.
+  const droppedCount = segments.length > 0 ? typedAudiences - segments.length : 0;
+
+  /** Move focus to a topic's audience input after the list changes (add/remove) so a
+   *  keyboard user isn't stranded. rAF waits for the new/re-laid-out DOM to mount. */
+  function focusAudience(i: number) {
+    requestAnimationFrame(() => {
+      document.getElementById(`audience-${i}`)?.focus();
+    });
+  }
 
   function update(i: number, patch: Partial<Topic>) {
     setError(null);
     setTopics((prev) => prev.map((t, idx) => (idx === i ? { ...t, ...patch } : t)));
   }
   function addTopic() {
+    if (topics.length >= MAX_TOPICS) return;
     setError(null);
-    setTopics((prev) => (prev.length >= MAX_TOPICS ? prev : [...prev, emptyTopic()]));
+    setTopics((prev) => [...prev, emptyTopic()]);
+    focusAudience(topics.length); // the new row's index
   }
   function removeTopic(i: number) {
+    if (topics.length <= 1) return;
     setError(null);
-    setTopics((prev) => (prev.length <= 1 ? prev : prev.filter((_, idx) => idx !== i)));
+    setTopics((prev) => prev.filter((_, idx) => idx !== i));
+    focusAudience(Math.max(0, i - 1)); // fall back to the previous row
   }
 
   async function handleSubmit() {
@@ -146,13 +155,13 @@ function GeneratePagesDialogBody({
       await onGenerate(payload);
       onClose();
     } catch (e) {
-      // Turn the API's SEGMENTS_REQUIRED into an inline hint rather than a toast:
-      // it means this (non-platform) business must name at least one topic.
-      const code = (e as { code?: string } | null)?.code;
-      if (code === "SEGMENTS_REQUIRED") {
+      // Turn the API's SEGMENTS_REQUIRED into an inline hint rather than a toast: it
+      // means this (non-platform) business must name at least one topic. Any other
+      // failure gets a friendly generic — never surface a raw backend/AI message.
+      if (e instanceof ApiError && e.code === "SEGMENTS_REQUIRED") {
         setError("Add at least one topic — tell us who your pages should be for.");
       } else {
-        setError(e instanceof Error ? e.message : "Couldn't start generating. Please try again.");
+        setError("Couldn't start generating your pages. Please try again.");
       }
       setSubmitting(false);
     }
@@ -165,6 +174,10 @@ function GeneratePagesDialogBody({
   return (
     <DialogContent
       className="sm:max-w-lg"
+      // No built-in X — its DialogPrimitive.Close bypasses the `block` guards below
+      // (Radix fires onOpenChange directly), which would unmount mid-submit and
+      // silently swallow an in-flight failure. Cancel is the close affordance.
+      showCloseButton={false}
       onEscapeKeyDown={block}
       onPointerDownOutside={block}
       onInteractOutside={block}
@@ -236,6 +249,12 @@ function GeneratePagesDialogBody({
         {(error || typedButUnusable) && (
           <p className="text-sm text-destructive" role="alert">
             {error ?? "Please use letters or numbers to describe who a topic is for."}
+          </p>
+        )}
+        {!error && !typedButUnusable && droppedCount > 0 && (
+          <p className="text-sm text-amber-700 dark:text-amber-400" role="alert">
+            {droppedCount === 1 ? "1 topic needs" : `${droppedCount} topics need`} letters or numbers
+            to describe who they&apos;re for, and {droppedCount === 1 ? "it" : "they"} will be skipped.
           </p>
         )}
       </div>

--- a/src/app/(site)/dashboard/pages/page.tsx
+++ b/src/app/(site)/dashboard/pages/page.tsx
@@ -1,18 +1,20 @@
 "use client";
 
+import { useState } from "react";
 import { FileStack, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { useAuth } from "@/providers/auth-provider";
-import { ApiError } from "@/lib/api";
 import {
   usePendingWebPages,
   useGenerateWebPages,
   type GenerateResult,
+  type GenerateSegmentInput,
 } from "@/hooks/use-web-pages";
 import { WebPageRow } from "./components/web-page-row";
+import { GeneratePagesDialog } from "./components/generate-pages-dialog";
 
 /** Turn a generate result into one plain-language toast line. */
 function summarize(r: GenerateResult): { kind: "success" | "info"; msg: string } {
@@ -35,20 +37,17 @@ export default function PagesDashboard() {
   const { business, isLoading: authLoading } = useAuth();
   const pending = usePendingWebPages();
   const generate = useGenerateWebPages();
+  const [generateOpen, setGenerateOpen] = useState(false);
 
-  async function onGenerate() {
-    try {
-      const res = await generate.mutateAsync(undefined);
-      const { kind, msg } = summarize(res);
-      if (kind === "success") toast.success(msg);
-      else toast.info(msg);
-    } catch (e) {
-      if (e instanceof ApiError && e.code === "SEGMENTS_REQUIRED") {
-        toast.info("Choosing your own page topics is coming soon.");
-      } else {
-        toast.error(e instanceof ApiError ? e.message : "Couldn't generate pages. Please try again.");
-      }
-    }
+  /** Runs a generate request with the owner's chosen topics. Resolves on success
+   *  (with a plain-language toast) so the dialog closes; throws on failure so the
+   *  dialog can keep itself open and show the error inline (incl. SEGMENTS_REQUIRED,
+   *  which it turns into a "name at least one topic" hint). */
+  async function runGenerate(segments?: GenerateSegmentInput[]) {
+    const res = await generate.mutateAsync(segments && segments.length > 0 ? { segments } : undefined);
+    const { kind, msg } = summarize(res);
+    if (kind === "success") toast.success(msg);
+    else toast.info(msg);
   }
 
   const rows = pending.data?.rows ?? [];
@@ -64,7 +63,7 @@ export default function PagesDashboard() {
             approve to publish — nothing goes live until you say so.
           </p>
         </div>
-        <Button onClick={onGenerate} disabled={generate.isPending || !business}>
+        <Button onClick={() => setGenerateOpen(true)} disabled={generate.isPending || !business}>
           <Sparkles className="size-4" aria-hidden="true" />
           {generate.isPending ? "Writing pages…" : "Generate pages"}
         </Button>
@@ -99,7 +98,7 @@ export default function PagesDashboard() {
             icon={FileStack}
             title="No pages to review"
             description="Generate pages to get started. They'll appear here for you to read and approve."
-            action={{ label: "Generate pages", onClick: onGenerate }}
+            action={{ label: "Generate pages", onClick: () => setGenerateOpen(true) }}
           />
         ) : (
           <div className="space-y-3">
@@ -114,6 +113,8 @@ export default function PagesDashboard() {
           </div>
         )}
       </section>
+
+      <GeneratePagesDialog open={generateOpen} onOpenChange={setGenerateOpen} onGenerate={runGenerate} />
     </div>
   );
 }

--- a/src/hooks/use-web-pages.ts
+++ b/src/hooks/use-web-pages.ts
@@ -72,6 +72,14 @@ export interface GenerateResult {
   outcomes: GenerateOutcome[];
 }
 
+/** A page target the owner supplies from the b2c segment picker. Mirrors the subset
+ *  of the API's zSegment the UI sends; the server derives/defaults the rest. */
+export interface GenerateSegmentInput {
+  industry: string;
+  industryLabel: string;
+  segmentSummary?: string;
+}
+
 export interface PublishResult {
   pageId: string;
   slug: string;
@@ -114,7 +122,7 @@ export function useWebPageDraft(id: string | null | undefined) {
 export function useGenerateWebPages() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body?: { segments?: unknown[]; dryRun?: boolean }) =>
+    mutationFn: (body?: { segments?: GenerateSegmentInput[]; dryRun?: boolean }) =>
       api.post<GenerateResult>("/v1/content/web-pages/generate", body ?? {}),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: webPagesKeys.all }),
   });


### PR DESCRIPTION
## What

Replaces the **"coming soon"** toast on the Pages dashboard (`/dashboard/pages`) with a real **segment-input dialog**, so any business — not just the internal platform org — can generate landing pages targeted at its own audiences.

The API (`POST /v1/content/web-pages/generate` with `segments[]`, validated by `zSegment`) already shipped; this is the b2c UI that was the only remaining gap (previously a `SEGMENTS_REQUIRED` → "coming soon" dead end).

## Changes (b2c only)

- **New `GeneratePagesDialog`** — the owner adds **1–4 "page topics"**, each an **Audience** (required, → `industryLabel` + a client-derived kebab `industry` key via `slugify`) plus an optional **focus note** (→ `segmentSummary`). Owner-facing, non-technical copy (no "segment"/"pillar"/collection names). Field caps mirror the API's `zSegment`. Follows the `RejectReasonDialog` idiom: controlled open, inner body mounted only while open (state resets on close, no `useEffect`), dialog dismissal blocked while a submit is in flight.
- **`page.tsx`** — the header button and the empty-state action now open the dialog. `runGenerate` summarizes on success (plain-language toast) and **re-throws on failure** so the dialog surfaces the error inline — `SEGMENTS_REQUIRED` becomes an inline "name at least one topic" hint instead of a toast.
- **`use-web-pages.ts`** — typed `GenerateSegmentInput` instead of `unknown[]`.

## Behavior

| Case | Before | After |
|------|--------|-------|
| Internal platform org, no topics | seed-default set | **unchanged** — seed-default set |
| Customer, no topics | dead "coming soon" toast | inline "name at least one topic" hint |
| Customer, typed topics | (not possible) | `segments[]` sent → pages generated |

**Seed-default preserved:** submitting with no topics sends no `segments`, so the platform org still falls back to its seed set; the headless `npm run generate:platform-pages` script is untouched.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npm run build` — success (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)