### PR TITLE
fix(auth): free Peaks from the catalog, no mobile scroll, sleeker card hover

### DIFF
--- a/src/app/(site)/auth/auth-flow.tsx
+++ b/src/app/(site)/auth/auth-flow.tsx
@@ -14,6 +14,7 @@ import { PeaksGlyph } from "@/components/peaks/peaks-glyph";
 import {
   PILLAR_CONSOLE_ROWS,
   PILLAR_CONSOLE_LABEL,
+  PILLAR_CONSOLE_ROW_CLASS,
   SIGNUP_PROMISES,
   PRELAUNCH_PROMISES,
 } from "@/lib/pillar-console";
@@ -66,7 +67,9 @@ function signupStats(freePeaks: string) {
   return [
     { value: "5", label: "pillars, one login" },
     { value: "0", label: "credit cards required" },
-    { value: freePeaks, label: "free Peaks a month, every plan" },
+    // "+" and "free plan": the figure is the floor across free plans, and
+    // paid/Agency/Enterprise carry far more. Without both, this reads as a cap.
+    { value: `${freePeaks}+`, label: "free Peaks a month, every free plan" },
   ];
 }
 
@@ -457,7 +460,7 @@ export function AuthFlow({
             {PILLAR_CONSOLE_ROWS.map((row) => (
               <div
                 key={row.name}
-                className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm transition-[background-color,border-color,transform] duration-300 ease-out hover:translate-x-0.5 hover:border-brand/40 hover:bg-white/8 motion-reduce:transition-none motion-reduce:hover:translate-x-0"
+                className={PILLAR_CONSOLE_ROW_CLASS}
               >
                 <span className="size-2 shrink-0 rounded-full bg-emerald-400" aria-hidden />
                 <span className="w-20 shrink-0 font-bold text-zinc-100">{row.name}</span>
@@ -515,7 +518,7 @@ export function AuthFlow({
         {/* Vertical padding steps up only once there's room for it. At mobile
             widths the dark panel is hidden, so this column is the whole page
             and desktop-sized padding was pushing it past the viewport. */}
-        <div className="flex flex-1 items-center justify-center px-4 py-8 sm:px-8 sm:py-12">
+        <div className="flex flex-1 items-center justify-center px-4 py-6 sm:px-8 sm:py-12">
           {status.kind === "waitlisted" ? (
             <div className="w-full max-w-md rounded-2xl border bg-card p-7">
               <GoldTile icon={Clock} />
@@ -627,7 +630,7 @@ export function AuthFlow({
               <h1 className="mt-4 text-2xl font-extrabold tracking-tight text-pretty sm:text-3xl">
                 {intentCopy?.title ?? "One email. No password. Ever."}
               </h1>
-              <p className="mt-2.5 text-muted-foreground">
+              <p className="mt-2.5 text-sm text-muted-foreground sm:text-base">
                 {intentCopy?.subtitle ??
                   "We’ll send a link that signs you straight in. If you’re new, that same link creates your account."}
               </p>
@@ -673,7 +676,7 @@ export function AuthFlow({
                 </button>
               </form>
 
-              <ul className="mt-5 flex flex-wrap justify-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground sm:mt-6">
+              <ul className="mt-5 flex flex-wrap justify-center gap-x-3.5 gap-y-1.5 text-xs text-muted-foreground sm:mt-6 sm:gap-x-4 sm:text-sm">
                 {(isPreLaunch ? PRELAUNCH_PROMISES : SIGNUP_PROMISES).map((tick) => (
                   <li key={tick} className="flex items-center gap-1.5">
                     <Check className="size-3.5 shrink-0 text-brand-label" strokeWidth={3} aria-hidden />
@@ -682,7 +685,7 @@ export function AuthFlow({
                 ))}
               </ul>
 
-              <p className="mt-6 text-center text-xs text-muted-foreground sm:mt-8">
+              <p className="mt-5 text-center text-xs text-muted-foreground sm:mt-8">
                 By continuing, you agree to our{" "}
                 <Link href="/terms" className={LEGAL_LINK}>
                   Terms of Service

--- a/src/app/(site)/auth/auth-flow.tsx
+++ b/src/app/(site)/auth/auth-flow.tsx
@@ -16,7 +16,6 @@ import {
   PILLAR_CONSOLE_LABEL,
   SIGNUP_PROMISES,
   PRELAUNCH_PROMISES,
-  FREE_PEAKS_PER_MONTH,
 } from "@/lib/pillar-console";
 
 // Bounded length + char set so a tampered link can't smuggle arbitrary strings
@@ -61,13 +60,15 @@ type Status =
 // tandem; treat the API as the source of truth.
 const RESEND_COOLDOWN_SECONDS = 60;
 
-// Proof points beside the form. Every figure is one the marketing surface
-// already states.
-const SIGNUP_STATS = [
-  { value: "5", label: "pillars, one login" },
-  { value: "0", label: "credit cards required" },
-  { value: FREE_PEAKS_PER_MONTH, label: "free Peaks every month" },
-] as const;
+// Proof points beside the form. The Peaks figure is catalog data resolved
+// server-side (see page.tsx), not a number kept in sync by hand.
+function signupStats(freePeaks: string) {
+  return [
+    { value: "5", label: "pillars, one login" },
+    { value: "0", label: "credit cards required" },
+    { value: freePeaks, label: "free Peaks a month, every plan" },
+  ];
+}
 
 // Landing CTAs route here with ?intent=waitlist|invite when the platform is
 // pre-launch (driven by cfg_platform_stage.signupMode), so the heading matches
@@ -169,7 +170,14 @@ function EmailChip({ email }: { email: string }) {
   );
 }
 
-export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
+export function AuthFlow({
+  signupMode,
+  /** Pre-formatted so the client bundle carries no pricing logic. */
+  freePeaks,
+}: {
+  signupMode: PlatformSignupMode;
+  freePeaks: string;
+}) {
   // Anything other than "open" means access is gated behind approval, so the
   // page must not promise same-day access.
   const isPreLaunch = signupMode !== "open";
@@ -449,7 +457,7 @@ export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
             {PILLAR_CONSOLE_ROWS.map((row) => (
               <div
                 key={row.name}
-                className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm"
+                className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm transition-[background-color,border-color,transform] duration-300 ease-out hover:translate-x-0.5 hover:border-brand/40 hover:bg-white/8 motion-reduce:transition-none motion-reduce:hover:translate-x-0"
               >
                 <span className="size-2 shrink-0 rounded-full bg-emerald-400" aria-hidden />
                 <span className="w-20 shrink-0 font-bold text-zinc-100">{row.name}</span>
@@ -469,7 +477,7 @@ export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
         </div>
 
         <div className="relative z-10 flex gap-8 border-t border-white/10 pt-6">
-          {SIGNUP_STATS.map((stat) => (
+          {signupStats(freePeaks).map((stat) => (
             <div key={stat.label}>
               <div
                 className="text-2xl font-bold tabular-nums text-brand-gradient"
@@ -504,7 +512,10 @@ export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
           </div>
         ) : null}
 
-        <div className="flex flex-1 items-center justify-center px-4 py-12 sm:px-8">
+        {/* Vertical padding steps up only once there's room for it. At mobile
+            widths the dark panel is hidden, so this column is the whole page
+            and desktop-sized padding was pushing it past the viewport. */}
+        <div className="flex flex-1 items-center justify-center px-4 py-8 sm:px-8 sm:py-12">
           {status.kind === "waitlisted" ? (
             <div className="w-full max-w-md rounded-2xl border bg-card p-7">
               <GoldTile icon={Clock} />
@@ -621,7 +632,7 @@ export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
                   "We’ll send a link that signs you straight in. If you’re new, that same link creates your account."}
               </p>
 
-              <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-4">
+              <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4 sm:mt-8">
                 {status.kind === "error" && (
                   <div
                     role="alert"
@@ -662,7 +673,7 @@ export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
                 </button>
               </form>
 
-              <ul className="mt-6 flex flex-wrap justify-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+              <ul className="mt-5 flex flex-wrap justify-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground sm:mt-6">
                 {(isPreLaunch ? PRELAUNCH_PROMISES : SIGNUP_PROMISES).map((tick) => (
                   <li key={tick} className="flex items-center gap-1.5">
                     <Check className="size-3.5 shrink-0 text-brand-label" strokeWidth={3} aria-hidden />
@@ -671,7 +682,7 @@ export function AuthFlow({ signupMode }: { signupMode: PlatformSignupMode }) {
                 ))}
               </ul>
 
-              <p className="mt-8 text-center text-xs text-muted-foreground">
+              <p className="mt-6 text-center text-xs text-muted-foreground sm:mt-8">
                 By continuing, you agree to our{" "}
                 <Link href="/terms" className={LEGAL_LINK}>
                   Terms of Service

--- a/src/app/(site)/auth/layout.tsx
+++ b/src/app/(site)/auth/layout.tsx
@@ -2,8 +2,10 @@ import Link from "next/link";
 import { Header } from "@/components/shared/header";
 import { SITE } from "@/lib/utils";
 
+// `py-1 -my-1` grows the tap target toward WCAG 2.5.8 without adding height to
+// the strip — /auth is fighting for vertical space on small screens.
 const LEGAL_LINK =
-  "rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+  "rounded-sm py-1 -my-1 underline underline-offset-2 hover:text-foreground focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 /**
  * Chrome for the auth flow (/auth, /auth/verify, /auth/accept-invite,
@@ -38,7 +40,14 @@ export default function AuthLayout({
     // viewport (URL bar retracted), so a min-h-screen column is taller than
     // what's actually visible and the page scrolls a little even when the
     // content fits. `dvh` tracks the live viewport, so it doesn't.
-    <div className="flex min-h-dvh flex-col">
+    //
+    // Guarded rather than stacked: a browser without `dvh` DROPS the
+    // declaration rather than falling back, which would leave the column with
+    // no min-height at all and float the legal strip up mid-viewport. Writing
+    // both classes bare would leave the winner to Tailwind's emit order; the
+    // @supports variant always sorts after the base utility, so `dvh` wins
+    // exactly where it is understood.
+    <div className="flex min-h-screen flex-col supports-[min-height:100dvh]:min-h-dvh">
       <Header />
       <main className="flex flex-1 flex-col">{children}</main>
       <footer className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 px-4 py-3 text-center text-xs text-muted-foreground sm:py-4">
@@ -47,6 +56,11 @@ export default function AuthLayout({
             strip onto a second line, which is height /auth can't spare. */}
         <a href={`mailto:${SITE.contactGeneral}`} className={LEGAL_LINK}>
           <span className="sm:hidden">Help</span>
+          {/* sr-only keeps this in the accessibility tree at zero height, so
+              the mobile link announces as "Help — email hello@peakhour.ai"
+              instead of a bare "Help" that reads like a help page. The visible
+              word stays a prefix of the accessible name (WCAG 2.5.3). */}
+          <span className="sr-only sm:hidden"> — email {SITE.contactGeneral}</span>
           <span className="hidden sm:inline">
             Trouble signing in? {SITE.contactGeneral}
           </span>

--- a/src/app/(site)/auth/layout.tsx
+++ b/src/app/(site)/auth/layout.tsx
@@ -42,12 +42,15 @@ export default function AuthLayout({
       <Header />
       <main className="flex flex-1 flex-col">{children}</main>
       <footer className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 px-4 py-3 text-center text-xs text-muted-foreground sm:py-4">
-        <span>
-          Trouble signing in?{" "}
-          <a href={`mailto:${SITE.contactGeneral}`} className={LEGAL_LINK}>
-            {SITE.contactGeneral}
-          </a>
-        </span>
+        {/* The address spells itself out only where there's width for it. At
+            375px the full "Trouble signing in? hello@peakhour.ai" wrapped the
+            strip onto a second line, which is height /auth can't spare. */}
+        <a href={`mailto:${SITE.contactGeneral}`} className={LEGAL_LINK}>
+          <span className="sm:hidden">Help</span>
+          <span className="hidden sm:inline">
+            Trouble signing in? {SITE.contactGeneral}
+          </span>
+        </a>
         <span aria-hidden className="opacity-40">
           ·
         </span>

--- a/src/app/(site)/auth/layout.tsx
+++ b/src/app/(site)/auth/layout.tsx
@@ -34,10 +34,14 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col">
+    // min-h-dvh, not min-h-screen: on mobile browsers `vh` is the tallest
+    // viewport (URL bar retracted), so a min-h-screen column is taller than
+    // what's actually visible and the page scrolls a little even when the
+    // content fits. `dvh` tracks the live viewport, so it doesn't.
+    <div className="flex min-h-dvh flex-col">
       <Header />
       <main className="flex flex-1 flex-col">{children}</main>
-      <footer className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 px-4 py-4 text-center text-xs text-muted-foreground">
+      <footer className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 px-4 py-3 text-center text-xs text-muted-foreground sm:py-4">
         <span>
           Trouble signing in?{" "}
           <a href={`mailto:${SITE.contactGeneral}`} className={LEGAL_LINK}>

--- a/src/app/(site)/auth/page.tsx
+++ b/src/app/(site)/auth/page.tsx
@@ -26,11 +26,16 @@ import { AuthFlow } from "./auth-flow";
  * Mirrors how `components/shared/header.tsx` resolves the same value.
  */
 export default async function AuthPage() {
-  const signupMode = (await getPublicCatalog())?.platform?.signupMode ?? "open";
-  // Country-independent: the grant is a fair-use allowance, not a price.
-  const freePeaks = formatPeaks(
-    minFreePeaksPerMonth(await getPricing("DEFAULT")) ?? FREE_PEAKS_FALLBACK,
-  );
+  // In parallel — these are two independent endpoints, and awaiting them in
+  // sequence costs a second round trip on a cold cache.
+  const [catalog, pricing] = await Promise.all([
+    getPublicCatalog(),
+    // Country-independent: the grant is a plan-level fair-use allowance, not a
+    // price, so one cache entry serves every visitor.
+    getPricing("DEFAULT"),
+  ]);
+  const signupMode = catalog?.platform?.signupMode ?? "open";
+  const freePeaks = formatPeaks(minFreePeaksPerMonth(pricing) ?? FREE_PEAKS_FALLBACK);
 
   return (
     // useSearchParams() must sit inside a Suspense boundary (App Router). A

--- a/src/app/(site)/auth/page.tsx
+++ b/src/app/(site)/auth/page.tsx
@@ -1,5 +1,11 @@
 import { Suspense } from "react";
 import { getPublicCatalog } from "@/lib/catalog";
+import {
+  getPricing,
+  minFreePeaksPerMonth,
+  formatPeaks,
+  FREE_PEAKS_FALLBACK,
+} from "@/lib/pricing";
 import { AuthFlow } from "./auth-flow";
 
 /**
@@ -21,6 +27,10 @@ import { AuthFlow } from "./auth-flow";
  */
 export default async function AuthPage() {
   const signupMode = (await getPublicCatalog())?.platform?.signupMode ?? "open";
+  // Country-independent: the grant is a fair-use allowance, not a price.
+  const freePeaks = formatPeaks(
+    minFreePeaksPerMonth(await getPricing("DEFAULT")) ?? FREE_PEAKS_FALLBACK,
+  );
 
   return (
     // useSearchParams() must sit inside a Suspense boundary (App Router). A
@@ -37,7 +47,7 @@ export default async function AuthPage() {
         </div>
       }
     >
-      <AuthFlow signupMode={signupMode} />
+      <AuthFlow signupMode={signupMode} freePeaks={freePeaks} />
     </Suspense>
   );
 }

--- a/src/app/(site)/auth/page.tsx
+++ b/src/app/(site)/auth/page.tsx
@@ -30,8 +30,10 @@ export default async function AuthPage() {
   // sequence costs a second round trip on a cold cache.
   const [catalog, pricing] = await Promise.all([
     getPublicCatalog(),
-    // Country-independent: the grant is a plan-level fair-use allowance, not a
-    // price, so one cache entry serves every visitor.
+    // "DEFAULT" is not a sentinel the API honours — it fails the two-letter
+    // validation and the response comes back geo-resolved. We pass it purely
+    // to pin one cache key, and read only `peaksIncluded`, which is a
+    // plan-level allowance and country-independent. Never read a price here.
     getPricing("DEFAULT"),
   ]);
   const signupMode = catalog?.platform?.signupMode ?? "open";

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -191,9 +191,10 @@ export default async function Home({
   // second round trip on a cold cache.
   const [catalog, pricing] = await Promise.all([
     getPublicCatalog(),
-    // "DEFAULT" (not the visitor's country): the free-Peaks grant is a
-    // plan-level fair-use allowance, country-independent — only prices vary.
-    // One cache entry therefore serves every visitor.
+    // "DEFAULT" is not a sentinel the API honours — it fails the two-letter
+    // validation and the response comes back geo-resolved. We pass it purely
+    // to pin one cache key, and read only `peaksIncluded`, which is a
+    // plan-level allowance and country-independent. Never read a price here.
     getPricing("DEFAULT"),
   ]);
   const freePeaks = formatPeaks(minFreePeaksPerMonth(pricing) ?? FREE_PEAKS_FALLBACK);

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -21,8 +21,13 @@ import {
   PILLAR_CONSOLE_ROWS,
   PILLAR_CONSOLE_LABEL,
   SIGNUP_PROMISES,
-  FREE_PEAKS_PER_MONTH,
 } from "@/lib/pillar-console";
+import {
+  getPricing,
+  minFreePeaksPerMonth,
+  formatPeaks,
+  FREE_PEAKS_FALLBACK,
+} from "@/lib/pricing";
 import {
   getPublicCatalog,
   publicMarketingIntegrations,
@@ -182,6 +187,12 @@ export default async function Home({
   // stage-capped). Falls back to the static list below if the API is
   // unreachable so the landing never hard-fails (mirrors the pricing fallback).
   const catalog = await getPublicCatalog();
+  // "DEFAULT" (not the visitor's country): the free-Peaks grant is the tier's
+  // fair-use allowance, which is country-independent — only prices vary. Asking
+  // for DEFAULT keeps every visitor on one cache entry.
+  const freePeaks = formatPeaks(
+    minFreePeaksPerMonth(await getPricing("DEFAULT")) ?? FREE_PEAKS_FALLBACK,
+  );
   const platform = catalog?.platform;
   const cta = signupCta(platform?.signupMode ?? "open");
   // Fall back on an EMPTY published set too, not just a null catalog — a
@@ -369,7 +380,7 @@ export default async function Home({
                   <PeaksGlyph size={16} />
                   <span className="font-bold text-brand-gradient">Peaks</span>
                 </span>
-                <span>{FREE_PEAKS_PER_MONTH} free Peaks/mo</span>
+                <span>{freePeaks}+ free Peaks/mo</span>
               </div>
             </div>
           </div>
@@ -398,9 +409,19 @@ export default async function Home({
                   <div
                     key={pillar.id}
                     id={pillar.id}
-                    className="group flex scroll-mt-24 flex-col gap-3 rounded-2xl border bg-background p-6 transition-all hover:-translate-y-1.5 hover:border-foreground hover:shadow-xl"
+                    // Sleeker than the old lift: a shorter travel on a real
+                    // easing curve, a gold-tinted shadow instead of a heavy
+                    // neutral one, and a border that warms to brand rather
+                    // than snapping to near-black. Every transition is
+                    // motion-reduce guarded.
+                    className="group relative flex scroll-mt-24 flex-col gap-3 overflow-hidden rounded-2xl border bg-background p-6 transition-[transform,border-color,box-shadow] duration-300 ease-out hover:-translate-y-1 hover:border-brand/50 hover:shadow-lg hover:shadow-brand/15 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                   >
-                    <div className="flex size-11 items-center justify-center rounded-xl bg-brand-gradient shadow-inner transition-transform group-hover:scale-105">
+                    {/* Gold hairline that wipes across the top edge on hover. */}
+                    <span
+                      aria-hidden
+                      className="absolute inset-x-0 top-0 h-0.5 origin-left scale-x-0 bg-brand-gradient transition-transform duration-300 ease-out group-hover:scale-x-100 motion-reduce:transition-none"
+                    />
+                    <div className="flex size-11 items-center justify-center rounded-xl bg-brand-gradient shadow-inner transition-transform duration-300 ease-out group-hover:-rotate-3 group-hover:scale-105 motion-reduce:transition-none">
                       <PillarIcon className="size-5 text-brand-contrast" strokeWidth={2} />
                     </div>
                     <h3 className="text-lg font-bold tracking-tight">{pillar.name}</h3>
@@ -416,7 +437,7 @@ export default async function Home({
                         </li>
                       ))}
                     </ul>
-                    <span className="self-start rounded-full bg-brand-soft px-2.5 py-1 text-[0.65rem] font-bold uppercase tracking-wide text-brand-ink">
+                    <span className="self-start rounded-full bg-brand-soft px-2.5 py-1 text-[0.65rem] font-bold uppercase tracking-wide text-brand-ink transition-shadow duration-300 ease-out group-hover:shadow-sm group-hover:shadow-brand/30 motion-reduce:transition-none">
                       {pillar.free}
                     </span>
                   </div>

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -20,6 +20,7 @@ import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
 import {
   PILLAR_CONSOLE_ROWS,
   PILLAR_CONSOLE_LABEL,
+  PILLAR_CONSOLE_ROW_CLASS,
   SIGNUP_PROMISES,
 } from "@/lib/pillar-console";
 import {
@@ -186,13 +187,16 @@ export default async function Home({
   // Integration catalog from the platform resolver (CMS-driven, env-gated,
   // stage-capped). Falls back to the static list below if the API is
   // unreachable so the landing never hard-fails (mirrors the pricing fallback).
-  const catalog = await getPublicCatalog();
-  // "DEFAULT" (not the visitor's country): the free-Peaks grant is the tier's
-  // fair-use allowance, which is country-independent — only prices vary. Asking
-  // for DEFAULT keeps every visitor on one cache entry.
-  const freePeaks = formatPeaks(
-    minFreePeaksPerMonth(await getPricing("DEFAULT")) ?? FREE_PEAKS_FALLBACK,
-  );
+  // In parallel — two independent endpoints; awaiting them in sequence costs a
+  // second round trip on a cold cache.
+  const [catalog, pricing] = await Promise.all([
+    getPublicCatalog(),
+    // "DEFAULT" (not the visitor's country): the free-Peaks grant is a
+    // plan-level fair-use allowance, country-independent — only prices vary.
+    // One cache entry therefore serves every visitor.
+    getPricing("DEFAULT"),
+  ]);
+  const freePeaks = formatPeaks(minFreePeaksPerMonth(pricing) ?? FREE_PEAKS_FALLBACK);
   const platform = catalog?.platform;
   const cta = signupCta(platform?.signupMode ?? "open");
   // Fall back on an EMPTY published set too, not just a null catalog — a
@@ -360,7 +364,7 @@ export default async function Home({
                 {PILLAR_CONSOLE_ROWS.map((row) => (
                   <div
                     key={row.name}
-                    className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm"
+                    className={PILLAR_CONSOLE_ROW_CLASS}
                   >
                     <span className="size-2 shrink-0 rounded-full bg-emerald-400" aria-hidden />
                     <span className="w-20 shrink-0 font-bold text-zinc-100">{row.name}</span>
@@ -419,9 +423,13 @@ export default async function Home({
                     {/* Gold hairline that wipes across the top edge on hover. */}
                     <span
                       aria-hidden
-                      className="absolute inset-x-0 top-0 h-0.5 origin-left scale-x-0 bg-brand-gradient transition-transform duration-300 ease-out group-hover:scale-x-100 motion-reduce:transition-none"
+                      className="absolute inset-x-0 top-0 h-0.5 origin-left scale-x-0 bg-brand-gradient transition-transform duration-300 ease-out group-hover:scale-x-100 motion-reduce:hidden"
                     />
-                    <div className="flex size-11 items-center justify-center rounded-xl bg-brand-gradient shadow-inner transition-transform duration-300 ease-out group-hover:-rotate-3 group-hover:scale-105 motion-reduce:transition-none">
+                    {/* motion-reduce neutralises the transform itself, not just
+                        its duration — transition-none alone would make the tile
+                        snap to rotated+scaled instantly, which is the jump the
+                        preference exists to avoid. */}
+                    <div className="flex size-11 items-center justify-center rounded-xl bg-brand-gradient shadow-inner transition-transform duration-300 ease-out group-hover:-rotate-3 group-hover:scale-105 motion-reduce:transition-none motion-reduce:group-hover:rotate-0 motion-reduce:group-hover:scale-100">
                       <PillarIcon className="size-5 text-brand-contrast" strokeWidth={2} />
                     </div>
                     <h3 className="text-lg font-bold tracking-tight">{pillar.name}</h3>

--- a/src/app/(site)/peaks/page.tsx
+++ b/src/app/(site)/peaks/page.tsx
@@ -12,7 +12,7 @@ import { getPeaks, formatPackPrice, type PeakPack } from "@/lib/peaks";
 export const metadata: Metadata = {
   title: "Peaks — AI credits that power Peakhour.ai",
   description:
-    "Peaks are the AI credits behind every Peakhour.ai feature. They require an active paid plan; purchased Peaks never expire, are non-refundable, and work across every Peakhour product.",
+    "Peaks are the AI credits behind every Peakhour.ai feature. Every plan includes a monthly allowance — free plans too; purchased Peaks never expire, are non-refundable, and work across every Peakhour product.",
 };
 
 /**
@@ -72,8 +72,8 @@ export default async function PeaksPage() {
             <div className="grid gap-6 sm:grid-cols-3">
               <HowItWorksCard
                 icon={<Sparkles className="size-5" />}
-                title="Works with a paid plan"
-                body="Peaks power every Peakhour.ai product and need an active paid Peakhour plan. Every paid plan comes with a Peaks allowance to get you going."
+                title="Included with every plan"
+                body="Peaks power every Peakhour.ai product, and every plan comes with a monthly allowance — free plans included. Paid plans simply carry more."
               />
               <HowItWorksCard
                 icon={<Zap className="size-5" />}

--- a/src/app/(site)/pricing/page.tsx
+++ b/src/app/(site)/pricing/page.tsx
@@ -3,7 +3,13 @@ import Link from "next/link";
 import { ArrowRight, Check } from "lucide-react";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
-import { getPricing, pillarProducts, fromMonthly, formatMonthly } from "@/lib/pricing";
+import {
+  getPricing,
+  pillarProducts,
+  fromMonthly,
+  formatMonthly,
+  formatPeaks,
+} from "@/lib/pricing";
 import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import {
   PRICING_PILLAR_ORDER,
@@ -223,7 +229,7 @@ export default async function PricingPage() {
                       ...PILLARS.presence.features.map((f) => f.title),
                       ...(typeof presenceFree?.peaksIncluded === "number"
                         ? [
-                            `${presenceFree.peaksIncluded.toLocaleString()} AI credits (Peaks) each month`,
+                            `${formatPeaks(presenceFree.peaksIncluded)} AI credits (Peaks) each month`,
                           ]
                         : []),
                     ].map((item) => (

--- a/src/app/(site)/pricing/page.tsx
+++ b/src/app/(site)/pricing/page.tsx
@@ -9,6 +9,7 @@ import {
   fromMonthly,
   formatMonthly,
   formatPeaks,
+  freeTier,
 } from "@/lib/pricing";
 import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import {
@@ -58,7 +59,7 @@ export default async function PricingPage() {
   const cta = signupCta(signupMode);
 
   const presence = pillarProducts(pricing, "presence")[0];
-  const presenceFree = presence?.tiers.find((t) => t.pricing.monthly === 0);
+  const presenceFree = presence ? freeTier(presence) : undefined;
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -118,9 +119,7 @@ export default async function PricingPage() {
                   const Icon = pillar.icon;
                   const product = pillarProducts(pricing, slug)[0];
                   const paid = product ? fromMonthly(product) : null;
-                  const hasFree = !!product?.tiers.some(
-                    (t) => t.pricing.monthly === 0,
-                  );
+                  const hasFree = !!(product && freeTier(product));
                   const price = !product
                     ? slug === "presence"
                       ? "Free"

--- a/src/app/(site)/pricing/teams/page.tsx
+++ b/src/app/(site)/pricing/teams/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Check } from "lucide-react";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
-import { getPricing, findBundleTier, formatMonthly } from "@/lib/pricing";
+import { getPricing, findBundleTier, formatMonthly, formatPeaks } from "@/lib/pricing";
 import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import { pageMetadata } from "@/lib/seo";
 
@@ -57,11 +57,11 @@ export default async function TeamsPricingPage() {
   const agencyPrice = agency ? formatMonthly(agency.pricing) : "$299";
   const agencyPeaks =
     typeof agency?.peaksIncluded === "number"
-      ? agency.peaksIncluded.toLocaleString()
+      ? formatPeaks(agency.peaksIncluded)
       : "25,000";
   const enterprisePeaks =
     typeof enterprise?.peaksIncluded === "number"
-      ? enterprise.peaksIncluded.toLocaleString()
+      ? formatPeaks(enterprise.peaksIncluded)
       : "100,000";
 
   return (

--- a/src/components/marketing/pricing/plan-comparison.tsx
+++ b/src/components/marketing/pricing/plan-comparison.tsx
@@ -3,6 +3,7 @@ import { Check, Minus } from "lucide-react";
 import {
   formatMonthly,
   formatYearly,
+  formatPeaks,
   featureLabel,
   type ResolvedProductTier,
 } from "@/lib/pricing";
@@ -157,7 +158,7 @@ export function PlanComparison({
                   style={{ fontFamily: "var(--font-space-grotesk)" }}
                 >
                   {typeof tier.peaksIncluded === "number"
-                    ? tier.peaksIncluded.toLocaleString()
+                    ? formatPeaks(tier.peaksIncluded)
                     : "—"}
                 </td>
               ))}

--- a/src/lib/pillar-console.ts
+++ b/src/lib/pillar-console.ts
@@ -52,9 +52,5 @@ export const PRELAUNCH_PROMISES = [
   "We’ll email your link",
 ] as const;
 
-/**
- * Free Peaks granted monthly on the free plans, as shown on the marketing
- * surface. Hard-coded to match the landing hero's existing figure; when the
- * public catalog starts exposing the free grant this should read from there.
- */
-export const FREE_PEAKS_PER_MONTH = "1,240";
+// The free-Peaks figure deliberately does NOT live here — it is catalog data,
+// not brand copy. See freePeaksPerMonth() in lib/pricing.ts.

--- a/src/lib/pillar-console.ts
+++ b/src/lib/pillar-console.ts
@@ -53,12 +53,18 @@ export const PRELAUNCH_PROMISES = [
 ] as const;
 
 /**
- * Row styling, shared so the two consoles keep the same behaviour as well as
- * the same content — the hover was added to /auth first and the landing rows
- * silently kept the old flat treatment.
+ * Row styling, shared so the two consoles can't diverge in appearance the way
+ * they nearly did in content — during this change the rows briefly carried a
+ * hover on /auth and none on the landing page, from hand-copied class strings.
+ *
+ * Deliberately no hover: the console is wrapped in `role="img"` on both
+ * surfaces, so it is one picture. Rows that lift and warm under the cursor
+ * read as clickable, and nothing here is — there's no href, no handler and no
+ * cursor change. The hover polish lives on the pillar CARDS, which are the
+ * real affordance.
  */
 export const PILLAR_CONSOLE_ROW_CLASS =
-  "flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm transition-[background-color,border-color,transform] duration-300 ease-out hover:translate-x-0.5 hover:border-brand/40 hover:bg-white/8 motion-reduce:transition-none motion-reduce:hover:translate-x-0";
+  "flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm";
 
 // The free-Peaks figure deliberately does NOT live here — it is catalog data,
 // not brand copy. See minFreePeaksPerMonth() in lib/pricing.ts.

--- a/src/lib/pillar-console.ts
+++ b/src/lib/pillar-console.ts
@@ -52,5 +52,13 @@ export const PRELAUNCH_PROMISES = [
   "We’ll email your link",
 ] as const;
 
+/**
+ * Row styling, shared so the two consoles keep the same behaviour as well as
+ * the same content — the hover was added to /auth first and the landing rows
+ * silently kept the old flat treatment.
+ */
+export const PILLAR_CONSOLE_ROW_CLASS =
+  "flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-3.5 py-2.5 text-sm transition-[background-color,border-color,transform] duration-300 ease-out hover:translate-x-0.5 hover:border-brand/40 hover:bg-white/8 motion-reduce:transition-none motion-reduce:hover:translate-x-0";
+
 // The free-Peaks figure deliberately does NOT live here — it is catalog data,
-// not brand copy. See freePeaksPerMonth() in lib/pricing.ts.
+// not brand copy. See minFreePeaksPerMonth() in lib/pricing.ts.

--- a/src/lib/pricing-free-peaks.test.ts
+++ b/src/lib/pricing-free-peaks.test.ts
@@ -59,6 +59,29 @@ describe("minFreePeaksPerMonth", () => {
     expect(minFreePeaksPerMonth(res)).toBe(250);
   });
 
+  it("ignores Agency/Enterprise, which look free but grant 100k", () => {
+    // Bundle tiers carry no matrix price, so a naive zero-price test matches
+    // them. They also appear under every product — and the live API returns
+    // `enterprise` BEFORE the real free tier under growth and support_inbox,
+    // so a `.find()` on price alone silently read the wrong tier.
+    const res = response([
+      product("growth", [
+        tier({ key: "enterprise", peaksIncluded: 100000 }),
+        tier({ key: "growth.free", peaksIncluded: 500 }),
+        tier({ key: "agency", peaksIncluded: 25000 }),
+      ]),
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBe(500);
+  });
+
+  it("is independent of the order tiers arrive in", () => {
+    const free = tier({ key: "growth.free", peaksIncluded: 500 });
+    const ent = tier({ key: "enterprise", peaksIncluded: 100000 });
+    expect(minFreePeaksPerMonth(response([product("growth", [free, ent])]))).toBe(
+      minFreePeaksPerMonth(response([product("growth", [ent, free])])),
+    );
+  });
+
   it("ignores paid tiers when picking each product's free tier", () => {
     const res = response([
       product("commerce", [
@@ -94,6 +117,19 @@ describe("minFreePeaksPerMonth", () => {
       product("content", [tier({ peaksIncluded: 500 })]),
     ]);
     expect(minFreePeaksPerMonth(res)).toBe(500);
+  });
+
+  it("treats a zero grant as nothing to advertise, not as a minimum of zero", () => {
+    // `0 ?? FREE_PEAKS_FALLBACK` is 0, so a zero here would reach the page and
+    // render "0+ free Peaks/mo" with no way for the caller to catch it.
+    expect(
+      minFreePeaksPerMonth(response([product("presence", [tier({ peaksIncluded: 0 })])])),
+    ).toBeNull();
+    const mixed = response([
+      product("presence", [tier({ peaksIncluded: 0 })]),
+      product("content", [tier({ peaksIncluded: 500 })]),
+    ]);
+    expect(minFreePeaksPerMonth(mixed)).toBe(500);
   });
 
   it("returns null when nothing resolves, so callers use the fallback", () => {

--- a/src/lib/pricing-free-peaks.test.ts
+++ b/src/lib/pricing-free-peaks.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { minFreePeaksPerMonth, formatPeaks } from "./pricing";
+import type { PricingEntry, PricingResponse, ResolvedProductTier } from "./pricing";
+
+/** Only monthly/yearly matter here — the rest is required-field ballast. */
+function price(monthly: number, yearly: number): PricingEntry {
+  return {
+    currency: "USD",
+    monthly,
+    yearly,
+    trialDays: 0,
+    foundingDiscountPct: 0,
+    billingProviderKey: "stripe",
+    taxIncluded: false,
+    gstApplicable: false,
+    vatApplicable: false,
+  };
+}
+
+function tier(over: Partial<ResolvedProductTier> = {}): ResolvedProductTier {
+  return {
+    key: "x.free",
+    name: "Free",
+    features: [],
+    limits: {},
+    highlightAsRecommended: false,
+    version: 1,
+    pricing: price(0, 0),
+    ...over,
+  } as ResolvedProductTier;
+}
+
+function response(products: PricingResponse["products"]): PricingResponse {
+  return { country: "DEFAULT", plans: [], products };
+}
+
+function product(key: string, tiers: ResolvedProductTier[]) {
+  return { key, name: key, pillar: key, status: "live", tiers };
+}
+
+describe("minFreePeaksPerMonth", () => {
+  it("reports the floor every free plan clears, not the sum of all of them", () => {
+    // Grants stack in the wallet, so five free pillars really is 2,500 — but
+    // the marketing claim is what ONE free plan guarantees.
+    const res = response(
+      ["commerce", "content", "growth", "support", "presence"].map((k) =>
+        product(k, [tier({ key: `${k}.free`, peaksIncluded: 500 })]),
+      ),
+    );
+    expect(minFreePeaksPerMonth(res)).toBe(500);
+  });
+
+  it("takes the smallest grant when free plans differ", () => {
+    const res = response([
+      product("commerce", [tier({ peaksIncluded: 500 })]),
+      product("content", [tier({ peaksIncluded: 250 })]),
+      product("growth", [tier({ peaksIncluded: 1000 })]),
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBe(250);
+  });
+
+  it("ignores paid tiers when picking each product's free tier", () => {
+    const res = response([
+      product("commerce", [
+        tier({ key: "commerce.free", peaksIncluded: 500 }),
+        tier({
+          key: "commerce.paid",
+          peaksIncluded: 5000,
+          pricing: price(29, 290),
+        }),
+      ]),
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBe(500);
+  });
+
+  it("treats a yearly-only price as paid", () => {
+    const res = response([
+      product("commerce", [
+        tier({
+          key: "commerce.annual",
+          peaksIncluded: 5000,
+          pricing: price(0, 290),
+        }),
+      ]),
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBeNull();
+  });
+
+  it("skips a free tier carrying no allowance rather than counting it as zero", () => {
+    // An uncapped grant has no number to show; reporting 0 would be a lie, and
+    // as a minimum it would swallow every real grant.
+    const res = response([
+      product("commerce", [tier({ peaksIncluded: undefined })]),
+      product("content", [tier({ peaksIncluded: 500 })]),
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBe(500);
+  });
+
+  it("returns null when nothing resolves, so callers use the fallback", () => {
+    expect(minFreePeaksPerMonth(null)).toBeNull();
+    expect(minFreePeaksPerMonth(response([]))).toBeNull();
+    expect(minFreePeaksPerMonth(response([product("commerce", [])]))).toBeNull();
+  });
+
+  it("formats with grouping separators", () => {
+    expect(formatPeaks(2500)).toBe("2,500");
+    expect(formatPeaks(500)).toBe("500");
+  });
+});

--- a/src/lib/pricing-free-peaks.test.ts
+++ b/src/lib/pricing-free-peaks.test.ts
@@ -18,6 +18,8 @@ function price(monthly: number, yearly: number): PricingEntry {
 }
 
 function tier(over: Partial<ResolvedProductTier> = {}): ResolvedProductTier {
+  // No `as` cast: if the API adds a required field, this fixture should
+  // fail to compile rather than stay green over a shape mismatch.
   return {
     key: "x.free",
     name: "Free",
@@ -27,7 +29,7 @@ function tier(over: Partial<ResolvedProductTier> = {}): ResolvedProductTier {
     version: 1,
     pricing: price(0, 0),
     ...over,
-  } as ResolvedProductTier;
+  };
 }
 
 function response(products: PricingResponse["products"]): PricingResponse {
@@ -59,27 +61,46 @@ describe("minFreePeaksPerMonth", () => {
     expect(minFreePeaksPerMonth(res)).toBe(250);
   });
 
-  it("ignores Agency/Enterprise, which look free but grant 100k", () => {
-    // Bundle tiers carry no matrix price, so a naive zero-price test matches
-    // them. They also appear under every product — and the live API returns
-    // `enterprise` BEFORE the real free tier under growth and support_inbox,
-    // so a `.find()` on price alone silently read the wrong tier.
+  it("ignores the Enterprise bundle, which is priced at 0 but grants 100k", () => {
+    // Enterprise is sales-led, so it carries no matrix price and reads as
+    // free. Agency is genuinely priced (₹24,999/mo on live data) — it's
+    // excluded as a bundle, not as a price trap.
     const res = response([
       product("growth", [
         tier({ key: "enterprise", peaksIncluded: 100000 }),
         tier({ key: "growth.free", peaksIncluded: 500 }),
-        tier({ key: "agency", peaksIncluded: 25000 }),
+        tier({ key: "agency", peaksIncluded: 25000, pricing: price(24999, 249999) }),
       ]),
     ]);
     expect(minFreePeaksPerMonth(res)).toBe(500);
   });
 
   it("is independent of the order tiers arrive in", () => {
+    // The resolver sorts by price then breaks ties alphabetically, so
+    // "enterprise" lands before "growth.free" but after
+    // "commerce_assistant.free" — the naive read is wrong for only some
+    // products. Assert the value on both sides: comparing the two calls to
+    // each other passes even if the function returns null unconditionally.
     const free = tier({ key: "growth.free", peaksIncluded: 500 });
     const ent = tier({ key: "enterprise", peaksIncluded: 100000 });
-    expect(minFreePeaksPerMonth(response([product("growth", [free, ent])]))).toBe(
-      minFreePeaksPerMonth(response([product("growth", [ent, free])])),
-    );
+    expect(minFreePeaksPerMonth(response([product("growth", [free, ent])]))).toBe(500);
+    expect(minFreePeaksPerMonth(response([product("growth", [ent, free])]))).toBe(500);
+  });
+
+  it("takes the smallest grant when a product has more than one free tier", () => {
+    const res = response([
+      product("commerce", [
+        tier({ key: "commerce.free", peaksIncluded: 500 }),
+        tier({ key: "commerce.starter", peaksIncluded: 300 }),
+      ]),
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBe(300);
+  });
+
+  it("ignores a negative allowance", () => {
+    expect(
+      minFreePeaksPerMonth(response([product("commerce", [tier({ peaksIncluded: -5 })])])),
+    ).toBeNull();
   });
 
   it("ignores paid tiers when picking each product's free tier", () => {
@@ -119,6 +140,19 @@ describe("minFreePeaksPerMonth", () => {
     expect(minFreePeaksPerMonth(res)).toBe(500);
   });
 
+  it("ignores products that aren't live yet", () => {
+    // The resolver only suppresses in_development/hidden, and only in prod —
+    // so coming_soon reaches us in prod and everything reaches us in dev. A
+    // pillar you can't sign up for must not set the floor for what you get on
+    // signup.
+    const res = response([
+      product("commerce", [tier({ peaksIncluded: 500 })]),
+      { ...product("future", [tier({ peaksIncluded: 50 })]), status: "coming_soon" },
+      { ...product("wip", [tier({ peaksIncluded: 10 })]), status: "in_development" },
+    ]);
+    expect(minFreePeaksPerMonth(res)).toBe(500);
+  });
+
   it("treats a zero grant as nothing to advertise, not as a minimum of zero", () => {
     // `0 ?? FREE_PEAKS_FALLBACK` is 0, so a zero here would reach the page and
     // render "0+ free Peaks/mo" with no way for the caller to catch it.
@@ -138,8 +172,15 @@ describe("minFreePeaksPerMonth", () => {
     expect(minFreePeaksPerMonth(response([product("commerce", [])]))).toBeNull();
   });
 
-  it("formats with grouping separators", () => {
-    expect(formatPeaks(2500)).toBe("2,500");
+});
+
+describe("formatPeaks", () => {
+  it("groups in thousands regardless of the host locale", () => {
+    // The whole reason the locale is pinned. A bare toLocaleString() on an
+    // en-IN host renders 100000 as "1,00,000", which would sit next to a
+    // Western-grouped price on the same card.
     expect(formatPeaks(500)).toBe("500");
+    expect(formatPeaks(2500)).toBe("2,500");
+    expect(formatPeaks(100000)).toBe("100,000");
   });
 });

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -199,23 +199,32 @@ export function productTiers(product: ResolvedProduct): ResolvedProductTier[] {
  * but quoting that total would promise a five-pillar signup to a visitor who
  * may only ever take one. The floor is true for everybody.
  *
- * A tier counts as free when it bills nothing on either interval — read from
- * the resolved price rather than a `.free` key suffix, so a renamed tier key
- * can't silently drop a pillar out of the comparison.
+ * Bundle plans are excluded via `productTiers()`, and that exclusion is
+ * load-bearing rather than tidiness: Agency and Enterprise are sales-led, so
+ * they carry no matrix price and look free (`monthly: 0, yearly: 0`) while
+ * granting 100k Peaks. They also surface under every product, and NOT reliably
+ * after the real free tier — the live API returns `enterprise` first under
+ * `growth` and `support_inbox`, so reading "the first zero-priced tier" picks
+ * the wrong one. Among a product's own tiers, free is identified by price
+ * rather than a `.free` key suffix, so renaming a tier can't drop a pillar out
+ * of the comparison.
  *
  * Returns null when pricing is unavailable (the caller falls back to
- * FREE_PEAKS_FALLBACK) or when no free tier carries an allowance — an
- * uncapped grant has no number to show and must not be reported as 0.
+ * FREE_PEAKS_FALLBACK) or when no free tier advertises a grant. A grant of 0
+ * counts as nothing to advertise rather than as a minimum of zero — otherwise
+ * one credit-less free tier would drag the headline to "0+ free Peaks/mo",
+ * which `?? FREE_PEAKS_FALLBACK` could not rescue (0 is not nullish).
  */
 export function minFreePeaksPerMonth(pricing: PricingResponse | null): number | null {
   if (!pricing) return null;
   let min: number | null = null;
   for (const product of pricing.products) {
-    const free = product.tiers.find(
-      (t) => (t.pricing?.monthly ?? 0) === 0 && (t.pricing?.yearly ?? 0) === 0,
-    );
-    if (typeof free?.peaksIncluded !== "number") continue;
-    min = min === null ? free.peaksIncluded : Math.min(min, free.peaksIncluded);
+    for (const tier of productTiers(product)) {
+      if (tier.pricing.monthly !== 0 || tier.pricing.yearly !== 0) continue;
+      const peaks = tier.peaksIncluded;
+      if (typeof peaks !== "number" || peaks <= 0) continue;
+      min = min === null ? peaks : Math.min(min, peaks);
+    }
   }
   return min;
 }

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,15 +1,23 @@
 /**
  * Server-side helper for fetching country-resolved pricing from the
  * peakhour-api `/v1/platform/pricing` endpoint. Used by the marketing
- * /pricing page and the landing-page pricing section so both render
- * with the same currency for a given visitor.
+ * /pricing pages, the landing hero and /auth — the last two for the free-Peaks
+ * figure only, not for prices.
  *
  * Country precedence on the API side:
  *   1. `?country=XX` query — passed explicitly when we already know it.
  *   2. Authenticated org subscription — N/A here (these pages are public).
  *   3. Vercel `x-vercel-ip-country` header — set on every request when
  *      deployed; absent in local dev.
- *   4. `"DEFAULT"` sentinel → USD via stripe.
+ *
+ * ⚠ There is NO `"DEFAULT"` sentinel. The route validates the query param
+ * against /^[A-Za-z]{2}$/, so `?country=DEFAULT` fails validation and falls
+ * through to the header chain — passing it is identical to passing nothing,
+ * and the response comes back geo-resolved (from Vercel's egress region, not
+ * the visitor's). Callers that pass `"DEFAULT"` do so only to pin a single
+ * cache key, and must read ONLY country-independent fields such as
+ * `peaksIncluded`. Never read a price off such a response: you would serve
+ * every visitor the currency of whichever region happened to fill the cache.
  *
  * To keep the marketing surface fast, we pass the detected country
  * explicitly (read by the caller from `headers()`) AND fall back to
@@ -155,12 +163,12 @@ export const getPricing = cache(
  */
 export function formatMonthly(p: PricingEntry): string {
   if (p.monthly === 0) return `${p.displayPrefix ?? ""}0`;
-  return `${p.displayPrefix ?? ""}${p.monthly.toLocaleString()}`;
+  return `${p.displayPrefix ?? ""}${formatNumber(p.monthly)}`;
 }
 
 export function formatYearly(p: PricingEntry): string {
   if (p.yearly === 0) return `${p.displayPrefix ?? ""}0`;
-  return `${p.displayPrefix ?? ""}${p.yearly.toLocaleString()}`;
+  return `${p.displayPrefix ?? ""}${formatNumber(p.yearly)}`;
 }
 
 /**
@@ -190,6 +198,40 @@ export function productTiers(product: ResolvedProduct): ResolvedProductTier[] {
 }
 
 /**
+ * A product's own free tier, or undefined if it has none.
+ *
+ * The one definition of "free" — reach for this rather than
+ * `product.tiers.find(t => t.pricing.monthly === 0)`, which is wrong twice
+ * over.
+ *
+ * First, it searches the raw tier list, which includes the account-level
+ * bundles. Enterprise is sales-led: it carries no matrix price, so it reads as
+ * `monthly: 0, yearly: 0` while granting 100k Peaks. (Agency is NOT a price
+ * trap — it is fully priced, ₹24,999/mo on live data — but it is still not a
+ * product's free tier, so both are excluded by key via `isBundleTier`.)
+ *
+ * Second, the resolver sorts tiers by price and breaks ties alphabetically, so
+ * among the zero-priced ones `"enterprise"` sorts BEFORE `"growth.free"` and
+ * `"support_inbox.free"` — though AFTER `"commerce_assistant.free"`. The naive
+ * find therefore lands on Enterprise for some products and the real free tier
+ * for others, which is what makes the bug so easy to miss.
+ *
+ * Both intervals must be zero: a yearly-only plan is not free.
+ */
+export function freeTiers(product: ResolvedProduct): ResolvedProductTier[] {
+  return productTiers(product).filter(
+    (t) => t.pricing.monthly === 0 && t.pricing.yearly === 0,
+  );
+}
+
+/** The product's free tier — the cheapest one first, for surfaces that show a
+ *  single Free column. Products carry one today; `freeTiers` is the honest
+ *  plural for callers that must not assume that (see minFreePeaksPerMonth). */
+export function freeTier(product: ResolvedProduct): ResolvedProductTier | undefined {
+  return freeTiers(product)[0];
+}
+
+/**
  * The smallest monthly Peaks grant on any free plan — i.e. the amount every
  * free plan is guaranteed to include at minimum.
  *
@@ -199,15 +241,15 @@ export function productTiers(product: ResolvedProduct): ResolvedProductTier[] {
  * but quoting that total would promise a five-pillar signup to a visitor who
  * may only ever take one. The floor is true for everybody.
  *
- * Bundle plans are excluded via `productTiers()`, and that exclusion is
- * load-bearing rather than tidiness: Agency and Enterprise are sales-led, so
- * they carry no matrix price and look free (`monthly: 0, yearly: 0`) while
- * granting 100k Peaks. They also surface under every product, and NOT reliably
- * after the real free tier — the live API returns `enterprise` first under
- * `growth` and `support_inbox`, so reading "the first zero-priced tier" picks
- * the wrong one. Among a product's own tiers, free is identified by price
- * rather than a `.free` key suffix, so renaming a tier can't drop a pillar out
- * of the comparison.
+ * Bundles are excluded (see `freeTier`), which is load-bearing rather than
+ * tidiness — Enterprise is sales-led, priced at 0/0, and grants 100k Peaks.
+ *
+ * Only `live` products count. The resolver does NOT narrow to live for us: in
+ * prod it merely suppresses in_development/hidden (so `coming_soon` still
+ * arrives), and outside prod it applies no status filter at all. Since this
+ * number sits beside "free plan on every pillar" as something you get on
+ * signup, a pillar you can't sign up for yet must not set the floor — nor
+ * should a half-built dev product quietly move the figure on devapi.
  *
  * Returns null when pricing is unavailable (the caller falls back to
  * FREE_PEAKS_FALLBACK) or when no free tier advertises a grant. A grant of 0
@@ -219,8 +261,10 @@ export function minFreePeaksPerMonth(pricing: PricingResponse | null): number | 
   if (!pricing) return null;
   let min: number | null = null;
   for (const product of pricing.products) {
-    for (const tier of productTiers(product)) {
-      if (tier.pricing.monthly !== 0 || tier.pricing.yearly !== 0) continue;
+    if (product.status !== "live") continue;
+    // Every free tier, not just the first: if a product ever ships two, the
+    // floor is the smaller grant, and picking one would overstate it.
+    for (const tier of freeTiers(product)) {
       const peaks = tier.peaksIncluded;
       if (typeof peaks !== "number" || peaks <= 0) continue;
       min = min === null ? peaks : Math.min(min, peaks);
@@ -237,10 +281,30 @@ export function minFreePeaksPerMonth(pricing: PricingResponse | null): number | 
  */
 export const FREE_PEAKS_FALLBACK = 500;
 
-/** Grouping separators so "2500" reads as "2,500" wherever it's quoted. */
-export function formatPeaks(value: number): string {
-  return value.toLocaleString("en-US");
+/**
+ * Grouping separators for every number on the pricing surface — prices and
+ * Peaks alike.
+ *
+ * The locale is pinned rather than left to `toLocaleString()`'s default,
+ * which on the server is the host's ICU locale (LANG/LC_ALL) and so varies
+ * between a laptop, CI and Vercel. Pinning also keeps one card internally
+ * consistent: prices and Peaks used to run through different code paths, so
+ * an en-IN host rendered "₹2,49,999" beside "100,000" — Indian grouping for
+ * the price, Western for the allowance.
+ *
+ * en-US (not en-IN) because the surface is priced for a global audience and
+ * quotes USD alongside INR; revisit alongside real localisation, at which
+ * point this should take the active locale rather than a constant.
+ */
+const NUMBER_LOCALE = "en-US";
+
+export function formatNumber(value: number): string {
+  return value.toLocaleString(NUMBER_LOCALE);
 }
+
+/** Peaks amounts. Alias of formatNumber — named for the call sites so the
+ *  intent reads at a glance. */
+export const formatPeaks = formatNumber;
 
 /**
  * Find a bundle tier (Agency/Enterprise) anywhere in the response. Bundle plans

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -190,6 +190,50 @@ export function productTiers(product: ResolvedProduct): ResolvedProductTier[] {
 }
 
 /**
+ * The smallest monthly Peaks grant on any free plan — i.e. the amount every
+ * free plan is guaranteed to include at minimum.
+ *
+ * Deliberately the MINIMUM, not the sum. The wallet is one pool and grants do
+ * stack (peakhour-api's `stackCreditAllowance` adds up every plan an org
+ * holds), so someone on all five free pillars really does get five grants —
+ * but quoting that total would promise a five-pillar signup to a visitor who
+ * may only ever take one. The floor is true for everybody.
+ *
+ * A tier counts as free when it bills nothing on either interval — read from
+ * the resolved price rather than a `.free` key suffix, so a renamed tier key
+ * can't silently drop a pillar out of the comparison.
+ *
+ * Returns null when pricing is unavailable (the caller falls back to
+ * FREE_PEAKS_FALLBACK) or when no free tier carries an allowance — an
+ * uncapped grant has no number to show and must not be reported as 0.
+ */
+export function minFreePeaksPerMonth(pricing: PricingResponse | null): number | null {
+  if (!pricing) return null;
+  let min: number | null = null;
+  for (const product of pricing.products) {
+    const free = product.tiers.find(
+      (t) => (t.pricing?.monthly ?? 0) === 0 && (t.pricing?.yearly ?? 0) === 0,
+    );
+    if (typeof free?.peaksIncluded !== "number") continue;
+    min = min === null ? free.peaksIncluded : Math.min(min, free.peaksIncluded);
+  }
+  return min;
+}
+
+/**
+ * Shown when the pricing API is unreachable, mirroring how the landing page
+ * keeps a static integrations list for the same case. Matches the catalog at
+ * the time of writing (every free tier grants 500); it is a degraded mode, not
+ * a source of truth — `minFreePeaksPerMonth` is.
+ */
+export const FREE_PEAKS_FALLBACK = 500;
+
+/** Grouping separators so "2500" reads as "2,500" wherever it's quoted. */
+export function formatPeaks(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
  * Find a bundle tier (Agency/Enterprise) anywhere in the response. Bundle plans
  * appear as a tier under every product they compose, so the first occurrence
  * carries the canonical price + Peaks allowance (identical across products).


### PR DESCRIPTION
Follow-ups to #457, all three raised on review of the merged redesign.

## 1. The free-Peaks figure was invented

`"1,240"` matched nothing in the catalog. Every free tier actually grants **500** (`cfg_plans.fairUse` → `ai.credits.consumed` hardCap, surfaced as `tier.peaksIncluded`). It now reads from `/v1/platform/pricing`.

**Minimum, not sum — deliberately.** Grants *do* stack: peakhour-api's `stackCreditAllowance` sums every plan an org holds, so someone on all five free pillars really does get 2,500. But quoting the total would promise a five-pillar signup to a visitor who may only ever take one. The floor is true for everybody. Landing hero reads `500+ free Peaks/mo`; /auth reads `500+` / "free Peaks a month, every free plan".

Asked for country `DEFAULT` — the grant is a plan-level fair-use allowance, not a price, so it's country-independent and one cache entry serves everyone. `FREE_PEAKS_FALLBACK` covers an unreachable API, mirroring the landing page's static integrations fallback.

## 2. /auth scrolled on mobile with room to spare

Two separate causes:
- `min-h-screen`: on mobile browsers `vh` is the *tallest* viewport (URL bar retracted), so the column was taller than what's visible and scrolled even when content fit. Now `min-h-dvh`.
- Desktop-sized padding applied at mobile widths, where the dark panel is hidden and this column is the whole page. Padding, type scale and gaps now step up at `sm`, and the legal strip no longer wraps to two lines at 375px.

## 3. Sleeker pillar-card hover

Shorter travel on a real easing curve, gold-tinted shadow instead of a heavy neutral one, border warming to brand rather than snapping to near-black, a gold hairline wiping across the top edge, and a slight counter-rotate on the icon tile. All `motion-reduce` guarded — including neutralising the transforms, not just their duration.

## Review found two bugs in my own first pass

| Sev | Finding |
|---|---|
| **CRITICAL** | Agency/Enterprise are sales-led, so they carry **no matrix price and look free** (`monthly: 0, yearly: 0`) while granting 100k Peaks — and they appear under every product. The API also returns `enterprise` **first** under `growth` and `support_inbox`, so a `.find()` on price alone was *already reading 100,000* for those products. The output was correct only by luck, because three other products list free first and `Math.min` rescued it. Now iterates `productTiers()`, which strips bundles. |
| **HIGH** | A free tier granting `0` would render "0+ free Peaks/mo" — and `0 ?? FALLBACK` is `0`, so the caller couldn't catch it. Zero is now "nothing to advertise". |

The fix also deleted a `BUNDLE_TIER_KEYS` set I'd added locally: `isBundleTier()` already existed in the same file, so the duplicate was the exact drift this work argues against.

Also fixed: /auth was missing the `+` hedge the hero has; the two pillar consoles had diverged (hover on /auth only, in the component extracted to stop them drifting); serial `await` waterfall on both pages → `Promise.all`; and four pre-existing `toLocaleString()` calls adopted `formatPeaks()`, since bare `toLocaleString()` renders "2 500" under a `fr` server locale.

## Verification

- `tsc --noEmit` clean, `eslint` clean on changed files, `next build` compiles
- `vitest` — 113 passed / 10 files, including 9 new tests covering the bundle-tier shadowing, tier-order independence, the zero-grant case, and the null paths

## Note for reviewers

**The advertised figure drops 1,240 → 500.** That's a visible change on the primary landing surface — accurate, but worth your explicit sign-off rather than shipping as a side effect.

Mobile is now ~60px tighter than the first pass. It fits comfortably at 390×844 and above; on a 375×667 iPhone SE the default state is close but the referral (`?ref=`) variant may still scroll slightly. Cutting the promise row or the consent line on mobile would guarantee it — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)