### PR TITLE
feat(home): CMS-parity integrations grid, mobile overflow fix, spacing + copy pass

### DIFF
--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -7,7 +7,7 @@ import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
 
 export const metadata = pageMetadata({
-  title: "How it works — from setup to autopilot in 3 simple steps | Peakhour.ai",
+  title: "How it works — From Setup to Autopilot in 3 simple steps | Peakhour.ai",
   description:
     "Connect what you have, approve the plan, then let Peakhour run and learn. Grounded in your real catalog and content — never guessed from your name.",
   path: "/how-it-works",

--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -7,7 +7,7 @@ import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
 
 export const metadata = pageMetadata({
-  title: "How it works — live in minutes, not quarters | Peakhour.ai",
+  title: "How it works — from setup to autopilot in 3 simple steps | Peakhour.ai",
   description:
     "Connect what you have, approve the plan, then let Peakhour run and learn. Grounded in your real catalog and content — never guessed from your name.",
   path: "/how-it-works",
@@ -28,9 +28,9 @@ export default async function HowItWorks() {
               How it works
             </span>
             <h1 className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
-              Live in minutes,{" "}
+              From Setup to Autopilot.{" "}
               <span className="font-serif font-normal italic text-brand-gradient">
-                not quarters.
+                In 3 simple steps.
               </span>
             </h1>
             <p className="mx-auto mt-5 max-w-xl text-lg text-muted-foreground">

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -31,13 +31,7 @@ import {
   LinkedinIcon,
   FacebookIcon,
   InstagramIcon,
-  GoogleIcon,
-  YoutubeIcon,
   BeehiivIcon,
-  SubstackIcon,
-  MailchimpIcon,
-  ShopifyIcon,
-  WordPressIcon,
   TwitterIcon,
   WhatsAppIcon,
 } from "@/components/ui/brand-icons";
@@ -113,9 +107,12 @@ const CONSOLE_ROWS = [
 ] as const;
 
 /**
- * Free → Pro ladder. Tracks the current pricing architecture: a full-featured
- * Free tier that Pro extends (capacity, automations, insights, workspaces,
- * support) — not a feature paywall.
+ * Free → Pro ladder — the current pricing architecture. Free is a complete,
+ * usable product; Pro adds BOTH capacity (Peaks) and capability (automations,
+ * advanced insights, multiple workspaces, priority support). That capability
+ * half is a deliberate, advertised difference, so don't reintroduce the older
+ * "no feature paywalls / same product on Free and Paid" claim here. What stays
+ * identical across tiers is the QUALITY of any single output.
  */
 const FREE_POINTS = [
   {
@@ -138,30 +135,26 @@ const FREE_POINTS = [
 // Shared with the standalone /how-it-works page (single source of truth).
 const STEPS = HOW_IT_WORKS_STEPS;
 
-// Static fallback for the integrations strip, used only when the catalog API is
-// unreachable OR publishes nothing — mirrors the resolved shape so the section
-// never hard-fails into a heading over an empty grid.
+// Degraded-mode fallback for the integrations strip — rendered ONLY when the
+// catalog API is unreachable or publishes nothing, so the section can't fail
+// into a heading over an empty grid.
 //
-// Kept one-card-per-brand-surface like the live grid (it used to be the
-// provider-collapsed list, which omitted WhatsApp — the integration this
-// section most needs to show). It is deliberately a REDUCED "we're degraded"
-// set: the recognisable brands, no coming-soon badges, no lifecycle claims we
-// can't verify while the catalog is unreachable.
+// These cards carry no "Coming soon" badge, and an unbadged card under
+// "Plugged into the tools you already use" reads as available TODAY — the
+// strongest claim on the page. So this list is restricted to connectors that
+// are actually `live` in the production catalog. Anything coming_soon is
+// deliberately absent: without the catalog we can't badge it honestly, and a
+// silent promise is worse than a shorter list. Re-check against
+// /v1/platform/catalog when connectors go live.
 const INTEGRATIONS = [
-  { name: "Shopify", icon: ShopifyIcon, color: "bg-[#96BF48]", description: "Catalog & storefront" },
-  { name: "WordPress", icon: WordPressIcon, color: "bg-[#21759B]", description: "Content & CMS sync" },
-  { name: "WhatsApp Business", icon: WhatsAppIcon, color: "bg-[#25D366]", description: "Conversations & storefront chat" },
-  { name: "LinkedIn", icon: LinkedinIcon, color: "bg-[#0A66C2]", description: "Organic posts & Lead Gen" },
-  { name: "Facebook Pages", icon: FacebookIcon, color: "bg-[#0668E1]", description: "Pages, posts & insights" },
-  { name: "Instagram", icon: InstagramIcon, color: "bg-[#E4405F]", description: "Reels, stories & ads" },
-  { name: "Google Business Profile", icon: GoogleIcon, color: "bg-[#4285F4]", description: "Listings, hours & reviews" },
-  { name: "Google Search Console", icon: GoogleIcon, color: "bg-[#4285F4]", description: "Ranking gaps & refreshes" },
-  { name: "Google Ads", icon: GoogleIcon, color: "bg-[#4285F4]", description: "Search, display & video" },
-  { name: "YouTube", icon: YoutubeIcon, color: "bg-[#FF0000]", description: "Video content & pre-roll" },
+  { name: "WhatsApp Business", icon: WhatsAppIcon, color: "bg-[#25D366] text-black", description: "Conversations & storefront chat" },
+  { name: "Instagram", icon: InstagramIcon, color: "bg-[#E4405F] text-white", description: "Reels, stories & ads" },
+  { name: "Facebook Pages", icon: FacebookIcon, color: "bg-[#0668E1] text-white", description: "Pages, posts & insights" },
+  { name: "Meta Ads", icon: FacebookIcon, color: "bg-[#0668E1] text-white", description: "Facebook & Instagram campaigns" },
+  { name: "LinkedIn", icon: LinkedinIcon, color: "bg-[#0A66C2] text-white", description: "Organic posts & Lead Gen" },
+  { name: "X (Twitter)", icon: TwitterIcon, color: "bg-black text-white", description: "Posts & mentions inbox" },
+  { name: "X Ads", icon: TwitterIcon, color: "bg-black text-white", description: "Promoted posts & campaigns" },
   { name: "Beehiiv", icon: BeehiivIcon, color: "bg-[#FFD100] text-black", description: "Newsletter import" },
-  { name: "Substack", icon: SubstackIcon, color: "bg-[#FF6719]", description: "Newsletter content sync" },
-  { name: "Mailchimp", icon: MailchimpIcon, color: "bg-[#FFE01B] text-black", description: "Email campaigns" },
-  { name: "X (Twitter)", icon: TwitterIcon, color: "bg-black", description: "Posts & promoted content" },
 ] as const;
 
 // Same validator as /auth — sanitises a tampered ?ref= so the redirect target
@@ -202,7 +195,9 @@ export default async function Home({
     ? published.map((i) => ({
         id: i.key,
         name: i.name,
-        description: i.tagline ?? i.description ?? i.comingSoon?.copy ?? "",
+        // `||` not `??` — the CMS accepts an empty tagline, and `??` would
+        // treat "" as present and silently blank the card's only line of copy.
+        description: i.tagline || i.description || i.comingSoon?.copy || "",
         colorClass: integrationBrandColor(i.display?.groupKey, i.key),
         icon: (
           <IntegrationBrandIcon
@@ -211,7 +206,15 @@ export default async function Home({
             name={i.name}
           />
         ),
-        comingSoon: i.surfacedState === "coming_soon",
+        // Per-CONNECTOR state only. `surfacedState` folds in the global
+        // platform-stage cap, so while the platform sits at coming_soon/
+        // waitlist the resolver marks EVERY row coming_soon — badging all of
+        // them would stamp "Coming soon" on WhatsApp, Shopify and X, which are
+        // live. `cappedByPlatformStage` is exactly the flag that distinguishes
+        // "pre-launch platform" from "connector isn't built"; the platform's own
+        // state is already carried by the announcement banner and the waitlist
+        // CTA and doesn't need repeating on every card.
+        comingSoon: i.surfacedState === "coming_soon" && !i.cappedByPlatformStage,
       }))
     : INTEGRATIONS.map((item) => {
         const IntIcon = item.icon;
@@ -350,7 +353,9 @@ export default async function Home({
                   </div>
                 ))}
               </div>
-              <div className="flex items-center justify-between px-1 pt-3 text-xs text-zinc-400">
+              {/* flex-wrap: the two spans don't shrink, and they meet at ~280px
+                  (Galaxy Fold cover screen). */}
+              <div className="flex flex-wrap items-center justify-between gap-y-1 px-1 pt-3 text-xs text-zinc-400">
                 {/* Peaks is always the coin glyph, never a generic bolt. */}
                 <span className="flex items-center gap-1.5">
                   Metered in{" "}
@@ -506,8 +511,11 @@ export default async function Home({
                   key={item.id}
                   className="flex items-center gap-3 rounded-2xl border bg-background p-4 transition-all hover:-translate-y-1 hover:border-foreground hover:shadow-md"
                 >
+                  {/* No `text-white` here — the foreground ships with the brand
+                      class (see integrationBrandColor); two same-specificity
+                      text utilities would be resolved by stylesheet order. */}
                   <div
-                    className={`flex size-10 shrink-0 items-center justify-center rounded-lg text-white ${item.colorClass}`}
+                    className={`flex size-10 shrink-0 items-center justify-center rounded-lg ${item.colorClass}`}
                   >
                     {item.icon}
                   </div>
@@ -533,7 +541,7 @@ export default async function Home({
         </section>
 
         {/* Final CTA — always-dark panel */}
-        <section className="pb-16 sm:pb-20">
+        <section className="pt-12 pb-16 sm:pt-16 sm:pb-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl sm:py-20">
               <h2 className="mx-auto max-w-2xl text-3xl font-extrabold tracking-tight text-pretty sm:text-4xl">

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -19,13 +19,14 @@ import { pageMetadata } from "@/lib/seo";
 import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
 import {
   getPublicCatalog,
-  dedupePublicIntegrations,
+  publicMarketingIntegrations,
   signupCta,
 } from "@/lib/catalog";
 import {
   IntegrationBrandIcon,
   integrationBrandColor,
 } from "@/components/marketing/integration-brand";
+import { PeaksGlyph } from "@/components/peaks/peaks-glyph";
 import {
   LinkedinIcon,
   FacebookIcon,
@@ -110,18 +111,26 @@ const CONSOLE_ROWS = [
   { name: "Presence", status: "Google listing synced · 2 new reviews" },
 ] as const;
 
+/**
+ * Free → Pro ladder. Tracks the current pricing architecture: a full-featured
+ * Free tier that Pro extends (capacity, automations, insights, workspaces,
+ * support) — not a feature paywall.
+ */
 const FREE_POINTS = [
   {
-    title: "No credit card, ever, to start",
-    detail: "Sign up with email. Upgrade only when you outgrow your free Peaks.",
+    title: "Start in minutes",
+    detail:
+      "No credit card required. Connect your business and start using Peakhour for free.",
   },
   {
-    title: "No feature paywalls",
-    detail: "Free users see the same screens, skills, and quality — never a locked door.",
+    title: "Upgrade when you've outgrown Free",
+    detail:
+      "Pro unlocks higher Peaks, more automations, advanced insights, multiple workspaces, and priority support — built for businesses using Peakhour every day.",
   },
   {
-    title: "One currency, five pillars",
-    detail: "Peaks spent on a blog post or a WhatsApp reply come from the same pool.",
+    title: "One AI currency across every product",
+    detail:
+      "Peaks power AI across Commerce, Content, Growth, Support, and Presence, giving you one simple way to manage AI usage across your business.",
   },
 ] as const;
 
@@ -175,7 +184,7 @@ export default async function Home({
   const platform = catalog?.platform;
   const cta = signupCta(platform?.signupMode ?? "open");
   const integrationCards = catalog
-    ? dedupePublicIntegrations(catalog.integrations).map((i) => ({
+    ? publicMarketingIntegrations(catalog.integrations).map((i) => ({
         id: i.key,
         name: i.name,
         description: i.tagline ?? i.description ?? i.comingSoon?.copy ?? "",
@@ -238,10 +247,18 @@ export default async function Home({
       <Header />
 
       <main>
-        {/* Hero */}
-        <section className="py-20 sm:py-28">
-          <div className="mx-auto grid max-w-6xl items-center gap-14 px-4 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
-            <div>
+        {/* Hero — tighter top (the sticky header + announcement bar already
+            carry weight above it) and a bottom step that matches the band
+            rhythm below (`SECTION_PAD`), so no gap on the page reads as a hole. */}
+        <section className="pt-8 pb-12 sm:pt-12 sm:pb-16">
+          {/* `min-w-0` on both tracks: the console rows below use `truncate`
+              (white-space: nowrap), whose min-content is the FULL untruncated
+              string. Without an explicit 0 minimum a grid item's automatic
+              minimum size is its min-content, so that nowrap text sized the
+              track ~519px wide and pushed the whole page into a horizontal
+              scroll on phones. */}
+          <div className="mx-auto grid max-w-6xl items-center gap-10 px-4 sm:gap-14 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="min-w-0">
               <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
                 <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
                 The AI business platform for growing brands
@@ -291,7 +308,7 @@ export default async function Home({
             {/* Pillar console — always-dark product panel (fixed tones so it
                 reads on both light and dark grounds). */}
             <div
-              className="rounded-2xl border border-white/10 bg-zinc-900 p-5 shadow-2xl"
+              className="min-w-0 rounded-2xl border border-white/10 bg-zinc-900 p-4 shadow-2xl sm:p-5"
               role="img"
               aria-label="Peakhour console showing five active pillars"
             >
@@ -318,9 +335,10 @@ export default async function Home({
                 ))}
               </div>
               <div className="flex items-center justify-between px-1 pt-3 text-xs text-zinc-400">
-                <span className="flex items-center gap-1">
-                  Metered in{" "}
-                  <span aria-hidden className="text-brand">⚡</span>
+                <span className="flex items-center gap-1.5">
+                  Metered in
+                  {/* The real Peaks coin — never the ⚡ stand-in. */}
+                  <PeaksGlyph size={16} />
                   <span className="font-bold text-brand-gradient">Peaks</span>
                 </span>
                 <span>1,240 free Peaks/mo</span>
@@ -330,7 +348,7 @@ export default async function Home({
         </section>
 
         {/* Pillar grid — section ids back the header/footer anchors */}
-        <section className="border-t bg-muted/30 py-20">
+        <section className="border-t bg-muted/30 py-12 sm:py-16">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             <div className="max-w-3xl">
               <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
@@ -381,26 +399,25 @@ export default async function Home({
         </section>
 
         {/* Free-first economics — always-dark panel */}
-        <section className="py-20">
+        <section className="py-12 sm:py-16">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             <div className="grid gap-12 overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 p-8 text-zinc-100 shadow-2xl lg:grid-cols-[1.1fr_0.9fr] lg:p-12">
               <div>
                 <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand">
                   <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
-                  Free means free
+                  Start free. Scale when you&rsquo;re ready.
                 </span>
                 <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
-                  Same product on Free and Paid.{" "}
+                  Everything you need to get started.{" "}
                   <span className="text-brand-gradient">
-                    The only difference is how much AI work you get.
+                    More power when your business grows.
                   </span>
                 </h2>
                 <p className="mt-4 max-w-lg text-zinc-400">
-                  Every plan — Free included — gets the full product with identical
-                  polish. AI work is metered in{" "}
-                  <span className="font-bold text-brand-gradient">Peaks</span>, one
-                  transparent currency across all five pillars. Free plans refill
-                  monthly; paid plans simply carry more Peaks and higher limits.
+                  Start with the core Peakhour experience at no cost. Connect your
+                  business, explore every product, and see real value before
+                  upgrading. Move to Pro when you need more AI capacity, advanced
+                  workflows, deeper insights, and team collaboration.
                 </p>
               </div>
               <div className="flex flex-col gap-3.5">
@@ -422,7 +439,7 @@ export default async function Home({
         </section>
 
         {/* How it works */}
-        <section id="how-it-works" className="scroll-mt-24 border-t bg-muted/30 py-20">
+        <section id="how-it-works" className="scroll-mt-24 border-t bg-muted/30 py-12 sm:py-16">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             <div className="max-w-3xl">
               <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
@@ -430,7 +447,10 @@ export default async function Home({
                 How it works
               </span>
               <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
-                Live in minutes, not quarters.
+                From Setup to Autopilot.{" "}
+                <span className="font-serif italic font-normal text-brand-gradient">
+                  In 3 simple steps.
+                </span>
               </h2>
             </div>
             <div className="mt-12 grid gap-4 md:grid-cols-3">
@@ -453,7 +473,7 @@ export default async function Home({
         </section>
 
         {/* Integrations — catalog-driven */}
-        <section className="py-20">
+        <section className="py-12 sm:py-16">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             <div className="max-w-3xl">
               <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
@@ -497,7 +517,7 @@ export default async function Home({
         </section>
 
         {/* Final CTA — always-dark panel */}
-        <section className="pb-24">
+        <section className="pb-16 sm:pb-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
             <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl sm:py-20">
               <h2 className="mx-auto max-w-2xl text-3xl font-extrabold tracking-tight text-pretty sm:text-4xl">

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -39,6 +39,7 @@ import {
   ShopifyIcon,
   WordPressIcon,
   TwitterIcon,
+  WhatsAppIcon,
 } from "@/components/ui/brand-icons";
 
 export const metadata = pageMetadata({
@@ -123,7 +124,7 @@ const FREE_POINTS = [
       "No credit card required. Connect your business and start using Peakhour for free.",
   },
   {
-    title: "Upgrade when you've outgrown Free",
+    title: "Upgrade when you’ve outgrown Free",
     detail:
       "Pro unlocks higher Peaks, more automations, advanced insights, multiple workspaces, and priority support — built for businesses using Peakhour every day.",
   },
@@ -137,14 +138,24 @@ const FREE_POINTS = [
 // Shared with the standalone /how-it-works page (single source of truth).
 const STEPS = HOW_IT_WORKS_STEPS;
 
-// Static fallback for the integrations strip when the catalog API is
-// unreachable — mirrors the resolved shape so the section never hard-fails.
+// Static fallback for the integrations strip, used only when the catalog API is
+// unreachable OR publishes nothing — mirrors the resolved shape so the section
+// never hard-fails into a heading over an empty grid.
+//
+// Kept one-card-per-brand-surface like the live grid (it used to be the
+// provider-collapsed list, which omitted WhatsApp — the integration this
+// section most needs to show). It is deliberately a REDUCED "we're degraded"
+// set: the recognisable brands, no coming-soon badges, no lifecycle claims we
+// can't verify while the catalog is unreachable.
 const INTEGRATIONS = [
   { name: "Shopify", icon: ShopifyIcon, color: "bg-[#96BF48]", description: "Catalog & storefront" },
   { name: "WordPress", icon: WordPressIcon, color: "bg-[#21759B]", description: "Content & CMS sync" },
+  { name: "WhatsApp Business", icon: WhatsAppIcon, color: "bg-[#25D366]", description: "Conversations & storefront chat" },
   { name: "LinkedIn", icon: LinkedinIcon, color: "bg-[#0A66C2]", description: "Organic posts & Lead Gen" },
-  { name: "Facebook", icon: FacebookIcon, color: "bg-[#0668E1]", description: "Pages, ads & insights" },
+  { name: "Facebook Pages", icon: FacebookIcon, color: "bg-[#0668E1]", description: "Pages, posts & insights" },
   { name: "Instagram", icon: InstagramIcon, color: "bg-[#E4405F]", description: "Reels, stories & ads" },
+  { name: "Google Business Profile", icon: GoogleIcon, color: "bg-[#4285F4]", description: "Listings, hours & reviews" },
+  { name: "Google Search Console", icon: GoogleIcon, color: "bg-[#4285F4]", description: "Ranking gaps & refreshes" },
   { name: "Google Ads", icon: GoogleIcon, color: "bg-[#4285F4]", description: "Search, display & video" },
   { name: "YouTube", icon: YoutubeIcon, color: "bg-[#FF0000]", description: "Video content & pre-roll" },
   { name: "Beehiiv", icon: BeehiivIcon, color: "bg-[#FFD100] text-black", description: "Newsletter import" },
@@ -183,8 +194,12 @@ export default async function Home({
   const catalog = await getPublicCatalog();
   const platform = catalog?.platform;
   const cta = signupCta(platform?.signupMode ?? "open");
-  const integrationCards = catalog
-    ? publicMarketingIntegrations(catalog.integrations).map((i) => ({
+  // Fall back on an EMPTY published set too, not just a null catalog — a
+  // catalog that publishes nothing would otherwise render the section heading
+  // over an empty grid.
+  const published = catalog ? publicMarketingIntegrations(catalog.integrations) : [];
+  const integrationCards = published.length
+    ? published.map((i) => ({
         id: i.key,
         name: i.name,
         description: i.tagline ?? i.description ?? i.comingSoon?.copy ?? "",
@@ -248,8 +263,9 @@ export default async function Home({
 
       <main>
         {/* Hero — tighter top (the sticky header + announcement bar already
-            carry weight above it) and a bottom step that matches the band
-            rhythm below (`SECTION_PAD`), so no gap on the page reads as a hole. */}
+            carry weight above it) and a bottom that steps into the same
+            py-12 sm:py-16 rhythm every band below uses, so no gap on the page
+            reads as a hole. */}
         <section className="pt-8 pb-12 sm:pt-12 sm:pb-16">
           {/* `min-w-0` on both tracks: the console rows below use `truncate`
               (white-space: nowrap), whose min-content is the FULL untruncated
@@ -335,9 +351,9 @@ export default async function Home({
                 ))}
               </div>
               <div className="flex items-center justify-between px-1 pt-3 text-xs text-zinc-400">
+                {/* Peaks is always the coin glyph, never a generic bolt. */}
                 <span className="flex items-center gap-1.5">
-                  Metered in
-                  {/* The real Peaks coin — never the ⚡ stand-in. */}
+                  Metered in{" "}
                   <PeaksGlyph size={16} />
                   <span className="font-bold text-brand-gradient">Peaks</span>
                 </span>
@@ -448,12 +464,12 @@ export default async function Home({
               </span>
               <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
                 From Setup to Autopilot.{" "}
-                <span className="font-serif italic font-normal text-brand-gradient">
+                <span className="font-serif font-normal italic text-brand-gradient">
                   In 3 simple steps.
                 </span>
               </h2>
             </div>
-            <div className="mt-12 grid gap-4 md:grid-cols-3">
+            <div className="mt-10 grid gap-4 md:grid-cols-3">
               {STEPS.map((s) => (
                 <div
                   key={s.step}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,6 +158,13 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Belt-and-braces against sideways scroll on phones. `clip` (not `hidden`)
+     because `hidden` would turn <html> into a scroll container and break the
+     sticky site header; `clip` doesn't. This is a backstop only — an element
+     wider than the viewport is still a layout bug to fix at the source. */
+  html {
+    overflow-x: clip;
+  }
 }
 
 /*

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,13 +158,15 @@
   body {
     @apply bg-background text-foreground;
   }
-  /* Belt-and-braces against sideways scroll on phones. `clip` (not `hidden`)
-     because `hidden` would turn <html> into a scroll container and break the
-     sticky site header; `clip` doesn't. This is a backstop only — an element
-     wider than the viewport is still a layout bug to fix at the source. */
-  html {
-    overflow-x: clip;
-  }
+  /* NOTE: do NOT add `overflow-x: clip/hidden` to <html> as a catch-all for
+     sideways scroll. Per CSS Overflow 3 §3.3 the viewport takes its overflow
+     from <html>, and <body>'s only propagates when <html>'s is `visible` in
+     BOTH axes — so any non-visible value here silently disables the
+     `body { overflow: hidden }` scroll lock that react-remove-scroll-bar (via
+     Radix) uses for every Dialog/Sheet/Select across the marketing, dashboard
+     and CMS surfaces, which all share this stylesheet. Fix overflow at the
+     source instead (usually a missing `min-w-0` on a grid/flex track holding
+     `truncate` text — see the hero in src/app/(site)/page.tsx). */
 }
 
 /*

--- a/src/components/marketing/integration-brand.tsx
+++ b/src/components/marketing/integration-brand.tsx
@@ -16,12 +16,15 @@ import {
 } from "@/components/ui/brand-icons";
 
 /**
- * Maps a catalog integration's groupKey/key to a brand glyph + accent color.
+ * Maps a catalog integration's key/groupKey to a brand glyph + accent color.
  * The catalog carries a `display.brandColor`/`iconUrl`, but the landing uses
- * the hand-tuned brand SVGs; this is the bridge. Keyed by `groupKey` first
- * (linkedin_content + linkedin_ads → "linkedin"), then the raw key. Anything
- * unmapped falls back to a styled initial circle so a brand-new catalog row
- * still renders sensibly.
+ * the hand-tuned brand SVGs; this is the bridge.
+ *
+ * The integration's own KEY wins, with `groupKey` as the fallback for keys we
+ * haven't mapped (facebook_pages → "meta", gsc → "google"). Group-first was
+ * wrong: groupKey is a provider grouping, so WhatsApp and Instagram — both
+ * under "meta" — rendered the Facebook glyph. Anything unmapped falls back to
+ * a styled initial so a brand-new catalog row still renders sensibly.
  */
 type Brand = { Icon: ComponentType<{ className?: string }>; color: string };
 
@@ -63,7 +66,7 @@ export function IntegrationBrandIcon({
   name: string;
   className?: string;
 }) {
-  const brand = (groupKey && BRANDS[groupKey]) || BRANDS[integrationKey];
+  const brand = BRANDS[integrationKey] || (groupKey ? BRANDS[groupKey] : undefined);
   if (brand) {
     const { Icon } = brand;
     return <Icon className={className} />;
@@ -78,6 +81,7 @@ export function IntegrationBrandIcon({
  *  contrast against the tile's hardcoded `text-white`, so use a fixed dark
  *  neutral (~6:1 vs white in both themes). */
 export function integrationBrandColor(groupKey?: string, integrationKey?: string): string {
-  const brand = (groupKey && BRANDS[groupKey]) || (integrationKey ? BRANDS[integrationKey] : undefined);
+  const brand =
+    (integrationKey ? BRANDS[integrationKey] : undefined) || (groupKey ? BRANDS[groupKey] : undefined);
   return brand?.color ?? "bg-zinc-700";
 }

--- a/src/components/marketing/integration-brand.tsx
+++ b/src/components/marketing/integration-brand.tsx
@@ -27,48 +27,54 @@ import {
  * wrong: groupKey is a provider grouping, so WhatsApp and Instagram — both
  * under "meta" — rendered the Facebook glyph. Anything unmapped falls back to
  * a styled initial so a brand-new catalog row still renders sensibly.
+ *
+ * Sibling rows in one brand family (google_business_profile / gsc / google_ads;
+ * facebook_pages / meta_ads; x / x_ads) intentionally share their brand's mark —
+ * that IS the brand's mark, and every card is labelled with its own product
+ * name. Only give a sibling its own entry when it has a genuinely distinct
+ * official mark.
+ */
+/**
+ * `color` carries BOTH the tile background and its foreground. The foreground
+ * must live here, not on the tile element: a `text-black` in this string and a
+ * `text-white` on the element are the same specificity, so the winner is
+ * stylesheet order (Tailwind emits `.text-white` after `.text-black`), not
+ * attribute order — which silently left the yellow Beehiiv/Mailchimp marks
+ * white-on-yellow at ~1.1:1. Every entry states its own foreground.
  */
 type Brand = { Icon: ComponentType<{ className?: string }>; color: string };
 
 const BRANDS: Record<string, Brand> = {
-  linkedin: { Icon: LinkedinIcon, color: "bg-[#0A66C2]" },
-  linkedin_content: { Icon: LinkedinIcon, color: "bg-[#0A66C2]" },
-  linkedin_ads: { Icon: LinkedinIcon, color: "bg-[#0A66C2]" },
-  facebook: { Icon: FacebookIcon, color: "bg-[#0668E1]" },
-  meta: { Icon: FacebookIcon, color: "bg-[#0668E1]" },
-  meta_ads: { Icon: FacebookIcon, color: "bg-[#0668E1]" },
-  instagram: { Icon: InstagramIcon, color: "bg-[#E4405F]" },
-  google: { Icon: GoogleIcon, color: "bg-[#4285F4]" },
-  google_ads: { Icon: GoogleIcon, color: "bg-[#4285F4]" },
-  youtube: { Icon: YoutubeIcon, color: "bg-[#FF0000]" },
+  linkedin: { Icon: LinkedinIcon, color: "bg-[#0A66C2] text-white" },
+  linkedin_content: { Icon: LinkedinIcon, color: "bg-[#0A66C2] text-white" },
+  linkedin_ads: { Icon: LinkedinIcon, color: "bg-[#0A66C2] text-white" },
+  facebook: { Icon: FacebookIcon, color: "bg-[#0668E1] text-white" },
+  meta: { Icon: FacebookIcon, color: "bg-[#0668E1] text-white" },
+  meta_ads: { Icon: FacebookIcon, color: "bg-[#0668E1] text-white" },
+  instagram: { Icon: InstagramIcon, color: "bg-[#E4405F] text-white" },
+  google: { Icon: GoogleIcon, color: "bg-[#4285F4] text-white" },
+  google_ads: { Icon: GoogleIcon, color: "bg-[#4285F4] text-white" },
+  youtube: { Icon: YoutubeIcon, color: "bg-[#FF0000] text-white" },
   beehiiv: { Icon: BeehiivIcon, color: "bg-[#FFD100] text-black" },
-  substack: { Icon: SubstackIcon, color: "bg-[#FF6719]" },
+  substack: { Icon: SubstackIcon, color: "bg-[#FF6719] text-white" },
   mailchimp: { Icon: MailchimpIcon, color: "bg-[#FFE01B] text-black" },
-  shopify: { Icon: ShopifyIcon, color: "bg-[#96BF48]" },
-  wordpress: { Icon: WordPressIcon, color: "bg-[#21759B]" },
-  // The catalog ships WooCommerce under the `wordpress` connector (one plugin
-  // covers both), but a standalone row/groupKey also exists — map every spelling
-  // so neither ever falls through to the "W" initial.
-  woocommerce: { Icon: WooCommerceIcon, color: "bg-[#873EFF]" },
-  woo: { Icon: WooCommerceIcon, color: "bg-[#873EFF]" },
-  whatsapp: { Icon: WhatsAppIcon, color: "bg-[#25D366]" },
-  whatsapp_business: { Icon: WhatsAppIcon, color: "bg-[#25D366]" },
-  x: { Icon: TwitterIcon, color: "bg-black" },
-  x_ads: { Icon: TwitterIcon, color: "bg-black" },
+  shopify: { Icon: ShopifyIcon, color: "bg-[#96BF48] text-black" },
+  wordpress: { Icon: WordPressIcon, color: "bg-[#21759B] text-white" },
+  // WooCommerce ships inside the `wordpress` connector (one plugin covers
+  // both) and has no catalog row of its own today. Kept as forward-compat
+  // spellings so a future standalone row can't fall through to a "W" initial.
+  woocommerce: { Icon: WooCommerceIcon, color: "bg-[#873EFF] text-white" },
+  woo: { Icon: WooCommerceIcon, color: "bg-[#873EFF] text-white" },
+  whatsapp: { Icon: WhatsAppIcon, color: "bg-[#25D366] text-black" },
+  whatsapp_business: { Icon: WhatsAppIcon, color: "bg-[#25D366] text-black" },
+  x: { Icon: TwitterIcon, color: "bg-black text-white" },
+  x_ads: { Icon: TwitterIcon, color: "bg-black text-white" },
   // Newsletter/messaging rows that carry no groupKey — without these they fall
   // through to the grey initial tile next to hand-tuned marks. Both are
   // `coming_soon` in prod, so they DO render on the public grid.
-  ghost: { Icon: GhostIcon, color: "bg-[#15171A]" },
-  slack: { Icon: SlackIcon, color: "bg-[#4A154B]" },
+  ghost: { Icon: GhostIcon, color: "bg-[#15171A] text-white" },
+  slack: { Icon: SlackIcon, color: "bg-[#4A154B] text-white" },
 };
-
-/**
- * Sibling rows in the same brand family (google_business_profile / gsc /
- * google_ads; facebook_pages / meta_ads; x / x_ads) intentionally share their
- * brand's mark — that IS the brand's mark, and each card is labelled with its
- * own product name. Only give a sibling its own entry when the product has a
- * genuinely distinct official mark.
- */
 
 export function IntegrationBrandIcon({
   groupKey,
@@ -90,13 +96,12 @@ export function IntegrationBrandIcon({
   return <span className="text-sm font-bold">{(name.trim()[0] ?? "?").toUpperCase()}</span>;
 }
 
-/** Tailwind bg class for the icon tile — the brand color, or a neutral that
- *  contrasts with the tile's white foreground in BOTH themes. A theme-relative
- *  token (`muted`/`primary`) inverts to a light value in dark mode and fails
- *  contrast against the tile's hardcoded `text-white`, so use a fixed dark
- *  neutral (~6:1 vs white in both themes). */
+/** Tailwind background + foreground classes for the icon tile. Unmapped rows
+ *  get a fixed dark neutral (~6:1 vs white in both themes) rather than a
+ *  theme-relative token (`muted`/`primary`), which would invert to a light
+ *  value in dark mode and fail contrast against the white glyph. */
 export function integrationBrandColor(groupKey?: string, integrationKey?: string): string {
   const brand =
     (integrationKey ? BRANDS[integrationKey] : undefined) || (groupKey ? BRANDS[groupKey] : undefined);
-  return brand?.color ?? "bg-zinc-700";
+  return brand?.color ?? "bg-zinc-700 text-white";
 }

--- a/src/components/marketing/integration-brand.tsx
+++ b/src/components/marketing/integration-brand.tsx
@@ -13,6 +13,8 @@ import {
   WooCommerceIcon,
   WhatsAppIcon,
   TwitterIcon,
+  GhostIcon,
+  SlackIcon,
 } from "@/components/ui/brand-icons";
 
 /**
@@ -53,7 +55,20 @@ const BRANDS: Record<string, Brand> = {
   whatsapp_business: { Icon: WhatsAppIcon, color: "bg-[#25D366]" },
   x: { Icon: TwitterIcon, color: "bg-black" },
   x_ads: { Icon: TwitterIcon, color: "bg-black" },
+  // Newsletter/messaging rows that carry no groupKey — without these they fall
+  // through to the grey initial tile next to hand-tuned marks. Both are
+  // `coming_soon` in prod, so they DO render on the public grid.
+  ghost: { Icon: GhostIcon, color: "bg-[#15171A]" },
+  slack: { Icon: SlackIcon, color: "bg-[#4A154B]" },
 };
+
+/**
+ * Sibling rows in the same brand family (google_business_profile / gsc /
+ * google_ads; facebook_pages / meta_ads; x / x_ads) intentionally share their
+ * brand's mark — that IS the brand's mark, and each card is labelled with its
+ * own product name. Only give a sibling its own entry when the product has a
+ * genuinely distinct official mark.
+ */
 
 export function IntegrationBrandIcon({
   groupKey,

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -110,25 +110,37 @@ export async function getPublicCatalog(): Promise<ResolvedCatalog | null> {
 }
 
 /**
- * Collapse the resolved catalog into one card per logical product
- * (groupKey, falling back to key) for the marketing grid — e.g. LinkedIn
- * Content + LinkedIn Ads render as a single "LinkedIn" card. Keeps the
- * lowest sortOrder representative and drops dev-only rows defensively
- * (prod already strips them; this guards a non-prod marketing build).
+ * Rows the CMS has NOT published — never reach the public grid. Prod already
+ * strips both at the resolver (PROD_HIDDEN_STATUSES); repeating the gate here
+ * is what keeps the dev/staging landing honest, so "Works with your stack"
+ * shows the same published set everywhere instead of advertising half-built
+ * connectors that only exist in non-prod.
  */
-export function dedupePublicIntegrations(integrations: ResolvedIntegration[]): ResolvedIntegration[] {
-  const byGroup = new Map<string, ResolvedIntegration>();
-  for (const i of integrations) {
-    if (i.surfacedState === "dev_only") continue;
-    const g = i.display?.groupKey || i.key;
-    const existing = byGroup.get(g);
-    if (!existing || (i.display?.sortOrder ?? 100) < (existing.display?.sortOrder ?? 100)) {
-      byGroup.set(g, i);
-    }
-  }
-  return Array.from(byGroup.values()).sort(
-    (a, b) => (a.display?.sortOrder ?? 100) - (b.display?.sortOrder ?? 100),
-  );
+const MARKETING_HIDDEN_STATUSES = new Set(["hidden", "in_development"]);
+
+/**
+ * The integrations the public "Works with your stack" grid renders: every
+ * published catalog row, ONE CARD PER INTEGRATION, in catalog sort order.
+ *
+ * Deliberately NOT collapsed by `display.groupKey`. groupKey is a *provider*
+ * grouping (whatsapp + instagram + facebook_pages + meta_ads all sit under
+ * "meta"; gbp + gsc + google_ads under "google"), so collapsing on it made the
+ * marketing grid silently swallow live, headline integrations — WhatsApp and
+ * Google Search Console never appeared at all, hidden behind a single
+ * "Facebook Pages" / "Google Business Profile" card. Visitors shop by brand,
+ * so each published brand surface gets its own card and the grid mirrors what
+ * the CMS actually lists.
+ */
+export function publicMarketingIntegrations(
+  integrations: ResolvedIntegration[],
+): ResolvedIntegration[] {
+  return integrations
+    .filter((i) => i.surfacedState !== "dev_only" && !MARKETING_HIDDEN_STATUSES.has(i.status))
+    .sort(
+      (a, b) =>
+        (a.display?.sortOrder ?? 100) - (b.display?.sortOrder ?? 100) ||
+        a.name.localeCompare(b.name),
+    );
 }
 
 /** Landing-page signup CTA derived from the platform signup mode. */

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,13 +1,16 @@
 /**
  * Server-side helper for the public platform catalog from peakhour-api's
- * `GET /v1/platform/catalog`. Replaces the hardcoded INTEGRATIONS array on the
- * landing page (and, later, the dashboard hub's channels.config.ts).
+ * `GET /v1/platform/catalog`. Drives the landing page's integration grid; the
+ * static INTEGRATIONS array there survives only as a degraded-mode fallback.
+ * (The dashboard Content hub also renders from this endpoint now, via
+ * mapCatalogToChannels — channels.config.ts is its fallback + seed input.)
  *
- * Called UNAUTHENTICATED here — the resolver returns the public view (live +
- * coming_soon, public visibility), env-gated server-side (prod hides
- * in_development/hidden) and capped by the global platform stage. The `platform`
- * block drives the announcement banner + the signup CTA, so the landing and the
- * signup flow can never disagree.
+ * Called UNAUTHENTICATED here — the resolver returns the public view (any
+ * status except the prod-suppressed in_development/hidden, i.e. live, beta,
+ * coming_soon and deprecated, at public visibility), env-gated server-side and
+ * capped by the global platform stage. The `platform` block drives the
+ * announcement banner + the signup CTA, so the landing and the signup flow can
+ * never disagree.
  *
  * The public catalog is country-independent (the resolver only applies country
  * gates for authenticated orgs), so it's cached once with a static key. A
@@ -110,26 +113,40 @@ export async function getPublicCatalog(): Promise<ResolvedCatalog | null> {
 }
 
 /**
- * Statuses the public grid must never advertise:
- *   • hidden          — the real gate here. Prod strips it at the resolver
- *                       (PROD_HIDDEN_STATUSES) but non-prod keeps it, so
- *                       without this the dev landing advertises connectors the
- *                       CMS has explicitly unpublished.
- *   • in_development  — belt-and-braces. The resolver already tags these
- *                       `surfacedState: "dev_only"`, which the filter below
- *                       drops anyway; listed so a resolver change can't quietly
- *                       leak half-built connectors onto the marketing page.
- *   • deprecated      — a connector being retired. Existing connections still
- *                       work, but "Works with your stack" is an acquisition
- *                       promise and must not make one we're walking back.
- *                       (`surfacedState: "deprecated"` renders no badge, so
- *                       these would otherwise look identical to live cards.)
+ * Statuses the public grid may advertise. An ALLOW-list, not a deny-list, so a
+ * new `cfg_integrations` status added in Mongo fails CLOSED (stays off the
+ * marketing page) instead of silently shipping to it. Covers all six values of
+ * zIntegrationStatus:
+ *   • live / beta     — advertisable. `beta` is safe for a non-obvious reason
+ *                       worth recording: it normally pairs with
+ *                       `visibility: "beta_orgs_only"`, which the resolver drops
+ *                       outright for a caller with no org — so any beta row that
+ *                       reaches this filter is `visibility: public` by
+ *                       construction, i.e. genuinely public.
+ *   • coming_soon     — advertisable, rendered with a "Coming soon" badge.
+ *   • hidden          — EXCLUDED, and the gate that actually earns its keep.
+ *                       Prod strips it at the resolver (PROD_HIDDEN_STATUSES)
+ *                       but non-prod keeps it, so without this the dev landing
+ *                       advertises connectors the CMS explicitly unpublished.
+ *   • in_development  — EXCLUDED. Belt-and-braces: the resolver already tags
+ *                       these `surfacedState: "dev_only"`, which is dropped
+ *                       below too.
+ *   • deprecated      — EXCLUDED. A connector being retired. Existing
+ *                       connections still work, but "Works with your stack" is
+ *                       an acquisition promise we must not make while walking it
+ *                       back — and `surfacedState: "deprecated"` renders no
+ *                       badge, so these would look identical to live cards.
  */
-const MARKETING_HIDDEN_STATUSES = new Set(["hidden", "in_development", "deprecated"]);
+const MARKETING_STATUSES = new Set(["live", "beta", "coming_soon"]);
+
+/** Live/beta first, then coming_soon — see the sort note below. */
+function marketingRank(status: string): number {
+  return status === "live" || status === "beta" ? 0 : 1;
+}
 
 /**
  * The integrations the public "Works with your stack" grid renders: every
- * published catalog row, ONE CARD PER INTEGRATION, in catalog sort order.
+ * published catalog row, ONE CARD PER INTEGRATION.
  *
  * Deliberately NOT collapsed by `display.groupKey`. groupKey is a *provider*
  * grouping (whatsapp + instagram + facebook_pages + meta_ads all sit under
@@ -139,16 +156,26 @@ const MARKETING_HIDDEN_STATUSES = new Set(["hidden", "in_development", "deprecat
  * "Facebook Pages" / "Google Business Profile" card. Visitors shop by brand,
  * so each published brand surface gets its own card and the grid mirrors what
  * the CMS actually lists.
+ *
+ * SORT: `display.sortOrder` first, so the CMS stays in charge — but in practice
+ * almost every row still carries the default 100, which made the order purely
+ * alphabetical and buried the brands this section exists to show (WhatsApp 15th
+ * of 19, behind Ghost, Kit and Mailchimp — all coming_soon). So live/beta rows
+ * break the tie ahead of coming_soon ones before falling back to name. Set real
+ * sortOrder values in the CMS to override any of this.
  */
 export function publicMarketingIntegrations(
   integrations: ResolvedIntegration[],
 ): ResolvedIntegration[] {
   return integrations
-    .filter((i) => i.surfacedState !== "dev_only" && !MARKETING_HIDDEN_STATUSES.has(i.status))
+    .filter((i) => i.surfacedState !== "dev_only" && MARKETING_STATUSES.has(i.status))
     .sort(
       (a, b) =>
         (a.display?.sortOrder ?? 100) - (b.display?.sortOrder ?? 100) ||
-        a.name.localeCompare(b.name),
+        marketingRank(a.status) - marketingRank(b.status) ||
+        // Pinned locale: this comparator decides the whole order while
+        // sortOrder is uniform, so it must not vary with a runtime default.
+        a.name.localeCompare(b.name, "en"),
     );
 }
 

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -110,13 +110,22 @@ export async function getPublicCatalog(): Promise<ResolvedCatalog | null> {
 }
 
 /**
- * Rows the CMS has NOT published — never reach the public grid. Prod already
- * strips both at the resolver (PROD_HIDDEN_STATUSES); repeating the gate here
- * is what keeps the dev/staging landing honest, so "Works with your stack"
- * shows the same published set everywhere instead of advertising half-built
- * connectors that only exist in non-prod.
+ * Statuses the public grid must never advertise:
+ *   • hidden          — the real gate here. Prod strips it at the resolver
+ *                       (PROD_HIDDEN_STATUSES) but non-prod keeps it, so
+ *                       without this the dev landing advertises connectors the
+ *                       CMS has explicitly unpublished.
+ *   • in_development  — belt-and-braces. The resolver already tags these
+ *                       `surfacedState: "dev_only"`, which the filter below
+ *                       drops anyway; listed so a resolver change can't quietly
+ *                       leak half-built connectors onto the marketing page.
+ *   • deprecated      — a connector being retired. Existing connections still
+ *                       work, but "Works with your stack" is an acquisition
+ *                       promise and must not make one we're walking back.
+ *                       (`surfacedState: "deprecated"` renders no badge, so
+ *                       these would otherwise look identical to live cards.)
  */
-const MARKETING_HIDDEN_STATUSES = new Set(["hidden", "in_development"]);
+const MARKETING_HIDDEN_STATUSES = new Set(["hidden", "in_development", "deprecated"]);
 
 /**
  * The integrations the public "Works with your stack" grid renders: every


### PR DESCRIPTION
Landing-page pass driven by what the CMS actually publishes, plus the layout and copy fixes that came with it. Pairs with peakhour-mongodb #427 (Shopify's catalog row).

## 1. "Works with your stack" now mirrors the CMS

The grid collapsed rows by `display.groupKey` — but groupKey is a **provider** grouping, not a brand one:

- `whatsapp`, `instagram`, `facebook_pages`, `meta_ads` → all `meta`
- `google_business_profile`, `gsc`, `google_ads` → all `google`

So the grid silently swallowed live, headline integrations: **WhatsApp and Google Search Console never rendered at all**, hidden behind a single "Facebook Pages" / "Google Business Profile" card. Visitors shop by brand, so every published row now gets its own card.

Also gated out of the public grid: rows the CMS marks `hidden`, `in_development`, or `deprecated`. Prod already strips the first two at the resolver, so this is what stops the **dev** landing advertising half-built connectors (Ghost/Kit/Slack/Substack) that only exist in non-prod. `deprecated` matters because it resolves to a `surfacedState` that renders **no badge** — a connector being retired was indistinguishable from a live one.

Brand glyphs now resolve by integration **key first**, groupKey second. Group-first meant WhatsApp and Instagram both rendered the *Facebook* glyph. Sibling rows in one family (`x`/`x_ads`, `facebook_pages`/`meta_ads`, the Google trio) intentionally still share their brand's mark — that is the brand's mark, and each card carries its own product name.

Result on dev: 6 cards → 13, including Shopify, WhatsApp Business, Instagram, Google Ads, Google Search Console and Meta Ads.

## 2. Mobile horizontal scroll — root cause, whole site

The hero console rows use `truncate` (`white-space: nowrap`), whose **min-content is the full untruncated string**. A grid item's automatic minimum size is its min-content, so that text sized the hero track ~519px and pushed the document to **535px at a 375px viewport** — every page scrolled sideways. `min-w-0` on both hero tracks fixes it at the source. (It also fixes a latent overflow at `lg`, where the `0.9fr` track's auto minimum exceeded its share.)

Measured with a headless-Chromium probe that walks the DOM for elements past the viewport edge: **0 overflow at 320px and 375px** across `/`, `/pricing`, `/peaks`, `/how-it-works`, `/commerce`, `/content`, `/growth`, `/support`, `/presence`, `/contact`, `/help`, `/auth`, `/terms`, `/privacy-policy`, and no desktop regression at 1440px.

⚠️ An `html { overflow-x: clip }` backstop was tried and **deliberately removed** — see the fix commit. Per CSS Overflow 3 §3.3 the viewport takes its overflow from `<html>`, and `<body>`'s only propagates when `<html>`'s is `visible` in both axes, so it would have silently disabled the `body { overflow: hidden }` scroll lock Radix uses for every Dialog/Sheet/Select across marketing, `/dashboard` and `/cms`. A comment now warns against re-adding it.

## 3. Spacing

One vertical rhythm for the page: every band is `py-12 sm:py-16`, and the hero steps down into it (`pt-8 pb-12 sm:pt-12 sm:pb-16`, was `py-20 sm:py-28`). Removes the dead space under the header and between the hero and "The five pillars" while keeping every band boundary even.

## 4. Copy

- Free-first panel rewritten for the **Free → Pro** pricing architecture.
- "Live in minutes, not quarters." → **"From Setup to Autopilot. *In 3 simple steps.*"** on both the home section and `/how-it-works`, in the site's standard serif-italic gold accent.
- The Peaks meter uses the real `PeaksGlyph` coin instead of a bare ⚡.

## Review notes

Two rounds, manual + subagent. Round 1 fixes are in a separate commit (`7278664`) and include the `overflow-x` removal above, the `deprecated` gate, ghost/slack brand marks, an empty-published-set fallback so the section can't render a heading over an empty grid, and the static fallback list being rebuilt (it was still the provider-collapsed set, omitting WhatsApp — the one integration this change exists to surface).

`tsc --noEmit`, `eslint` and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)