### PR TITLE
feat(billing): grouped picker, product actions, and visible orders

### DIFF
--- a/src/app/(site)/dashboard/settings/billing/page.tsx
+++ b/src/app/(site)/dashboard/settings/billing/page.tsx
@@ -20,7 +20,13 @@ import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { TaxAndInvoices } from "@/components/settings-tax-invoices";
 import { UpgradePlanDialog } from "@/components/upgrade/upgrade-plan-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useBillingSummary, BILLING_SUMMARY_KEY } from "@/hooks/use-billing-summary";
+import {
+  useBillingSummary,
+  useBillingOrders,
+  useCancelProduct,
+  BILLING_SUMMARY_KEY,
+  BILLING_ORDERS_KEY,
+} from "@/hooks/use-billing-summary";
 
 /** Money in the buyer's own currency. Falls back to "CUR 1499" when Intl can't
  *  resolve the code, so a price never renders as a bare number. */
@@ -56,6 +62,8 @@ export default function BillingPage() {
   const { formatDate } = useLocale();
   const { data: details, isLoading } = useDashboardOrg();
   const { data: summary } = useBillingSummary();
+  const { data: orders } = useBillingOrders();
+  const cancelProduct = useCancelProduct();
   const extend = useExtendTrial();
   const [upgradeOpen, setUpgradeOpen] = useState(false);
 
@@ -66,6 +74,7 @@ export default function BillingPage() {
   const refreshBilling = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ["/v1/dashboard/org"] });
     void queryClient.invalidateQueries({ queryKey: [BILLING_SUMMARY_KEY] });
+    void queryClient.invalidateQueries({ queryKey: [BILLING_ORDERS_KEY] });
   }, [queryClient]);
 
   // Reconcile-on-return: Stripe embedded Checkout redirects back to
@@ -155,6 +164,9 @@ export default function BillingPage() {
   // Assistant) — without this, the page reads "Free" and prompts a re-purchase.
   const products = details?.products ?? [];
   const hasProducts = products.length > 0;
+  // Paid vs free matters for the headline: an org can hold a free floor product
+  // (the Shopify claim grant) without having bought anything.
+  const paidCount = products.filter((p) => !p.tier.endsWith(".free")).length;
   // Per-product price / renewal, keyed by tier, so each row can show what it
   // costs rather than just that it exists.
   const priceByTier = new Map(
@@ -213,12 +225,29 @@ export default function BillingPage() {
               <h3 className="font-semibold">
                 {hasProducts ? "Your subscription" : "Current Plan"}
               </h3>
-              <Badge
-                variant="secondary"
-                className={cn("font-medium", planClass)}
-              >
-                {planLabel}
-              </Badge>
+              {/* The badge has to describe what they OWN. It rendered the BASE
+                  plan unconditionally, so an org holding two paid products was
+                  still labelled "Peakhour.ai Content: Free" — reported by the team
+                  as the heading being wrong after buying two plans. The base plan
+                  is a floor, not the headline; once any product is held it moves
+                  to the footnote line below. */}
+              {hasProducts ? (
+                <Badge
+                  variant="secondary"
+                  className="font-medium bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300"
+                >
+                  {paidCount > 0
+                    ? `${paidCount} paid ${paidCount === 1 ? "product" : "products"}`
+                    : `${products.length} ${products.length === 1 ? "product" : "products"}`}
+                </Badge>
+              ) : (
+                <Badge
+                  variant="secondary"
+                  className={cn("font-medium", planClass)}
+                >
+                  {planLabel}
+                </Badge>
+              )}
               {trialActive && trialDays > 0 ? (
                 <Badge variant="outline" className="font-medium">
                   Trial · {trialDays}d left
@@ -285,7 +314,17 @@ export default function BillingPage() {
               charge of {money(summary.monthlyTotal, summary.currency)}
               {summary.monthlyTotalComplete ? "" : " or more"}
               {summary.nextChargeAt ? ` on ${formatDate(summary.nextChargeAt)}` : ""}.
-              {summary.basePlanName ? ` Included plan: ${summary.basePlanName}.` : ""}
+            </p>
+          ) : null}
+
+          {/* The base plan, demoted. Shown whenever products exist — the
+              combined-charge line above only renders when everything genuinely
+              rides one subscription, so tying the footnote to it meant an org
+              with a Shopify-granted product saw its included plan nowhere at all
+              after the badge stopped showing it. */}
+          {hasProducts && (summary?.basePlanName || planLabel) ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Included plan: {summary?.basePlanName ?? planLabel}
             </p>
           ) : null}
 
@@ -340,6 +379,10 @@ export default function BillingPage() {
                       })()}
                     </p>
                   </div>
+                  {/* State stays a chip, but it is no longer the ONLY thing here:
+                      the team reported the badges as "not editable" — there was
+                      nothing to act on. Actions sit beside it. */}
+                  <div className="flex items-center gap-2">
                   <Badge
                     variant="outline"
                     className={cn(
@@ -353,6 +396,59 @@ export default function BillingPage() {
                   >
                     {p.state === "trial" ? "Trial" : p.state}
                   </Badge>
+                    {/* A FREE tier upgrades rather than cancels — offering
+                        "Cancel" on something that costs nothing is noise, and the
+                        server would refuse it anyway. */}
+                    {p.tier.endsWith(".free") ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setUpgradeOpen(true)}
+                      >
+                        Upgrade
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-muted-foreground hover:text-destructive"
+                        disabled={cancelProduct.isPending}
+                        onClick={() => {
+                          if (!p.productKey) return;
+                          const label = p.name || p.tier;
+                          // Removing a paid product stops access and changes what
+                          // they pay — confirm before, not a toast after.
+                          if (
+                            !window.confirm(
+                              `Cancel ${label}? You'll keep access until the end of the current period, and your monthly total will drop.`,
+                            )
+                          ) {
+                            return;
+                          }
+                          cancelProduct.mutate(p.productKey, {
+                            onSuccess: () => {
+                              toast.success(`${label} cancelled`, {
+                                description:
+                                  "Your subscription and monthly total have been updated.",
+                              });
+                              refreshBilling();
+                            },
+                            onError: (err: Error) => {
+                              // The server refuses a Shopify-billed product on
+                              // purpose — surfacing its message tells the merchant
+                              // WHERE to cancel instead of failing blankly.
+                              toast.error("Couldn't cancel", {
+                                description:
+                                  err.message ?? "Please try again or contact support.",
+                              });
+                            },
+                          });
+                        }}
+                      >
+                        {cancelProduct.isPending ? "Cancelling…" : "Cancel"}
+                      </Button>
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -436,6 +532,48 @@ export default function BillingPage() {
             </Button>
           </CardContent>
         </Card>
+
+        {/* Orders — the confirmations a purchase produces IMMEDIATELY.
+            These exist because a tax invoice legally cannot: with a 14-day trial
+            on every plan, the first charge (and so the first invoice) is two
+            weeks out, and until now the customer saw only an empty Invoices
+            table and concluded nothing had happened. */}
+        {orders && orders.length > 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Orders</CardTitle>
+              <CardDescription>
+                Confirmations of changes to your subscription. Your tax invoice is
+                issued separately, when a payment is actually taken.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2">
+                {orders.map((o) => (
+                  <li
+                    key={o._id}
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-background px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium">
+                        {o.lines.map((l) => l.name).join(" + ") || o.tier}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatDate(o.issuedAt)} · {o.orderNumber}
+                        {o.firstChargeAt
+                          ? ` · first charge ${formatDate(o.firstChargeAt)}`
+                          : ""}
+                      </p>
+                    </div>
+                    <span className="text-sm font-medium tabular-nums">
+                      {money(Number(o.monthlyTotal), o.currency)}/mo
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ) : null}
 
         {/* Tax details + self-issued invoices */}
         <TaxAndInvoices />

--- a/src/app/(site)/dashboard/settings/billing/page.tsx
+++ b/src/app/(site)/dashboard/settings/billing/page.tsx
@@ -169,6 +169,10 @@ export default function BillingPage() {
   const paidCount = products.filter((p) => !p.tier.endsWith(".free")).length;
   // Per-product price / renewal, keyed by tier, so each row can show what it
   // costs rather than just that it exists.
+  // WHICH product is cancelling. One mutation instance is shared by every row, so
+  // keying the pending state off isPending alone put "Cancelling…" on all of them
+  // and disabled the lot while one was in flight.
+  const cancellingKey = cancelProduct.isPending ? cancelProduct.variables : null;
   const priceByTier = new Map(
     (summary?.products ?? []).map((p) => [p.tier ?? "", p]),
   );
@@ -412,7 +416,7 @@ export default function BillingPage() {
                         variant="ghost"
                         size="sm"
                         className="text-muted-foreground hover:text-destructive"
-                        disabled={cancelProduct.isPending}
+                        disabled={cancellingKey === p.productKey}
                         onClick={() => {
                           if (!p.productKey) return;
                           const label = p.name || p.tier;
@@ -445,7 +449,7 @@ export default function BillingPage() {
                           });
                         }}
                       >
-                        {cancelProduct.isPending ? "Cancelling…" : "Cancel"}
+                        {cancellingKey === p.productKey ? "Cancelling…" : "Cancel"}
                       </Button>
                     )}
                   </div>

--- a/src/components/upgrade/upgrade-plan-dialog.tsx
+++ b/src/components/upgrade/upgrade-plan-dialog.tsx
@@ -44,11 +44,26 @@ interface PurchasablePlan {
    *  ever). The trial always collects a card — it runs at the gateway and defers
    *  the first charge; it never skips payment details. */
   trialApplies: boolean;
+  /** Priced at 0 WITH a tagline — talk to sales, not a buy button. */
+  contactSales?: boolean;
+  /** Spans more than one product (Agency/Enterprise). */
+  bundle?: boolean;
+  /** 0..100 from the org's connected integrations; 0 = not recommended. */
+  recommendScore?: number;
+  /** e.g. "Works with your Shopify" — the WHY behind the badge. */
+  recommendReason?: string;
 }
 interface PlansResponse {
   country: string;
   purchasable: boolean;
   plans: PurchasablePlan[];
+  /** Server-side grouping. Optional so an older api keeps working — the
+   *  component falls back to deriving the groups from the flat list. */
+  groups?: {
+    recommended: PurchasablePlan[];
+    others: PurchasablePlan[];
+    bundles: PurchasablePlan[];
+  };
 }
 
 function formatPrice(amount: number, currency: string): string {
@@ -147,6 +162,42 @@ export function UpgradePlanDialog({
   const selectedPlan = plans.find((p) => p.tier === selected) ?? null;
   const busy = checkoutMut.isPending;
 
+  // Three sections answering three different questions: what should I add next,
+  // what else exists, and what if I've outgrown per-product pricing. Bundles are
+  // SEPARATED rather than sorted down — Agency at ₹24,999 next to a ₹1,499
+  // product reads as a mistake rather than a choice, which is what the team saw
+  // when everything shared one flat grid.
+  //
+  // The server groups; this falls back to deriving them so an older api (or a
+  // cached response) still renders something sensible instead of nothing.
+  const groups = plansQ.data?.groups ?? {
+    recommended: plans.filter((p) => !p.bundle && (p.recommendScore ?? 0) > 0),
+    others: plans.filter((p) => !p.bundle && !((p.recommendScore ?? 0) > 0)),
+    bundles: plans.filter((p) => p.bundle),
+  };
+  const sections = [
+    {
+      key: "recommended",
+      title: "Recommended for you",
+      blurb: "Based on what you've already connected.",
+      items: groups.recommended,
+    },
+    {
+      key: "others",
+      // Only call them "other" when something was recommended above; with no
+      // connections there is no "other" to be other than.
+      title: groups.recommended.length > 0 ? "Other products" : "Products",
+      blurb: undefined as string | undefined,
+      items: groups.others,
+    },
+    {
+      key: "bundles",
+      title: "For larger teams",
+      blurb: "Every product in one plan — for agencies and multi-brand businesses.",
+      items: groups.bundles,
+    },
+  ];
+
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
@@ -176,71 +227,113 @@ export function UpgradePlanDialog({
               No plans available right now.
             </p>
           ) : (
-            <div className="grid gap-3 sm:grid-cols-2">
-              {plans.map((p) => {
-                const active = selected === p.tier;
-                const disabled = p.isCurrent || !purchasable;
-                return (
-                  <button
-                    key={p.tier}
-                    type="button"
-                    disabled={disabled}
-                    onClick={() => setSelected(p.tier)}
-                    className={cn(
-                      "flex flex-col rounded-lg border p-4 text-left transition",
-                      active
-                        ? "border-primary ring-1 ring-primary"
-                        : "hover:border-foreground/30",
-                      disabled && "cursor-not-allowed opacity-60",
-                    )}
-                  >
-                    {/* Header row: the badges sit INLINE beside the name rather
-                        than absolutely positioned, so a long plan name can no
-                        longer run underneath them. */}
-                    <div className="flex items-start justify-between gap-2">
-                      <span className="font-medium leading-tight">{p.name}</span>
-                      <span className="flex shrink-0 items-center gap-1">
-                        {p.recommended && (
-                          <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                            <Sparkles className="size-3" />
-                            Popular
-                          </span>
-                        )}
-                        {active && !disabled && (
-                          <Check className="size-4 text-primary" />
-                        )}
-                      </span>
+            <div className="space-y-5">
+              {sections.map((section) =>
+                section.items.length === 0 ? null : (
+                  <div key={section.key}>
+                    <div className="mb-2">
+                      <p className="text-sm font-medium">{section.title}</p>
+                      {section.blurb ? (
+                        <p className="text-xs text-muted-foreground">{section.blurb}</p>
+                      ) : null}
                     </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      {section.items.map((p) => {
+                        const active = selected === p.tier;
+                        // A contact-sales plan has nothing to select — its action
+                        // is an email, not a checkout — so it is never disabled
+                        // for being unpurchasable, only for being current.
+                        const disabled = p.isCurrent || (!purchasable && !p.contactSales);
+                        return (
+                          <button
+                            key={p.tier}
+                            type="button"
+                            disabled={disabled}
+                            onClick={() =>
+                              p.contactSales
+                                ? window.open(
+                                    `mailto:hello@peakhour.ai?subject=${encodeURIComponent(`Enquiry: ${p.name}`)}`,
+                                    "_blank",
+                                  )
+                                : setSelected(p.tier)
+                            }
+                            className={cn(
+                              "flex flex-col rounded-lg border p-4 text-left transition",
+                              active
+                                ? "border-primary ring-1 ring-primary"
+                                : "hover:border-foreground/30",
+                              disabled && "cursor-not-allowed opacity-60",
+                            )}
+                          >
+                            {/* Header row: the badges sit INLINE beside the name
+                                rather than absolutely positioned, so a long plan
+                                name can no longer run underneath them. */}
+                            <div className="flex items-start justify-between gap-2">
+                              <span className="font-medium leading-tight">{p.name}</span>
+                              <span className="flex shrink-0 items-center gap-1">
+                                {/* A reason beats a bare "Popular": the badge is
+                                    only credible if it says why. Falls back to the
+                                    static flag when nothing is connected. */}
+                                {p.recommendReason ? (
+                                  <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                                    <Sparkles className="size-3" />
+                                    For you
+                                  </span>
+                                ) : p.recommended ? (
+                                  <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                                    <Sparkles className="size-3" />
+                                    Popular
+                                  </span>
+                                ) : null}
+                                {active && !disabled && (
+                                  <Check className="size-4 text-primary" />
+                                )}
+                              </span>
+                            </div>
 
-                    {p.tagline && (
-                      <p className="mt-1 text-xs leading-snug text-muted-foreground">
-                        {p.tagline}
-                      </p>
-                    )}
+                            {p.recommendReason ? (
+                              <p className="mt-1 text-xs leading-snug text-primary">
+                                {p.recommendReason}
+                              </p>
+                            ) : p.tagline ? (
+                              <p className="mt-1 text-xs leading-snug text-muted-foreground">
+                                {p.tagline}
+                              </p>
+                            ) : null}
 
-                    {/* Price pinned to the bottom so cards of differing tagline
-                        length still line their prices up across the row. */}
-                    <div className="mt-auto pt-3">
-                      <div className="text-lg font-semibold">
-                        {formatPrice(p.amount, p.currency)}
-                        <span className="text-xs font-normal text-muted-foreground">
-                          /mo
-                        </span>
-                      </div>
-                      {p.trialDays > 0 && p.trialApplies && (
-                        <div className="text-xs text-emerald-600 dark:text-emerald-400">
-                          {p.trialDays}-day free trial · card required
-                        </div>
-                      )}
-                      {p.isCurrent && (
-                        <span className="mt-2 inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
-                          Current plan
-                        </span>
-                      )}
+                            {/* Price pinned to the bottom so cards of differing
+                                tagline length still line their prices up. */}
+                            <div className="mt-auto pt-3">
+                              <div className="text-lg font-semibold">
+                                {p.contactSales ? (
+                                  <span className="text-base">Contact sales</span>
+                                ) : (
+                                  <>
+                                    {formatPrice(p.amount, p.currency)}
+                                    <span className="text-xs font-normal text-muted-foreground">
+                                      /mo
+                                    </span>
+                                  </>
+                                )}
+                              </div>
+                              {!p.contactSales && p.trialDays > 0 && p.trialApplies && (
+                                <div className="text-xs text-emerald-600 dark:text-emerald-400">
+                                  {p.trialDays}-day free trial · card required
+                                </div>
+                              )}
+                              {p.isCurrent && (
+                                <span className="mt-2 inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                                  Current plan
+                                </span>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })}
                     </div>
-                  </button>
-                );
-              })}
+                  </div>
+                ),
+              )}
             </div>
           )}
 

--- a/src/hooks/use-billing-summary.ts
+++ b/src/hooks/use-billing-summary.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -63,5 +63,56 @@ export function useBillingSummary() {
     // Matches useDashboardOrg: billing state changes rarely, and every mutation
     // (checkout, trial start, cancel) invalidates this key explicitly.
     staleTime: 60_000,
+  });
+}
+
+/** One order confirmation — the document a purchase produces immediately, for
+ *  the window before any tax invoice can legally exist. */
+export interface OrderConfirmation {
+  _id: string;
+  orderNumber: string;
+  kind: "purchased" | "trial_started" | "added" | "upgraded" | "removed";
+  tier: string;
+  monthlyTotal: string;
+  currency: string;
+  firstChargeAt?: string | null;
+  issuedAt: string;
+  lines: Array<{ name: string; amount: string; trialEndsAt?: string | null }>;
+}
+
+export const BILLING_ORDERS_KEY = "/v1/billing/orders";
+
+/**
+ * Order confirmations for the billing page.
+ *
+ * Separate from invoices deliberately. With a 14-day trial on every plan a tax
+ * invoice cannot legally exist until the first charge, so without these the
+ * customer stares at an empty Invoices table for two weeks after a purchase that
+ * definitely happened — which is exactly what was reported.
+ */
+export function useBillingOrders() {
+  const { org, isAuthenticated } = useAuth();
+  return useQuery<OrderConfirmation[]>({
+    queryKey: [BILLING_ORDERS_KEY, org?._id ?? null],
+    queryFn: () => api.get<OrderConfirmation[]>("/v1/billing/orders"),
+    enabled: isAuthenticated && !!org?._id,
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Cancel ONE product, leaving the rest of the subscription billing.
+ *
+ * The server REFUSES a Shopify-billed product — Shopify owns that billing
+ * relationship — and returns a message saying where to cancel instead. Surface
+ * that message rather than flattening it into a generic failure.
+ */
+export function useCancelProduct() {
+  return useMutation({
+    mutationFn: (productKey: string) =>
+      api.post<{ cancelled: boolean; productKey: string }>(
+        `/v1/billing/products/${encodeURIComponent(productKey)}/cancel`,
+        {},
+      ),
   });
 }


### PR DESCRIPTION
Four of the team's post-merge findings, all on surfaces they could see. Pairs with peakhour-api #966 and peakhour-mongodb #425.

## "Your subscription — Peakhour.ai Content: Free" after buying two plans

The badge rendered the **base** plan unconditionally. The base plan is a floor, not the headline: it now moves to a footnote once anything is held, and the badge says what they actually own — *"2 paid products"*.

The footnote renders whenever products exist, **not** only when the combined-charge line does. Tying it to that line meant an org with a Shopify-granted product — which correctly fails the billed-together test — would have lost sight of its included plan entirely once the badge stopped showing it.

## "Badges in front of your product section are still not editable"

There was nothing to act on. The state chip stays, with actions beside it:

- **Cancel** on a paid product — confirmed first, because it stops access and changes what they pay
- **Upgrade** on a free tier, where offering "Cancel" on something that costs nothing is noise the server would refuse anyway

A **Shopify-billed** product is refused *by the server* with a message saying where to cancel, and that message is surfaced rather than flattened into a generic failure.

## "No separate section for agency and enterprise plan"

The picker was one flat grid. Now three groups answering three different questions: what to add next, what else exists, and what if you've outgrown per-product pricing.

Bundles are **separated, not sorted down** — Agency at ₹24,999 beside a ₹1,499 product reads as a mistake rather than a choice. **Enterprise** renders as a contact-sales card: no price, no buy button, opens an enquiry.

## "No product recommendation based on where the product is integrated from"

Cards carry a **"For you"** badge with the **reason** — *"Works with your Shopify"* — from the server's connection scoring. A reason beats a bare "Popular": the badge is only credible if it says why. Falls back to the static flag when nothing is connected, and the grouping falls back to client-side derivation so an older api still renders sensibly.

## "No change on the dashboard yet"

Largely this: the order confirmations were being written and emailed, but appeared **nowhere on the dashboard**. With a 14-day trial the tax invoice is two weeks out, so the Invoices table is legitimately empty and the customer reasonably concluded nothing happened.

An **Orders** section now lists them, and says plainly that the tax invoice is issued separately when a payment is actually taken.

## Verification

`tsc` clean, eslint clean.

## Note on invoices

*"No invoice generation"* is expected right now and not a bug: nothing has been charged yet, because every plan has a 14-day trial. The first tax invoice is issued at the first charge. The genuinely missing piece is the **consolidated multi-line** invoice (consolidation Phase 5) — today the engine writes one single-line invoice per charge event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)