### PR TITLE
fix(x-ads): send accountId when changing a campaign's status

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/x-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/x-ads-panel.tsx
@@ -267,9 +267,10 @@ function ConnectedView({ channelKey }: { channelKey: AdsChannelKey }) {
   }
 
   // A failed fetch is NOT "no ad accounts". /ad-accounts requires a connection
-  // with status "active", so a stale (needs_reauth) connection 404s here — and
-  // any upstream X error 400s — both of which used to render as "your X account
-  // doesn't have any ad accounts", sending the user to ads.x.com for nothing.
+  // with status "active", so a stale (needs_reauth) connection fails here with
+  // NOT_CONNECTED — as does any upstream X error — both of which used to render
+  // as "your X account doesn't have any ad accounts", sending the user to
+  // ads.x.com for nothing.
   if (accounts.isError) {
     return (
       <EmptyState

--- a/src/app/(site)/dashboard/ads/_components/x-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/x-ads-panel.tsx
@@ -353,6 +353,18 @@ function ConnectedView({ channelKey }: { channelKey: AdsChannelKey }) {
             <div className="p-5">
               <Skeleton className="h-48 w-full" />
             </div>
+          ) : campaigns.isError ? (
+            // A failed fetch is not "no campaigns". Same trap the ad-accounts
+            // list had: telling someone with live campaigns to create their
+            // first one. Reachable when the api refuses the chosen account
+            // (403) or X is briefly unavailable.
+            <div className="p-8">
+              <EmptyState
+                icon={RefreshCw}
+                title="Couldn't load campaigns"
+                description="X didn't return this account's campaigns. Try again in a moment, or pick a different ad account."
+              />
+            </div>
           ) : (campaigns.data ?? []).length === 0 ? (
             <div className="p-8">
               <EmptyState

--- a/src/lib/api/x-ads.ts
+++ b/src/lib/api/x-ads.ts
@@ -61,16 +61,19 @@ export const xAdsApi = {
   createCampaign: (input: CreateCampaignInput) =>
     api.post<XCampaign>("/v1/x/ads/campaigns", input),
 
-  // Note: the backend resolves the ad account from the stored connection
-  // (single ad account per int_connection), so accountId isn't part of the
-  // request body. We still take it as a parameter so callers stay symmetric
-  // with the rest of this surface.
+  // accountId IS sent: an X user can have several ad accounts, and the api
+  // used to fall back to whichever one was stored at connect time — so pausing
+  // or activating a campaign could hit an account the operator wasn't looking
+  // at. The api validates it and still falls back when it's absent.
   setCampaignStatus: (
-    _accountId: string,
+    accountId: string,
     campaignId: string,
     status: "ACTIVE" | "PAUSED"
   ) =>
-    api.patch<unknown>(`/v1/x/ads/campaigns/${campaignId}/status`, { status }),
+    api.patch<unknown>(`/v1/x/ads/campaigns/${campaignId}/status`, {
+      accountId,
+      status,
+    }),
 
   analytics: (params: {
     accountId: string;


### PR DESCRIPTION
Client half of [peakhour-api#956](https://github.com/travelxp/peakhour-api/pull/956).

`setCampaignStatus` took `_accountId` and dropped it, with a comment claiming the backend resolved the account itself. That comment described a bug: the api fell back to whichever account was stored at connect time, so pausing or activating a campaign could hit an account the operator wasn't looking at.

Only this call needed changing — `listCampaigns`, `listFundingInstruments`, `analytics` and `createCampaign` already sent `accountId` and were simply being ignored server-side.

Safe to merge in either order: the api validates the field and still falls back when it's absent.

Verified: `tsc --noEmit` clean, 82/82 tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)