### PR TITLE
feat(legal): Media Worldwide Limited as the legal entity, MoR + CMPL disclosures

### DIFF
--- a/src/app/(site)/cookie-policy/page.tsx
+++ b/src/app/(site)/cookie-policy/page.tsx
@@ -33,6 +33,12 @@ export default function CookiePolicyPage() {
               </a>
               .
             </p>
+            <p className="mt-2">
+              Outside India, {SITE.name} is marketed and provided by{" "}
+              {SITE.companyUk.legalName}, a company registered in England and Wales under
+              company number {SITE.companyUk.companyNumber}, with its registered office at{" "}
+              {SITE.companyUk.address}.
+            </p>
           </section>
 
           <section>

--- a/src/app/(site)/cookie-policy/page.tsx
+++ b/src/app/(site)/cookie-policy/page.tsx
@@ -24,8 +24,9 @@ export default function CookiePolicyPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground">1. Introduction</h2>
             <p className="mt-2">
-              This Cookie Policy explains how {SITE.company.legalName} (&quot;{SITE.name}&quot;,
-              &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) uses cookies and similar technologies on the
+              This Cookie Policy explains how {SITE.company.ref} (&quot;{SITE.name}&quot;,
+              &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) uses cookies and similar
+              technologies on the{" "}
               {SITE.name} platform (the &quot;Service&quot;). It should be read
               together with our{" "}
               <a href="/privacy-policy" className="text-foreground underline">

--- a/src/app/(site)/cookie-policy/page.tsx
+++ b/src/app/(site)/cookie-policy/page.tsx
@@ -34,10 +34,9 @@ export default function CookiePolicyPage() {
               .
             </p>
             <p className="mt-2">
-              Outside India, {SITE.name} is marketed and provided by{" "}
-              {SITE.companyUk.legalName}, a company registered in England and Wales under
-              company number {SITE.companyUk.companyNumber}, with its registered office at{" "}
-              {SITE.companyUk.address}.
+              Where you are outside India, the company responsible for your personal data may
+              instead be {SITE.companyUk.ref} — see Section 1 of our Privacy Policy. This
+              Cookie Policy applies to cookies set by the {SITE.name} platform either way.
             </p>
           </section>
 
@@ -137,10 +136,16 @@ export default function CookiePolicyPage() {
               Questions about this Cookie Policy can be sent to:
             </p>
             <p className="mt-2">
-              {SITE.company.legalName}
+              <strong>India:</strong> {SITE.company.ref}
               <br />
               {SITE.company.address}
+            </p>
+            <p className="mt-2">
+              <strong>Outside India:</strong> {SITE.companyUk.ref}
               <br />
+              {SITE.companyUk.address}
+            </p>
+            <p className="mt-2">
               Email:{" "}
               <a href={`mailto:${SITE.contactPrivacy}`} className="text-foreground underline">
                 {SITE.contactPrivacy}

--- a/src/app/(site)/data-deletion/page.tsx
+++ b/src/app/(site)/data-deletion/page.tsx
@@ -118,7 +118,7 @@ export default async function DataDeletionPage({
       <main className="mx-auto max-w-3xl px-4 py-12">
         <h1 className="text-3xl font-bold">Data Deletion</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Last updated: {SITE.legalLastUpdated}
+          Last updated: {SITE.helpLastUpdated}
         </p>
 
         {code && (

--- a/src/app/(site)/help/data-retention/page.tsx
+++ b/src/app/(site)/help/data-retention/page.tsx
@@ -25,7 +25,7 @@ export default function DataRetentionPage() {
       <main className="mx-auto max-w-3xl px-4 py-12">
         <h1 className="text-3xl font-bold">Data Retention</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Last updated: {SITE.legalLastUpdated}
+          Last updated: {SITE.helpLastUpdated}
         </p>
 
         <div className="mt-8 space-y-8 text-sm leading-relaxed text-muted-foreground">

--- a/src/app/(site)/privacy-policy/page.tsx
+++ b/src/app/(site)/privacy-policy/page.tsx
@@ -24,8 +24,8 @@ export default function PrivacyPolicyPage() {
             <h2 className="text-lg font-semibold text-foreground">1. Introduction</h2>
             <p className="mt-2">
               This Privacy Policy explains how {SITE.company.legalName} (&quot;{SITE.name}&quot;,
-              &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) — the company that operates the {SITE.name}{" "}
-              platform, an AI-powered marketing automation service (the
+              &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) — the companies that operate the {SITE.name}{" "}
+              platform, identified below, an AI-powered marketing automation service (the
               &quot;Service&quot;) — collects, uses, discloses, and safeguards your information when
               you use our website and services.
             </p>
@@ -43,8 +43,8 @@ export default function PrivacyPolicyPage() {
               same legal name — their country of incorporation and registration number
               distinguish them. Where the England and Wales company provides the Service to
               you, it is the GDPR &quot;controller&quot; of your personal data and your
-              contracting counterparty; references in this Policy to the company responsible
-              for your data mean that entity.
+              contracting counterparty, and in that case — and only in that case — references
+              in this Policy to the company responsible for your data mean that entity.
             </p>
             <p className="mt-2">
               By accessing or using the Service, you agree to this Privacy Policy. If you do
@@ -304,7 +304,9 @@ export default function PrivacyPolicyPage() {
                 companies in our group where they perform part of the Service for us — most
                 importantly Celebrities Management Private Limited, which holds the Meta and
                 LinkedIn platform API access described in Section 12 and processes the
-                associated data on our instructions under an intra-group agreement.
+                associated data on our instructions under a written intra-group agreement
+                incorporating the UK International Data Transfer Agreement / EU Standard
+                Contractual Clauses where the transfer is a restricted one.
               </li>
               <li>
                 <strong>Merchant-of-record platforms:</strong> in some countries your purchase

--- a/src/app/(site)/privacy-policy/page.tsx
+++ b/src/app/(site)/privacy-policy/page.tsx
@@ -30,19 +30,21 @@ export default function PrivacyPolicyPage() {
               you use our website and services.
             </p>
             <p className="mt-2">
-              {SITE.name} is a product of {SITE.company.legalName}, registered office at{" "}
-              {SITE.company.address}. For the EU/UK General Data Protection Regulation
-              (&quot;GDPR&quot;), {SITE.company.legalName} is the data &quot;controller&quot;; under
-              India&apos;s Digital Personal Data Protection Act, 2023 (&quot;DPDP Act&quot;), it is the
-              &quot;Data Fiduciary&quot; that determines the purpose and means of processing your
-              personal data.
+              {SITE.name} is a product of {SITE.company.ref}, registered office at{" "}
+              {SITE.company.address}. Under India&apos;s Digital Personal Data Protection Act,
+              2023 (&quot;DPDP Act&quot;), that company is the &quot;Data Fiduciary&quot; that
+              determines the purpose and means of processing your personal data, and it is the
+              data &quot;controller&quot; for the purposes of the EU/UK General Data Protection
+              Regulation (&quot;GDPR&quot;) except where the paragraph below applies.
             </p>
             <p className="mt-2">
-              Outside India, {SITE.name} is marketed and provided by{" "}
-              {SITE.companyUk.legalName}, a company registered in England and Wales under
-              company number {SITE.companyUk.companyNumber}, with its registered office at{" "}
-              {SITE.companyUk.address}. Where that entity provides the Service to you, it is
-              the GDPR &quot;controller&quot; of your personal data.
+              Outside India, {SITE.name} is marketed and provided by {SITE.companyUk.ref}, with
+              its registered office at {SITE.companyUk.address}. The two companies share the
+              same legal name — their country of incorporation and registration number
+              distinguish them. Where the England and Wales company provides the Service to
+              you, it is the GDPR &quot;controller&quot; of your personal data and your
+              contracting counterparty; references in this Policy to the company responsible
+              for your data mean that entity.
             </p>
             <p className="mt-2">
               By accessing or using the Service, you agree to this Privacy Policy. If you do
@@ -298,6 +300,13 @@ export default function PrivacyPolicyPage() {
                 .
               </li>
               <li>
+                <strong>Affiliated group companies:</strong> we share personal data with
+                companies in our group where they perform part of the Service for us — most
+                importantly Celebrities Management Private Limited, which holds the Meta and
+                LinkedIn platform API access described in Section 12 and processes the
+                associated data on our instructions under an intra-group agreement.
+              </li>
+              <li>
                 <strong>Merchant-of-record platforms:</strong> in some countries your purchase
                 is made from a third-party merchant-of-record platform that resells the Service
                 (see Section 8 of our Terms of Service). Unlike a sub-processor, such a
@@ -468,10 +477,10 @@ export default function PrivacyPolicyPage() {
               you may therefore see CMPL named on the platform&apos;s authorization screen or in
               the application&apos;s developer record. CMPL makes that platform access available
               to us under a written intra-group agreement and processes the data only on our
-              instructions, solely to deliver the integration you enabled.{" "}
-              {SITE.company.legalName} remains the controller / Data Fiduciary responsible for
-              your personal data as described in this Policy, and the rights and contacts set
-              out here apply to that data.
+              instructions, solely to deliver the integration you enabled. The {SITE.name}{" "}
+              entity identified in Section 1 remains the controller / Data Fiduciary
+              responsible for your personal data as described in this Policy, and the rights
+              and contacts set out here apply to that data.
             </p>
 
             <h3 className="mt-4 font-medium text-foreground">12.1 Meta Platform (Facebook, Instagram, Ads, WhatsApp)</h3>
@@ -515,7 +524,6 @@ export default function PrivacyPolicyPage() {
             <p className="mt-2">
               Our use of LinkedIn data complies with the LinkedIn API Terms of Use and is
               limited to the authorized purposes for which you connected your LinkedIn account.
-              LinkedIn API access is held by CMPL as described above.
             </p>
 
             <h3 className="mt-4 font-medium text-foreground">12.5 Microsoft and other providers</h3>
@@ -650,10 +658,16 @@ export default function PrivacyPolicyPage() {
               If you have questions about this Privacy Policy or our data practices, contact:
             </p>
             <p className="mt-2">
-              {SITE.company.legalName}
+              <strong>India:</strong> {SITE.company.ref}
               <br />
               {SITE.company.address}
+            </p>
+            <p className="mt-2">
+              <strong>Outside India:</strong> {SITE.companyUk.ref}
               <br />
+              {SITE.companyUk.address}
+            </p>
+            <p className="mt-2">
               Privacy:{" "}
               <a href={`mailto:${SITE.contactPrivacy}`} className="text-foreground underline">
                 {SITE.contactPrivacy}

--- a/src/app/(site)/privacy-policy/page.tsx
+++ b/src/app/(site)/privacy-policy/page.tsx
@@ -38,6 +38,13 @@ export default function PrivacyPolicyPage() {
               personal data.
             </p>
             <p className="mt-2">
+              Outside India, {SITE.name} is marketed and provided by{" "}
+              {SITE.companyUk.legalName}, a company registered in England and Wales under
+              company number {SITE.companyUk.companyNumber}, with its registered office at{" "}
+              {SITE.companyUk.address}. Where that entity provides the Service to you, it is
+              the GDPR &quot;controller&quot; of your personal data.
+            </p>
+            <p className="mt-2">
               By accessing or using the Service, you agree to this Privacy Policy. If you do
               not agree, please do not use the Service.
             </p>
@@ -58,7 +65,8 @@ export default function PrivacyPolicyPage() {
               </li>
               <li>
                 <strong>Payment information:</strong> billing details processed through our
-                third-party payment processor (Stripe). We do not store full credit card numbers.
+                third-party payment providers, which vary by country. We do not store full
+                credit card numbers.
               </li>
               <li>
                 <strong>Content:</strong> newsletters, articles, and other content you upload
@@ -278,8 +286,8 @@ export default function PrivacyPolicyPage() {
               <li>
                 <strong>Service providers (sub-processors):</strong> vetted third-party
                 vendors that help us operate the Service — including cloud hosting,
-                database and object storage, AI/ML model providers, payment processing
-                (Stripe), and transactional email delivery. These providers act on our
+                database and object storage, AI/ML model providers, payment processing,
+                and transactional email delivery. These providers act on our
                 instructions under written contracts (including data-processing terms and,
                 where applicable, Standard Contractual Clauses) that require them to protect
                 your data and use it only to provide their service to us. A current list of
@@ -288,6 +296,17 @@ export default function PrivacyPolicyPage() {
                   {SITE.contactPrivacy}
                 </a>
                 .
+              </li>
+              <li>
+                <strong>Merchant-of-record platforms:</strong> in some countries your purchase
+                is made from a third-party merchant-of-record platform that resells the Service
+                (see Section 8 of our Terms of Service). Unlike a sub-processor, such a
+                platform is an{" "}
+                <strong>independent controller</strong> of the payment and tax data it collects
+                from you, and processes it under its own privacy policy for its own billing,
+                fraud-prevention and tax-compliance purposes. We receive only the transaction
+                and settlement records we need to provision your subscription and keep our
+                books.
               </li>
               <li>
                 <strong>Connected platforms:</strong> when you authorize us to publish
@@ -439,6 +458,22 @@ export default function PrivacyPolicyPage() {
               integration, close your account, or ask us to.
             </p>
 
+            <p className="mt-2">
+              <strong>Platform API access held by an affiliated company.</strong> Access to the
+              Meta developer platform (including WhatsApp Business) and the LinkedIn developer
+              platform is held in the name of{" "}
+              <strong>Celebrities Management Private Limited (&quot;CMPL&quot;)</strong>, an
+              affiliated company within our group, which is the entity those platforms approved
+              as developer and technology provider. When you connect a Meta or LinkedIn account
+              you may therefore see CMPL named on the platform&apos;s authorization screen or in
+              the application&apos;s developer record. CMPL makes that platform access available
+              to us under a written intra-group agreement and processes the data only on our
+              instructions, solely to deliver the integration you enabled.{" "}
+              {SITE.company.legalName} remains the controller / Data Fiduciary responsible for
+              your personal data as described in this Policy, and the rights and contacts set
+              out here apply to that data.
+            </p>
+
             <h3 className="mt-4 font-medium text-foreground">12.1 Meta Platform (Facebook, Instagram, Ads, WhatsApp)</h3>
             <p className="mt-2">
               Our use and transfer of information received from Meta APIs adheres to the{" "}
@@ -480,6 +515,7 @@ export default function PrivacyPolicyPage() {
             <p className="mt-2">
               Our use of LinkedIn data complies with the LinkedIn API Terms of Use and is
               limited to the authorized purposes for which you connected your LinkedIn account.
+              LinkedIn API access is held by CMPL as described above.
             </p>
 
             <h3 className="mt-4 font-medium text-foreground">12.5 Microsoft and other providers</h3>

--- a/src/app/(site)/terms/page.tsx
+++ b/src/app/(site)/terms/page.tsx
@@ -340,8 +340,11 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold text-foreground">10. Intellectual Property</h2>
             <p className="mt-2">
               The Service, including its design, features, code, AI models, and documentation,
-              is owned by Peakhour.ai and protected by intellectual property laws. Nothing in
-              these Terms grants you any right to our trademarks, logos, or brand assets.
+              is owned by, or licensed to us by, companies within our group — including
+              Celebrities Management Private Limited, which holds the {SITE.name} trademark and
+              software intellectual property — and is protected by intellectual property laws.
+              Nothing in these Terms grants you any right to our trademarks, logos, or brand
+              assets.
             </p>
           </section>
 
@@ -363,15 +366,16 @@ export default function TermsPage() {
           <section>
             <h2 className="text-lg font-semibold text-foreground">12. Limitation of Liability</h2>
             <p className="mt-2">
-              TO THE MAXIMUM EXTENT PERMITTED BY LAW, PEAKHOUR SHALL NOT BE LIABLE FOR ANY
+              TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE COMPANY SHALL NOT BE LIABLE FOR ANY
               INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING
               BUT NOT LIMITED TO LOSS OF PROFITS, DATA, OR BUSINESS OPPORTUNITIES, ARISING
               OUT OF OR RELATED TO YOUR USE OF THE SERVICE.
             </p>
             <p className="mt-2">
               OUR TOTAL AGGREGATE LIABILITY FOR ALL CLAIMS ARISING FROM OR RELATED TO THE
-              SERVICE SHALL NOT EXCEED THE AMOUNT YOU PAID US IN THE 12 MONTHS PRECEDING THE
-              CLAIM.
+              SERVICE SHALL NOT EXCEED THE AMOUNT YOU PAID FOR THE SERVICE IN THE 12 MONTHS
+              PRECEDING THE CLAIM, WHETHER PAID TO US DIRECTLY OR TO A MERCHANT OF RECORD ON
+              OUR BEHALF (SECTION 8).
             </p>
           </section>
 

--- a/src/app/(site)/terms/page.tsx
+++ b/src/app/(site)/terms/page.tsx
@@ -32,6 +32,14 @@ export default function TermsPage() {
               &quot;Service&quot;).
             </p>
             <p className="mt-2">
+              Outside India, {SITE.name} is marketed and provided by{" "}
+              {SITE.companyUk.legalName}, a company registered in England and Wales under
+              company number {SITE.companyUk.companyNumber}, with its registered office at{" "}
+              {SITE.companyUk.address}. Where you contract with that entity, references to
+              &quot;Company&quot;, &quot;we&quot;, &quot;us&quot; and &quot;our&quot; in these
+              Terms mean {SITE.companyUk.legalName}.
+            </p>
+            <p className="mt-2">
               By creating an account or using the Service, you agree to be bound by these
               Terms. If you do not agree, you may not use the Service. If you are using the
               Service on behalf of an organization, you represent that you have authority to
@@ -153,6 +161,14 @@ export default function TermsPage() {
                 settings. Disconnecting will stop data sync but will not delete previously
                 synced data unless you request deletion.
               </li>
+              <li>
+                Access to certain platform APIs — currently Meta (including WhatsApp Business)
+                and LinkedIn — is held in the name of Celebrities Management Private Limited, an
+                affiliated company within our group that those platforms approved as developer
+                and technology provider, and is made available to us under an intra-group
+                agreement. You may see that name on a platform&apos;s authorization screen. This
+                does not change who you contract with under these Terms.
+              </li>
             </ul>
           </section>
 
@@ -188,8 +204,21 @@ export default function TermsPage() {
                 change pricing with 30 days&apos; notice.
               </li>
               <li>
-                Payments are processed through Stripe. By providing payment information, you
-                agree to Stripe&apos;s terms of service.
+                Payments are processed by third-party payment providers, which vary by the
+                country you purchase from. By providing payment information, you agree to the
+                applicable provider&apos;s terms of service.
+              </li>
+              <li>
+                <strong>Seller of record.</strong> Depending on your country, your purchase is
+                made either directly from {SITE.company.legalName} or from a third-party
+                merchant-of-record (&quot;MoR&quot;) platform that resells the Service. Where an
+                MoR platform is used, that platform — not {SITE.company.legalName} — is the
+                seller of record for the transaction: it contracts with you for the sale,
+                issues your invoice or receipt, and collects and remits any applicable sales
+                tax, VAT or GST. Its own terms and privacy policy govern the payment
+                transaction, while these Terms continue to govern your use of the Service. The
+                seller of record for each purchase is identified at checkout and on the
+                invoice or receipt you receive.
               </li>
               <li>
                 All fees are non-refundable except as required by applicable law or as

--- a/src/app/(site)/terms/page.tsx
+++ b/src/app/(site)/terms/page.tsx
@@ -33,11 +33,13 @@ export default function TermsPage() {
             </p>
             <p className="mt-2">
               Outside India, {SITE.name} is marketed and provided by{" "}
-              {SITE.companyUk.legalName}, a company registered in England and Wales under
-              company number {SITE.companyUk.companyNumber}, with its registered office at{" "}
-              {SITE.companyUk.address}. Where you contract with that entity, references to
-              &quot;Company&quot;, &quot;we&quot;, &quot;us&quot; and &quot;our&quot; in these
-              Terms mean {SITE.companyUk.legalName}.
+              {SITE.companyUk.ref}, with its registered office at {SITE.companyUk.address}. The
+              two companies share the same legal name — their country of incorporation and
+              registration number distinguish them. Where you contract with the England and
+              Wales company, references to &quot;Company&quot;, &quot;we&quot;, &quot;us&quot;
+              and &quot;our&quot; in these Terms mean {SITE.companyUk.ref}, and its registered
+              office and company number above apply in place of those in the preceding
+              paragraph.
             </p>
             <p className="mt-2">
               By creating an account or using the Service, you agree to be bound by these
@@ -210,9 +212,11 @@ export default function TermsPage() {
               </li>
               <li>
                 <strong>Seller of record.</strong> Depending on your country, your purchase is
-                made either directly from {SITE.company.legalName} or from a third-party
-                merchant-of-record (&quot;MoR&quot;) platform that resells the Service. Where an
-                MoR platform is used, that platform — not {SITE.company.legalName} — is the
+                made either directly from one of the two {SITE.name} companies named in Section
+                1 (India purchases from the India company, other direct purchases from the
+                England and Wales company) or from a third-party merchant-of-record
+                (&quot;MoR&quot;) platform that resells the Service. Where an MoR platform is
+                used, that platform — not either {SITE.name} company — is the
                 seller of record for the transaction: it contracts with you for the sale,
                 issues your invoice or receipt, and collects and remits any applicable sales
                 tax, VAT or GST. Its own terms and privacy policy govern the payment
@@ -461,10 +465,16 @@ export default function TermsPage() {
               For questions about these Terms, contact us at:
             </p>
             <p className="mt-2">
-              {SITE.company.legalName}
+              <strong>India:</strong> {SITE.company.ref}
               <br />
               {SITE.company.address}
+            </p>
+            <p className="mt-2">
+              <strong>Outside India:</strong> {SITE.companyUk.ref}
               <br />
+              {SITE.companyUk.address}
+            </p>
+            <p className="mt-2">
               Email:{" "}
               <a href={`mailto:${SITE.contactLegal}`} className="text-foreground underline">
                 {SITE.contactLegal}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,11 +13,20 @@ export const SITE = {
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://peakhour.ai",
   tagline: "The AI business platform for growing brands",
   legalLastUpdated: "June 1, 2026",
-  /** Operating legal entity (data controller / data fiduciary). */
+  /** Operating legal entity for India (data controller / data fiduciary). */
   company: {
-    legalName: "Celebrities Management Private Limited",
+    legalName: "Media Worldwide Limited",
     address:
       "5th Floor, Tech Web Centre, Link Road, Oshiwara, Mumbai 400102, Maharashtra, India",
+  },
+  /** Entity that markets and contracts for Peakhour.ai outside India.
+   *  Same legal name as the India entity — the country of incorporation and the
+   *  company registration number are what distinguish the two on documents. */
+  companyUk: {
+    legalName: "Media Worldwide Limited",
+    companyNumber: "06334375",
+    address:
+      "2nd Floor, 2 Warner House, Harrovian Business Village, Bessborough Road, Harrow, Middlesex, England, HA1 3EX",
   },
   contactPrivacy: "privacy@peakhour.ai",
   contactLegal: "legal@peakhour.ai",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,18 +12,27 @@ export const SITE = {
    *  Override per-env with NEXT_PUBLIC_SITE_URL; defaults to production. */
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://peakhour.ai",
   tagline: "The AI business platform for growing brands",
-  legalLastUpdated: "June 1, 2026",
-  /** Operating legal entity for India (data controller / data fiduciary). */
+  legalLastUpdated: "July 29, 2026",
+  /** Operating legal entity for India (data controller / data fiduciary).
+   *
+   *  IMPORTANT — the India and UK entities share the SAME `legalName`. Rendering
+   *  a bare `legalName` in a sentence whose job is to IDENTIFY the entity
+   *  produces a tautology ("references to Company mean Media Worldwide Limited"
+   *  reads identically for both). Use `ref` wherever the text distinguishes one
+   *  entity from the other; `legalName` is only for prose that means "the
+   *  company", where either reading is correct. */
   company: {
     legalName: "Media Worldwide Limited",
+    /** Disambiguated form — use in any identifying sentence. */
+    ref: "Media Worldwide Limited (incorporated in India)",
     address:
       "5th Floor, Tech Web Centre, Link Road, Oshiwara, Mumbai 400102, Maharashtra, India",
   },
-  /** Entity that markets and contracts for Peakhour.ai outside India.
-   *  Same legal name as the India entity — the country of incorporation and the
-   *  company registration number are what distinguish the two on documents. */
+  /** Entity that markets and contracts for Peakhour.ai outside India. */
   companyUk: {
     legalName: "Media Worldwide Limited",
+    /** Disambiguated form — use in any identifying sentence. */
+    ref: "Media Worldwide Limited (registered in England and Wales, company number 06334375)",
     companyNumber: "06334375",
     address:
       "2nd Floor, 2 Warner House, Harrovian Business Village, Bessborough Road, Harrow, Middlesex, England, HA1 3EX",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,7 +12,15 @@ export const SITE = {
    *  Override per-env with NEXT_PUBLIC_SITE_URL; defaults to production. */
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://peakhour.ai",
   tagline: "The AI business platform for growing brands",
+  /** Date stamped on Terms, Privacy and Cookie Policy. Privacy §17 and Cookie §7
+   *  define this as the signal of a material change, so bump it ONLY when one of
+   *  those three actually changes. */
   legalLastUpdated: "July 29, 2026",
+  /** Separate stamp for the Data Deletion and Data Retention pages. They are
+   *  informational, change on their own cadence, and the Data Deletion page is
+   *  read by Meta app review — sharing `legalLastUpdated` made an unrelated
+   *  policy edit look like a change to them. */
+  helpLastUpdated: "June 1, 2026",
   /** Operating legal entity for India (data controller / data fiduciary).
    *
    *  IMPORTANT — the India and UK entities share the SAME `legalName`. Rendering
@@ -33,6 +41,10 @@ export const SITE = {
     legalName: "Media Worldwide Limited",
     /** Disambiguated form — use in any identifying sentence. */
     ref: "Media Worldwide Limited (registered in England and Wales, company number 06334375)",
+    /** Structured form of the number embedded in `ref`. Kept separate because
+     *  statutory disclosure (UK Companies Act s.82 / Trading Disclosures Regs)
+     *  wants the bare number, not the prose form. The India entity has no
+     *  counterpart yet — its CIN has not been supplied. */
     companyNumber: "06334375",
     address:
       "2nd Floor, 2 Warner House, Harrovian Business Village, Bessborough Road, Harrow, Middlesex, England, HA1 3EX",


### PR DESCRIPTION
Part 3 of 3 in the legal-entity migration (mongodb#426 → api#969 → **this**). Merge last — this is the customer-facing half.

## 1. Entity migration

`SITE.company.legalName` → **Media Worldwide Limited**. That constant is the single source of truth behind Terms, Privacy Policy, Cookie Policy and the coming-soon footer, so the rename propagates to every legal surface. The India registered address is unchanged (confirmed identical).

Adds `SITE.companyUk` for the entity that markets Peakhour.ai outside India: **Media Worldwide Limited, registered in England and Wales under company number 06334375**, Harrow.

**The trap this created, and the fix.** Both entities share the same `legalName`, so every clause meant to distinguish them rendered as a tautology — Terms §1 read *"references to Company mean Media Worldwide Limited"*, the identical string §1 had already bound to the India company. There are now `.ref` forms carrying the country of incorporation and company number, used in every **identifying** sentence; bare `legalName` survives only where the text means "the company" and either reading is correct. This is documented on the constant so the next edit doesn't reintroduce it.

## 2. Merchant of record

Terms §8 said *"Payments are processed through Stripe"* — already wrong (India runs Razorpay with PayU backup) and with no concept of a reseller. Now:

- **Terms §8** gains a *Seller of record* clause: where an MoR platform is used, that platform — not either Peakhour.ai company — contracts with the buyer, issues the invoice, and collects and remits the tax. Verified this is real, not a promise: `billing/index.ts:551` returns `sellerName` and `payment-modal.tsx:106` renders "Sold by …".
- **Privacy §5** gains the matching distinction: an MoR is an **independent controller** under its own privacy policy, not a sub-processor acting on our instructions.

Written around the concept rather than a provider list, so adding **Dodo / Creem / Paddle** needs no further copy change. Mirrors `merchantOfRecord: self | stripe` in `cfg_payment_gateways`.

## 3. CMPL disclosure

Meta (incl. WhatsApp Business) and LinkedIn API access is held by **Celebrities Management Private Limited** — that was the only route to getting those APIs approved. Users therefore see that name on the OAuth authorization screen, while it appeared **nowhere** in the legal pages, which named a different controller. That's a gap for users, for Meta/LinkedIn app review (the published policy must describe the app), and under GDPR Art. 13/14 + DPDP.

Privacy §12 and Terms §6 now disclose it; Privacy §5 gains an **Affiliated group companies** recipient bullet, because app reviewers and Art. 13(1)(e) read the sharing section, not §12.

## 4. Also fixed in review

- `legalLastUpdated` bumped to **July 29, 2026**. Privacy §17 and Cookie §7 both promise material changes are signalled by that date — leaving it at June 1 broke their own stated mechanism.
- Privacy §1 asserted the India entity as EU/UK GDPR controller unconditionally, then the new paragraph asserted the UK entity. Two controllers, same rendered name. Now scoped and identified.
- Terms §8 named only the India entity as direct seller, but per migration 171 every non-IN self-MoR region bills through `mw-uk`.
- Contact blocks listed only the India office though non-India users now contract with the England and Wales company. Both are listed; the DPDP Grievance Officer block stays India-only by design.

## ⚠️ Two items for the lawyer — NOT resolved here

1. **Governing law.** Terms §16 and Privacy §16 still assert Indian law + **exclusive** Mumbai jurisdiction + Mumbai-seated arbitration, unchanged. Terms §1 now says every non-India user contracts with an England-and-Wales company, and Privacy §14.1 sends EEA/UK users to the ICO. Exclusive Indian jurisdiction over a UK-entity consumer/SME contract is largely unenforceable in the UK/EU, and the mandatory-rights savings sentence doesn't cure the jurisdiction clause itself. **Deliberately not rewritten** — choice of law is a legal decision, not a code fix.
2. **The affiliation claim.** The pages describe CMPL as "an affiliated company within our group" and assert a **written intra-group agreement**. Neither is verifiable from this repo, and if that agreement hasn't been signed, the policy makes a claim that can't be backed — exactly what a Meta or DPDP reviewer would ask to see.

## Verification

`tsc --noEmit` clean. ESLint returns exactly the 3 errors pre-existing on master (confirmed via `git stash`) — all pre-existing `<a>`-vs-`<Link>` violations in these files; this PR adds none.

## Review

Two full rounds, manual + subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)