### PR TITLE
feat(billing): handle "invoice_required" checkout mode (Phase 4)

### DIFF
--- a/src/components/upgrade/upgrade-plan-dialog.tsx
+++ b/src/components/upgrade/upgrade-plan-dialog.tsx
@@ -88,13 +88,24 @@ export function UpgradePlanDialog({
   // UI: the saved mandate was used, so we just confirm + refresh.
   const checkoutMut = useMutation({
     mutationFn: (tier: string) =>
-      api.post<CheckoutResult | { mode: "added"; tier: string; tierLabel?: string }>(
-        "/v1/billing/checkout",
-        { tier },
-      ),
+      api.post<
+        | CheckoutResult
+        | { mode: "added"; tier: string; tierLabel?: string }
+        | { mode: "invoice_required"; tier: string; tierLabel?: string }
+      >("/v1/billing/checkout", { tier }),
     onSuccess: (res) => {
       if (res && "mode" in res && res.mode === "added") {
         toast.success(`${res.tierLabel || res.tier} added to your subscription`);
+        onOpenChange(false);
+        onPurchased?.();
+        return;
+      }
+      // India RBI: a total above the auto-mandate cap (₹1L) can't be auto-debited,
+      // so it's billed by invoice instead of opening a payment surface.
+      if (res && "mode" in res && res.mode === "invoice_required") {
+        toast.success(`${res.tierLabel || res.tier} — we'll email you an invoice to pay`, {
+          description: "This plan is billed by invoice (bank rules cap auto-debit amounts).",
+        });
         onOpenChange(false);
         onPurchased?.();
         return;


### PR DESCRIPTION
India RBI: a consolidated total above the auto-mandate cap (₹1L) can't be auto-debited, so `/billing/checkout` returns `{ mode:"invoice_required" }` instead of a Razorpay payment surface. Shows a "we'll email you an invoice" confirmation (no overlay). Pairs with peakhour-api Phase 4.

- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)