### PR TITLE
feat(billing): billing page shows the subscription, not a tier key

### DIFF
--- a/src/app/(site)/dashboard/settings/billing/page.tsx
+++ b/src/app/(site)/dashboard/settings/billing/page.tsx
@@ -19,7 +19,23 @@ import { useQueryClient } from "@tanstack/react-query";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { TaxAndInvoices } from "@/components/settings-tax-invoices";
 import { UpgradePlanDialog } from "@/components/upgrade/upgrade-plan-dialog";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useBillingSummary, BILLING_SUMMARY_KEY } from "@/hooks/use-billing-summary";
+
+/** Money in the buyer's own currency. Falls back to "CUR 1499" when Intl can't
+ *  resolve the code, so a price never renders as a bare number. */
+function money(amount: number, currency: string | null): string {
+  if (!currency) return String(amount);
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount}`;
+  }
+}
 
 // Mirrors the navbar PlanBadge tier accents so plan presentation stays
 // consistent across surfaces.
@@ -39,8 +55,18 @@ export default function BillingPage() {
   const queryClient = useQueryClient();
   const { formatDate } = useLocale();
   const { data: details, isLoading } = useDashboardOrg();
+  const { data: summary } = useBillingSummary();
   const extend = useExtendTrial();
   const [upgradeOpen, setUpgradeOpen] = useState(false);
+
+  // Both billing reads must move together. The page states a combined total and a
+  // next-charge date from /billing/summary alongside the product list from
+  // /dashboard/org — refreshing one without the other shows a new product against
+  // a stale total, which is worse than showing neither.
+  const refreshBilling = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ["/v1/dashboard/org"] });
+    void queryClient.invalidateQueries({ queryKey: [BILLING_SUMMARY_KEY] });
+  }, [queryClient]);
 
   // Reconcile-on-return: Stripe embedded Checkout redirects back to
   // ?checkout=success&session_id=cs_… the instant the session completes — often
@@ -83,18 +109,16 @@ export default function BillingPage() {
       } catch {
         // Best-effort: the webhook remains the backstop. Never alarm the buyer.
       } finally {
-        void queryClient.invalidateQueries({ queryKey: ["/v1/dashboard/org"] });
+        refreshBilling();
         stripParams();
       }
     })();
-  }, [queryClient]);
+  }, [refreshBilling]);
 
   const cronToolbar = (
     <CronToolbar
       crons={["trial-expiry-sweep"]}
-      onTriggered={() =>
-        queryClient.invalidateQueries({ queryKey: ["/v1/dashboard/org"] })
-      }
+      onTriggered={refreshBilling}
     />
   );
 
@@ -114,6 +138,10 @@ export default function BillingPage() {
   // but kept on the response for old consumers).
   const plan = details?.subscription?.plan ?? details?.billing?.plan ?? "free";
   const planClass = PLAN_STYLES[plan] ?? PLAN_STYLES.free;
+  // Prefer the server-resolved NAME. `plan` is a machine tier key, and this badge
+  // used to render it under `capitalize` — which is how customers came to see
+  // "Commerce_assistant.Free" as their plan name.
+  const planLabel = details?.subscription?.planName ?? plan;
   const trialActive = details?.subscription?.trialActive === true;
   const trialDays = details?.subscription?.trialDaysRemaining ?? 0;
   const trialEndsAt = details?.subscription?.trialEndsAt
@@ -126,6 +154,12 @@ export default function BillingPage() {
   // base plan can be Free while the org owns a purchased product (e.g. Commerce
   // Assistant) — without this, the page reads "Free" and prompts a re-purchase.
   const products = details?.products ?? [];
+  const hasProducts = products.length > 0;
+  // Per-product price / renewal, keyed by tier, so each row can show what it
+  // costs rather than just that it exists.
+  const priceByTier = new Map(
+    (summary?.products ?? []).map((p) => [p.tier ?? "", p]),
+  );
 
   const handleExtend = () => {
     extend.mutate(undefined, {
@@ -168,16 +202,22 @@ export default function BillingPage() {
       </div>
 
       <div className="max-w-3xl space-y-6">
-        {/* Current plan card */}
+        {/* Your subscription — ONE subscription, N products, one charge.
+            This card used to read "Current Plan: {tier key}", which showed
+            customers "Commerce_assistant.Free" and said nothing about the paid
+            products they actually hold. The headline is now what they are
+            charged; the base plan is a footnote. */}
         <div className="rounded-2xl border bg-muted/30 px-5 pt-4 pb-5">
           <div className="flex flex-col justify-between gap-2 sm:flex-row sm:items-center mb-4">
             <div className="flex items-center gap-2">
-              <h3 className="font-semibold">Current Plan</h3>
+              <h3 className="font-semibold">
+                {hasProducts ? "Your subscription" : "Current Plan"}
+              </h3>
               <Badge
                 variant="secondary"
-                className={cn("font-medium capitalize", planClass)}
+                className={cn("font-medium", planClass)}
               >
-                {plan}
+                {planLabel}
               </Badge>
               {trialActive && trialDays > 0 ? (
                 <Badge variant="outline" className="font-medium">
@@ -209,28 +249,59 @@ export default function BillingPage() {
               </Button>
             </div>
           </div>
+          {/* Fixed labels. An earlier draft flipped the first column between
+              "Monthly total" and "Organization" depending on whether a total had
+              resolved — a label that changes meaning is worse than an em dash. */}
           <div className="grid gap-3 sm:grid-cols-3">
+            <div>
+              <p className="text-xs text-muted-foreground">Monthly total</p>
+              <p className="text-sm font-medium">
+                {summary?.monthlyTotal != null
+                  ? `${money(summary.monthlyTotal, summary.currency)}${summary.monthlyTotalComplete ? "" : "+"}`
+                  : "—"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Next charge</p>
+              <p className="text-sm font-medium">
+                {summary?.nextChargeAt
+                  ? formatDate(summary.nextChargeAt)
+                  : trialActive && trialEndsAt
+                    ? formatDate(trialEndsAt.toISOString())
+                    : "—"}
+              </p>
+            </div>
             <div>
               <p className="text-xs text-muted-foreground">Organization</p>
               <p className="text-sm font-medium">{details?.name || "—"}</p>
             </div>
-            <div>
-              <p className="text-xs text-muted-foreground">Member since</p>
-              <p className="text-sm font-medium">
-                {formatDate(details?.createdAt)}
-              </p>
-            </div>
-            <div>
-              <p className="text-xs text-muted-foreground">
-                {trialActive ? "Trial ends" : "Billing cycle"}
-              </p>
-              <p className="text-sm font-medium">
-                {trialActive && trialEndsAt
-                  ? formatDate(trialEndsAt.toISOString())
-                  : "Monthly"}
-              </p>
-            </div>
           </div>
+
+          {/* The combined-charge promise, stated only when it is actually true —
+              i.e. the server confirmed every product rides one subscription. */}
+          {summary?.billedTogether && summary.monthlyTotal != null ? (
+            <p className="mt-3 text-xs text-muted-foreground">
+              All {summary.products.length} products are billed together as one
+              charge of {money(summary.monthlyTotal, summary.currency)}
+              {summary.monthlyTotalComplete ? "" : " or more"}
+              {summary.nextChargeAt ? ` on ${formatDate(summary.nextChargeAt)}` : ""}.
+              {summary.basePlanName ? ` Included plan: ${summary.basePlanName}.` : ""}
+            </p>
+          ) : null}
+
+          {/* India (RBI): a bigger COMBINED debit changes what the buyer has to do
+              each cycle. Say so before the charge, not after it fails. */}
+          {summary?.collectionTier === "afa" ? (
+            <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+              Your bank will ask you to approve each renewal, because the combined
+              amount is above the limit for automatic payments in India.
+            </p>
+          ) : summary?.collectionTier === "invoice" ? (
+            <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+              This total is above the limit for automatic payments in India, so
+              we&rsquo;ll email you an invoice to pay each cycle.
+            </p>
+          ) : null}
         </div>
 
         {/* Your products — paid products held beyond the base plan. Shown only
@@ -248,11 +319,26 @@ export default function BillingPage() {
                 >
                   <div>
                     <p className="text-sm font-medium">{p.name}</p>
-                    {p.since ? (
-                      <p className="text-xs text-muted-foreground">
-                        Since {formatDate(p.since)}
-                      </p>
-                    ) : null}
+                    <p className="text-xs text-muted-foreground">
+                      {(() => {
+                        const priced = priceByTier.get(p.tier);
+                        const cost =
+                          priced && priced.amountKnown && priced.amount != null
+                            ? `${money(priced.amount, priced.currency)}/mo`
+                            : null;
+                        // A row-level trialEndsAt means the product is granted now
+                        // and starts billing on that date — say when, so a "free"
+                        // product doesn't look permanently free.
+                        const when = p.trialEndsAt
+                          ? `Free until ${formatDate(p.trialEndsAt)}`
+                          : p.renewsAt
+                            ? `Renews ${formatDate(p.renewsAt)}`
+                            : p.since
+                              ? `Since ${formatDate(p.since)}`
+                              : null;
+                        return [cost, when].filter(Boolean).join(" · ") || "—";
+                      })()}
+                    </p>
                   </div>
                   <Badge
                     variant="outline"
@@ -358,9 +444,7 @@ export default function BillingPage() {
       <UpgradePlanDialog
         open={upgradeOpen}
         onOpenChange={setUpgradeOpen}
-        onPurchased={() =>
-          queryClient.invalidateQueries({ queryKey: ["/v1/dashboard/org"] })
-        }
+        onPurchased={refreshBilling}
       />
     </div>
   );

--- a/src/hooks/use-billing-summary.ts
+++ b/src/hooks/use-billing-summary.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+
+/**
+ * `GET /v1/billing/summary` — the ONE-SUBSCRIPTION view of what the org owns.
+ *
+ * The billing page used to render only the legacy base plan, so an org paying for
+ * three products read as "Free" with no total and no charge date. This is the
+ * server's assembled answer: every granting product with the price the CHARGE
+ * will use, the combined monthly total, whether they bill together, and when.
+ */
+
+export interface BillingSummaryProduct {
+  productKey: string | null;
+  tier: string | null;
+  /** Customer-facing plan name — never the machine tier key. */
+  name: string | null;
+  state: string | null;
+  /** Set only on a pending-attach trial: the date this product starts billing.
+   *  A gateway-native trial has none — the gateway owns that clock — so absence
+   *  does NOT mean "not trialing". */
+  trialEndsAt: string | null;
+  since: string | null;
+  renewsAt: string | null;
+  amount: number | null;
+  currency: string | null;
+  /** False when a PAID tier couldn't be priced for this country: the amount is
+   *  unknown, not zero. */
+  amountKnown: boolean;
+  interval: string;
+}
+
+export interface BillingSummary {
+  country: string;
+  basePlan: string | null;
+  basePlanName: string | null;
+  products: BillingSummaryProduct[];
+  monthlyTotal: number | null;
+  /** False when at least one product's amount is unknown — the total is a floor,
+   *  not the whole charge, and the UI must say so rather than present it as final. */
+  monthlyTotalComplete: boolean;
+  currency: string | null;
+  /** Every product rides one gateway subscription → ONE combined charge. */
+  billedTogether: boolean;
+  nextChargeAt: string | null;
+  /** India (RBI), for the COMBINED debit: "silent" auto-debit, "afa" (the buyer
+   *  authenticates every cycle), or "invoice". Null outside India. */
+  collectionTier: "silent" | "afa" | "invoice" | null;
+  paymentMethod: { gateway: string | null; status: string | null } | null;
+}
+
+export const BILLING_SUMMARY_KEY = "/v1/billing/summary";
+
+export function useBillingSummary() {
+  const { org, isAuthenticated } = useAuth();
+  return useQuery<BillingSummary>({
+    queryKey: [BILLING_SUMMARY_KEY, org?._id ?? null],
+    queryFn: () => api.get<BillingSummary>("/v1/billing/summary"),
+    enabled: isAuthenticated && !!org?._id,
+    // Matches useDashboardOrg: billing state changes rarely, and every mutation
+    // (checkout, trial start, cancel) invalidates this key explicitly.
+    staleTime: 60_000,
+  });
+}

--- a/src/hooks/use-dashboard-org.ts
+++ b/src/hooks/use-dashboard-org.ts
@@ -11,6 +11,10 @@ export interface DashboardOrgPlanSummary {
   name?: string;
   subscription?: {
     plan?: string;
+    /** Customer-facing plan name from cfg_plans. ALWAYS prefer this for display —
+     *  `plan` is a machine tier key ("commerce_assistant.free"), and rendering it
+     *  is what showed customers "Commerce_assistant.Free" as their plan name. */
+    planName?: string;
     planVersion?: number;
     trialEndsAt?: string | null;
     trialActive?: boolean;
@@ -34,6 +38,14 @@ export interface DashboardOrgPlanSummary {
     state: string;
     name: string;
     since?: string | null;
+    /** Next charge for this product. Every product on a consolidated subscription
+     *  shares one date — that shared date is what lets the page say they are
+     *  billed together. Null until a gateway event has established it. */
+    renewsAt?: string | null;
+    /** Set only on a pending-attach trial (a product added to an existing
+     *  subscription): the date it starts billing. A gateway-native trial carries
+     *  none, so absence does NOT mean "not trialing". */
+    trialEndsAt?: string | null;
   }>;
   billing?: { plan?: string };
   createdAt?: string;


### PR DESCRIPTION
Consumes the new `GET /v1/billing/summary` (peakhour-api #962).

## Before

The card read **"Current Plan: `commerce_assistant.free`"** — a machine tier key rendered under a CSS `capitalize`, so customers saw **"Commerce_assistant.Free"**. It said nothing about the paid products the org actually holds, what they cost, or when money moves.

## After

- **Plan NAME** from the server (`subscription.planName`), never the tier key.
- **Monthly total** and **Next charge** as first-class fields.
- When — and only when — the server confirms every product rides one gateway subscription, an explicit line: *"All N products are billed together as one charge of ₹X on 1 Sep."* The base plan is demoted to a footnote.
- **Per-product rows** show price and timing: `₹1,499/mo · Renews 1 Sep`, or `Free until 11 Aug` for a product still inside its trial — so a product that isn't billing yet doesn't read as permanently free.
- **India (RBI):** when the *combined* debit crosses the AFA threshold, the page says the bank will ask for approval each cycle; above the mandate cap, that it will be invoiced. That's a property of the total, so it can only be stated here — and it needs saying **before** the charge, not after one fails.

An unknown amount is never presented as zero: an incomplete total renders as `₹X+` and the combined-charge line says "or more".

Both billing reads are invalidated together through one `refreshBilling` callback. Showing a new product against a stale total is worse than showing neither.

## Review round 1

The first column flipped its label between "Monthly total" and "Organization" depending on whether a total had resolved. A label that changes meaning is worse than an em dash — labels are now fixed and "Member since" gives up its slot on the billing card.

## Verification

`tsc` clean, eslint clean.

## Depends on

- peakhour-api #962 (merged) — `/billing/summary`, `planName`, `renewsAt`
- peakhour-api #963 — fixes `billedTogether` claiming products that aren't on the subscription. **Merge that first**, or this page can overstate the combined charge for an org holding a Shopify-granted product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)