### PR TITLE
fix(dashboard): the two P0 layout defects, and finish the padding migration

### DIFF
--- a/src/app/(site)/dashboard/ask/page.tsx
+++ b/src/app/(site)/dashboard/ask/page.tsx
@@ -30,11 +30,11 @@ function AskPageInner() {
 
   return (
     // `fill` instead of the old `h-[calc(100dvh-5rem)]`, which assumed 80px of
-    // shell chrome when the real figure is 120px — so this page overflowed its
-    // container by 40px on every device and pushed the composer below the fold.
-    // The shell owns the measurement now; nothing here can go stale when its
-    // padding or banner slot changes. Also drops a duplicate `p-4`: the shell
-    // already insets the page.
+    // shell chrome when the real figure is 104px on desktop and 88px at 375px
+    // (header 56 + the shell's own 48/32 of padding) — so this page overflowed
+    // its container on every device. The shell owns the measurement now, so
+    // nothing here goes stale when its padding changes. Also drops a duplicate
+    // `p-4`: the shell already insets the page.
     <PageShell width="narrow" fill className="space-y-3 sm:space-y-3">
       <PageHeader
         icon={

--- a/src/app/(site)/dashboard/ask/page.tsx
+++ b/src/app/(site)/dashboard/ask/page.tsx
@@ -12,6 +12,7 @@ import { useSearchParams } from "next/navigation";
 import { Sparkles, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AskConversation } from "@/components/ask/ask-conversation";
+import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 
 function newThreadId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -28,29 +29,37 @@ function AskPageInner() {
   const [threadId, setThreadId] = useState<string>(() => newThreadId());
 
   return (
-    <div className="mx-auto flex h-[calc(100dvh-5rem)] w-full max-w-3xl flex-col p-4">
-      <div className="mb-3 flex items-center gap-3">
-        <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
-          <Sparkles className="size-5 text-primary" />
-        </div>
-        <div className="flex-1">
-          <h1 className="text-lg font-semibold leading-none tracking-tight">Ask Peakhour</h1>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Your SEO manager + data analyst — answers grounded in your real analytics.
-          </p>
-        </div>
-        <Button variant="outline" size="sm" onClick={() => setThreadId(newThreadId())}>
-          <Plus className="mr-1.5 size-3.5" />
-          New conversation
-        </Button>
-      </div>
+    // `fill` instead of the old `h-[calc(100dvh-5rem)]`, which assumed 80px of
+    // shell chrome when the real figure is 120px — so this page overflowed its
+    // container by 40px on every device and pushed the composer below the fold.
+    // The shell owns the measurement now; nothing here can go stale when its
+    // padding or banner slot changes. Also drops a duplicate `p-4`: the shell
+    // already insets the page.
+    <PageShell width="narrow" fill className="space-y-3 sm:space-y-3">
+      <PageHeader
+        icon={
+          <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
+            <Sparkles className="size-5 text-primary" />
+          </div>
+        }
+        title="Ask Peakhour"
+        description="Your SEO manager + data analyst — answers grounded in your real analytics."
+        actions={
+          <Button variant="outline" size="sm" onClick={() => setThreadId(newThreadId())}>
+            <Plus className="mr-1.5 size-3.5" />
+            New conversation
+          </Button>
+        }
+      />
 
-      <div className="flex-1 overflow-hidden rounded-xl border bg-background">
+      {/* min-h-0 lets this shrink below its content so the thread scrolls
+          inside the bordered box rather than growing the page. */}
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border bg-background">
         {/* useChat resets on threadId change, so no key needed; initialInput seeds
             the composer once from the ?q deep-link. */}
         <AskConversation threadId={threadId} className="h-full" initialInput={initialInput} />
       </div>
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/app/(site)/dashboard/calendar/page.tsx
+++ b/src/app/(site)/dashboard/calendar/page.tsx
@@ -58,6 +58,7 @@ import type {
 import { CalendarItemDrawer } from "./_components/calendar-item-drawer";
 import { ComposeNewSheet } from "./_components/compose-new-sheet";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 type Mode = "week" | "month";
 
@@ -418,7 +419,7 @@ export default function CalendarPage() {
   }, [data]);
 
   return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
+    <PageShell width="full">
       <CronToolbar
         crons={["publish-scheduled", "publish-retry", "recurring-spawn"]}
         onTriggered={() =>
@@ -686,6 +687,6 @@ export default function CalendarPage() {
           )}
         </SheetContent>
       </Sheet>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/calendar/recurring/page.tsx
+++ b/src/app/(site)/dashboard/calendar/recurring/page.tsx
@@ -22,6 +22,7 @@ import { scheduler } from "@/lib/scheduler/client";
 import type { RecurringRuleDto, RecurringRuleStatus } from "@/lib/scheduler/types";
 import { ApiError } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 /**
  * /dashboard/calendar/recurring — manage recurring schedule rules
@@ -115,7 +116,7 @@ export default function RecurringRulesPage() {
       : null;
 
   return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
+    <PageShell width="standard">
       <CronToolbar crons={["recurring-spawn"]} onTriggered={invalidate} />
 
       {/* Header */}
@@ -174,7 +175,7 @@ export default function RecurringRulesPage() {
           ))}
         </ul>
       )}
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/app/(site)/dashboard/commerce/assistant/page.tsx
+++ b/src/app/(site)/dashboard/commerce/assistant/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { CommerceAssistantPreview } from "@/components/commerce/assistant-preview";
+import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 
 export const metadata: Metadata = {
   title: "Assistant preview · Commerce",
@@ -12,16 +13,12 @@ export const metadata: Metadata = {
  */
 export default function CommerceAssistantPreviewPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <header className="mb-6">
-        <h1 className="text-xl font-semibold">Assistant preview</h1>
-        <p className="mt-1 text-sm text-neutral-500">
-          This is the same catalog-grounded assistant that answers your customers on WhatsApp,
-          running against your connected store. Ask it anything a shopper might — in any language.
-          It only states facts from your real product catalog.
-        </p>
-      </header>
+    <PageShell width="narrow">
+      <PageHeader
+        title="Assistant preview"
+        description="This is the same catalog-grounded assistant that answers your customers on WhatsApp, running against your connected store. Ask it anything a shopper might — in any language. It only states facts from your real product catalog."
+      />
       <CommerceAssistantPreview />
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/commerce/assistant/page.tsx
+++ b/src/app/(site)/dashboard/commerce/assistant/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
  */
 export default function CommerceAssistantPreviewPage() {
   return (
-    <PageShell width="narrow">
+    <PageShell width="standard">
       <PageHeader
         title="Assistant preview"
         description="This is the same catalog-grounded assistant that answers your customers on WhatsApp, running against your connected store. Ask it anything a shopper might — in any language. It only states facts from your real product catalog."

--- a/src/app/(site)/dashboard/commerce/inventory/page.tsx
+++ b/src/app/(site)/dashboard/commerce/inventory/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { InventoryPanel } from "@/components/commerce/inventory-panel";
 import { ReplenisherPanel } from "@/components/commerce/replenisher-panel";
+import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 
 export const metadata: Metadata = {
   title: "Inventory & Supply · Commerce",
@@ -17,19 +18,17 @@ export const metadata: Metadata = {
  */
 export default function CommerceInventoryPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <header className="mb-6">
-        <h1 className="text-xl font-semibold">Inventory &amp; Supply</h1>
-        <p className="mt-1 text-sm text-neutral-500">
-          See which products are at risk of stocking out, which are tying up
-          capital, and exactly what to reorder — graded from your live stock and
-          the last 30 days of sales.
-        </p>
-      </header>
-      <div className="space-y-10">
+    <PageShell width="narrow">
+      <PageHeader
+        title="Inventory & Supply"
+        description="See which products are at risk of stocking out, which are tying up capital, and exactly what to reorder — graded from your live stock and the last 30 days of sales."
+      />
+      {/* `space-y-10` was the only 40px rhythm in the dashboard; tracks the
+          shell's pair like everything else now. */}
+      <div className="space-y-4 sm:space-y-6">
         <InventoryPanel />
         <ReplenisherPanel />
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/commerce/inventory/page.tsx
+++ b/src/app/(site)/dashboard/commerce/inventory/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
  */
 export default function CommerceInventoryPage() {
   return (
-    <PageShell width="narrow">
+    <PageShell width="standard">
       <PageHeader
         title="Inventory & Supply"
         description="See which products are at risk of stocking out, which are tying up capital, and exactly what to reorder — graded from your live stock and the last 30 days of sales."

--- a/src/app/(site)/dashboard/content/autopilot/page.tsx
+++ b/src/app/(site)/dashboard/content/autopilot/page.tsx
@@ -13,6 +13,7 @@ import { NeedsYouRail } from "./_components/needs-you-rail";
 import { ChannelWidgets } from "./_components/channel-widgets";
 import { AutopilotEmpty } from "./_components/autopilot-empty";
 import { CommerceLane } from "./_components/commerce-lane";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 /**
  * Content > Autopilot — the entitlement-composed content command center.
@@ -66,7 +67,7 @@ export default function AutopilotHomePage() {
   if (isProd) return null;
 
   return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
+    <PageShell width="wide">
       <CronToolbar
         crons={["publish-scheduled", "publish-retry", "recurring-spawn"]}
         onTriggered={() =>
@@ -127,6 +128,6 @@ export default function AutopilotHomePage() {
           )}
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -246,7 +246,9 @@ function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; 
         }}
       />
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">LinkedIn</h2>
+        {/* h1: this was the page's only heading and it was an h2, so the
+            route had no page title in the document outline at all. */}
+        <h1 className="text-2xl font-semibold tracking-tight">LinkedIn</h1>
         <p className="text-muted-foreground">
           Publish to your personal feed or any company page you administer.
         </p>

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -55,19 +55,19 @@ export default function LinkedInDashboardPage() {
   const enabledIdentity = isConnected ? identity : null;
 
   if (integrations.isLoading) {
-    return <PageShell loading />;
+    return <LinkedInPageShell loading />;
   }
 
   if (!isConnected) {
     return (
-      <PageShell>
+      <LinkedInPageShell>
         <EmptyState
           icon={MessageSquare}
           title="Connect LinkedIn to get started"
           description="Once connected, you can publish to your personal feed or any company page you administer, all from here."
           action={{ label: "Connect LinkedIn", href: "/dashboard/integrations" }}
         />
-      </PageShell>
+      </LinkedInPageShell>
     );
   }
 
@@ -77,7 +77,7 @@ export default function LinkedInDashboardPage() {
     const err = identity.error;
     const code = err instanceof ApiError ? err.code : "UNKNOWN";
     return (
-      <PageShell>
+      <LinkedInPageShell>
         <EmptyState
           icon={RefreshCw}
           title="LinkedIn needs a quick reconnect"
@@ -88,7 +88,7 @@ export default function LinkedInDashboardPage() {
           }
           action={{ label: "Reconnect LinkedIn", href: "/dashboard/integrations" }}
         />
-      </PageShell>
+      </LinkedInPageShell>
     );
   }
 
@@ -96,7 +96,7 @@ export default function LinkedInDashboardPage() {
     enabledIdentity?.data && enabledIdentity.data.status !== "active";
 
   return (
-    <PageShell>
+    <LinkedInPageShell>
       {needsReauth && (
         <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-900 dark:bg-amber-950/30">
           <CardContent className="flex items-center justify-between gap-4 p-4 text-sm">
@@ -116,7 +116,7 @@ export default function LinkedInDashboardPage() {
       )}
 
       <LinkedInTabs identity={identity} enabledIdentity={enabledIdentity} />
-    </PageShell>
+    </LinkedInPageShell>
   );
 }
 
@@ -213,7 +213,14 @@ function LinkedInTabs({
   );
 }
 
-function PageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
+/**
+ * Page-local wrapper: cron toolbar + rhythm + loading state. Named for this
+ * route specifically because it is NOT the shared layout primitive — that is
+ * <PageShell> in @/components/dashboard/page-shell, which owns measure. This
+ * was called `PageShell` too until the shared one landed and the collision
+ * became a trap for anyone importing the real thing here.
+ */
+function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
   const queryClient = useQueryClient();
   return (
     <div className="space-y-6">

--- a/src/app/(site)/dashboard/content/page.tsx
+++ b/src/app/(site)/dashboard/content/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "./channels.config";
 import { mapCatalogToChannels } from "./channels-from-catalog";
 import { resolveChannelCta } from "./channel-cta";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 interface ApiIntegration {
   provider: string;
@@ -108,15 +109,15 @@ export default function ContentChannelsHubPage() {
 
   if (isLoading) {
     return (
-      <div className="container max-w-5xl py-8 space-y-6">
+      <PageShell>
         {cronToolbar}
         <HubSkeleton />
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="container max-w-5xl py-8 space-y-6">
+    <PageShell>
       {cronToolbar}
       <header className="space-y-2 border-b pb-6">
         <h1 className="text-2xl font-semibold tracking-tight">Content channels</h1>
@@ -175,7 +176,7 @@ export default function ContentChannelsHubPage() {
           );
         })}
       </Tabs>
-    </div>
+    </PageShell>
   );
 }
 
@@ -397,7 +398,7 @@ function useLastSyncedLabel(lastSyncAt: string | undefined): string | undefined 
 
 function HubSkeleton() {
   return (
-    <div className="container max-w-5xl py-8 space-y-6">
+    <PageShell>
       <div className="space-y-2 border-b pb-6">
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-4 w-96" />
@@ -414,6 +415,6 @@ function HubSkeleton() {
           </div>
         ))}
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/content/page.tsx
+++ b/src/app/(site)/dashboard/content/page.tsx
@@ -408,6 +408,10 @@ function HubSkeleton() {
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-4 w-96" />
       </div>
+      {/* Stands in for the category TabsList in the loaded branch. Without it
+          every channel row jumped down by the strip height plus its margin
+          the moment data arrived. */}
+      <Skeleton className="h-9 w-72" />
       <div className="space-y-3">
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="flex items-start gap-4 rounded-lg border p-4">

--- a/src/app/(site)/dashboard/content/page.tsx
+++ b/src/app/(site)/dashboard/content/page.tsx
@@ -396,9 +396,14 @@ function useLastSyncedLabel(lastSyncAt: string | undefined): string | undefined 
   }, [lastSyncAt, now]);
 }
 
+/**
+ * Rendered INSIDE the page-level <PageShell> (the loading branch), so it must
+ * not open one of its own — nested page shells double the measure wrapper and
+ * break the "one per route" contract the primitive documents.
+ */
 function HubSkeleton() {
   return (
-    <PageShell>
+    <div className="space-y-4 sm:space-y-6">
       <div className="space-y-2 border-b pb-6">
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-4 w-96" />
@@ -415,6 +420,6 @@ function HubSkeleton() {
           </div>
         ))}
       </div>
-    </PageShell>
+    </div>
   );
 }

--- a/src/app/(site)/dashboard/content/whatsapp/analytics/page.tsx
+++ b/src/app/(site)/dashboard/content/whatsapp/analytics/page.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Peaks } from "@/components/peaks/peaks";
 import { AskYourInbox } from "@/components/whatsapp/ask-your-inbox";
 import { useWaAnalytics } from "@/hooks/use-wa-analytics";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 const PILLAR_LABEL: Record<string, string> = {
   support: "Support",
@@ -23,7 +24,7 @@ export default function WhatsAppAnalyticsPage() {
   const maxPillar = Math.max(1, ...(data?.byPillar ?? []).map((p) => p.peaks));
 
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+    <PageShell>
       <CronToolbar crons={["wa-outcome-billing"]} />
 
       <div>
@@ -72,6 +73,6 @@ export default function WhatsAppAnalyticsPage() {
           ))}
         </div>
       </Card>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/content/whatsapp/page.tsx
+++ b/src/app/(site)/dashboard/content/whatsapp/page.tsx
@@ -1,4 +1,5 @@
 import { WhatsAppEmbeddedSignup } from "@/components/integrations/whatsapp-embedded-signup";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 type ConnectSource = "peakhour" | "shopify" | "wordpress";
 
@@ -18,7 +19,7 @@ export default async function WhatsAppConnectPage({ searchParams }: Props) {
   const trimmedShop = shop?.trim();
 
   return (
-    <div className="mx-auto w-full max-w-2xl space-y-6 p-4 md:p-6">
+    <PageShell width="narrow">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">WhatsApp</h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -57,6 +58,6 @@ export default async function WhatsAppConnectPage({ searchParams }: Props) {
           View WhatsApp analytics →
         </a>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/content/whatsapp/templates/page.tsx
+++ b/src/app/(site)/dashboard/content/whatsapp/templates/page.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { PageShell } from "@/components/dashboard/page-shell";
 import {
   Select,
   SelectContent,
@@ -207,7 +208,7 @@ export default function WhatsAppTemplatesPage() {
   const errorCount = issues?.filter((i) => i.severity === "error").length ?? 0;
 
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-6 p-4 md:p-6">
+    <PageShell>
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">WhatsApp templates</h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -357,6 +358,6 @@ export default function WhatsAppTemplatesPage() {
           </Card>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/content/x/page.tsx
+++ b/src/app/(site)/dashboard/content/x/page.tsx
@@ -284,7 +284,9 @@ function XPageShell({ children, loading }: { children?: React.ReactNode; loading
         }}
       />
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">X (Twitter)</h2>
+        {/* h1: this was the page's only heading and it was an h2, so the
+            route had no page title in the document outline at all. */}
+        <h1 className="text-2xl font-semibold tracking-tight">X (Twitter)</h1>
         <p className="text-muted-foreground">
           Publish tweets, track engagement, and manage your mentions inbox.
         </p>

--- a/src/app/(site)/dashboard/content/x/page.tsx
+++ b/src/app/(site)/dashboard/content/x/page.tsx
@@ -42,7 +42,7 @@ const X_TABS: readonly XTab[] = ["compose", "recent", "mentions"];
  */
 export default function XContentDashboardPage() {
   return (
-    <Suspense fallback={<PageShell loading />}>
+    <Suspense fallback={<XPageShell loading />}>
       <XContentDashboardInner />
     </Suspense>
   );
@@ -140,24 +140,24 @@ function XContentDashboardInner() {
   }
 
   if (integrations.isLoading) {
-    return <PageShell loading />;
+    return <XPageShell loading />;
   }
 
   if (!isConnected) {
     return (
-      <PageShell>
+      <XPageShell>
         <EmptyState
           icon={MessageCircle}
           title="Connect X (Twitter) to get started"
           description="Once connected, you can publish tweets, track engagement, and manage your mentions inbox from here."
           action={{ label: "Connect X", href: "/dashboard/integrations" }}
         />
-      </PageShell>
+      </XPageShell>
     );
   }
 
   return (
-    <PageShell>
+    <XPageShell>
       {/* KPI strip */}
       <div className="grid gap-4 sm:grid-cols-3">
         <KpiCard title="Tweets shown" value={stats?.total} loading={tweets.isLoading} />
@@ -257,11 +257,18 @@ function XContentDashboardInner() {
         }}
         source={repurposeSource}
       />
-    </PageShell>
+    </XPageShell>
   );
 }
 
-function PageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
+/**
+ * Page-local wrapper: cron toolbar + rhythm + loading state. Named for this
+ * route specifically because it is NOT the shared layout primitive — that is
+ * <PageShell> in @/components/dashboard/page-shell, which owns measure. This
+ * was called `PageShell` too until the shared one landed and the collision
+ * became a trap for anyone importing the real thing here.
+ */
+function XPageShell({ children, loading }: { children?: React.ReactNode; loading?: boolean }) {
   const queryClient = useQueryClient();
   return (
     <div className="space-y-6">

--- a/src/app/(site)/dashboard/inbox/page.tsx
+++ b/src/app/(site)/dashboard/inbox/page.tsx
@@ -17,6 +17,7 @@ import {
   type WaConversation,
 } from "@/hooks/use-wa-conversations";
 import { inboxApi, type InboxItem, type InboxPriority } from "@/lib/api/inbox";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 /**
  * Inbox — ONE queue for everything inbound (D-inbox): every channel is
@@ -250,7 +251,7 @@ export default function InboxPage() {
   const resume = useWaResume();
 
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-6 p-4 md:p-6">
+    <PageShell>
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Inbox</h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -354,6 +355,6 @@ export default function InboxPage() {
           </div>
         </TabsContent>
       </Tabs>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -149,7 +149,7 @@ export default function AnalyticsInsightsPage() {
 
   if (statusQ.isLoading) {
     return (
-      <PageShell width="wide" className="space-y-4">
+      <PageShell width="wide">
         {cronToolbar}
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-32 w-full" />

--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -35,6 +35,7 @@ import {
   type AnalyticsInsightsResponse,
   type Ga4Digest,
 } from "@/hooks/use-analytics-insights";
+import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 
 interface ConnectionStatus {
   provider: string;
@@ -148,30 +149,26 @@ export default function AnalyticsInsightsPage() {
 
   if (statusQ.isLoading) {
     return (
-      <div className="p-6 space-y-4">
+      <PageShell width="wide" className="space-y-4">
         {cronToolbar}
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-32 w-full" />
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <PageShell width="wide">
       {cronToolbar}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+      <PageHeader
+        icon={
           <div className="rounded-lg bg-[#E37400] p-2">
             <LineChart className="h-5 w-5 text-white" />
           </div>
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Analytics 4</h1>
-            <p className="text-sm text-muted-foreground">
-              Conversion funnel + top page performance — drives Optimizer budget allocation and Strategist content suggestions.
-            </p>
-          </div>
-        </div>
-      </div>
+        }
+        title="Analytics 4"
+        description="Conversion funnel + top page performance — drives Optimizer budget allocation and Strategist content suggestions."
+      />
 
       {!isWorking ? (
         <Card>
@@ -321,7 +318,7 @@ export default function AnalyticsInsightsPage() {
           )}
         </>
       )}
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/app/(site)/dashboard/insights/search-console/page.tsx
+++ b/src/app/(site)/dashboard/insights/search-console/page.tsx
@@ -38,6 +38,7 @@ import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { TrendChart } from "@/components/ui/trend-chart";
 import { ExplainCard } from "@/components/dashboard/explain-card";
 import { useSetAskEntityIds } from "@/providers/ask-context-provider";
+import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 
 // ── Types (mirror peakhour-api search-insights service) ─────────────────────
 interface ConnectionStatus {
@@ -225,11 +226,11 @@ export default function SearchConsoleInsightsPage() {
 
   if (statusQ.isLoading) {
     return (
-      <div className="p-6 space-y-4">
+      <PageShell width="wide" className="space-y-4">
         {cronToolbar}
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-32 w-full" />
-      </div>
+      </PageShell>
     );
   }
 
@@ -248,50 +249,55 @@ export default function SearchConsoleInsightsPage() {
   const data = insightsQ.data;
 
   return (
-    <div className="p-6 space-y-6">
+    <PageShell width="wide">
       {cronToolbar}
 
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
+      <PageHeader
+        icon={
           <div className="rounded-lg bg-[#458CF7] p-2">
             <Search className="h-5 w-5 text-white" />
           </div>
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Search Console</h1>
-            <p className="text-sm text-muted-foreground">
-              What&apos;s happening in Google Search — and what to do about it.
-            </p>
-          </div>
-        </div>
-        {isWorking && (
-          <div className="flex items-center gap-2">
-            {selectableProperties.length > 1 && (
-              <Select value={property ?? "__default__"} onValueChange={(v) => setProperty(v === "__default__" ? undefined : v)}>
-                <SelectTrigger className="w-55">
-                  <SelectValue placeholder="Property" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__default__">Default property</SelectItem>
-                  {selectableProperties.map((siteUrl) => (
-                    <SelectItem key={siteUrl} value={siteUrl}>
-                      {siteUrl}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={syncMut.isPending}
-              onClick={() => syncMut.mutate()}
-            >
-              <RefreshCw className={`mr-2 h-4 w-4 ${syncMut.isPending ? "animate-spin" : ""}`} />
-              Sync now
-            </Button>
-          </div>
-        )}
-      </div>
+        }
+        title="Search Console"
+        description="What's happening in Google Search — and what to do about it."
+        actions={
+          isWorking && (
+            <>
+              {selectableProperties.length > 1 && (
+                <Select
+                  value={property ?? "__default__"}
+                  onValueChange={(v) =>
+                    setProperty(v === "__default__" ? undefined : v)
+                  }
+                >
+                  <SelectTrigger className="w-55">
+                    <SelectValue placeholder="Property" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default__">Default property</SelectItem>
+                    {selectableProperties.map((siteUrl) => (
+                      <SelectItem key={siteUrl} value={siteUrl}>
+                        {siteUrl}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={syncMut.isPending}
+                onClick={() => syncMut.mutate()}
+              >
+                <RefreshCw
+                  className={`mr-2 h-4 w-4 ${syncMut.isPending ? "animate-spin" : ""}`}
+                />
+                Sync now
+              </Button>
+            </>
+          )
+        }
+      />
 
       {!isWorking ? (
         <Card>
@@ -589,7 +595,7 @@ export default function SearchConsoleInsightsPage() {
           </Card>
         </>
       )}
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/app/(site)/dashboard/insights/search-console/page.tsx
+++ b/src/app/(site)/dashboard/insights/search-console/page.tsx
@@ -226,7 +226,7 @@ export default function SearchConsoleInsightsPage() {
 
   if (statusQ.isLoading) {
     return (
-      <PageShell width="wide" className="space-y-4">
+      <PageShell width="wide">
         {cronToolbar}
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-32 w-full" />

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -294,7 +294,23 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
 
   return (
     <AskContextProvider>
-    <SidebarProvider>
+    {/* `h-svh` is load-bearing, and it is what makes the `overflow-auto`
+        further down actually mean something. SidebarProvider ships
+        `min-h-svh` — a MINIMUM, so the wrapper grows with its content and the
+        shell has never had a definite height. A `flex: 1 1 0%` item still
+        contributes its max-content flex fraction to the container's intrinsic
+        size (Flexbox §9.9.1), so the content area below stretched with the
+        page, its `overflow-auto` never engaged, and the document scrolled
+        instead. That is also why /dashboard/ask's `calc()` was the only thing
+        holding it in: percentage/flex heights had nothing definite to resolve
+        against.
+
+        Scoped here rather than in components/ui/sidebar.tsx because /cms
+        shares that primitive and should keep document scrolling for now.
+        `min-h-0` on the inset lets the content area shrink below its content
+        so it, not the document, is the scroller. Net effect: the header row
+        stays put while the page scrolls under it. */}
+    <SidebarProvider className="h-svh">
       <Sidebar collapsible="icon" variant="sidebar">
         {/* ── Header: Logo + Switchers ──────────────────────── */}
         <SidebarHeader>
@@ -510,7 +526,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
       <CommandMenu />
 
       {/* ── Main Content ──────────────────────────────────── */}
-      <SidebarInset>
+      <SidebarInset className="min-h-0">
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
           <div className="ml-auto flex items-center gap-3">
@@ -525,19 +541,16 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
             @/components/dashboard/page-shell). Steps down to 16px on mobile:
             at 375px a flat 24px inset costs 13% of the screen width before a
             card's own 24px padding is even applied. */}
-        {/* `flex flex-col` so a route can opt into filling the viewport
-            (<PageShell fill>) without hard-coding the chrome height. The
-            height here IS definite — `flex-1` is `flex: 1 1 0%`, so this div
-            contributes nothing to the wrapper's intrinsic height and settles
-            at exactly `100svh - 3.5rem` (the header) — which is why
-            /dashboard/ask could compute a `calc()` against it at all, and why
-            it was wrong to (it also has to subtract this padding and the
-            banner slot).
+        {/* This is the app's scroll container (see the `h-svh` note above).
+            `flex flex-col` so a route can opt into filling the viewport
+            (<PageShell fill>) without hard-coding what the chrome costs —
+            which is 104px here (header 56 + this padding 48; the banner slot
+            contributes 0 in the common case because it is `empty:hidden`).
 
-            Ordinary pages are unaffected: a block child of a column flex
-            container keeps `min-height: auto`, whose automatic minimum size
-            is its content height, so nothing shrinks below its content and
-            long pages still scroll here rather than being squashed. */}
+            Ordinary pages are unaffected by the flex change: a block child of
+            a column flex container keeps `min-height: auto`, whose automatic
+            minimum size is its content height, so nothing shrinks below its
+            content and long pages scroll here rather than being squashed. */}
         <div className="flex flex-1 flex-col overflow-auto p-4 sm:p-6">
           {/* Banner slot — sits above the route content. Trial-expiry shows
               only inside the final 3 days of a trial; the credit-cap banner

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -525,7 +525,20 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
             @/components/dashboard/page-shell). Steps down to 16px on mobile:
             at 375px a flat 24px inset costs 13% of the screen width before a
             card's own 24px padding is even applied. */}
-        <div className="flex-1 overflow-auto p-4 sm:p-6">
+        {/* `flex flex-col` so a route can opt into filling the viewport
+            (<PageShell fill>) without hard-coding the chrome height. The
+            height here IS definite — `flex-1` is `flex: 1 1 0%`, so this div
+            contributes nothing to the wrapper's intrinsic height and settles
+            at exactly `100svh - 3.5rem` (the header) — which is why
+            /dashboard/ask could compute a `calc()` against it at all, and why
+            it was wrong to (it also has to subtract this padding and the
+            banner slot).
+
+            Ordinary pages are unaffected: a block child of a column flex
+            container keeps `min-height: auto`, whose automatic minimum size
+            is its content height, so nothing shrinks below its content and
+            long pages still scroll here rather than being squashed. */}
+        <div className="flex flex-1 flex-col overflow-auto p-4 sm:p-6">
           {/* Banner slot — sits above the route content. Trial-expiry shows
               only inside the final 3 days of a trial; the credit-cap banner
               only once usage crosses its cap. Both render nothing otherwise

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -307,9 +307,22 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
 
         Scoped here rather than in components/ui/sidebar.tsx because /cms
         shares that primitive and should keep document scrolling for now.
-        `min-h-0` on the inset lets the content area shrink below its content
-        so it, not the document, is the scroller. Net effect: the header row
-        stays put while the page scrolls under it. */}
+        Net effect: the header row stays put while the page scrolls under it.
+        (No `min-h-0` needed on SidebarInset — it is a flex item in a ROW
+        container, and automatic minimum size only applies on the main axis,
+        so its cross-axis `min-height: auto` already resolves to 0.)
+
+        `svh` not `dvh`: the small viewport height is the one that assumes
+        mobile browser chrome is fully EXPANDED, so the shell can never be
+        taller than what is actually visible — worst case it leaves a strip
+        at the bottom once the URL bar retracts, where `dvh` would instead
+        resize the scroll container mid-scroll. It also matches the unit
+        SidebarProvider already chose for its `min-h-`.
+
+        Radix's scroll lock still holds: react-remove-scroll blocks wheel and
+        touchmove outside the modal subtree rather than relying only on
+        `body { overflow: hidden }`, so moving the scroller off the document
+        does not let the background scroll behind a Dialog or Sheet. */}
     <SidebarProvider className="h-svh">
       <Sidebar collapsible="icon" variant="sidebar">
         {/* ── Header: Logo + Switchers ──────────────────────── */}
@@ -526,7 +539,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
       <CommandMenu />
 
       {/* ── Main Content ──────────────────────────────────── */}
-      <SidebarInset className="min-h-0">
+      <SidebarInset>
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
           <div className="ml-auto flex items-center gap-3">
@@ -550,8 +563,17 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
             Ordinary pages are unaffected by the flex change: a block child of
             a column flex container keeps `min-height: auto`, whose automatic
             minimum size is its content height, so nothing shrinks below its
-            content and long pages scroll here rather than being squashed. */}
-        <div className="flex flex-1 flex-col overflow-auto p-4 sm:p-6">
+            content and long pages scroll here rather than being squashed.
+
+            `scroll-pt-*` is required, not decoration. Next's
+            ScrollAndFocusHandler tries `document.documentElement.scrollTop = 0`
+            on navigation and falls back to `scrollIntoView()` when that does
+            not move anything — and now that the document does not scroll, it
+            ALWAYS falls back. `scrollIntoView` aligns to the scrollport's
+            padding-box edge, so without a matching scroll-padding every
+            sidebar navigation from a scrolled position parked the page's
+            first element flush against the header, eating this inset. */}
+        <div className="flex flex-1 flex-col overflow-auto p-4 scroll-pt-4 sm:p-6 sm:scroll-pt-6">
           {/* Banner slot — sits above the route content. Trial-expiry shows
               only inside the final 3 days of a trial; the credit-cap banner
               only once usage crosses its cap. Both render nothing otherwise

--- a/src/app/(site)/dashboard/settings/team/page.tsx
+++ b/src/app/(site)/dashboard/settings/team/page.tsx
@@ -52,6 +52,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useLocale } from "@/hooks/use-locale";
+import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 
 const ROLE_LABELS: Record<string, string> = {
   owner: "Owner",
@@ -163,35 +164,33 @@ export default function TeamPage() {
 
   if (loading) {
     return (
-      <div className="p-6 space-y-4">
+      <PageShell width="narrow" className="space-y-4">
         <div className="h-8 w-48 bg-muted animate-pulse rounded" />
         <div className="h-64 bg-muted animate-pulse rounded-lg" />
-      </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+    <PageShell width="narrow">
+      {/* The title was `text-xl` here and `text-2xl` on every sibling settings
+          page; PageHeader settles that. The back-link keeps its place as the
+          header's leading slot. */}
+      <PageHeader
+        icon={
           <Link
             href="/dashboard/settings"
-            className="p-1.5 rounded-md hover:bg-muted transition"
+            aria-label="Back to settings"
+            className="rounded-md p-1.5 transition hover:bg-muted"
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <div>
-            <h1 className="text-xl font-semibold">Team & Permissions</h1>
-            <p className="text-sm text-muted-foreground">
-              {members.length} member{members.length !== 1 ? "s" : ""} in{" "}
-              {org?.name || "your organization"}
-            </p>
-          </div>
-        </div>
-
-        {isAdmin && (
-          <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+        }
+        title="Team &amp; Permissions"
+        description={`${members.length} member${members.length !== 1 ? "s" : ""} in ${org?.name || "your organization"}`}
+        actions={
+          isAdmin && (
+            <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
             <DialogTrigger asChild>
               <Button size="sm" className="gap-2">
                 <UserPlus className="h-4 w-4" />
@@ -254,9 +253,10 @@ export default function TeamPage() {
                 </Button>
               </div>
             </DialogContent>
-          </Dialog>
-        )}
-      </div>
+            </Dialog>
+          )
+        }
+      />
 
       {/* Notifications */}
       {error && (
@@ -462,6 +462,6 @@ export default function TeamPage() {
           </div>
         </CardContent>
       </Card>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/(site)/dashboard/settings/team/page.tsx
+++ b/src/app/(site)/dashboard/settings/team/page.tsx
@@ -173,9 +173,11 @@ export default function TeamPage() {
 
   return (
     <PageShell width="narrow">
-      {/* The title was `text-xl` here and `text-2xl` on every sibling settings
-          page; PageHeader settles that. The back-link keeps its place as the
-          header's leading slot. */}
+      {/* This was the only `text-xl` page title in settings — its siblings run
+          `text-2xl` in two weights and two of them have no <h1> at all —
+          so PageHeader settles it. The back-link keeps its place as the
+          header's leading slot. `narrow` matches settings/billing; it costs
+          the role grid below ~30px per column, which it can afford. */}
       <PageHeader
         icon={
           <Link

--- a/src/app/(site)/dashboard/settings/team/page.tsx
+++ b/src/app/(site)/dashboard/settings/team/page.tsx
@@ -164,7 +164,7 @@ export default function TeamPage() {
 
   if (loading) {
     return (
-      <PageShell width="narrow" className="space-y-4">
+      <PageShell width="narrow">
         <div className="h-8 w-48 bg-muted animate-pulse rounded" />
         <div className="h-64 bg-muted animate-pulse rounded-lg" />
       </PageShell>
@@ -186,73 +186,73 @@ export default function TeamPage() {
             <ArrowLeft className="h-4 w-4" />
           </Link>
         }
-        title="Team &amp; Permissions"
+        title="Team & Permissions"
         description={`${members.length} member${members.length !== 1 ? "s" : ""} in ${org?.name || "your organization"}`}
         actions={
           isAdmin && (
             <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
-            <DialogTrigger asChild>
-              <Button size="sm" className="gap-2">
-                <UserPlus className="h-4 w-4" />
-                Invite
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Invite team member</DialogTitle>
-              </DialogHeader>
-              <div className="space-y-4 pt-2">
-                <div>
-                  <label className="text-sm font-medium mb-1.5 block">
-                    Email address
-                  </label>
-                  <Input
-                    type="email"
-                    placeholder="colleague@company.com"
-                    value={inviteEmail}
-                    onChange={(e) => setInviteEmail(e.target.value)}
-                    onKeyDown={(e) => e.key === "Enter" && handleInvite()}
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium mb-1.5 block">
-                    Role
-                  </label>
-                  <Select value={inviteRole} onValueChange={setInviteRole}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="admin">
-                        <div className="flex items-center gap-2">
-                          <ShieldCheck className="h-3.5 w-3.5" />
-                          Admin — full access, manage settings
-                        </div>
-                      </SelectItem>
-                      <SelectItem value="editor">
-                        <div className="flex items-center gap-2">
-                          <Pencil className="h-3.5 w-3.5" />
-                          Editor — create and edit content
-                        </div>
-                      </SelectItem>
-                      <SelectItem value="viewer">
-                        <div className="flex items-center gap-2">
-                          <Eye className="h-3.5 w-3.5" />
-                          Viewer — read-only access
-                        </div>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <Button
-                  onClick={handleInvite}
-                  disabled={inviting || !inviteEmail.trim()}
-                  className="w-full"
-                >
-                  {inviting ? "Sending..." : "Send invitation"}
+              <DialogTrigger asChild>
+                <Button size="sm" className="gap-2">
+                  <UserPlus className="h-4 w-4" />
+                  Invite
                 </Button>
-              </div>
-            </DialogContent>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Invite team member</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4 pt-2">
+                  <div>
+                    <label className="text-sm font-medium mb-1.5 block">
+                      Email address
+                    </label>
+                    <Input
+                      type="email"
+                      placeholder="colleague@company.com"
+                      value={inviteEmail}
+                      onChange={(e) => setInviteEmail(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && handleInvite()}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium mb-1.5 block">
+                      Role
+                    </label>
+                    <Select value={inviteRole} onValueChange={setInviteRole}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="admin">
+                          <div className="flex items-center gap-2">
+                            <ShieldCheck className="h-3.5 w-3.5" />
+                            Admin — full access, manage settings
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="editor">
+                          <div className="flex items-center gap-2">
+                            <Pencil className="h-3.5 w-3.5" />
+                            Editor — create and edit content
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="viewer">
+                          <div className="flex items-center gap-2">
+                            <Eye className="h-3.5 w-3.5" />
+                            Viewer — read-only access
+                          </div>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    onClick={handleInvite}
+                    disabled={inviting || !inviteEmail.trim()}
+                    className="w-full"
+                  >
+                    {inviting ? "Sending..." : "Send invitation"}
+                  </Button>
+                </div>
+              </DialogContent>
             </Dialog>
           )
         }
@@ -433,7 +433,9 @@ export default function TeamPage() {
       {/* Role descriptions */}
       <Card className="bg-muted/30">
         <CardContent className="pt-5">
-          <h3 className="text-sm font-medium mb-3">Role permissions</h3>
+          {/* h2, not h3: PageHeader emits this page's <h1> and nothing sits
+              between, so h3 skipped a level (axe `heading-order`). */}
+          <h2 className="text-sm font-medium mb-3">Role permissions</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs text-muted-foreground">
             <div>
               <div className="font-medium text-foreground mb-1 flex items-center gap-1">

--- a/src/app/(site)/dashboard/strategist/components/kanban-board.tsx
+++ b/src/app/(site)/dashboard/strategist/components/kanban-board.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from "react";
 import {
   DndContext,
+  DragOverlay,
   type DragEndEvent,
+  type DragStartEvent,
   PointerSensor,
   useSensor,
   useSensors,
@@ -12,7 +14,7 @@ import {
 import { api } from "@/lib/api";
 import { KanbanColumn } from "./kanban-column";
 import { PIPELINE_COLUMNS } from "./status-badge";
-import type { PipelineIdea } from "./kanban-card";
+import { KanbanCard, type PipelineIdea } from "./kanban-card";
 
 // Client-side state machine matching the API
 const VALID_TRANSITIONS: Record<string, string[]> = {
@@ -34,6 +36,12 @@ interface KanbanBoardProps {
 
 export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
   const [localData, setLocalData] = useState(data);
+  // The card being dragged, mirrored into a <DragOverlay>. Required now that
+  // the board is a horizontal scroller: `overflow-x: auto` forces the computed
+  // `overflow-y` to `auto` too, so the board clips to its padding box and a
+  // card dragged up or out of it simply disappeared mid-drag. The overlay is
+  // portaled and positioned outside that clip.
+  const [activeIdea, setActiveIdea] = useState<PipelineIdea | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
   );
@@ -43,7 +51,14 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
     setLocalData(data);
   }, [data]);
 
+  function handleDragStart(event: DragStartEvent) {
+    setActiveIdea((event.active.data.current?.idea as PipelineIdea) ?? null);
+  }
+
   async function handleDragEnd(event: DragEndEvent) {
+    // Clear the overlay first — every path below returns or awaits, and
+    // leaving it set would strand a floating card over the board.
+    setActiveIdea(null);
     const { active, over } = event;
     if (!over) return;
 
@@ -118,7 +133,9 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
     <DndContext
       sensors={sensors}
       collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveIdea(null)}
     >
       {/* The board scrolls sideways below `xl` instead of dividing whatever
           width it is given between five `flex-1` columns. It used to do the
@@ -127,14 +144,22 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
           tablet with the sidebar expanded — narrow enough that a card title
           wrapped to a couple of characters per line.
 
+          The columns carry `min-w-70 flex-1`, so there is no breakpoint to
+          get wrong: they hold 280px and scroll when the board is narrower
+          than 5x280 + gaps, and share the row once it is wider. A first
+          attempt dropped the scroller at `xl` on the assumption the columns
+          fit by then — they do not. Five 280px columns plus gaps need
+          ~1448px of board, i.e. a ~1750px viewport with the sidebar
+          expanded, so `xl` (1280px) handed back 186px columns and quietly
+          reintroduced the very defect this fixes.
+
           No scroll-snap: dnd-kit auto-scrolls this container when a drag
           nears its edge, and mandatory snapping fights that.
 
-          The `xl:` overrides drop the scroll container once the columns fit
-          anyway. That matters beyond tidiness — `overflow-x: auto` forces the
-          computed `overflow-y` to `auto` as well, making this a scroll
-          container in both axes, so it is worth not having on desktop. */}
-      <div className="flex gap-3 overflow-x-auto pb-2 xl:overflow-x-visible xl:pb-0">
+          Note `overflow-x: auto` forces the computed `overflow-y` to `auto`
+          too, so this clips its own children — which is why the dragged card
+          renders in a <DragOverlay> below rather than in flow. */}
+      <div className="flex gap-3 overflow-x-auto pb-2">
         {PIPELINE_COLUMNS.map((col) => {
           // Merge ideas from all statuses that belong to this column group
           const ideas = col.statuses.flatMap((s) => localData[s] || []);
@@ -149,6 +174,17 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
           );
         })}
       </div>
+
+      {/* Portaled out of the clipping scroll container, so the card stays
+          visible wherever the pointer takes it. `w-70` matches the column so
+          the overlay is the same size as the card it replaces. */}
+      <DragOverlay dropAnimation={null}>
+        {activeIdea ? (
+          <div className="w-70 cursor-grabbing">
+            <KanbanCard idea={activeIdea} />
+          </div>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   );
 }

--- a/src/app/(site)/dashboard/strategist/components/kanban-board.tsx
+++ b/src/app/(site)/dashboard/strategist/components/kanban-board.tsx
@@ -14,7 +14,7 @@ import {
 import { api } from "@/lib/api";
 import { KanbanColumn } from "./kanban-column";
 import { PIPELINE_COLUMNS } from "./status-badge";
-import { KanbanCard, type PipelineIdea } from "./kanban-card";
+import { KanbanCardPreview, type PipelineIdea } from "./kanban-card";
 
 // Client-side state machine matching the API
 const VALID_TRANSITIONS: Record<string, string[]> = {
@@ -175,13 +175,20 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
         })}
       </div>
 
-      {/* Portaled out of the clipping scroll container, so the card stays
-          visible wherever the pointer takes it. `w-70` matches the column so
-          the overlay is the same size as the card it replaces. */}
+      {/* Escapes the clipping scroll container — not by portalling (dnd-kit
+          renders DragOverlay in place) but because it is a SIBLING of the
+          `overflow-x-auto` div and dnd-kit gives it `position: fixed`. `w-70`
+          matches the column so the overlay is the same width as the card it
+          stands in for.
+
+          KanbanCardPreview, not KanbanCard: the in-flow card stays mounted
+          while it is being dragged, so rendering the sortable component here
+          would register a second node under the same id. See the note on
+          KanbanCardBody. */}
       <DragOverlay dropAnimation={null}>
         {activeIdea ? (
-          <div className="w-70 cursor-grabbing">
-            <KanbanCard idea={activeIdea} />
+          <div className="w-70">
+            <KanbanCardPreview idea={activeIdea} />
           </div>
         ) : null}
       </DragOverlay>

--- a/src/app/(site)/dashboard/strategist/components/kanban-board.tsx
+++ b/src/app/(site)/dashboard/strategist/components/kanban-board.tsx
@@ -120,7 +120,21 @@ export function KanbanBoard({ data, onRefresh }: KanbanBoardProps) {
       collisionDetection={closestCorners}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex gap-3">
+      {/* The board scrolls sideways below `xl` instead of dividing whatever
+          width it is given between five `flex-1` columns. It used to do the
+          latter, with no min-width and no overflow, so the columns collapsed
+          with the container: ~56px each on a 375px phone and ~83px at a 768px
+          tablet with the sidebar expanded — narrow enough that a card title
+          wrapped to a couple of characters per line.
+
+          No scroll-snap: dnd-kit auto-scrolls this container when a drag
+          nears its edge, and mandatory snapping fights that.
+
+          The `xl:` overrides drop the scroll container once the columns fit
+          anyway. That matters beyond tidiness — `overflow-x: auto` forces the
+          computed `overflow-y` to `auto` as well, making this a scroll
+          container in both axes, so it is worth not having on desktop. */}
+      <div className="flex gap-3 overflow-x-auto pb-2 xl:overflow-x-visible xl:pb-0">
         {PIPELINE_COLUMNS.map((col) => {
           // Merge ideas from all statuses that belong to this column group
           const ideas = col.statuses.flatMap((s) => localData[s] || []);

--- a/src/app/(site)/dashboard/strategist/components/kanban-card.tsx
+++ b/src/app/(site)/dashboard/strategist/components/kanban-card.tsx
@@ -76,50 +76,29 @@ function getPriorityLabel(score?: number): { label: string; className: string } 
   return { label: "Low", className: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400" };
 }
 
-export function KanbanCard({ idea, onChanged }: { idea: PipelineIdea; onChanged?: () => void }) {
-  const router = useRouter();
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: idea._id, data: { idea } });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-
+/**
+ * The card's visual content, with no dnd wiring.
+ *
+ * Shared by the in-flow <KanbanCard> and the <DragOverlay> preview, so the
+ * overlay does not have to render <KanbanCard> itself. Doing that would call
+ * useSortable with the same id as the card still mounted in the column,
+ * registering a second node under one key in dnd-kit's registry, and would
+ * carry a router.push onClick onto an element that only exists mid-drag.
+ *
+ * To be accurate about the stakes: measured against @dnd-kit/core 6.3.1 the
+ * duplicate registration does not actually break drops — collision detection
+ * still resolves correctly and the overlay's own transform stays empty. What
+ * it does cost is a duplicated role/tabIndex/aria-describedby on two nodes
+ * and a second IdeaCardActions mounted for the length of every drag. This
+ * split is hygiene against a real hazard, not a fix for an observed bug.
+ */
+function KanbanCardBody({ idea, onChanged }: { idea: PipelineIdea; onChanged?: () => void }) {
   const priority = getPriorityLabel(idea.aiScore);
   const progress = STATUS_PROGRESS[idea.status] ?? 0;
   const progressPct = Math.round((progress / TOTAL_STEPS) * 100);
 
-  // The WHOLE card is the drag handle (dnd listeners below). To still allow
-  // "click to open", we record the pointer-down position and only navigate
-  // when the pointer barely moved — a real drag moves >8px (the sensor's
-  // activation distance), so it won't trigger navigation.
-  const downPos = useRef<{ x: number; y: number } | null>(null);
-
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-      onPointerDownCapture={(e) => { downPos.current = { x: e.clientX, y: e.clientY }; }}
-      onClick={(e) => {
-        const d = downPos.current;
-        if (d && (Math.abs(e.clientX - d.x) > 8 || Math.abs(e.clientY - d.y) > 8)) return; // was a drag
-        router.push(`/dashboard/strategist/${idea._id}`);
-      }}
-      className={cn(
-        "group cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-all duration-150 active:cursor-grabbing",
-        "hover:shadow-md hover:border-primary/20",
-        isDragging && "opacity-50 shadow-lg ring-2 ring-primary/20",
-      )}
-    >
+    <>
       {/* Title row — grip is now just a visual "draggable" cue; the whole
           card carries the drag listeners. */}
       <div className="flex items-start gap-1.5">
@@ -230,6 +209,61 @@ export function KanbanCard({ idea, onChanged }: { idea: PipelineIdea; onChanged?
           />
         </div>
       </div>
+    </>
+  );
+}
+
+/** Presentational clone for <DragOverlay>. Matches the in-flow card's chrome. */
+export function KanbanCardPreview({ idea }: { idea: PipelineIdea }) {
+  return (
+    <div className="group cursor-grabbing rounded-lg border bg-card p-3 shadow-lg ring-2 ring-primary/20">
+      <KanbanCardBody idea={idea} />
+    </div>
+  );
+}
+
+export function KanbanCard({ idea, onChanged }: { idea: PipelineIdea; onChanged?: () => void }) {
+  const router = useRouter();
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: idea._id, data: { idea } });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+
+  // The WHOLE card is the drag handle (dnd listeners below). To still allow
+  // "click to open", we record the pointer-down position and only navigate
+  // when the pointer barely moved — a real drag moves >8px (the sensor's
+  // activation distance), so it won't trigger navigation.
+  const downPos = useRef<{ x: number; y: number } | null>(null);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onPointerDownCapture={(e) => { downPos.current = { x: e.clientX, y: e.clientY }; }}
+      onClick={(e) => {
+        const d = downPos.current;
+        if (d && (Math.abs(e.clientX - d.x) > 8 || Math.abs(e.clientY - d.y) > 8)) return; // was a drag
+        router.push(`/dashboard/strategist/${idea._id}`);
+      }}
+      className={cn(
+        "group cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-all duration-150 active:cursor-grabbing",
+        "hover:shadow-md hover:border-primary/20",
+        isDragging && "opacity-50 shadow-lg ring-2 ring-primary/20",
+      )}
+    >
+      <KanbanCardBody idea={idea} onChanged={onChanged} />
     </div>
   );
 }

--- a/src/app/(site)/dashboard/strategist/components/kanban-column.tsx
+++ b/src/app/(site)/dashboard/strategist/components/kanban-column.tsx
@@ -38,12 +38,14 @@ export function KanbanColumn({
         // reaching for: enough that an empty column still reads as a drop
         // target.
         //
-        // Sized, not `flex-1`: the board is a horizontal scroller up to `xl`,
-        // where a flexible column would collapse to a fraction of the
-        // viewport. 280px is the narrowest width at which a KanbanCard's
-        // title, badge row and meta line still hold their layout. From `xl`
-        // the board stops scrolling and the columns share the row again.
-        "flex min-h-80 w-70 shrink-0 flex-col rounded-xl bg-muted/40 p-3 xl:w-auto xl:flex-1",
+        // `min-w-70 flex-1`, not a width plus a breakpoint: 280px is the
+        // narrowest width at which a KanbanCard's title, badge row and meta
+        // line hold their layout, so it is a floor the column must never go
+        // below — and above that it should use whatever room there is. This
+        // pair says exactly that at every viewport. It replaced `w-70
+        // shrink-0 xl:flex-1`, which handed back 186px columns from 1280px
+        // (five 280px columns need a ~1750px viewport to fit).
+        "flex min-h-80 min-w-70 flex-1 flex-col rounded-xl bg-muted/40 p-3",
         isOver && "bg-accent/50 ring-2 ring-primary/20"
       )}
     >

--- a/src/app/(site)/dashboard/strategist/components/kanban-column.tsx
+++ b/src/app/(site)/dashboard/strategist/components/kanban-column.tsx
@@ -32,7 +32,18 @@ export function KanbanColumn({
     <div
       ref={setNodeRef}
       className={cn(
-        "flex min-h-screen/2 flex-1 flex-col rounded-xl bg-muted/40 p-3",
+        // `min-h-screen/2` was not a real utility — Tailwind has no fractional
+        // modifier for min-height, so it compiled to nothing and the column
+        // had no minimum height at all. `min-h-80` (320px) is what it was
+        // reaching for: enough that an empty column still reads as a drop
+        // target.
+        //
+        // Sized, not `flex-1`: the board is a horizontal scroller up to `xl`,
+        // where a flexible column would collapse to a fraction of the
+        // viewport. 280px is the narrowest width at which a KanbanCard's
+        // title, badge row and meta line still hold their layout. From `xl`
+        // the board stops scrolling and the columns share the row again.
+        "flex min-h-80 w-70 shrink-0 flex-col rounded-xl bg-muted/40 p-3 xl:w-auto xl:flex-1",
         isOver && "bg-accent/50 ring-2 ring-primary/20"
       )}
     >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -181,6 +181,28 @@
 }
 
 /*
+ * Print: undo the dashboard's fixed-height inner scroll container.
+ *
+ * /dashboard pins `h-svh` on the sidebar wrapper so the content area — not
+ * the document — is the scroller (see src/app/(site)/dashboard/layout.tsx).
+ * That is right on screen and wrong on paper: a fixed-height `overflow: auto`
+ * box clips everything past the first viewport, so Ctrl+P on a long billing,
+ * analytics or invoice page produced a single truncated page. Releasing the
+ * height and the clip lets the document paginate normally again.
+ */
+@media print {
+  [data-slot="sidebar-wrapper"] {
+    height: auto !important;
+  }
+  [data-slot="sidebar-inset"] {
+    overflow: visible !important;
+  }
+  [data-slot="sidebar-inset"] > * {
+    overflow: visible !important;
+  }
+}
+
+/*
  * Molten-gold brand gradient helpers for the marketing surface. Tailwind
  * can't express a 3-stop token gradient inline, so these thin utilities wrap
  * --brand-gradient for fills (buttons, icon tiles, announcement bar) and for

--- a/src/components/commerce/autopilot.tsx
+++ b/src/components/commerce/autopilot.tsx
@@ -7,6 +7,7 @@ import { CommerceNeedsYou } from "@/components/commerce/needs-you-rail";
 import { PendingExecutions } from "@/components/commerce/pending-executions";
 import { AutonomyBoard } from "@/components/commerce/autonomy-board";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 /**
  * Commerce → Autopilot (Phase 0). The engine's cockpit: the approvals queue
@@ -30,7 +31,7 @@ function CommerceAutopilotBody() {
   const { isError: noStore } = useCommerceSummary();
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <PageShell width="standard">
       <header className="mb-6">
         <h1 className="text-xl font-semibold">Autopilot</h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -73,6 +74,6 @@ function CommerceAutopilotBody() {
           </section>
         </>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/components/commerce/catalog.tsx
+++ b/src/components/commerce/catalog.tsx
@@ -18,6 +18,7 @@ import {
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { useLocale } from "@/hooks/use-locale";
 import { minorToMajor } from "@/lib/money";
+import { PageShell } from "@/components/dashboard/page-shell";
 import {
   useCommerceCatalog,
   LISTING_ISSUE_LABEL,
@@ -134,16 +135,16 @@ function CatalogBody() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <Skeleton className="h-64 w-full rounded-lg" />
-      </div>
+      </PageShell>
     );
   }
 
   if (isError || !data) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <EmptyState
           icon={Store}
@@ -151,7 +152,7 @@ function CatalogBody() {
           description="Catalog & Listings lights up once a Shopify or WooCommerce store is connected to this business."
           action={{ label: "Connect a store", href: "/dashboard/integrations" }}
         />
-      </div>
+      </PageShell>
     );
   }
 
@@ -162,7 +163,7 @@ function CatalogBody() {
   const capped = data.total > loaded;
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <PageShell width="standard">
       <Header />
 
       <div className="mb-4 flex flex-wrap items-center gap-2">
@@ -191,7 +192,7 @@ function CatalogBody() {
       />
 
       <ListingDrawer item={selected} money={money} onClose={() => setSelected(null)} />
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/components/commerce/channels.tsx
+++ b/src/components/commerce/channels.tsx
@@ -10,6 +10,7 @@ import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { PendingItemsCard } from "@/components/molecules/pending-items-card";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 /**
  * Commerce → Channels (Phase 0). The four channel archetypes. Only D2C
@@ -21,7 +22,7 @@ import { useCommerceSummary } from "@/hooks/use-commerce-summary";
 export function CommerceChannels() {
   return (
     <FeatureGate feature="commerce.nav" featureName="Commerce">
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <header className="mb-6">
           <h1 className="text-xl font-semibold">Channels</h1>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -71,7 +72,7 @@ export function CommerceChannels() {
             />
           </TabsContent>
         </Tabs>
-      </div>
+      </PageShell>
     </FeatureGate>
   );
 }

--- a/src/components/commerce/command-center.tsx
+++ b/src/components/commerce/command-center.tsx
@@ -18,6 +18,7 @@ import { ActivityDigest } from "@/components/commerce/activity-digest";
 import { useLocale } from "@/hooks/use-locale";
 import { minorToMajor } from "@/lib/money";
 import { useCommerceSummary } from "@/hooks/use-commerce-summary";
+import { PageShell } from "@/components/dashboard/page-shell";
 
 /**
  * Commerce → Command Center (Phase 0). The outcome home for the Commerce pillar:
@@ -52,7 +53,7 @@ function CommandCenterBody() {
   };
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <PageShell width="standard">
       <header className="mb-6">
         <h1 className="text-xl font-semibold">Command Center</h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -133,7 +134,7 @@ function CommandCenterBody() {
           <ActivityDigest />
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/components/commerce/pricing.tsx
+++ b/src/components/commerce/pricing.tsx
@@ -20,6 +20,7 @@ import { EmptyState } from "@/components/molecules/empty-state";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { useLocale } from "@/hooks/use-locale";
 import { minorToMajor } from "@/lib/money";
+import { PageShell } from "@/components/dashboard/page-shell";
 import {
   usePricer,
   usePricerBrief,
@@ -73,16 +74,16 @@ function PricingBody() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <Skeleton className="h-64 w-full rounded-lg" />
-      </div>
+      </PageShell>
     );
   }
 
   if (isError || !data) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <EmptyState
           icon={Store}
@@ -90,14 +91,14 @@ function PricingBody() {
           description="Pricing & Promotions lights up once a Shopify or WooCommerce store is connected to this business."
           action={{ label: "Connect a store", href: "/dashboard/integrations" }}
         />
-      </div>
+      </PageShell>
     );
   }
 
   const { guardrails } = data;
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <PageShell width="standard">
       <Header />
 
       {/* Guardrails — always visible so the merchant sees the safety rails */}
@@ -121,7 +122,7 @@ function PricingBody() {
       <PriceGrid proposals={data.proposals} scanned={data.scanned} money={money} />
 
       <Promotions formatMajor={formatNumber} />
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/components/commerce/reviews.tsx
+++ b/src/components/commerce/reviews.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from "@/components/molecules/empty-state";
 import { RankedListCard } from "@/components/molecules/ranked-list-card";
 import { ProportionListCard } from "@/components/molecules/proportion-list-card";
 import { FeatureGate } from "@/components/upgrade/feature-gate";
+import { PageShell } from "@/components/dashboard/page-shell";
 import {
   useReviewsSummary,
   useReviewsList,
@@ -50,16 +51,16 @@ function ReviewsBody() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <Skeleton className="h-64 w-full rounded-lg" />
-      </div>
+      </PageShell>
     );
   }
 
   if (isError || !data) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <EmptyState
           icon={Store}
@@ -67,13 +68,13 @@ function ReviewsBody() {
           description="Reviews light up once a store with reviews is connected — Peakhour reads them across channels and finds the recurring themes."
           action={{ label: "Connect a store", href: "/dashboard/integrations" }}
         />
-      </div>
+      </PageShell>
     );
   }
 
   if (data.totalReviews === 0) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-8">
+      <PageShell width="standard">
         <Header />
         <Card>
           <CardContent className="py-10 text-center text-sm text-muted-foreground">
@@ -81,7 +82,7 @@ function ReviewsBody() {
             sentiment breakdown appear here.
           </CardContent>
         </Card>
-      </div>
+      </PageShell>
     );
   }
 
@@ -106,7 +107,7 @@ function ReviewsBody() {
   const fixThemes = data.topThemes.filter((t) => t.negativeCount > 0).slice(0, 6);
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <PageShell width="standard">
       <Header />
 
       {/* Stat row + analyse */}
@@ -172,7 +173,7 @@ function ReviewsBody() {
       {fixThemes.length > 0 && <FixIntents themes={fixThemes} />}
 
       <ResponseCards />
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/components/dashboard/page-shell.tsx
+++ b/src/components/dashboard/page-shell.tsx
@@ -24,13 +24,15 @@ import { cn } from "@/lib/utils";
  * single owner, and routes that re-declare it are the bug. PageShell owns
  * MEASURE (max-width + centring) and VERTICAL RHYTHM. Pages own neither: a
  * page adopting PageShell should carry no `p-*`, `max-w-*` or `mx-auto` on its
- * root, and should pick a `width` instead. That is a convention, not yet an
- * enforced invariant. The twelve routes still declaring their own root
- * padding — ask, calendar, calendar/recurring, content, content/autopilot,
- * content/whatsapp, content/whatsapp/analytics, content/whatsapp/templates,
- * inbox, insights/analytics, insights/search-console, settings/team — are
- * migrated in the follow-up, and the lint rule that pins the convention lands
- * with them.
+ * root, and should pick a `width` instead. Every route that declared its own
+ * root padding has been migrated, so no dashboard page double-pads today —
+ * but this is still a convention rather than an enforced invariant: nothing
+ * stops the next route from reintroducing one. The lint rule that would pin
+ * it is not written yet.
+ *
+ * One shell per route. A component rendered INSIDE a page must not open its
+ * own — nested shells double the measure wrapper and break any
+ * `[data-slot="page-shell"]` selector or lint rule built on the contract.
  *
  * NOTE ON TYPE SCALE: PageHeader's description renders at `text-sm` (14px).
  * The ad-hoc headers it replaces used an unsized `text-muted-foreground`
@@ -74,11 +76,16 @@ export interface PageShellProps extends React.ComponentProps<"div"> {
    *
    * This exists so such a page never has to guess the shell's chrome height.
    * /dashboard/ask used to hard-code `h-[calc(100dvh-5rem)]`, which assumed
-   * 80px of chrome when the real figure was 120px (header 56 + shell padding
-   * 48 + banner-slot margin 16) — so it overflowed by 40px on every device,
-   * pushing its composer below the fold. Anything computed from a literal
-   * goes stale the moment the shell's padding or banner slot changes; this
-   * cannot.
+   * 80px of chrome when the real figure is 104px (header 56 + shell padding
+   * 48; the banner slot adds nothing in the common case, being
+   * `empty:hidden`) — so it overflowed its container by 24px on every device.
+   * Anything computed from a literal goes stale the moment the shell's
+   * padding changes; this cannot.
+   *
+   * Requires the shell to have a definite height, which is why the dashboard
+   * layout pins `h-svh` on SidebarProvider — see the comment there. Without
+   * that, `flex-1` here resolves against an indefinite height and sizes to
+   * content, i.e. `fill` silently does nothing.
    *
    * `min-h-0` is the load-bearing half: without it this flex item's automatic
    * minimum size is its content height, so a long thread would push the shell

--- a/src/components/dashboard/page-shell.tsx
+++ b/src/components/dashboard/page-shell.tsx
@@ -66,6 +66,25 @@ export type PageShellWidth = keyof typeof PAGE_WIDTHS;
 export interface PageShellProps extends React.ComponentProps<"div"> {
   /** Content measure. Defaults to `standard`. See PAGE_WIDTHS. */
   width?: PageShellWidth;
+  /**
+   * Fill the available viewport height instead of growing with content, and
+   * become a column flex container so one child can take the remaining space
+   * with `min-h-0 flex-1`. For surfaces that own their own scrolling — chat
+   * threads, boards, split panes.
+   *
+   * This exists so such a page never has to guess the shell's chrome height.
+   * /dashboard/ask used to hard-code `h-[calc(100dvh-5rem)]`, which assumed
+   * 80px of chrome when the real figure was 120px (header 56 + shell padding
+   * 48 + banner-slot margin 16) — so it overflowed by 40px on every device,
+   * pushing its composer below the fold. Anything computed from a literal
+   * goes stale the moment the shell's padding or banner slot changes; this
+   * cannot.
+   *
+   * `min-h-0` is the load-bearing half: without it this flex item's automatic
+   * minimum size is its content height, so a long thread would push the shell
+   * into a nested scrollbar instead of scrolling inside the page.
+   */
+  fill?: boolean;
 }
 
 /**
@@ -78,6 +97,7 @@ export interface PageShellProps extends React.ComponentProps<"div"> {
  */
 export function PageShell({
   width = "standard",
+  fill = false,
   className,
   children,
   ...props
@@ -85,9 +105,11 @@ export function PageShell({
   return (
     <div
       data-slot="page-shell"
+      data-fill={fill || undefined}
       className={cn(
         "mx-auto w-full space-y-4 sm:space-y-6",
         PAGE_WIDTHS[width],
+        fill && "flex min-h-0 flex-1 flex-col",
         className,
       )}
       {...props}

--- a/src/components/dashboard/page-shell.tsx
+++ b/src/components/dashboard/page-shell.tsx
@@ -24,15 +24,20 @@ import { cn } from "@/lib/utils";
  * single owner, and routes that re-declare it are the bug. PageShell owns
  * MEASURE (max-width + centring) and VERTICAL RHYTHM. Pages own neither: a
  * page adopting PageShell should carry no `p-*`, `max-w-*` or `mx-auto` on its
- * root, and should pick a `width` instead. Every route that declared its own
- * root padding has been migrated, so no dashboard page double-pads today —
- * but this is still a convention rather than an enforced invariant: nothing
- * stops the next route from reintroducing one. The lint rule that would pin
- * it is not written yet.
+ * root, and should pick a `width` instead. This is a convention, not an
+ * enforced invariant — nothing stops the next route from reintroducing its
+ * own padding, and the lint rule that would pin it is not written yet.
  *
- * One shell per route. A component rendered INSIDE a page must not open its
- * own — nested shells double the measure wrapper and break any
- * `[data-slot="page-shell"]` selector or lint rule built on the contract.
+ * "Root" means the outermost element the route renders, which is not always
+ * in the page.tsx: the Commerce routes are one-line pages delegating to a
+ * component in src/components/commerce, and that component is the root. A
+ * first pass searched page.tsx files only and so missed six of them, which is
+ * why they are listed here.
+ *
+ * One shell per route, though. A component rendered INSIDE a page that
+ * already opened a shell must not open another — nested shells double the
+ * measure wrapper and break any `[data-slot="page-shell"]` selector or lint
+ * rule built on this contract.
  *
  * NOTE ON TYPE SCALE: PageHeader's description renders at `text-sm` (14px).
  * The ad-hoc headers it replaces used an unsized `text-muted-foreground`


### PR DESCRIPTION
Follow-up to #460, which added the layout contract. This lands the two P0 defects from the audit and migrates every route off its own root padding.

## The two P0s

**Strategist's Kanban was unusable below ~1750px.** Five columns rendered `flex-1` with no min-width and no overflow, so they collapsed with the container — ~56px per column on a 375px phone, ~83px at a 768px tablet with the sidebar expanded. Narrow enough that a card title wrapped to a couple of characters per line. The board now scrolls horizontally, columns are `min-w-70 flex-1` (280px floor, grow into whatever room exists). Also: `min-h-screen/2` on the column was never a real utility — Tailwind has no fractional modifier for min-height, so it compiled to nothing and the column had no minimum height at all.

**Ask Peakhour miscomputed its height on every device**, hard-coding `h-[calc(100dvh-5rem)]` against 104px of actual chrome.

Fixing the second one surfaced something bigger: **the dashboard shell never had a definite height.** `SidebarProvider` ships `min-h-svh`, and a `flex: 1 1 0%` item still contributes its max-content flex fraction to the container's intrinsic size, so the content area grew with the page and its `overflow-auto` never engaged — the document scrolled, and Ask's `calc()` was the only thing holding it in. Pinned `h-svh` + `min-h-0` (scoped to the dashboard layout by className, since `/cms` shares that primitive), so the shell is now the inner scroll container its markup always implied and `<PageShell fill>` can claim the remaining height without knowing what the chrome costs.

## The migration

All fourteen self-padding routes now use PageShell: ask, calendar, calendar/recurring, commerce/assistant, commerce/inventory, content, content/autopilot, content/whatsapp ×3, inbox, insights ×2, settings/team. Their six ad-hoc measures collapse into the four tiers. Zero dashboard routes double-pad now.

Also renamed two page-local components that were *already called* `PageShell` (content/linkedin, content/x) to `LinkedInPageShell`/`XPageShell` — a different abstraction, and sharing the name with the real primitive is a shadowing trap.

## Review

Round 1 (manual + subagent) was worth the whole exercise. The subagent ran headless Chromium against a faithful reproduction of the shell's ancestor chain and **measured** that my `fill` fix made Ask strictly worse — turning master's bounded 24px overflow into an unbounded one (2291px page in an 800px viewport at 40 messages, composer 1570px below the fold). It also measured that the Kanban's `xl:` escape hatch handed back 186px columns from 1280px, silently reintroducing the defect between there and ~1750px. Both premises were mine and both were wrong; both are fixed in a separate commit, along with a `<DragOverlay>` the new scroll container turned out to require.

## Verification

- `tsc --noEmit` clean, `next build` clean
- `eslint` reports the same 10 problems as `master` (confirmed by stashing); none introduced
- Utilities confirmed in the built CSS: `min-w-70` = 280px, `min-h-80` = 320px, `h-svh` = `100svh`
- Confirmed nothing depended on document scroll — the only scroll call under `/dashboard` is a `scrollIntoView`, which targets the nearest scrollable ancestor either way

**Wants a browser pass** on the scroll-container change before merge if anyone has a signed-in dev session: the header staying fixed while the page scrolls under it is the intended behaviour, but it is the widest-reaching change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)