### PR TITLE
feat(ads): let a human actually make the advertising declaration

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -43,6 +43,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { AdvertisingDeclarationCard } from "@/components/ads/advertising-declaration-card";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { AlertTriangle, Archive, Megaphone, Pause, Play, RefreshCw, Rocket, Target } from "lucide-react";
 import { TargetingDialog, editorTargeting } from "./targeting-dialog";
@@ -121,6 +122,13 @@ export function LinkedInAdsPanel() {
           gate below renders an EmptyState — which used to hide this warning in
           the one case it matters most. */}
       <SpendAlarmBanner />
+      {/* Above the gate for the same reason, plus one of its own: the
+          declaration governs every campaign create including the autonomous
+          ones, and a business can make it before it connects. Not on
+          /dashboard/optimizer — that page is FeatureGate'd on
+          growth.optimizer, so a business entitled to ads but not the
+          optimizer could boost campaigns and never be able to declare. */}
+      <AdvertisingDeclarationCard />
       {integrations.isLoading ? (
         <Card>
           <CardContent className="space-y-3 p-6">

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -80,6 +80,11 @@ const OBJECTIVES: Array<{ value: BoostObjective; label: string }> = [
   { value: "website_traffic", label: "Website traffic" },
 ];
 
+/** How long the boost will wait for the durable declaration write before
+ *  closing anyway. Long enough for a normal PATCH, short enough that a stalled
+ *  one can't hide a campaign that already exists. */
+const DURABLE_WRITE_CAP_MS = 2500;
+
 export function BoostCampaignDialog({
   open,
   onOpenChange,
@@ -181,14 +186,24 @@ export function BoostCampaignDialog({
         // request, so a user who ticked this and clicked through would land on
         // the Ads hub being told they had not declared. Awaited inside the
         // mutation instead, before the dialog closes.
-        try {
-          const res = await growthApi.updateSettings({ notPolitical: true });
-          queryClient.setQueryData(["growth-settings"], res);
-        } catch {
-          // The campaign itself is created and already carries the answer, so
-          // this is not worth a second error toast — the Ads-hub card still
-          // offers the durable declaration.
-        }
+        // Awaited so the success toast's "Open Ads Manager" — a full-document
+        // navigation — can't abort it. But CAPPED: Cancel is disabled while
+        // this mutation is pending and the dismissal guard blocks Escape, so an
+        // un-capped await would trap the user on "Creating…" with no hint that
+        // the LinkedIn draft already exists. After the cap we stop waiting; the
+        // request usually still lands, and the Ads-hub card offers the
+        // declaration either way.
+        const write = growthApi
+          .updateSettings({ notPolitical: true })
+          .then((res) => queryClient.setQueryData(["growth-settings"], res))
+          .catch(() => {
+            // The campaign is created and already carries this answer, so a
+            // second error toast would bury the one that matters.
+          });
+        await Promise.race([
+          write,
+          new Promise((resolve) => setTimeout(resolve, DURABLE_WRITE_CAP_MS)),
+        ]);
       }
       onOpenChange(false);
       toast.success("Draft campaign created on LinkedIn.", {
@@ -425,7 +440,12 @@ export function BoostCampaignDialog({
             </Label>
           </div>
 
-          {notPolitical && stampableNotice ? (
+          {/* Shown while the settings query is still in flight: gating on
+              `stampableNotice` alone hid this on a fast submit — every field is
+              pre-filled, so open-then-create inside 300ms is ordinary, and the
+              user would never learn the durable option exists. Hidden only
+              when we positively KNOW the api is on wording we don't hold. */}
+          {notPolitical && !(settings.data && !stampableNotice) ? (
             <div className="flex items-start gap-2 pl-3">
               <Checkbox
                 id="boost-apply-future"

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
 import { growthApi } from "@/lib/api/growth";
+import {
+  LATEST_POLITICAL_DECLARATION_NOTICE,
+  noticeTextFor,
+  POLITICAL_DECLARATION_POLICY_URL,
+} from "@/lib/ads-copy";
 import {
   toastUnhandledApiError,
   toastAdAccountNotAuthorized,
@@ -107,6 +112,18 @@ export function BoostCampaignDialog({
   // statement than answering for one campaign, so it is opt-in even though
   // LinkedIn's own notice is checked by default.
   const [applyToFuture, setApplyToFuture] = useState(false);
+
+  // Shared cache with the Ads-hub declaration card. Read here for ONE reason:
+  // to know which notice version the api will stamp if the user opts in
+  // durably. The per-campaign answer below needs no version — it rides the
+  // boost request straight to LinkedIn and is never recorded against wording.
+  const settings = useQuery({
+    queryKey: ["growth-settings"],
+    queryFn: () => growthApi.settings(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+  const stampableNotice = noticeTextFor(settings.data?.currentNoticeVersion);
   // Latched on a failure a resubmit cannot improve on — the button stays
   // disabled for this dialog instance, and the reason picks its label:
   //   "persisted"      PERSIST_FAILED — the draft EXISTS on LinkedIn, so
@@ -135,7 +152,11 @@ export function BoostCampaignDialog({
     durationNumber <= 366;
 
   const boost = useMutation({
-    mutationFn: () =>
+    // The declaration answers travel as VARIABLES, not read from state in
+    // onSuccess. Inputs stay enabled while the request is in flight, so a
+    // toggle during that window would otherwise make the durable declaration
+    // disagree with the campaign that was actually created.
+    mutationFn: (vars: { notPolitical: boolean; applyToFuture: boolean }) =>
       linkedInAdsApi.boost({
         postUrn,
         name: name.trim(),
@@ -143,9 +164,9 @@ export function BoostCampaignDialog({
         dailyBudget: budgetNumber,
         currencyCode: currencyCode.trim().toUpperCase(),
         durationDays: durationNumber,
-        notPolitical,
+        notPolitical: vars.notPolitical,
       }),
-    onSuccess: () => {
+    onSuccess: async (_data, vars) => {
       // The Ads Manager list must show the new campaign even within
       // its staleTime window.
       queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
@@ -154,13 +175,20 @@ export function BoostCampaignDialog({
       // answer on its own create call, so a settings write that fails costs
       // the user nothing they can see. Silent by design — a toast about a
       // settings write would bury the one that matters.
-      if (applyToFuture && notPolitical) {
-        growthApi
-          .updateSettings({ notPolitical: true })
-          .then((res) => queryClient.setQueryData(["growth-settings"], res))
-          .catch(() => {
-            /* campaign is created and declared; the Ads-hub card still offers this */
-          });
+      if (vars.applyToFuture && vars.notPolitical) {
+        // NOT fire-and-forget. The success toast offers "Open Ads Manager",
+        // which is a full-document navigation — that aborts an in-flight
+        // request, so a user who ticked this and clicked through would land on
+        // the Ads hub being told they had not declared. Awaited inside the
+        // mutation instead, before the dialog closes.
+        try {
+          const res = await growthApi.updateSettings({ notPolitical: true });
+          queryClient.setQueryData(["growth-settings"], res);
+        } catch {
+          // The campaign itself is created and already carries the answer, so
+          // this is not worth a second error toast — the Ads-hub card still
+          // offers the durable declaration.
+        }
       }
       onOpenChange(false);
       toast.success("Draft campaign created on LinkedIn.", {
@@ -366,20 +394,21 @@ export function BoostCampaignDialog({
             <Checkbox
               id="boost-not-political"
               checked={notPolitical}
-              onCheckedChange={(v) => setNotPolitical(v === true)}
+              onCheckedChange={(v) => {
+                setNotPolitical(v === true);
+                // Un-ticking the notice must also clear the durable opt-in, or
+                // re-ticking shows it already armed without a fresh gesture.
+                if (v !== true) setApplyToFuture(false);
+              }}
               className="mt-0.5"
             />
             <Label
               htmlFor="boost-not-political"
               className="text-[11px] font-normal leading-relaxed text-muted-foreground"
             >
-              I confirm this is not political advertising. None of my ads
-              qualify as political advertising under the law of the targeted
-              countries, including EU law for ads targeted to the EU.
-              Advertisers must comply with LinkedIn&apos;s policies and
-              regulatory requirements.{" "}
+              {stampableNotice ?? LATEST_POLITICAL_DECLARATION_NOTICE}{" "}
               <a
-                href="https://www.linkedin.com/legal/ads-policy"
+                href={POLITICAL_DECLARATION_POLICY_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline underline-offset-2"
@@ -396,7 +425,7 @@ export function BoostCampaignDialog({
             </Label>
           </div>
 
-          {notPolitical ? (
+          {notPolitical && stampableNotice ? (
             <div className="flex items-start gap-2 pl-3">
               <Checkbox
                 id="boost-apply-future"
@@ -442,7 +471,7 @@ export function BoostCampaignDialog({
           </Button>
           <Button
             type="button"
-            onClick={() => boost.mutate()}
+            onClick={() => boost.mutate({ notPolitical, applyToFuture })}
             disabled={!valid || boost.isPending || blocked !== null}
           >
             {boost.isPending

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
+import { growthApi } from "@/lib/api/growth";
 import {
   toastUnhandledApiError,
   toastAdAccountNotAuthorized,
@@ -97,6 +98,15 @@ export function BoostCampaignDialog({
   // ticked — and unticking it is meaningful: the campaign is then created
   // NOT_DECLARED, which LinkedIn may hold from EU delivery until declared.
   const [notPolitical, setNotPolitical] = useState(true);
+  // "Also apply to my future campaigns" — converts this per-campaign answer
+  // into the business-level declaration in the SAME gesture. The user is
+  // already reading LinkedIn's wording and ticking it here; expecting them to
+  // visit a settings page afterwards is how the record stays empty, and an
+  // empty record is why autonomous creates (WhatsApp, optimizer) fall back to
+  // NOT_DECLARED. Defaults OFF: recording a durable declaration is a bigger
+  // statement than answering for one campaign, so it is opt-in even though
+  // LinkedIn's own notice is checked by default.
+  const [applyToFuture, setApplyToFuture] = useState(false);
   // Latched on a failure a resubmit cannot improve on — the button stays
   // disabled for this dialog instance, and the reason picks its label:
   //   "persisted"      PERSIST_FAILED — the draft EXISTS on LinkedIn, so
@@ -139,6 +149,19 @@ export function BoostCampaignDialog({
       // The Ads Manager list must show the new campaign even within
       // its staleTime window.
       queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+      // Record the durable declaration only AFTER the boost succeeded, and
+      // never block or fail the boost on it: the campaign already carries this
+      // answer on its own create call, so a settings write that fails costs
+      // the user nothing they can see. Silent by design — a toast about a
+      // settings write would bury the one that matters.
+      if (applyToFuture && notPolitical) {
+        growthApi
+          .updateSettings({ notPolitical: true })
+          .then((res) => queryClient.setQueryData(["growth-settings"], res))
+          .catch(() => {
+            /* campaign is created and declared; the Ads-hub card still offers this */
+          });
+      }
       onOpenChange(false);
       toast.success("Draft campaign created on LinkedIn.", {
         description:
@@ -372,6 +395,25 @@ export function BoostCampaignDialog({
               ) : null}
             </Label>
           </div>
+
+          {notPolitical ? (
+            <div className="flex items-start gap-2 pl-3">
+              <Checkbox
+                id="boost-apply-future"
+                checked={applyToFuture}
+                onCheckedChange={(v) => setApplyToFuture(v === true)}
+                className="mt-0.5"
+              />
+              <Label
+                htmlFor="boost-apply-future"
+                className="text-[11px] font-normal leading-relaxed text-muted-foreground"
+              >
+                Also apply this to my future campaigns, including ones created
+                automatically from WhatsApp or by the optimizer. You can withdraw
+                it any time from the Ads hub.
+              </Label>
+            </div>
+          ) : null}
 
           <p className="text-[11px] text-muted-foreground">
             Currency must match your LinkedIn ad account&apos;s billing

--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -164,7 +164,7 @@ export function AdjustmentsBoard() {
     <div className="space-y-4">
       <Card>
         <CardContent className="space-y-3 p-4">
-          {settings.isError ? (
+          {(settings.isError && !settings.data) ? (
             // Honest failure: NEVER render a confident OFF state from a
             // failed read — the business may well be opted in and
             // running.
@@ -203,7 +203,7 @@ export function AdjustmentsBoard() {
               </Button>
             </div>
           )}
-          {!settings.isError && optimizerEnabled ? (
+          {!(settings.isError && !settings.data) && optimizerEnabled ? (
             <EnvelopeEditor
               current={settings.data?.settings.weeklyBudgetEnvelope}
               onSaved={(res) => queryClient.setQueryData(["growth-settings"], res)}

--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -12,7 +12,7 @@ import {
 import { reconnectHref, adsProviderFor } from "@/lib/integrations-connect";
 import {
   growthApi,
-  type GrowthSettings,
+  type GrowthSettingsResponse,
   type OptimizerProposal,
   type OptimizerRun,
   type ProposalStatus,
@@ -245,7 +245,7 @@ function EnvelopeEditor({
   onSaved,
 }: {
   current: number | undefined;
-  onSaved: (settings: { settings: GrowthSettings }) => void;
+  onSaved: (settings: GrowthSettingsResponse) => void;
 }) {
   const [value, setValue] = useState(current !== undefined ? String(current) : "");
 

--- a/src/components/ads/advertising-declaration-card.tsx
+++ b/src/components/ads/advertising-declaration-card.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+/**
+ * The business's one-time political-advertising declaration.
+ *
+ * WHY IT LIVES ON THE ADS PANEL AND NOT THE OPTIMIZER PAGE: the declaration
+ * governs EVERY campaign create, not just the optimizer's. /dashboard/optimizer
+ * is wrapped in FeatureGate on `growth.optimizer`, so a business entitled to
+ * ads but not the optimizer could boost campaigns and never be able to declare
+ * — the exact hole this closes.
+ *
+ * WHY IT MOUNTS ABOVE THE CONNECTION GATE: a business can declare before or
+ * after connecting, and the gate renders an EmptyState that would otherwise
+ * hide this entirely. Same reasoning as SpendAlarmBanner directly above it.
+ *
+ * The four states come from `declarationState` (pure, tested in
+ * lib/ads-copy.test.ts). The one that matters most is `superseded`: the api's
+ * resolvePoliticalIntent IGNORES a declaration made against wording that has
+ * since changed, so rendering it as active would claim protection the engine
+ * is not giving.
+ */
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, ShieldCheck, ShieldAlert, ShieldQuestion } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { growthApi } from "@/lib/api/growth";
+import {
+  POLITICAL_DECLARATION_NOTICE,
+  POLITICAL_DECLARATION_POLICY_URL,
+  POLITICAL_DECLARATION_CONSEQUENCE,
+  POLITICAL_DECLARATION_WITHDRAW_WARNING,
+  declarationState,
+  formatDeclaredAt,
+} from "@/lib/ads-copy";
+
+export function AdvertisingDeclarationCard() {
+  const queryClient = useQueryClient();
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
+  const [ticked, setTicked] = useState(false);
+
+  // Shares the cache key with the optimizer board, so declaring on either
+  // surface updates both without a refetch.
+  const settings = useQuery({
+    queryKey: ["growth-settings"],
+    queryFn: () => growthApi.settings(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const save = useMutation({
+    mutationFn: (notPolitical: boolean) => growthApi.updateSettings({ notPolitical }),
+    onSuccess: (res, notPolitical) => {
+      // PATCH returns the same envelope as GET (currentNoticeVersion +
+      // declaredByName included), so writing it straight into the cache
+      // cannot blank the version and flip this card to "unknown".
+      queryClient.setQueryData(["growth-settings"], res);
+      setTicked(false);
+      toast.success(
+        notPolitical
+          ? "Declaration recorded — automatic campaigns can now declare on your behalf."
+          : "Declaration withdrawn.",
+      );
+    },
+    onError: () =>
+      toast.error("Couldn't save your declaration. Try again in a moment — nothing was changed."),
+  });
+
+  const state = declarationState({
+    declaration: settings.data?.settings.advertisingDeclaration,
+    currentNoticeVersion: settings.data?.currentNoticeVersion,
+    declaredByName: settings.data?.declaredByName,
+    failed: settings.isError,
+  });
+
+  if (settings.isLoading) return null;
+
+  const notice = (
+    <>
+      {POLITICAL_DECLARATION_NOTICE}{" "}
+      <a
+        href={POLITICAL_DECLARATION_POLICY_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2"
+      >
+        Learn more
+      </a>
+    </>
+  );
+
+  return (
+    <Card>
+      <CardContent className="p-4">
+        {state.kind === "declared" ? (
+          <div className="flex items-start gap-2">
+            <ShieldCheck className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-500" />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-sm">
+                Declared not political advertising
+                {state.declaredByName ? (
+                  <>
+                    {" "}
+                    by <span className="font-medium">{state.declaredByName}</span>
+                  </>
+                ) : null}
+                {formatDeclaredAt(state.declaredAt) ? (
+                  <> on {formatDeclaredAt(state.declaredAt)}</>
+                ) : null}
+                .
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Automatic campaigns — from WhatsApp, or the optimizer — carry this
+                declaration.
+              </p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-muted-foreground"
+                disabled={save.isPending}
+                onClick={() => setWithdrawOpen(true)}
+              >
+                Withdraw
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-start gap-2">
+              {state.kind === "unknown" ? (
+                <ShieldQuestion className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <ShieldAlert className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+              )}
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className="text-sm font-medium">
+                  {state.kind === "superseded"
+                    ? "Please confirm the current wording"
+                    : state.kind === "unknown"
+                      ? "We couldn't check your advertising declaration"
+                      : "Advertising declaration"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {state.kind === "superseded" ? (
+                    <>
+                      LinkedIn has updated this notice since you declared
+                      {state.declaredAt && formatDeclaredAt(state.declaredAt)
+                        ? ` on ${formatDeclaredAt(state.declaredAt)}`
+                        : ""}
+                      . Until you confirm the current wording, automatic campaigns
+                      fall back to no declaration.
+                    </>
+                  ) : state.kind === "unknown" ? (
+                    // Honest about not knowing rather than showing a confident
+                    // "not declared": a false "not declared" only over-warns,
+                    // but a false "declared" would be a claim we can't support.
+                    <>
+                      The state shown here may be wrong. Refresh in a moment — your
+                      campaigns are unaffected.
+                    </>
+                  ) : (
+                    POLITICAL_DECLARATION_CONSEQUENCE
+                  )}
+                </p>
+              </div>
+            </div>
+
+            {state.kind !== "unknown" ? (
+              <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3">
+                <Checkbox
+                  id="ads-not-political"
+                  checked={ticked}
+                  onCheckedChange={(v) => setTicked(v === true)}
+                  disabled={save.isPending}
+                  className="mt-0.5"
+                />
+                <Label
+                  htmlFor="ads-not-political"
+                  className="text-[11px] font-normal leading-relaxed text-muted-foreground"
+                >
+                  {notice}
+                </Label>
+              </div>
+            ) : null}
+
+            {state.kind !== "unknown" ? (
+              <Button
+                type="button"
+                size="sm"
+                disabled={!ticked || save.isPending}
+                onClick={() => save.mutate(true)}
+              >
+                {save.isPending ? <Loader2 className="mr-1 size-3 animate-spin" /> : null}
+                {state.kind === "superseded" ? "Confirm" : "Save declaration"}
+              </Button>
+            ) : null}
+          </div>
+        )}
+      </CardContent>
+
+      <AlertDialog open={withdrawOpen} onOpenChange={setWithdrawOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Withdraw your declaration?</AlertDialogTitle>
+            {/* Says what it costs BEFORE the click, not after. */}
+            <AlertDialogDescription>
+              {POLITICAL_DECLARATION_WITHDRAW_WARNING}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep it</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setWithdrawOpen(false);
+                save.mutate(false);
+              }}
+            >
+              Withdraw
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/src/components/ads/advertising-declaration-card.tsx
+++ b/src/components/ads/advertising-declaration-card.tsx
@@ -23,7 +23,13 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Loader2, ShieldCheck, ShieldAlert, ShieldQuestion } from "lucide-react";
+import {
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldQuestion,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
@@ -40,7 +46,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { growthApi } from "@/lib/api/growth";
 import {
-  POLITICAL_DECLARATION_NOTICE,
+  noticeTextFor,
   POLITICAL_DECLARATION_POLICY_URL,
   POLITICAL_DECLARATION_CONSEQUENCE,
   POLITICAL_DECLARATION_WITHDRAW_WARNING,
@@ -84,14 +90,24 @@ export function AdvertisingDeclarationCard() {
     declaration: settings.data?.settings.advertisingDeclaration,
     currentNoticeVersion: settings.data?.currentNoticeVersion,
     declaredByName: settings.data?.declaredByName,
-    failed: settings.isError,
+    // `isError` alone is wrong: a failed BACKGROUND refetch sets it while
+    // `data` is retained, which would flip a business that has declared to
+    // "we couldn't check" — and hide the checkbox, so they couldn't act
+    // either. Only claim ignorance when we genuinely have nothing.
+    failed: settings.isError && !settings.data,
   });
 
-  if (settings.isLoading) return null;
+  // Not `isLoading`: that is pending AND fetching, so a paused/offline fetch
+  // leaves it false with no data, and `declarationState` would then render a
+  // confident "not declared" plus a Save button that hangs. Render nothing
+  // until we have either data or a definite failure.
+  if (!settings.data && !settings.isError) return null;
+
+  const noticeText = noticeTextFor(settings.data?.currentNoticeVersion);
 
   const notice = (
     <>
-      {POLITICAL_DECLARATION_NOTICE}{" "}
+      {noticeText}{" "}
       <a
         href={POLITICAL_DECLARATION_POLICY_URL}
         target="_blank"
@@ -106,7 +122,30 @@ export function AdvertisingDeclarationCard() {
   return (
     <Card>
       <CardContent className="p-4">
-        {state.kind === "declared" ? (
+        {state.kind === "political" ? (
+          // READ-ONLY. Political advertising carries obligations Peakhour does
+          // not support, so this must not offer the tick-box that would
+          // overwrite a legal statement in one click.
+          <div className="flex items-start gap-2">
+            <ShieldAlert className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-sm">
+                This business is recorded as running{" "}
+                <span className="font-medium">political advertising</span>
+                {state.declaredByName ? <> by {state.declaredByName}</> : null}
+                {formatDeclaredAt(state.declaredAt) ? (
+                  <> on {formatDeclaredAt(state.declaredAt)}</>
+                ) : null}
+                .
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Peakhour doesn&apos;t support the extra obligations political
+                advertising carries. Manage this campaign&apos;s declaration in
+                LinkedIn Campaign Manager.
+              </p>
+            </div>
+          </div>
+        ) : state.kind === "declared" ? (
           <div className="flex items-start gap-2">
             <ShieldCheck className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-500" />
             <div className="min-w-0 flex-1 space-y-1">
@@ -135,6 +174,9 @@ export function AdvertisingDeclarationCard() {
                 disabled={save.isPending}
                 onClick={() => setWithdrawOpen(true)}
               >
+                {save.isPending ? (
+                  <Loader2 className="mr-1 size-3 animate-spin" />
+                ) : null}
                 Withdraw
               </Button>
             </div>
@@ -208,7 +250,24 @@ export function AdvertisingDeclarationCard() {
                 {save.isPending ? <Loader2 className="mr-1 size-3 animate-spin" /> : null}
                 {state.kind === "superseded" ? "Confirm" : "Save declaration"}
               </Button>
-            ) : null}
+            ) : (
+              // "Refresh in a moment" with no way to refresh is a dead end,
+              // and refetchOnWindowFocus is off so tabbing away won't retry.
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={settings.isFetching}
+                onClick={() => void settings.refetch()}
+              >
+                {settings.isFetching ? (
+                  <Loader2 className="mr-1 size-3 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-1 size-3" />
+                )}
+                Try again
+              </Button>
+            )}
           </div>
         )}
       </CardContent>

--- a/src/components/ads/advertising-declaration-card.tsx
+++ b/src/components/ads/advertising-declaration-card.tsx
@@ -140,9 +140,35 @@ export function AdvertisingDeclarationCard() {
               </p>
               <p className="text-xs text-muted-foreground">
                 Peakhour doesn&apos;t support the extra obligations political
-                advertising carries. Manage this campaign&apos;s declaration in
-                LinkedIn Campaign Manager.
+                advertising carries, so this can&apos;t be changed here — only
+                withdrawn.
+                {state.superseded ? (
+                  <>
+                    {" "}
+                    LinkedIn has also updated its notice since this was
+                    recorded, so automatic campaigns are currently sending no
+                    declaration at all.
+                  </>
+                ) : null}
               </p>
+              {/* An exit, not a tick-box. Withdrawal UNSETS the record — a
+                  retraction rather than a new legal claim — so it is the one
+                  change this surface can safely offer. Without it a business
+                  that ever acquires a POLITICAL record could never clear it,
+                  and every autonomous create would keep sending POLITICAL. */}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-muted-foreground"
+                disabled={save.isPending}
+                onClick={() => setWithdrawOpen(true)}
+              >
+                {save.isPending ? (
+                  <Loader2 className="mr-1 size-3 animate-spin" />
+                ) : null}
+                Withdraw
+              </Button>
             </div>
           </div>
         ) : state.kind === "declared" ? (
@@ -194,7 +220,9 @@ export function AdvertisingDeclarationCard() {
                   {state.kind === "superseded"
                     ? "Please confirm the current wording"
                     : state.kind === "unknown"
-                      ? "We couldn't check your advertising declaration"
+                      ? state.reason === "unsupported_notice"
+                        ? "This notice has changed"
+                        : "We couldn't check your advertising declaration"
                       : "Advertising declaration"}
                 </p>
                 <p className="text-xs text-muted-foreground">
@@ -211,10 +239,23 @@ export function AdvertisingDeclarationCard() {
                     // Honest about not knowing rather than showing a confident
                     // "not declared": a false "not declared" only over-warns,
                     // but a false "declared" would be a claim we can't support.
-                    <>
-                      The state shown here may be wrong. Refresh in a moment — your
-                      campaigns are unaffected.
-                    </>
+                    // The two causes need different copy — saying "your
+                    // campaigns are unaffected" would be FALSE on a notice
+                    // change, where every stored declaration is superseded.
+                    state.reason === "unsupported_notice" ? (
+                      <>
+                        LinkedIn has updated this notice and Peakhour needs an
+                        update before you can confirm the new wording. Until
+                        then, automatic campaigns send no declaration — so
+                        LinkedIn may hold them from EU audiences. Contact
+                        support if this persists.
+                      </>
+                    ) : (
+                      <>
+                        The state shown here may be wrong. Try again in a moment
+                        — your campaigns are unaffected.
+                      </>
+                    )
                   ) : (
                     POLITICAL_DECLARATION_CONSEQUENCE
                   )}
@@ -250,9 +291,14 @@ export function AdvertisingDeclarationCard() {
                 {save.isPending ? <Loader2 className="mr-1 size-3 animate-spin" /> : null}
                 {state.kind === "superseded" ? "Confirm" : "Save declaration"}
               </Button>
+            ) : state.reason === "unsupported_notice" ? (
+              // No retry: the read succeeded. Re-fetching returns the same
+              // version we don't hold, so a button here would be a dead end
+              // dressed as a remedy.
+              null
             ) : (
-              // "Refresh in a moment" with no way to refresh is a dead end,
-              // and refetchOnWindowFocus is off so tabbing away won't retry.
+              // "Try again in a moment" with no way to try is a dead end, and
+              // refetchOnWindowFocus is off so tabbing away won't retry.
               <Button
                 type="button"
                 variant="outline"

--- a/src/lib/ads-copy.test.ts
+++ b/src/lib/ads-copy.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The declaration state matrix.
+ *
+ * Every case here is a place where getting it wrong has a real consequence,
+ * so they are worth pinning individually:
+ *
+ *   - showing a SUPERSEDED declaration as active claims protection the api
+ *     is not giving (`resolvePoliticalIntent` ignores it and sends
+ *     NOT_DECLARED), which is the worst outcome available here
+ *   - collapsing a failed read into "undeclared" is safe-ish; collapsing it
+ *     into "declared" is not — hence `unknown` exists as its own state
+ *   - a false "not declared" only over-warns, so it is the correct default
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  declarationState,
+  formatDeclaredAt,
+  POLITICAL_DECLARATION_NOTICE,
+} from "./ads-copy";
+
+const CURRENT = "linkedin-ttpa-2025-10";
+
+const declaration = {
+  politicalIntent: "NOT_POLITICAL" as const,
+  declaredAt: "2026-07-30T09:00:00.000Z",
+  declaredByUserId: "69bbc24ce89bee1288944def",
+  noticeVersion: CURRENT,
+};
+
+describe("declarationState", () => {
+  it("undeclared when nothing is stored — the default for every business", () => {
+    expect(declarationState({ currentNoticeVersion: CURRENT })).toEqual({ kind: "undeclared" });
+    expect(declarationState({ declaration: null, currentNoticeVersion: CURRENT })).toEqual({
+      kind: "undeclared",
+    });
+  });
+
+  it("declared, carrying the provenance the record exists to hold", () => {
+    expect(
+      declarationState({
+        declaration,
+        currentNoticeVersion: CURRENT,
+        declaredByName: "Vanshita Garg",
+      }),
+    ).toEqual({
+      kind: "declared",
+      declaredAt: declaration.declaredAt,
+      declaredByName: "Vanshita Garg",
+    });
+  });
+
+  it("declared without a name when the declarer is gone — date alone, not 'unknown user'", () => {
+    const out = declarationState({ declaration, currentNoticeVersion: CURRENT });
+    expect(out).toEqual({ kind: "declared", declaredAt: declaration.declaredAt });
+  });
+
+  it("SUPERSEDED — never rendered as active — when the wording has moved on", () => {
+    // The api ignores this declaration and sends NOT_DECLARED. A UI showing
+    // it as active would tell the user they are covered when they are not.
+    const out = declarationState({
+      declaration: { ...declaration, noticeVersion: "linkedin-ttpa-2024-01" },
+      currentNoticeVersion: CURRENT,
+      declaredByName: "Vanshita Garg",
+    });
+    expect(out.kind).toBe("superseded");
+  });
+
+  it("unknown — not undeclared — when the settings read failed", () => {
+    // Distinct state on purpose: we cannot claim either answer.
+    expect(declarationState({ failed: true })).toEqual({ kind: "unknown" });
+    expect(declarationState({ declaration, currentNoticeVersion: CURRENT, failed: true })).toEqual({
+      kind: "unknown",
+    });
+  });
+
+  it("unknown when the api sent no current version — we can't tell active from stale", () => {
+    // Assuming "still valid" is the assumption that overstates coverage, so
+    // the absent-version case must not resolve to `declared`.
+    expect(declarationState({ declaration }).kind).toBe("unknown");
+    expect(declarationState({ declaration, currentNoticeVersion: null }).kind).toBe("unknown");
+    expect(declarationState({ declaration, currentNoticeVersion: "" }).kind).toBe("unknown");
+  });
+
+  it("treats a POLITICAL declaration as undeclared rather than offering to overwrite it", () => {
+    // Political advertising carries obligations we don't support. Showing a
+    // tick-box that would silently rewrite that answer is worse than showing
+    // the undeclared state.
+    expect(
+      declarationState({
+        declaration: { ...declaration, politicalIntent: "POLITICAL" },
+        currentNoticeVersion: CURRENT,
+      }),
+    ).toEqual({ kind: "undeclared" });
+    expect(
+      declarationState({
+        declaration: { ...declaration, politicalIntent: "NOT_DECLARED" },
+        currentNoticeVersion: CURRENT,
+      }),
+    ).toEqual({ kind: "undeclared" });
+  });
+
+  it("a failed read wins over every other input", () => {
+    // Ordering guard: if this ever fell through to the version comparison, a
+    // failed read on a superseded declaration would render as needs-re-confirm,
+    // implying we know something we don't.
+    expect(
+      declarationState({
+        declaration: { ...declaration, noticeVersion: "old" },
+        currentNoticeVersion: CURRENT,
+        failed: true,
+      }).kind,
+    ).toBe("unknown");
+  });
+});
+
+describe("formatDeclaredAt", () => {
+  it("renders a readable date via Intl, not a hardcoded month list", () => {
+    expect(formatDeclaredAt("2026-07-30T09:00:00.000Z", "en-GB")).toBe("30 Jul 2026");
+  });
+
+  it("returns empty string on an unparseable date instead of 'Invalid Date'", () => {
+    expect(formatDeclaredAt("not-a-date")).toBe("");
+    expect(formatDeclaredAt("")).toBe("");
+  });
+});
+
+describe("the notice text", () => {
+  it("is LinkedIn's wording, not a paraphrase", () => {
+    // Guards against a well-meaning edit for tone. The contract requires
+    // their text; softening it would collect consent to something else.
+    expect(POLITICAL_DECLARATION_NOTICE).toContain("not political advertising");
+    expect(POLITICAL_DECLARATION_NOTICE).toContain("EU law for ads targeted to the EU");
+    expect(POLITICAL_DECLARATION_NOTICE).toContain("LinkedIn's policies");
+  });
+});

--- a/src/lib/ads-copy.test.ts
+++ b/src/lib/ads-copy.test.ts
@@ -18,7 +18,6 @@ import {
   formatDeclaredAt,
   noticeTextFor,
   POLITICAL_DECLARATION_NOTICES,
-  LATEST_POLITICAL_DECLARATION_NOTICE,
 } from "./ads-copy";
 
 const CURRENT = "linkedin-ttpa-2025-10";
@@ -70,9 +69,13 @@ describe("declarationState", () => {
 
   it("unknown — not undeclared — when the settings read failed", () => {
     // Distinct state on purpose: we cannot claim either answer.
-    expect(declarationState({ failed: true })).toEqual({ kind: "unknown" });
+    expect(declarationState({ failed: true })).toEqual({
+      kind: "unknown",
+      reason: "read_failed",
+    });
     expect(declarationState({ declaration, currentNoticeVersion: CURRENT, failed: true })).toEqual({
       kind: "unknown",
+      reason: "read_failed",
     });
   });
 
@@ -97,6 +100,24 @@ describe("declarationState", () => {
       kind: "political",
       declaredAt: declaration.declaredAt,
       declaredByName: "Vanshita Garg",
+      superseded: false,
+    });
+  });
+
+  it("a POLITICAL record under STALE wording reports superseded", () => {
+    // The api ignores any superseded declaration regardless of intent, so
+    // autonomous creates are sending NOT_DECLARED. Rendering this as an
+    // in-force political record would overstate it — the same mistake
+    // `superseded` exists to prevent, and the POLITICAL branch had it because
+    // the intent check ran before the version comparison.
+    const out = declarationState({
+      declaration: { ...declaration, politicalIntent: "POLITICAL", noticeVersion: "old" },
+      currentNoticeVersion: CURRENT,
+    });
+    expect(out).toEqual({
+      kind: "political",
+      declaredAt: declaration.declaredAt,
+      superseded: true,
     });
   });
 
@@ -115,21 +136,24 @@ describe("declarationState", () => {
     // against the OLD text the user actually read. Refusing to ask is the only
     // safe answer, and it must win even with nothing declared — otherwise an
     // undeclared business gets a Save button that records unseen wording.
+    // And it is a DEPLOY problem, not a network one — the read succeeded, so
+    // "try again" would be a dead end and "campaigns are unaffected" is false.
     expect(declarationState({ currentNoticeVersion: "linkedin-ttpa-2099-01" })).toEqual({
       kind: "unknown",
+      reason: "unsupported_notice",
     });
     expect(
       declarationState({
         declaration,
         currentNoticeVersion: "linkedin-ttpa-2099-01",
       }),
-    ).toEqual({ kind: "unknown" });
+    ).toEqual({ kind: "unknown", reason: "unsupported_notice" });
   });
 
   it("renders nothing confidently when there is no data at all", () => {
     // declarationState({}) must not resolve to `undeclared`: the card would
     // then show an amber warning and a Save button on a failed/paused fetch.
-    expect(declarationState({})).toEqual({ kind: "unknown" });
+    expect(declarationState({})).toEqual({ kind: "unknown", reason: "read_failed" });
   });
 
   it("a failed read wins over every other input", () => {
@@ -165,12 +189,13 @@ describe("formatDeclaredAt", () => {
 });
 
 describe("the notice text is keyed by the version it is", () => {
-  it("holds wording for the version the api currently stamps", () => {
-    // If the api bumps CURRENT_NOTICE_VERSION, this fails until the matching
-    // wording is added here — which is the point: the two must ship together
-    // or the card silently stops offering the declaration.
+  it("holds wording for the version this app expects the api to stamp", () => {
+    // NOTE: this cannot detect the api bumping its own constant — CURRENT here
+    // is a local literal and nothing compares the two repos. The real guard is
+    // runtime: an unheld version resolves to `unknown` and the card refuses to
+    // collect consent. This only asserts we shipped text for the version we
+    // believe is current.
     expect(noticeTextFor(CURRENT)).toBeTypeOf("string");
-    expect(noticeTextFor(CURRENT)).toBe(POLITICAL_DECLARATION_NOTICES[CURRENT]);
   });
 
   it("returns undefined for a version we don't hold, rather than a fallback", () => {
@@ -191,9 +216,4 @@ describe("the notice text is keyed by the version it is", () => {
     expect(text).toContain("LinkedIn's policies");
   });
 
-  it("the Boost dialog's display fallback is the wording we hold", () => {
-    // Used only for the per-campaign answer, which is never recorded against a
-    // version — anything that STAMPS must go through noticeTextFor.
-    expect(LATEST_POLITICAL_DECLARATION_NOTICE).toBe(POLITICAL_DECLARATION_NOTICES[CURRENT]);
-  });
 });

--- a/src/lib/ads-copy.test.ts
+++ b/src/lib/ads-copy.test.ts
@@ -16,7 +16,9 @@ import { describe, it, expect } from "vitest";
 import {
   declarationState,
   formatDeclaredAt,
-  POLITICAL_DECLARATION_NOTICE,
+  noticeTextFor,
+  POLITICAL_DECLARATION_NOTICES,
+  LATEST_POLITICAL_DECLARATION_NOTICE,
 } from "./ads-copy";
 
 const CURRENT = "linkedin-ttpa-2025-10";
@@ -82,22 +84,52 @@ describe("declarationState", () => {
     expect(declarationState({ declaration, currentNoticeVersion: "" }).kind).toBe("unknown");
   });
 
-  it("treats a POLITICAL declaration as undeclared rather than offering to overwrite it", () => {
-    // Political advertising carries obligations we don't support. Showing a
-    // tick-box that would silently rewrite that answer is worse than showing
-    // the undeclared state.
-    expect(
-      declarationState({
-        declaration: { ...declaration, politicalIntent: "POLITICAL" },
-        currentNoticeVersion: CURRENT,
-      }),
-    ).toEqual({ kind: "undeclared" });
+  it("gives a POLITICAL declaration its own READ-ONLY state", () => {
+    // Previously this collapsed to `undeclared` — which both misreported it
+    // (the api passes POLITICAL through) and put the tick-box on screen, so
+    // one click would have overwritten a legal statement.
+    const out = declarationState({
+      declaration: { ...declaration, politicalIntent: "POLITICAL" },
+      currentNoticeVersion: CURRENT,
+      declaredByName: "Vanshita Garg",
+    });
+    expect(out).toEqual({
+      kind: "political",
+      declaredAt: declaration.declaredAt,
+      declaredByName: "Vanshita Garg",
+    });
+  });
+
+  it("treats a stored NOT_DECLARED as undeclared", () => {
     expect(
       declarationState({
         declaration: { ...declaration, politicalIntent: "NOT_DECLARED" },
         currentNoticeVersion: CURRENT,
       }),
     ).toEqual({ kind: "undeclared" });
+  });
+
+  it("is `unknown`, not `undeclared`, when we don't hold the api's notice text", () => {
+    // The drift hazard: if the api bumps the version and deploys before this
+    // app ships the new wording, collecting consent would stamp the NEW version
+    // against the OLD text the user actually read. Refusing to ask is the only
+    // safe answer, and it must win even with nothing declared — otherwise an
+    // undeclared business gets a Save button that records unseen wording.
+    expect(declarationState({ currentNoticeVersion: "linkedin-ttpa-2099-01" })).toEqual({
+      kind: "unknown",
+    });
+    expect(
+      declarationState({
+        declaration,
+        currentNoticeVersion: "linkedin-ttpa-2099-01",
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
+  it("renders nothing confidently when there is no data at all", () => {
+    // declarationState({}) must not resolve to `undeclared`: the card would
+    // then show an amber warning and a Save button on a failed/paused fetch.
+    expect(declarationState({})).toEqual({ kind: "unknown" });
   });
 
   it("a failed read wins over every other input", () => {
@@ -119,18 +151,49 @@ describe("formatDeclaredAt", () => {
     expect(formatDeclaredAt("2026-07-30T09:00:00.000Z", "en-GB")).toBe("30 Jul 2026");
   });
 
+  it("is pinned to UTC, so the day can't shift by the viewer's timezone", () => {
+    // Without timeZone: "UTC" this renders "29 Jul" west of UTC-9 — a
+    // compliance record showing a different day than it holds.
+    expect(formatDeclaredAt("2026-07-30T01:00:00.000Z", "en-GB")).toBe("30 Jul 2026");
+    expect(formatDeclaredAt("2026-07-30T23:30:00.000Z", "en-GB")).toBe("30 Jul 2026");
+  });
+
   it("returns empty string on an unparseable date instead of 'Invalid Date'", () => {
     expect(formatDeclaredAt("not-a-date")).toBe("");
     expect(formatDeclaredAt("")).toBe("");
   });
 });
 
-describe("the notice text", () => {
+describe("the notice text is keyed by the version it is", () => {
+  it("holds wording for the version the api currently stamps", () => {
+    // If the api bumps CURRENT_NOTICE_VERSION, this fails until the matching
+    // wording is added here — which is the point: the two must ship together
+    // or the card silently stops offering the declaration.
+    expect(noticeTextFor(CURRENT)).toBeTypeOf("string");
+    expect(noticeTextFor(CURRENT)).toBe(POLITICAL_DECLARATION_NOTICES[CURRENT]);
+  });
+
+  it("returns undefined for a version we don't hold, rather than a fallback", () => {
+    // A fallback here would defeat the whole guard: the card would show
+    // wording that is not what the api is about to record.
+    expect(noticeTextFor("linkedin-ttpa-2099-01")).toBeUndefined();
+    expect(noticeTextFor(undefined)).toBeUndefined();
+    expect(noticeTextFor(null)).toBeUndefined();
+    expect(noticeTextFor("")).toBeUndefined();
+  });
+
   it("is LinkedIn's wording, not a paraphrase", () => {
-    // Guards against a well-meaning edit for tone. The contract requires
-    // their text; softening it would collect consent to something else.
-    expect(POLITICAL_DECLARATION_NOTICE).toContain("not political advertising");
-    expect(POLITICAL_DECLARATION_NOTICE).toContain("EU law for ads targeted to the EU");
-    expect(POLITICAL_DECLARATION_NOTICE).toContain("LinkedIn's policies");
+    // Guards against a well-meaning edit for tone. The contract requires their
+    // text; softening it would collect consent to something else.
+    const text = POLITICAL_DECLARATION_NOTICES[CURRENT];
+    expect(text).toContain("not political advertising");
+    expect(text).toContain("EU law for ads targeted to the EU");
+    expect(text).toContain("LinkedIn's policies");
+  });
+
+  it("the Boost dialog's display fallback is the wording we hold", () => {
+    // Used only for the per-campaign answer, which is never recorded against a
+    // version — anything that STAMPS must go through noticeTextFor.
+    expect(LATEST_POLITICAL_DECLARATION_NOTICE).toBe(POLITICAL_DECLARATION_NOTICES[CURRENT]);
   });
 });

--- a/src/lib/ads-copy.ts
+++ b/src/lib/ads-copy.ts
@@ -18,12 +18,50 @@
  * can be tested without rendering.
  */
 
-/** LinkedIn's notice, verbatim. Do not edit for tone. */
-export const POLITICAL_DECLARATION_NOTICE =
-  "I confirm this is not political advertising. None of my ads qualify as " +
-  "political advertising under the law of the targeted countries, including " +
-  "EU law for ads targeted to the EU. Advertisers must comply with " +
-  "LinkedIn's policies and regulatory requirements.";
+/**
+ * LinkedIn's notice text, KEYED BY THE VERSION IT IS.
+ *
+ * The text lives here but the version in force is decided by the api
+ * (`CURRENT_NOTICE_VERSION`), and nothing used to couple them. That gap was a
+ * real hazard, not a tidiness point: bump the version server-side and deploy
+ * before the b2c ships the new wording, and the card would tell the user "the
+ * notice has been updated, please confirm the current wording" while showing
+ * them the OLD text — then stamp the NEW version against it. The record would
+ * claim consent to wording the user never saw, which is the one thing this
+ * whole feature exists to prevent.
+ *
+ * Keying the text by version closes it: an unrecognised version means we do
+ * not have the text the api is asking about, so `declarationState` returns
+ * `unknown` and the card refuses to collect consent rather than collecting the
+ * wrong consent. Add the new wording here in the same PR that bumps the api.
+ *
+ * Verbatim. Not our wording to soften — LinkedIn's Advertising API contract
+ * requires an app that creates ads to present this text and pass back what the
+ * advertiser confirmed.
+ */
+export const POLITICAL_DECLARATION_NOTICES: Record<string, string> = {
+  "linkedin-ttpa-2025-10":
+    "I confirm this is not political advertising. None of my ads qualify as " +
+    "political advertising under the law of the targeted countries, including " +
+    "EU law for ads targeted to the EU. Advertisers must comply with " +
+    "LinkedIn's policies and regulatory requirements.",
+};
+
+/**
+ * The most recent wording we hold, for surfaces that must show SOMETHING.
+ *
+ * Only the Boost dialog uses this, and only for its per-campaign answer —
+ * which is passed straight to LinkedIn and never recorded against a version,
+ * so a deploy-skew mismatch has no lasting effect. Anything that STAMPS a
+ * version must use `noticeTextFor` and refuse when it returns undefined.
+ */
+export const LATEST_POLITICAL_DECLARATION_NOTICE =
+  POLITICAL_DECLARATION_NOTICES["linkedin-ttpa-2025-10"];
+
+/** The notice for a version, or undefined when we don't hold that wording. */
+export function noticeTextFor(version?: string | null): string | undefined {
+  return version ? POLITICAL_DECLARATION_NOTICES[version] : undefined;
+}
 
 export const POLITICAL_DECLARATION_POLICY_URL =
   "https://www.linkedin.com/legal/ads-policy";
@@ -54,6 +92,13 @@ export interface AdvertisingDeclaration {
 export type DeclarationState =
   /** Nobody has declared. The default for every business. */
   | { kind: "undeclared" }
+  /**
+   * A POLITICAL declaration is on record. READ-ONLY here: political
+   * advertising carries obligations Peakhour does not support, so this surface
+   * must neither claim it is handled nor offer a checkbox that would overwrite
+   * a legal statement in one click. Points the user at Campaign Manager.
+   */
+  | { kind: "political"; declaredAt: string; declaredByName?: string }
   /** Declared under the wording currently in force. */
   | { kind: "declared"; declaredAt: string; declaredByName?: string }
   /**
@@ -85,19 +130,28 @@ export function declarationState(input: {
 }): DeclarationState {
   if (input.failed) return { kind: "unknown" };
 
-  const d = input.declaration;
-  // Only NOT_POLITICAL is a declaration this UI can represent. POLITICAL
-  // advertising carries obligations Peakhour doesn't support, so a business
-  // that somehow holds one is shown as undeclared here rather than being
-  // offered a tick-box that would silently overwrite it.
-  if (!d || d.politicalIntent !== "NOT_POLITICAL") return { kind: "undeclared" };
+  // No current version to compare against means we cannot tell active from
+  // stale, and no notice text for it means we cannot honestly ASK. Both are
+  // "we don't know" rather than "not declared" — checked before the
+  // declaration itself so an undeclared business can't be shown a Save button
+  // that would record consent to wording we don't hold.
+  if (!input.currentNoticeVersion) return { kind: "unknown" };
+  if (!noticeTextFor(input.currentNoticeVersion)) return { kind: "unknown" };
 
+  const d = input.declaration;
   const declaredByName = input.declaredByName ?? undefined;
 
-  // No current version to compare against means we cannot tell active from
-  // stale. Treat as unknown rather than assuming it is still valid — that
-  // assumption is the one that overstates coverage.
-  if (!input.currentNoticeVersion) return { kind: "unknown" };
+  // A POLITICAL record gets its own read-only state. Rendering it as
+  // undeclared would both misreport it (the api sends POLITICAL through) and
+  // put a one-click overwrite of a legal statement on screen.
+  if (d?.politicalIntent === "POLITICAL") {
+    return {
+      kind: "political",
+      declaredAt: d.declaredAt,
+      ...(declaredByName ? { declaredByName } : {}),
+    };
+  }
+  if (!d || d.politicalIntent !== "NOT_POLITICAL") return { kind: "undeclared" };
 
   if (d.noticeVersion !== input.currentNoticeVersion) {
     return { kind: "superseded", declaredAt: d.declaredAt, ...(declaredByName ? { declaredByName } : {}) };
@@ -105,7 +159,15 @@ export function declarationState(input: {
   return { kind: "declared", declaredAt: d.declaredAt, ...(declaredByName ? { declaredByName } : {}) };
 }
 
-/** "30 Jul 2026" — locale-formatted, never a hardcoded month array. */
+/**
+ * "30 Jul 2026" — locale-formatted, never a hardcoded month array.
+ *
+ * Pinned to UTC, matching the convention the optimizer board already sets. The
+ * stamp is a UTC instant, so rendering it in the viewer's zone would show the
+ * previous day for anyone west of UTC — and "declared on the 29th" against a
+ * record that says the 30th is the kind of discrepancy that matters on a
+ * compliance record.
+ */
 export function formatDeclaredAt(iso: string, locale?: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
@@ -113,5 +175,6 @@ export function formatDeclaredAt(iso: string, locale?: string): string {
     day: "numeric",
     month: "short",
     year: "numeric",
+    timeZone: "UTC",
   }).format(d);
 }

--- a/src/lib/ads-copy.ts
+++ b/src/lib/ads-copy.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared advertising-declaration copy and state logic.
+ *
+ * WHY THIS FILE EXISTS: the political-advertising notice is not our wording
+ * to soften or paraphrase. LinkedIn's Advertising API contract requires an
+ * app that creates ads to present this text and pass back what the
+ * advertiser confirmed (`politicalIntent`), and it became a REQUIRED campaign
+ * field with the EU's TTPA regulation. Two surfaces now show it — the Boost
+ * dialog and the Ads-hub declaration card — and a second hand-edited copy is
+ * how they drift apart, leaving one surface collecting consent to text the
+ * other never showed.
+ *
+ * `declarationState` lives here too, because deciding "declared" vs "needs
+ * re-confirming" is the part that is easy to get wrong in a way that MATTERS:
+ * the api's `resolvePoliticalIntent` ignores a declaration whose
+ * noticeVersion has been superseded, so a UI that showed a stale one as
+ * active would claim protection the engine is not giving. It is pure so it
+ * can be tested without rendering.
+ */
+
+/** LinkedIn's notice, verbatim. Do not edit for tone. */
+export const POLITICAL_DECLARATION_NOTICE =
+  "I confirm this is not political advertising. None of my ads qualify as " +
+  "political advertising under the law of the targeted countries, including " +
+  "EU law for ads targeted to the EU. Advertisers must comply with " +
+  "LinkedIn's policies and regulatory requirements.";
+
+export const POLITICAL_DECLARATION_POLICY_URL =
+  "https://www.linkedin.com/legal/ads-policy";
+
+/**
+ * What an undeclared business is actually risking. Stated once, because the
+ * consequence is the reason the card exists: a human boosting from the UI
+ * answers per campaign, but a campaign created from WhatsApp or by the
+ * optimizer has no dialog to tick and falls back to NOT_DECLARED.
+ */
+export const POLITICAL_DECLARATION_CONSEQUENCE =
+  "Campaigns created automatically — from WhatsApp, or by the optimizer — " +
+  "can't declare on your behalf, so LinkedIn may hold them from EU audiences " +
+  "until you do.";
+
+/** What withdrawing costs, shown in the confirm rather than after the fact. */
+export const POLITICAL_DECLARATION_WITHDRAW_WARNING =
+  "Future automatic campaigns will fall back to no declaration, and LinkedIn " +
+  "may hold them from EU audiences. Campaigns already running are unaffected.";
+
+export interface AdvertisingDeclaration {
+  politicalIntent: "POLITICAL" | "NOT_POLITICAL" | "NOT_DECLARED";
+  declaredAt: string;
+  declaredByUserId: string;
+  noticeVersion: string;
+}
+
+export type DeclarationState =
+  /** Nobody has declared. The default for every business. */
+  | { kind: "undeclared" }
+  /** Declared under the wording currently in force. */
+  | { kind: "declared"; declaredAt: string; declaredByName?: string }
+  /**
+   * Declared, but against wording that has since changed. Rendered as
+   * needs-re-confirming, NOT as active — the api already treats it as
+   * NOT_DECLARED, and showing it as active would overstate our coverage.
+   */
+  | { kind: "superseded"; declaredAt: string; declaredByName?: string }
+  /**
+   * The settings read failed, so we don't know. Deliberately distinct from
+   * `undeclared`: a false "not declared" is safe (it only over-warns), a
+   * false "declared" is not. Never collapse this into either.
+   */
+  | { kind: "unknown" };
+
+/**
+ * Resolve which of the four states to render.
+ *
+ * `currentNoticeVersion` comes from the api response, never a local
+ * constant — a hardcoded copy here would drift from
+ * `CURRENT_NOTICE_VERSION` in the api and silently mis-state every
+ * business's status in one direction or the other.
+ */
+export function declarationState(input: {
+  declaration?: AdvertisingDeclaration | null;
+  currentNoticeVersion?: string | null;
+  declaredByName?: string | null;
+  failed?: boolean;
+}): DeclarationState {
+  if (input.failed) return { kind: "unknown" };
+
+  const d = input.declaration;
+  // Only NOT_POLITICAL is a declaration this UI can represent. POLITICAL
+  // advertising carries obligations Peakhour doesn't support, so a business
+  // that somehow holds one is shown as undeclared here rather than being
+  // offered a tick-box that would silently overwrite it.
+  if (!d || d.politicalIntent !== "NOT_POLITICAL") return { kind: "undeclared" };
+
+  const declaredByName = input.declaredByName ?? undefined;
+
+  // No current version to compare against means we cannot tell active from
+  // stale. Treat as unknown rather than assuming it is still valid — that
+  // assumption is the one that overstates coverage.
+  if (!input.currentNoticeVersion) return { kind: "unknown" };
+
+  if (d.noticeVersion !== input.currentNoticeVersion) {
+    return { kind: "superseded", declaredAt: d.declaredAt, ...(declaredByName ? { declaredByName } : {}) };
+  }
+  return { kind: "declared", declaredAt: d.declaredAt, ...(declaredByName ? { declaredByName } : {}) };
+}
+
+/** "30 Jul 2026" — locale-formatted, never a hardcoded month array. */
+export function formatDeclaredAt(iso: string, locale?: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(d);
+}

--- a/src/lib/ads-copy.ts
+++ b/src/lib/ads-copy.ts
@@ -93,12 +93,22 @@ export type DeclarationState =
   /** Nobody has declared. The default for every business. */
   | { kind: "undeclared" }
   /**
-   * A POLITICAL declaration is on record. READ-ONLY here: political
-   * advertising carries obligations Peakhour does not support, so this surface
-   * must neither claim it is handled nor offer a checkbox that would overwrite
-   * a legal statement in one click. Points the user at Campaign Manager.
+   * A POLITICAL declaration is on record. READ-ONLY apart from withdrawal:
+   * political advertising carries obligations Peakhour does not support, so
+   * this surface must neither claim it is handled nor offer a checkbox that
+   * would overwrite a legal statement in one click.
+   *
+   * `superseded` matters even here. The api ignores ANY declaration whose
+   * wording has changed — intent included — so a POLITICAL record under stale
+   * wording means autonomous creates are sending NOT_DECLARED right now. The
+   * card must say that rather than implying the record is in force.
    */
-  | { kind: "political"; declaredAt: string; declaredByName?: string }
+  | {
+      kind: "political";
+      declaredAt: string;
+      declaredByName?: string;
+      superseded: boolean;
+    }
   /** Declared under the wording currently in force. */
   | { kind: "declared"; declaredAt: string; declaredByName?: string }
   /**
@@ -108,11 +118,21 @@ export type DeclarationState =
    */
   | { kind: "superseded"; declaredAt: string; declaredByName?: string }
   /**
-   * The settings read failed, so we don't know. Deliberately distinct from
-   * `undeclared`: a false "not declared" is safe (it only over-warns), a
-   * false "declared" is not. Never collapse this into either.
+   * We cannot state the declaration, for one of two DIFFERENT reasons that
+   * need different copy and different remedies:
+   *
+   *   read_failed        — the settings request failed. Retrying may help.
+   *   unsupported_notice — the read SUCCEEDED, but the api is on a notice
+   *                        version whose wording this app doesn't hold. There
+   *                        is nothing to retry: it needs a deploy. And it is
+   *                        not benign — every stored declaration is superseded
+   *                        under that version, so autonomous creates are
+   *                        falling back to NOT_DECLARED.
+   *
+   * Distinct from `undeclared` either way: a false "not declared" only
+   * over-warns, a false "declared" is a claim we cannot support.
    */
-  | { kind: "unknown" };
+  | { kind: "unknown"; reason: "read_failed" | "unsupported_notice" };
 
 /**
  * Resolve which of the four states to render.
@@ -128,18 +148,26 @@ export function declarationState(input: {
   declaredByName?: string | null;
   failed?: boolean;
 }): DeclarationState {
-  if (input.failed) return { kind: "unknown" };
+  if (input.failed) return { kind: "unknown", reason: "read_failed" };
 
   // No current version to compare against means we cannot tell active from
   // stale, and no notice text for it means we cannot honestly ASK. Both are
   // "we don't know" rather than "not declared" — checked before the
   // declaration itself so an undeclared business can't be shown a Save button
   // that would record consent to wording we don't hold.
-  if (!input.currentNoticeVersion) return { kind: "unknown" };
-  if (!noticeTextFor(input.currentNoticeVersion)) return { kind: "unknown" };
+  // No version at all is indistinguishable from a failed read — we have no
+  // response to reason about.
+  if (!input.currentNoticeVersion) return { kind: "unknown", reason: "read_failed" };
+  // A version we don't hold text for is a DEPLOY problem, not a network one.
+  if (!noticeTextFor(input.currentNoticeVersion)) {
+    return { kind: "unknown", reason: "unsupported_notice" };
+  }
 
   const d = input.declaration;
   const declaredByName = input.declaredByName ?? undefined;
+  // Computed BEFORE the intent branches: the api ignores a superseded
+  // declaration whatever its intent, so every branch below needs this.
+  const superseded = !!d && d.noticeVersion !== input.currentNoticeVersion;
 
   // A POLITICAL record gets its own read-only state. Rendering it as
   // undeclared would both misreport it (the api sends POLITICAL through) and
@@ -148,13 +176,18 @@ export function declarationState(input: {
     return {
       kind: "political",
       declaredAt: d.declaredAt,
+      superseded,
       ...(declaredByName ? { declaredByName } : {}),
     };
   }
   if (!d || d.politicalIntent !== "NOT_POLITICAL") return { kind: "undeclared" };
 
-  if (d.noticeVersion !== input.currentNoticeVersion) {
-    return { kind: "superseded", declaredAt: d.declaredAt, ...(declaredByName ? { declaredByName } : {}) };
+  if (superseded) {
+    return {
+      kind: "superseded",
+      declaredAt: d.declaredAt,
+      ...(declaredByName ? { declaredByName } : {}),
+    };
   }
   return { kind: "declared", declaredAt: d.declaredAt, ...(declaredByName ? { declaredByName } : {}) };
 }

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import type { AdvertisingDeclaration } from "@/lib/ads-copy";
 
 /**
  * Growth-engine client (G3) — the channel-common /v1/growth surface.
@@ -29,6 +30,30 @@ export interface GrowthSettings {
   optimizerEnabled?: boolean;
   autonomyLevel?: number;
   weeklyBudgetEnvelope?: number;
+  /** The business's one-time political-advertising declaration, with
+   *  provenance. Absent means nobody has declared — the single reading of
+   *  absence, which is why withdrawing UNSETS it rather than storing
+   *  NOT_DECLARED. */
+  advertisingDeclaration?: AdvertisingDeclaration;
+}
+
+/**
+ * The settings envelope. `currentNoticeVersion` and `declaredByName` are
+ * read-only siblings of `settings`, not part of the stored record:
+ *   - `currentNoticeVersion` is the wording in force RIGHT NOW. The UI
+ *     compares it with the declaration's own version to tell "declared" from
+ *     "needs re-confirming". Never hardcode a copy — it would drift from the
+ *     api's CURRENT_NOTICE_VERSION and mis-state every business's status.
+ *   - `declaredByName` is resolved server-side from declaredByUserId, because
+ *     an ObjectId is not an attribution a human recognises. Absent when there
+ *     is no declaration or the declaring user is gone.
+ * Both GET and PATCH return this shape, so the card renders identically from
+ * either without waiting for a refetch.
+ */
+export interface GrowthSettingsResponse {
+  settings: GrowthSettings;
+  currentNoticeVersion?: string;
+  declaredByName?: string;
 }
 
 export interface OptimizerProposal {
@@ -89,10 +114,23 @@ export const growthApi = {
       `/v1/growth/adjustments/${runId}/proposals/${proposalId}/${decision}`,
     ),
 
-  /** Per-business growth settings (the optimizer opt-in lives here). */
-  settings: () => api.get<{ settings: GrowthSettings }>("/v1/growth/settings"),
+  /** Per-business growth settings (the optimizer opt-in and the advertising
+   *  declaration live here), plus the notice version in force. */
+  settings: () => api.get<GrowthSettingsResponse>("/v1/growth/settings"),
 
-  /** Self-serve optimizer opt-in / weekly budget envelope. */
-  updateSettings: (patch: { optimizerEnabled?: boolean; weeklyBudgetEnvelope?: number | null }) =>
-    api.patch<{ settings: GrowthSettings }>("/v1/growth/settings", patch),
+  /**
+   * Self-serve optimizer opt-in / weekly budget envelope / advertising
+   * declaration.
+   *
+   * `notPolitical: true` records the declaration with server-stamped
+   * provenance (who, when, which wording); `false` WITHDRAWS it by unsetting
+   * the record. The client cannot set declaredAt / declaredByUserId /
+   * noticeVersion — the whole value of the field is that the server knows a
+   * real person declared it at a known time under known wording.
+   */
+  updateSettings: (patch: {
+    optimizerEnabled?: boolean;
+    weeklyBudgetEnvelope?: number | null;
+    notPolitical?: boolean;
+  }) => api.patch<GrowthSettingsResponse>("/v1/growth/settings", patch),
 };


### PR DESCRIPTION
The b2c half of **D7** ([plan](https://github.com/travelxp/peakhour-mongodb/blob/master/docs/idea/linkedin-ads-d7-declaration-ui-plan.md)). Pairs with api#977.

Until now **nothing could write the declaration**, so every autonomous path resolved `NOT_DECLARED` regardless — the WhatsApp BOOST workflow and any optimizer-created campaign risked an EU delivery hold on campaigns nobody is watching. This is the L2 autonomy gate, not cosmetics.

## Two surfaces, both needed

**1. `AdvertisingDeclarationCard` on the LinkedIn Ads panel, above the connection gate.**

Deliberately **not** on `/dashboard/optimizer` — that page is `FeatureGate`'d on `growth.optimizer`, so a business entitled to ads but not the optimizer could boost campaigns and never be able to declare. That's the exact hole this closes. Above the gate for the same reason `SpendAlarmBanner` is: the gate renders an `EmptyState` that would hide it, and a business can declare before it connects.

**2. "Also apply this to my future campaigns" in the Boost dialog.**

The user is already reading LinkedIn's wording and ticking it there; expecting a separate trip to a settings page is how the record stays empty. **Defaults off** — a durable declaration is a bigger statement than answering for one campaign, so it's opt-in even though LinkedIn's own notice is checked by default. Fires only *after* the boost succeeds and never blocks or fails it: the campaign already carries the answer on its own create call, so a failed settings write costs the user nothing visible.

## Four states

From a pure `declarationState()` in `lib/ads-copy.ts`:

| State | Renders |
|---|---|
| `undeclared` | the notice, unticked, plus the consequence for automatic campaigns |
| `declared` | the provenance read back — *"by Vanshita Garg on 30 Jul 2026"* — since that IS the value of the record; plus a quiet Withdraw behind a confirm that says what it costs *beforehand* |
| `superseded` | **needs re-confirming, not active** |
| `unknown` | the read failed — says so |

`superseded` is the one most worth getting right: `resolvePoliticalIntent` *ignores* a declaration made against wording that has since changed, so rendering it as active would claim protection the engine is not giving.

`unknown` is a distinct state on purpose. A false "not declared" only over-warns; a false "declared" is a claim we cannot support. So it says the state shown may be wrong rather than rendering a confident answer.

## Shared copy, not a second hand-edited version

`lib/ads-copy.ts` extracts LinkedIn's notice + policy link out of the boost dialog so both surfaces import one copy. It isn't our wording to soften — their Advertising API contract requires an app creating ads to present that text and pass back what the advertiser confirmed — and a second copy is how the two surfaces drift into collecting consent to text the other never showed.

`currentNoticeVersion` comes from the api response, **never a local constant**: a hardcoded copy would drift from `CURRENT_NOTICE_VERSION` and mis-state every business's status. When the api sends no version the card renders `unknown` rather than assuming a stored declaration is still valid — that assumption is the one that overstates coverage.

A `POLITICAL` declaration renders as undeclared rather than offering a tick-box that would silently overwrite it; political advertising carries obligations Peakhour doesn't support.

## Cache

Shares `queryKey: ["growth-settings"]` with the optimizer board, so declaring on either surface updates both. This is only safe because PATCH now returns GET's envelope (api#977) — before that, `setQueryData` with a PATCH body would have blanked `currentNoticeVersion` and flipped this card to needs-re-confirming.

## Tests

11 on the state matrix and date formatting. Each case is a place where being wrong has a consequence — including that a failed read wins over every other input, since an ordering slip there would imply we know something we don't.

Build passes, lint clean, 137 tests.

## Ordering

Merge **after** api#977, or `currentNoticeVersion` is absent and the card renders `unknown` for everyone — which is honest, but useless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)