### PR TITLE
fix(linkedin): stop offering a Reconnect that can't work; land back where the user was

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
-import { toastUnhandledApiError } from "@/lib/toast-errors";
+import { toastUnhandledApiError, toastAdAccountNotAuthorized } from "@/lib/toast-errors";
+import { reconnectHref, ADS_LINKEDIN_PATH } from "@/lib/integrations-connect";
 import {
   linkedInAdsApi,
   type ManagedCampaign,
@@ -56,6 +57,10 @@ interface ApiIntegration {
   connected?: boolean;
   status?: string;
 }
+
+/** Reconnect CTAs come back HERE, not to /dashboard/settings — this is the
+ *  surface whose work the reconnect was meant to unblock. */
+const RECONNECT_HREF = reconnectHref(ADS_LINKEDIN_PATH);
 
 const STATUS_BADGE: Record<ManagedCampaignStatus, string> = {
   draft: "bg-muted text-muted-foreground",
@@ -121,7 +126,7 @@ export function LinkedInAdsPanel() {
           icon={Megaphone}
           title="Connect LinkedIn Ads to get started"
           description="Connect your LinkedIn ad account, then boost your best organic posts into campaigns from the Content → LinkedIn → Boost tab. Campaigns are created as drafts — nothing spends until you activate it."
-          action={{ label: "Connect LinkedIn Ads", href: "/dashboard/integrations" }}
+          action={{ label: "Connect LinkedIn Ads", href: RECONNECT_HREF }}
         />
       ) : (
         <>
@@ -135,7 +140,7 @@ export function LinkedInAdsPanel() {
                   below still works.
                 </span>
                 <Link
-                  href="/dashboard/integrations"
+                  href={RECONNECT_HREF}
                   className="font-medium text-amber-900 underline underline-offset-4 dark:text-amber-200"
                 >
                   Reconnect
@@ -306,9 +311,13 @@ function CampaignRow({
         toast.error("LinkedIn Ads needs a reconnect before changing campaigns.", {
           action: {
             label: "Reconnect",
-            onClick: () => { window.location.href = "/dashboard/integrations"; },
+            onClick: () => { window.location.href = RECONNECT_HREF; },
           },
         });
+      } else if (code === "AD_ACCOUNT_NOT_AUTHORIZED") {
+        // A 403 that looks like a token problem and isn't — no Reconnect
+        // CTA here, it can't clear it. See toastAdAccountNotAuthorized.
+        toastAdAccountNotAuthorized(err, "Changing campaigns");
       } else if (code === "INVALID_TRANSITION") {
         toast.error("That status change isn't possible from the campaign's current state.");
         // The row is by definition stale — resync the table.
@@ -346,9 +355,11 @@ function CampaignRow({
         toast.error("LinkedIn Ads needs a reconnect before syncing metrics.", {
           action: {
             label: "Reconnect",
-            onClick: () => { window.location.href = "/dashboard/integrations"; },
+            onClick: () => { window.location.href = RECONNECT_HREF; },
           },
         });
+      } else if (code === "AD_ACCOUNT_NOT_AUTHORIZED") {
+        toastAdAccountNotAuthorized(err, "Refreshing metrics");
       } else if (code === "RATE_LIMITED") {
         toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
       } else {

--- a/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
+++ b/src/app/(site)/dashboard/ads/_components/targeting-dialog.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
-import { toastUnhandledApiError } from "@/lib/toast-errors";
+import { toastUnhandledApiError, toastAdAccountNotAuthorized } from "@/lib/toast-errors";
+import { reconnectHref, ADS_LINKEDIN_PATH } from "@/lib/integrations-connect";
 import {
   linkedInAdsApi,
   type ManagedCampaign,
@@ -257,9 +258,15 @@ export function TargetingDialog({
         toast.error("LinkedIn Ads needs a reconnect before updating targeting.", {
           action: {
             label: "Reconnect",
-            onClick: () => { window.location.href = "/dashboard/integrations"; },
+            onClick: () => {
+              window.location.href = reconnectHref(ADS_LINKEDIN_PATH);
+            },
           },
         });
+      } else if (code === "AD_ACCOUNT_NOT_AUTHORIZED") {
+        // Reaches this surface as a 403 too — and a Reconnect CTA here
+        // would be the same dead end it is on boost.
+        toastAdAccountNotAuthorized(err, "Updating targeting");
       } else if (code === "VALIDATION_ERROR") {
         toast.error((err as ApiError).message || "Check the targeting selection.");
       } else if (code === "RATE_LIMITED") {

--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { OAuthConnectResult } from "@/components/integrations/oauth-connect-result";
 import { LinkedInAdsPanel } from "./_components/linkedin-ads-panel";
 import { XAdsPanel } from "./_components/x-ads-panel";
 import {
@@ -179,6 +180,10 @@ function AdsHub() {
 
   return (
     <div className="space-y-6">
+      {/* Confirms a reconnect that started from this hub (its CTAs pass
+          ?returnTo=/dashboard/ads?channel=linkedin) and strips the callback's
+          params without disturbing ?channel=. */}
+      <OAuthConnectResult />
       {/* CronToolbar is mandatory on a cron-backed page (see cron-toolbar.tsx),
           so it renders before a channel resolves too — with every channel's
           crons rather than none. */}

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
-import { toastUnhandledApiError } from "@/lib/toast-errors";
+import { toastUnhandledApiError, toastAdAccountNotAuthorized } from "@/lib/toast-errors";
+import { reconnectHref, ADS_LINKEDIN_PATH } from "@/lib/integrations-connect";
 import {
   linkedInAdsApi,
   type BoostObjective,
@@ -48,6 +49,15 @@ import { Rocket } from "lucide-react";
  * produced a guaranteed failure. Lead-gen campaigns are built in
  * LinkedIn Campaign Manager; the objective stays valid on other paths.
  */
+/**
+ * Where the Connect / Reconnect CTAs send the user. The `returnTo` is
+ * forwarded by the Integrations page into the OAuth authorize call, so the
+ * callback lands them back on the LinkedIn hub they were boosting from —
+ * the old flow dropped them on /dashboard/settings, several clicks from the
+ * post they came to boost.
+ */
+const RECONNECT_HREF = reconnectHref("/dashboard/content/linkedin");
+
 const OBJECTIVES: Array<{ value: BoostObjective; label: string }> = [
   { value: "engagement", label: "Engagement (boost the post)" },
   { value: "brand_awareness", label: "Brand awareness" },
@@ -71,10 +81,14 @@ export function BoostCampaignDialog({
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
-  // Latched after PERSIST_FAILED: the draft EXISTS on LinkedIn, so a
-  // resubmit would duplicate it — the button stays disabled for this
-  // dialog instance.
-  const [terminal, setTerminal] = useState(false);
+  // Latched on a failure a resubmit cannot improve on — the button stays
+  // disabled for this dialog instance, and the reason picks its label:
+  //   "persisted"      PERSIST_FAILED — the draft EXISTS on LinkedIn, so
+  //                    a resubmit would duplicate it.
+  //   "not_authorized" AD_ACCOUNT_NOT_AUTHORIZED — LinkedIn refuses this
+  //                    ad account for our app; nothing was created and
+  //                    nothing will be until that access is granted.
+  const [blocked, setBlocked] = useState<"persisted" | "not_authorized" | null>(null);
 
   // Round ONCE up front so validation, the displayed cap, and the
   // payload can never disagree (typing "14.7" must not show a x14.7
@@ -115,9 +129,9 @@ export function BoostCampaignDialog({
         action: {
           label: "Open Ads Manager",
           onClick: () => {
-            // Name the channel — the hub otherwise defaults to whichever ad
-            // channel is connected first, which may not be LinkedIn.
-            window.location.href = "/dashboard/ads?channel=linkedin";
+            // ADS_LINKEDIN_PATH names the channel — the hub otherwise
+            // defaults to whichever ad channel is connected first.
+            window.location.href = ADS_LINKEDIN_PATH;
           },
         },
       });
@@ -135,16 +149,26 @@ export function BoostCampaignDialog({
         toast.error("Connect (or reconnect) LinkedIn Ads first.", {
           action: {
             label: "Integrations",
-            onClick: () => { window.location.href = "/dashboard/integrations"; },
+            onClick: () => { window.location.href = RECONNECT_HREF; },
           },
         });
       } else if (code === "NEEDS_REAUTH") {
         toast.error("LinkedIn Ads needs a reconnect before boosting.", {
           action: {
             label: "Reconnect",
-            onClick: () => { window.location.href = "/dashboard/integrations"; },
+            // returnTo brings the user back HERE after the OAuth round
+            // trip instead of stranding them on Settings.
+            onClick: () => { window.location.href = RECONNECT_HREF; },
           },
         });
+      } else if (code === "AD_ACCOUNT_NOT_AUTHORIZED") {
+        // The 403 that used to masquerade as NEEDS_REAUTH. LinkedIn only
+        // lets an app write to ad accounts it has been granted in the
+        // Developer Portal, so this is OURS to fix — offering Reconnect
+        // here is the loop that wasted the user's time. No retry either:
+        // the answer will not change until the access is granted.
+        setBlocked("not_authorized");
+        toastAdAccountNotAuthorized(err, "Boosting");
       } else if (code === "NO_AD_ACCOUNT") {
         toast.error(
           "Your LinkedIn Ads connection has no ad account — reconnect it, or create an ad account in LinkedIn Campaign Manager first.",
@@ -153,7 +177,7 @@ export function BoostCampaignDialog({
         toast.error("Pick a business first, then boost.");
       } else if (code === "PERSIST_FAILED") {
         // The draft DOES exist on LinkedIn — retrying would duplicate it.
-        setTerminal(true);
+        setBlocked("persisted");
         toast.error(
           "The campaign was created on LinkedIn but couldn't be saved here. Contact support — don't retry.",
         );
@@ -168,7 +192,7 @@ export function BoostCampaignDialog({
           description: "Edit or activate it from the Ads Manager instead of creating a second one.",
           action: {
             label: "Open Ads Manager",
-            onClick: () => { window.location.href = "/dashboard/ads?channel=linkedin"; },
+            onClick: () => { window.location.href = ADS_LINKEDIN_PATH; },
           },
         });
       } else if (code === "RATE_LIMITED") {
@@ -312,9 +336,15 @@ export function BoostCampaignDialog({
           <Button
             type="button"
             onClick={() => boost.mutate()}
-            disabled={!valid || boost.isPending || terminal}
+            disabled={!valid || boost.isPending || blocked !== null}
           >
-            {boost.isPending ? "Creating…" : terminal ? "Created — see support note" : "Create draft campaign"}
+            {boost.isPending
+              ? "Creating…"
+              : blocked === "persisted"
+                ? "Created — see support note"
+                : blocked === "not_authorized"
+                  ? "Blocked — see support note"
+                  : "Create draft campaign"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -41,15 +41,6 @@ import { Rocket } from "lucide-react";
  */
 
 /**
- * Objectives a BOOST can use. `lead_generation` is deliberately absent:
- * LinkedIn requires a lead gen form on every creative under a lead-gen
- * campaign, and sponsoring an existing organic post gives us nowhere to
- * attach one — the server rejects that combination
- * (VALIDATION_LEADGEN_FORM_REQUIRED). Offering it here only ever
- * produced a guaranteed failure. Lead-gen campaigns are built in
- * LinkedIn Campaign Manager; the objective stays valid on other paths.
- */
-/**
  * Where the Connect / Reconnect CTAs send the user. The `returnTo` is
  * forwarded by the Integrations page into the OAuth authorize call, so the
  * callback lands them back on the LinkedIn hub they were boosting from —
@@ -58,6 +49,15 @@ import { Rocket } from "lucide-react";
  */
 const RECONNECT_HREF = reconnectHref("/dashboard/content/linkedin");
 
+/**
+ * Objectives a BOOST can use. `lead_generation` is deliberately absent:
+ * LinkedIn requires a lead gen form on every creative under a lead-gen
+ * campaign, and sponsoring an existing organic post gives us nowhere to
+ * attach one — the server rejects that combination
+ * (VALIDATION_LEADGEN_FORM_REQUIRED). Offering it here only ever
+ * produced a guaranteed failure. Lead-gen campaigns are built in
+ * LinkedIn Campaign Manager; the objective stays valid on other paths.
+ */
 const OBJECTIVES: Array<{ value: BoostObjective; label: string }> = [
   { value: "engagement", label: "Engagement (boost the post)" },
   { value: "brand_awareness", label: "Brand awareness" },

--- a/src/app/(site)/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/carousel-preview-dialog.tsx
@@ -16,6 +16,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { GalleryHorizontalEnd, ImageOff, Loader2, Send } from "lucide-react";
 import { ApiError } from "@/lib/api";
+import { reconnectHref } from "@/lib/integrations-connect";
 import {
   linkedInContentApi,
   type CarouselPreviewResult,
@@ -77,7 +78,8 @@ export function CarouselPreviewDialog({
           action: {
             label: "Reconnect",
             onClick: () => {
-              window.location.href = "/dashboard/integrations";
+              // returnTo lands them back on this hub, not on Settings.
+              window.location.href = reconnectHref("/dashboard/content/linkedin");
             },
           },
         });

--- a/src/app/(site)/dashboard/content/linkedin/_components/feed-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/feed-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
+import { reconnectHref } from "@/lib/integrations-connect";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -287,7 +288,8 @@ function CommentBox({
           action: {
             label: "Reconnect",
             onClick: () => {
-              window.location.href = "/dashboard/integrations";
+              // returnTo lands them back on this hub, not on Settings.
+              window.location.href = reconnectHref("/dashboard/content/linkedin");
             },
           },
         });

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { OAuthConnectResult } from "@/components/integrations/oauth-connect-result";
+import { reconnectHref } from "@/lib/integrations-connect";
 import { api, ApiError } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -18,6 +20,9 @@ import { AudiencePanel } from "./_components/audience-panel";
 import { BoostCandidatesPanel } from "./_components/boost-candidates-panel";
 import { FeedPanel } from "./_components/feed-panel";
 import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
+
+/** Reconnect round trips come back to this hub, not to Settings. */
+const RECONNECT_HREF = reconnectHref("/dashboard/content/linkedin");
 
 interface ApiIntegration {
   provider: string;
@@ -65,7 +70,7 @@ export default function LinkedInDashboardPage() {
           icon={MessageSquare}
           title="Connect LinkedIn to get started"
           description="Once connected, you can publish to your personal feed or any company page you administer, all from here."
-          action={{ label: "Connect LinkedIn", href: "/dashboard/integrations" }}
+          action={{ label: "Connect LinkedIn", href: RECONNECT_HREF }}
         />
       </LinkedInPageShell>
     );
@@ -86,7 +91,7 @@ export default function LinkedInDashboardPage() {
               ? "We're missing your LinkedIn member identity. Reconnect to repair the integration."
               : "We couldn't read your LinkedIn identity. Reconnect to continue posting."
           }
-          action={{ label: "Reconnect LinkedIn", href: "/dashboard/integrations" }}
+          action={{ label: "Reconnect LinkedIn", href: RECONNECT_HREF }}
         />
       </LinkedInPageShell>
     );
@@ -106,7 +111,7 @@ export default function LinkedInDashboardPage() {
               Reconnect to keep publishing.
             </span>
             <a
-              href="/dashboard/integrations"
+              href={RECONNECT_HREF}
               className="font-medium text-amber-900 underline underline-offset-4 dark:text-amber-200"
             >
               Reconnect
@@ -224,6 +229,10 @@ function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; 
   const queryClient = useQueryClient();
   return (
     <div className="space-y-6">
+      {/* Confirms a reconnect that started here (the Boost dialog's CTAs pass
+          ?returnTo=/dashboard/content/linkedin) — in the shell so every branch
+          of this page, including the empty states, announces it. */}
+      <OAuthConnectResult />
       {/* jobs-runner is required AFTER linkedin-post-sync on dev: the sync cron
           ENQUEUES a linkedin_post_sync job (it doesn't drain inline), so click
           linkedin-post-sync first, then jobs-runner to actually run it and

--- a/src/app/(site)/dashboard/integrations/page.tsx
+++ b/src/app/(site)/dashboard/integrations/page.tsx
@@ -11,6 +11,7 @@ import { StatusBadge } from "@/components/molecules/status-badge";
 import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
 import { WhatsAppEmbeddedSignup } from "@/components/integrations/whatsapp-embedded-signup";
+import { OAuthConnectResult } from "@/components/integrations/oauth-connect-result";
 import { WordPressConnectModal } from "@/components/integrations/wordpress-connect-modal";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -238,8 +239,40 @@ function friendlyRepairWebhookError(err: ApiError, providerLabel: string): strin
   }
 }
 
+/**
+ * Post-connect landing for OAuth started from THIS page. Passed to the api
+ * as `?returnTo=` and honoured by the callback, which otherwise dumps every
+ * provider on /dashboard/settings — the redirect that made "reconnect
+ * LinkedIn Ads" end two clicks away from the ads surface that needed it.
+ *
+ * A surface that sends the user here to reconnect (the Boost dialog, the
+ * LinkedIn ads panel) passes its OWN path as `?returnTo=`; we forward that
+ * so the round trip ends where the user actually was. Validated, not
+ * trusted: the api re-checks it too, but a bad value should never make it
+ * into an authorize URL in the first place.
+ */
+const DEFAULT_RETURN_TO = "/dashboard/integrations";
+
+function safeReturnTo(raw: string | null | undefined): string {
+  if (!raw) return DEFAULT_RETURN_TO;
+  const value = raw.trim();
+  if (
+    value.length === 0 ||
+    value.length > 256 ||
+    !value.startsWith("/dashboard/") ||
+    value.includes("\\") ||
+    value.includes("://") ||
+    value.includes("#")
+  ) {
+    return DEFAULT_RETURN_TO;
+  }
+  return value;
+}
+
 export default function IntegrationsPage() {
   const { org } = useAuth();
+  const searchParams = useSearchParams();
+  const returnTo = safeReturnTo(searchParams?.get("returnTo"));
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -300,7 +333,9 @@ export default function IntegrationsPage() {
       return;
     }
     if (authType === "oauth2") {
-      window.location.href = `${API_BASE_URL}/v1/integrations/${realProvider}/authorize`;
+      window.location.href =
+        `${API_BASE_URL}/v1/integrations/${realProvider}/authorize` +
+        `?returnTo=${encodeURIComponent(returnTo)}`;
     } else if (authType === "api_key") {
       setConnectModal(realProvider);
     }
@@ -531,6 +566,10 @@ export default function IntegrationsPage() {
 
   return (
     <PageShell width="standard">
+      {/* Confirms an OAuth round trip that came back here (?returnTo=). The
+          page's own fetch already shows the new state; this is the "it
+          worked" the user is owed. */}
+      <OAuthConnectResult />
       <PageHeader
         title="Integrations"
         description="Connect your platforms to power AI-driven content and ads"

--- a/src/app/(site)/dashboard/settings/page.tsx
+++ b/src/app/(site)/dashboard/settings/page.tsx
@@ -7,6 +7,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/providers/auth-provider";
 import { api, ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
+// Shared with every other surface the OAuth callback can return to
+// (?returnTo=), so a new provider is labelled once, not per page.
+import { formatProviderName } from "@/lib/provider-names";
 import { IntegrationFitAttention } from "@/components/integrations/integration-fit-attention";
 import { RequestReviewButton } from "@/components/integrations/request-review-button";
 import { CreateWorkspaceButton } from "@/components/integrations/create-workspace-button";
@@ -506,48 +509,6 @@ function SettingsContent() {
         </Link>
       </div>
     </div>
-  );
-}
-
-// Display names for known provider slugs the OAuth callback can pass back via
-// ?integration=connected&provider=<slug>. Unknown slugs fall through to a
-// title-cased fallback so a brand-new provider doesn't render "undefined" —
-// it just looks a bit raw until added here. Source of truth for the canonical
-// labels is each provider's `displayName` in peakhour-api/src/v1/integrations/providers/*.
-const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  x: "X (Twitter)",
-  x_ads: "X Ads",
-  linkedin_content: "LinkedIn",
-  linkedin_ads: "LinkedIn Ads",
-  facebook: "Meta",
-  meta_ads: "Meta Ads",
-  instagram: "Instagram",
-  youtube: "YouTube",
-  beehiiv: "Beehiiv",
-  substack: "Substack",
-  kit: "Kit",
-  mailchimp: "Mailchimp",
-  ghost: "Ghost",
-  wordpress: "WordPress",
-  shopify: "Shopify",
-  discord: "Discord",
-  slack: "Slack",
-  teams: "Microsoft Teams",
-  telegram: "Telegram",
-  google_ads: "Google Ads",
-  google_analytics: "Google Analytics",
-  google_search_console: "Google Search Console",
-  google_business_profile: "Google Business Profile",
-};
-
-function formatProviderName(slug: string): string {
-  if (!slug) return "Account";
-  return (
-    PROVIDER_DISPLAY_NAMES[slug] ??
-    slug
-      .split("_")
-      .map((w) => (w[0] ? w[0].toUpperCase() + w.slice(1) : w))
-      .join(" ")
   );
 }
 

--- a/src/components/integrations/oauth-connect-result.tsx
+++ b/src/components/integrations/oauth-connect-result.tsx
@@ -60,7 +60,6 @@ export function OAuthConnectResult() {
     const next = new URLSearchParams(searchParams.toString());
     next.delete("integration");
     next.delete("provider");
-    next.delete("select_page");
     const qs = next.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   }, [searchParams, pathname, router, queryClient]);

--- a/src/components/integrations/oauth-connect-result.tsx
+++ b/src/components/integrations/oauth-connect-result.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { formatProviderName } from "@/lib/provider-names";
+
+/**
+ * Post-OAuth confirmation for any surface the connect flow can return to.
+ *
+ * The api's callback used to send EVERY provider to /dashboard/settings,
+ * which is why reconnecting LinkedIn Ads to fix a boost ended on a
+ * settings page with a green banner and no way back to the post the user
+ * was boosting. `/v1/integrations/:provider/authorize?returnTo=` now
+ * brings them back here instead — and the surface they land on has to say
+ * the connect worked, which is this component's whole job.
+ *
+ * Mount it on any page passed as a `returnTo` target. It:
+ *   1. toasts success (a toast, not a banner: the returning surface is
+ *      the user's real destination and must not be pushed down by a
+ *      dismissible strip),
+ *   2. invalidates the connection-state queries so the page it returns to
+ *      doesn't keep rendering its pre-connect "Connect" CTA — the stale
+ *      state that invites a needless reconnect, which revokes the token
+ *      we just minted (the LinkedIn reconnect loop),
+ *   3. strips the params so a refresh (or a back-navigation) doesn't
+ *      re-announce a connect that happened minutes ago.
+ *
+ * ERRORS ARE NOT HANDLED HERE. The api deliberately keeps
+ * `?integration=error` on /dashboard/settings, the only surface that
+ * renders the full failure copy (including the brand-mismatch "request a
+ * review" affordance). If that ever changes, this is where the error
+ * branch belongs.
+ */
+export function OAuthConnectResult() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  // A ref, not state: React 18 double-invokes effects in dev, and the
+  // router.replace below is async — without this the toast fires twice.
+  const announced = useRef(false);
+
+  useEffect(() => {
+    if (announced.current) return;
+    if (searchParams?.get("integration") !== "connected") return;
+    announced.current = true;
+
+    const provider = searchParams.get("provider") ?? "";
+    toast.success(`${formatProviderName(provider)} connected.`);
+
+    // Same keys the settings page invalidates on connect.
+    queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
+    queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
+
+    // Drop only OUR params — a returnTo carrying its own query (e.g.
+    // /dashboard/ads?channel=linkedin) must keep it, or the page reloads
+    // onto a different channel than the user left.
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("integration");
+    next.delete("provider");
+    next.delete("select_page");
+    const qs = next.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [searchParams, pathname, router, queryClient]);
+
+  return null;
+}

--- a/src/lib/integrations-connect.ts
+++ b/src/lib/integrations-connect.ts
@@ -1,0 +1,24 @@
+/**
+ * Link builder for the "go reconnect this integration" CTAs.
+ *
+ * Every one of them used to be a bare `/dashboard/integrations`, and the
+ * api's OAuth callback then sent the user to /dashboard/settings — so a
+ * reconnect prompted by a failed boost ended two navigations away from the
+ * post being boosted, with a green banner on a page nobody asked for.
+ *
+ * The Integrations page forwards this `returnTo` into
+ * `/v1/integrations/:provider/authorize?returnTo=`, the callback carries it
+ * in the SIGNED state, and the surface named here gets the user back plus a
+ * "<provider> connected" toast (mount `<OAuthConnectResult />` there).
+ *
+ * `returnTo` must be an in-app `/dashboard/...` path; both the Integrations
+ * page and the api re-validate it, and anything else silently falls back to
+ * the Integrations page.
+ */
+export function reconnectHref(returnTo: string): string {
+  return `/dashboard/integrations?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
+/** The LinkedIn Ads hub, channel named explicitly — the hub otherwise
+ *  defaults to whichever ad channel is connected first. */
+export const ADS_LINKEDIN_PATH = "/dashboard/ads?channel=linkedin";

--- a/src/lib/provider-names.ts
+++ b/src/lib/provider-names.ts
@@ -1,0 +1,51 @@
+/**
+ * Display names for the provider slugs the api's OAuth callback hands
+ * back via `?integration=connected&provider=<slug>`.
+ *
+ * Extracted from dashboard/settings/page.tsx when the callback stopped
+ * always landing on Settings (`?returnTo=`): more than one surface now
+ * renders "<provider> connected", and two copies of this table would
+ * drift the moment a provider is added.
+ *
+ * Source of truth for the canonical labels is each provider's
+ * `displayName` in peakhour-api/src/v1/integrations/providers/*.
+ */
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  x: "X (Twitter)",
+  x_ads: "X Ads",
+  linkedin_content: "LinkedIn",
+  linkedin_ads: "LinkedIn Ads",
+  facebook: "Meta",
+  meta_ads: "Meta Ads",
+  instagram: "Instagram",
+  youtube: "YouTube",
+  beehiiv: "Beehiiv",
+  substack: "Substack",
+  kit: "Kit",
+  mailchimp: "Mailchimp",
+  ghost: "Ghost",
+  wordpress: "WordPress",
+  shopify: "Shopify",
+  discord: "Discord",
+  slack: "Slack",
+  teams: "Microsoft Teams",
+  telegram: "Telegram",
+  google_ads: "Google Ads",
+  google_analytics: "Google Analytics",
+  google_search_console: "Google Search Console",
+  google_business_profile: "Google Business Profile",
+};
+
+/** Unknown slugs fall through to a title-cased fallback so a brand-new
+ *  provider never renders "undefined" — it just looks a bit raw until
+ *  added to the table above. */
+export function formatProviderName(slug: string): string {
+  if (!slug) return "Account";
+  return (
+    PROVIDER_DISPLAY_NAMES[slug] ??
+    slug
+      .split("_")
+      .map((w) => (w[0] ? w[0].toUpperCase() + w.slice(1) : w))
+      .join(" ")
+  );
+}

--- a/src/lib/toast-errors.test.ts
+++ b/src/lib/toast-errors.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const errorToast = vi.fn();
 vi.mock("sonner", () => ({ toast: { error: (...args: unknown[]) => errorToast(...args) } }));
 
-import { toastUnhandledApiError } from "./toast-errors";
+import { toastUnhandledApiError, toastAdAccountNotAuthorized } from "./toast-errors";
 import { ApiError } from "@/lib/api";
 
 const REQ = "bc662f49-6c8a-41cb-9e40-5156925f6202";
@@ -168,4 +168,47 @@ describe("never leaks the raw provider message", () => {
       expect(rendered).not.toContain("E11000");
     });
   }
+});
+
+describe("AD_ACCOUNT_NOT_AUTHORIZED never offers a reconnect", () => {
+  // THE regression this code exists to end: the api used to answer this 403
+  // with NEEDS_REAUTH, so every ads surface told the user to reconnect a
+  // connection that was already healthy. Reconnecting cannot grant our app
+  // access to an advertiser account.
+  it("is not treated as user_fixable by the fallback handler", () => {
+    toastUnhandledApiError(apiError("AD_ACCOUNT_NOT_AUTHORIZED", 403), "create the campaign", "LinkedIn");
+    const { title, description, duration } = shown();
+    const rendered = `${title} ${description}`;
+    expect(rendered).not.toMatch(/reconnect/i);
+    expect(rendered).not.toMatch(/try again/i);
+    // Permanent: support, with the id, and no auto-dismiss.
+    expect(description).toContain(`reference ${REQ}`);
+    expect(duration).toBe(Infinity);
+  });
+
+  it("the dedicated helper names the cause without the provider body", () => {
+    toastAdAccountNotAuthorized(
+      apiError(
+        "AD_ACCOUNT_NOT_AUTHORIZED",
+        403,
+        '{"code":"FORBIDDEN","message":"…Account Management list.","status":403}',
+      ),
+      "Boosting",
+    );
+    const { title, description, duration } = shown();
+    expect(title).toBe("LinkedIn hasn't authorised Peakhour on this ad account yet.");
+    expect(description).toMatch(/^Boosting can't work/);
+    expect(description).toContain(`reference ${REQ}`);
+    expect(`${title} ${description}`).not.toMatch(/reconnect/i);
+    expect(`${title} ${description}`).not.toContain("FORBIDDEN");
+    expect(duration).toBe(Infinity);
+  });
+
+  it("falls back to a plain support pointer with no request id", () => {
+    toastAdAccountNotAuthorized(
+      new ApiError("AD_ACCOUNT_NOT_AUTHORIZED", "raw", 403),
+      "Updating targeting",
+    );
+    expect(shown().description).toMatch(/Please contact support\.$/);
+  });
 });

--- a/src/lib/toast-errors.ts
+++ b/src/lib/toast-errors.ts
@@ -80,6 +80,12 @@ function dispositionOf(code: string, status: number): Disposition {
   // gets the same answer.
   if (code.startsWith("PROVIDER_4XX_") || code.startsWith("VALIDATION_")) return "permanent";
 
+  // Our app isn't authorised on the advertiser account. Emphatically NOT
+  // user_fixable — that classification is what produced a Reconnect CTA
+  // for a problem no reconnect can reach. See toastAdAccountNotAuthorized
+  // for the surfaces that say it properly.
+  if (code === "AD_ACCOUNT_NOT_AUTHORIZED") return "permanent";
+
   // Route catch-alls for a NON-AdsOpError throw, i.e. an unexpected
   // programming or config error ("LINKEDIN_CLIENT_ID is not set").
   // 5xx-shaped and never transient — telling the user to retry means
@@ -163,6 +169,36 @@ export function toastUnhandledApiError(
 
   toast.error(`Couldn't ${whatFailed}.`, {
     description: `${rejected} ${support}`,
+    duration: Infinity,
+  });
+}
+
+/**
+ * AD_ACCOUNT_NOT_AUTHORIZED — the ad platform refuses the account because
+ * OUR APP hasn't been granted it (LinkedIn: the Developer Portal's Account
+ * Management list / Development tier), with a perfectly valid token.
+ *
+ * It has its own helper because the WRONG copy for it is so tempting: the
+ * api used to return NEEDS_REAUTH here, so every ads surface offered a
+ * Reconnect that could not possibly clear it, and users burned real time
+ * re-authorising a healthy connection. No Reconnect CTA, no "try again" —
+ * it is ours to fix, and support is the only useful next step.
+ *
+ * @param whatBlocked noun phrase for the blocked operation — "Boosting",
+ *   "Activating this campaign".
+ */
+export function toastAdAccountNotAuthorized(
+  err: unknown,
+  whatBlocked: string,
+  platform = "LinkedIn",
+): void {
+  const requestId = err instanceof ApiError ? err.requestId : undefined;
+  toast.error(`${platform} hasn't authorised Peakhour on this ad account yet.`, {
+    description:
+      `${whatBlocked} can't work until that access is granted — we've logged it. ` +
+      (requestId
+        ? `Contact support quoting reference ${requestId}.`
+        : "Please contact support."),
     duration: Infinity,
   });
 }


### PR DESCRIPTION
Pairs with **peakhour-api#970** (merge that first — this branches on the `AD_ACCOUNT_NOT_AUTHORIZED` code it introduces and passes the `?returnTo=` it honours).

## 1. The Reconnect that could never work

Boost's "LinkedIn Ads needs a reconnect before boosting." was answering a 403 that says LinkedIn hasn't authorised **our app** on the advertiser account. The token was healthy, so reconnecting could not clear it — the user just went round the loop.

Every LinkedIn ads surface now branches on `AD_ACCOUNT_NOT_AUTHORIZED` and says what is true, with no Reconnect CTA and no retry prompt: `toastAdAccountNotAuthorized` (boost, campaign status, metrics sync, targeting), carrying the request id so support can find the log holding LinkedIn's actual words. The code is classified `permanent` in `toast-errors.ts` — explicitly NOT `user_fixable`, which is the classification that produced the bad CTA in the first place.

The boost dialog also latches its button. `terminal` became `blocked` with a reason, because nothing was created here and the old label ("Created — see support note") would have claimed a campaign existed.

## 2. Reconnect landed on /dashboard/settings

Connect/Reconnect CTAs now pass `?returnTo=` (`reconnectHref`), the Integrations page forwards it into `/authorize`, and `<OAuthConnectResult />` on the three `returnTo` targets — Integrations, Ads hub, LinkedIn hub — toasts "&lt;provider&gt; connected", invalidates the connection queries so no surface keeps a stale "Connect" CTA (the stale state that invites a needless reconnect and revokes the token we just minted), and strips only its own params so `?channel=linkedin` survives.

`PROVIDER_DISPLAY_NAMES` / `formatProviderName` moved out of the settings page into `lib/provider-names.ts` now that more than one surface renders that label — two copies would drift on the next provider added.

Errors still land on Settings by design (server-side): it is the only page with the full failure copy, including the brand-mismatch "request a review" affordance.

## Review round 1 caught

- `RECONNECT_HREF` had been inserted between the `OBJECTIVES` docblock and `OBJECTIVES`, orphaning the "why lead_generation is absent" rationale. Moved.
- `OAuthConnectResult` stripped `select_page`, which can never reach these surfaces. Removed rather than left implying support.

## Testing

- `npx tsc --noEmit` clean; `npx next build` clean (every dashboard route is dynamic, so the new `useSearchParams` needs no Suspense boundary).
- `vitest run`: 116 passed.
- `eslint` on all changed files: no new findings (the 2 errors + 2 warnings reported in `integrations/page.tsx` are pre-existing, at lines far from this diff; b2c has no lint CI).
- Verified `QueryProvider` wraps the `(site)` group, so `OAuthConnectResult`'s `useQueryClient` is safe on the Integrations page (which otherwise doesn't use react-query).

Note: Boost will still fail on dev until ad account `549055351` is added to the `linkedin_ads` app's Account Management list in the LinkedIn Developer Portal — this PR only makes the failure honest and actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)