### PR TITLE
feat(ads): show LinkedIn's political-advertising declaration on Boost

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -90,6 +91,12 @@ export function BoostCampaignDialog({
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
+  // LinkedIn requires an ads-creating app to show its political-advertising
+  // notice and pass back the advertiser's confirmation. Their spec says the
+  // notice "must be clearly presented and checked by default", so it starts
+  // ticked — and unticking it is meaningful: the campaign is then created
+  // NOT_DECLARED, which LinkedIn may hold from EU delivery until declared.
+  const [notPolitical, setNotPolitical] = useState(true);
   // Latched on a failure a resubmit cannot improve on — the button stays
   // disabled for this dialog instance, and the reason picks its label:
   //   "persisted"      PERSIST_FAILED — the draft EXISTS on LinkedIn, so
@@ -126,6 +133,7 @@ export function BoostCampaignDialog({
         dailyBudget: budgetNumber,
         currencyCode: currencyCode.trim().toUpperCase(),
         durationDays: durationNumber,
+        notPolitical,
       }),
     onSuccess: () => {
       // The Ads Manager list must show the new campaign even within
@@ -323,6 +331,46 @@ export function BoostCampaignDialog({
                 onChange={(e) => setDurationDays(e.target.value)}
               />
             </div>
+          </div>
+
+          {/* LinkedIn's political-advertising self-declaration. Not our
+              wording to soften: their Advertising API contract requires an
+              app that creates ads to present this notice and pass back what
+              the advertiser confirmed (`politicalIntent`), and it became a
+              REQUIRED campaign field with the EU's TTPA regulation — every
+              create 422'd without it. Checked by default, per their spec. */}
+          <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3">
+            <Checkbox
+              id="boost-not-political"
+              checked={notPolitical}
+              onCheckedChange={(v) => setNotPolitical(v === true)}
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor="boost-not-political"
+              className="text-[11px] font-normal leading-relaxed text-muted-foreground"
+            >
+              I confirm this is not political advertising. None of my ads
+              qualify as political advertising under the law of the targeted
+              countries, including EU law for ads targeted to the EU.
+              Advertisers must comply with LinkedIn&apos;s policies and
+              regulatory requirements.{" "}
+              <a
+                href="https://www.linkedin.com/legal/ads-policy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2"
+              >
+                Learn more
+              </a>
+              {!notPolitical ? (
+                <span className="mt-1 block text-amber-700 dark:text-amber-400">
+                  Left unticked, the campaign is created without a declaration
+                  — LinkedIn may hold delivery to EU audiences until you make
+                  one in Campaign Manager.
+                </span>
+              ) : null}
+            </Label>
           </div>
 
           <p className="text-[11px] text-muted-foreground">

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -115,6 +115,16 @@ export interface BoostCampaignInput {
    *  a mismatch with code CURRENCY_MISMATCH naming the expected code. */
   currencyCode: string;
   durationDays: number;
+  /**
+   * The advertiser ticking LinkedIn's political-advertising consent notice.
+   *
+   * LinkedIn REQUIRES an app that creates ads to present that notice and
+   * pass back what was confirmed (`politicalIntent` on the campaign — it
+   * became a required field with the EU's TTPA regulation, and omitting it
+   * 422s every create). Absent/false means NOT_DECLARED, never
+   * "not political": that is a legal declaration the customer makes, not us.
+   */
+  notPolitical?: boolean;
 }
 
 export const linkedInAdsApi = {


### PR DESCRIPTION
Pairs with **peakhour-api#973** — merge that first.

LinkedIn requires an app that creates ads to present a political-advertising notice and pass back what the advertiser confirmed. The field (`politicalIntent`) became **required** on campaign create with the EU's TTPA regulation, and every create was 422-ing without it — which is what a user hit on dev today.

## What this adds

The notice, verbatim from LinkedIn's Advertising API docs, with their ads-policy link:

> ☑ I confirm this is not political advertising. None of my ads qualify as political advertising under the law of the targeted countries, including EU law for ads targeted to the EU. Advertisers must comply with LinkedIn's policies and regulatory requirements. [Learn more](https://www.linkedin.com/legal/ads-policy)

**Checked by default**, because their spec says so — *"must be clearly presented and checked by default during the campaign creation process."*

Unticking it is meaningful rather than cosmetic, so the dialog says what it costs: the campaign is created `NOT_DECLARED`, and LinkedIn may hold delivery to EU audiences until a declaration is made in Campaign Manager.

## Deliberately not a submit blocker

`NOT_DECLARED` is a valid, honest state. Forcing the tick to proceed would turn a legal declaration into a click-through — and the whole reason the api defaults to `NOT_DECLARED` rather than `NOT_POLITICAL` is that this statement is the customer's to make, not ours.

## Testing

`npx tsc --noEmit` clean · `vitest run` 126 passed · `npx next build` compiled successfully. The consent value's handling is tested api-side at the fetch layer, where the contract lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)