### PR TITLE
feat(ads): the engine gets a face — what we understand about your business (A1)

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/audience-profile-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-profile-panel.tsx
@@ -1,0 +1,715 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+import {
+  audiencesApi,
+  type CorrectableFieldSpec,
+  type EvidenceTier,
+  type ProfileSource,
+} from "@/lib/api/audiences";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { AlertTriangle, ChevronDown, Pencil, RefreshCw, X } from "lucide-react";
+
+/**
+ * "Here's what we understand about your business" — the Audience Engine's
+ * first user-facing surface, and the one that makes Phase 1 testable.
+ *
+ * WHY IT LOOKS LIKE THIS. The engine's whole claim is that it reads a business
+ * before it proposes an audience. A panel that showed a tidy summary would be
+ * indistinguishable from a black box guessing; what makes it a strategist is
+ * that every line says WHERE it came from and can be told it is wrong. So:
+ *
+ *   - EVERY claim carries its evidence tier — a human typed it / we measured it
+ *     / the model judged it — because the difference between those is the
+ *     difference between confidence and a guess, and the user is the only one
+ *     who can settle it.
+ *   - CONFLICTS ARE SURFACED FIRST, not resolved. A business that says it sells
+ *     to enterprises while its content addresses freelancers is the most
+ *     interesting thing the engine noticed. Flattening it into one answer is
+ *     the one thing this panel must never do.
+ *   - `classified: false` says the deeper read is UNAVAILABLE. An empty ICP
+ *     because the model call failed is not the finding "you have no ICP", and
+ *     rendering the two the same way is how absence gets read as fact.
+ *
+ * ★THE CORRECTABLE FIELDS COME FROM THE SERVER. `correctableFields` carries the
+ * field, its shape (one value vs a list), its length cap and any closed
+ * vocabulary. Hardcoding that list here is how a client comes to offer a
+ * control the server refuses — a dead control the user operates and nothing
+ * happens — which is the exact failure mode this engine keeps finding in
+ * itself.
+ */
+
+const TIER_LABEL: Record<EvidenceTier, string> = {
+  stated: "You told us",
+  observed: "We measured",
+  inferred: "We inferred",
+};
+
+const TIER_CLASS: Record<EvidenceTier, string> = {
+  stated: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  observed: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  inferred: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+};
+
+/** Human labels for the server's field ids. Anything the server sends that is
+ *  not here still renders — under its raw id — because a missing label must
+ *  never hide a control the server offers. */
+const FIELD_LABEL: Record<string, string> = {
+  "classification.industry": "Industry",
+  "classification.subIndustry": "Sub-industry",
+  "classification.marketType": "Who pays",
+  "classification.lifecycleStage": "Stage",
+  "classification.regionalPresence": "Where you operate",
+  icp: "Who buys from you",
+  personas: "The people inside them",
+  painPoints: "Problems you solve",
+  decisionMakers: "Who signs",
+};
+
+const MARKET_TYPE_LABEL: Record<string, string> = {
+  b2b: "Businesses (B2B)",
+  b2c: "People (B2C)",
+  b2b2c: "Both — you serve people, businesses pay (B2B2C)",
+  unknown: "Not sure yet",
+};
+
+function EvidenceBadge({ sources }: { sources?: ProfileSource[] }) {
+  // The HIGHEST tier present, because that is what the claim rests on: a
+  // segment the business declared AND we then measured is stated, not observed.
+  const tier: EvidenceTier | undefined = sources?.some((s) => s.tier === "stated")
+    ? "stated"
+    : sources?.some((s) => s.tier === "observed")
+      ? "observed"
+      : sources?.some((s) => s.tier === "inferred")
+        ? "inferred"
+        : undefined;
+  if (!tier) return null;
+  const detail = sources?.find((s) => s.detail)?.detail;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${TIER_CLASS[tier]}`}
+      // The evidence itself, for anyone who wants to check our working.
+      title={detail ? `${TIER_LABEL[tier]} — ${detail}` : TIER_LABEL[tier]}
+    >
+      {TIER_LABEL[tier]}
+    </span>
+  );
+}
+
+/** A claim and its evidence, with an edit affordance when the server says the
+ *  field is correctable. */
+function ClaimRow({
+  label,
+  value,
+  sources,
+  onEdit,
+}: {
+  label: string;
+  value?: string;
+  sources?: ProfileSource[];
+  onEdit?: () => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3 py-2">
+      <div className="min-w-0">
+        <div className="text-xs text-muted-foreground">{label}</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={value ? "text-sm" : "text-sm text-muted-foreground italic"}>
+            {/* Absent is stated as absent. "Unknown" is a fact about our
+                understanding; a blank line reads as a rendering bug. */}
+            {value || "Not known yet"}
+          </span>
+          <EvidenceBadge sources={sources} />
+        </div>
+      </div>
+      {onEdit && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 shrink-0 px-2"
+          onClick={onEdit}
+          aria-label={`Correct ${label}`}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** Editing state: one field at a time, so a half-finished correction can never
+ *  be submitted alongside a finished one. */
+type Editing = { spec: CorrectableFieldSpec; value: string; list: string[] } | null;
+
+export function AudienceProfilePanel() {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Editing>(null);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["audience-profile"],
+    queryFn: () => audiencesApi.getProfile(),
+  });
+
+  const profile = data?.profile ?? null;
+  const specs = useMemo(() => data?.correctableFields ?? [], [data]);
+  const specFor = (field: string) => specs.find((s) => s.field === field);
+
+  const refresh = useMutation({
+    mutationFn: () => audiencesApi.refreshProfile(),
+    onSuccess: (res) => {
+      queryClient.setQueryData(["audience-profile"], {
+        profile: res.profile,
+        correctableFields: specs,
+      });
+      toast.success(
+        res.classified
+          ? "Refreshed what we understand about your business."
+          : // NOT presented as a success with gaps: the deeper read genuinely
+            // did not happen, and saying so is the difference between "you have
+            // no ICP" and "we couldn't work one out just now".
+            "Refreshed the facts we can measure. The deeper read wasn't available just now — try again later.",
+      );
+    },
+    onError: (err) => toastUnhandledApiError(err, "refresh the business profile"),
+  });
+
+  const correct = useMutation({
+    mutationFn: (corrections: Parameters<typeof audiencesApi.correctProfile>[0]) =>
+      audiencesApi.correctProfile(corrections),
+    onSuccess: (res) => {
+      queryClient.setQueryData(["audience-profile"], {
+        profile: res.profile,
+        correctableFields: specs,
+      });
+      setEditing(null);
+      toast.success("Thanks — we'll use that from now on.");
+      // The audience is built from this profile, so a correction changes what
+      // the next campaign would target.
+      void queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+    },
+    onError: (err) => toastUnhandledApiError(err, "save that correction"),
+  });
+
+  const startEdit = (field: string, current: string | string[]) => {
+    const spec = specFor(field);
+    if (!spec) return;
+    setEditing({
+      spec,
+      value: typeof current === "string" ? current : "",
+      list: Array.isArray(current) ? current : [],
+    });
+  };
+
+  const submitEdit = () => {
+    if (!editing) return;
+    const { spec } = editing;
+    if (spec.shape === "list") {
+      correct.mutate([{ field: spec.field, toList: editing.list }]);
+      return;
+    }
+    const value = editing.value.trim();
+    // The server refuses a blank scalar, and it is right to — but bouncing off
+    // a 400 to learn that is a worse experience than not offering it.
+    if (!value) {
+      toast.error("Give us something to go on, or cancel.");
+      return;
+    }
+    correct.mutate([{ field: spec.field, to: value }]);
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="space-y-2 py-4">
+          <Skeleton className="h-4 w-64" />
+          <Skeleton className="h-3 w-full max-w-md" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // A failed READ is not "no profile" — offering the build button here would
+  // invite a user to rebuild something that may already exist.
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="py-4 text-sm text-muted-foreground">
+          We couldn&apos;t load what we understand about your business just now.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <Card>
+        <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+          <div>
+            <div className="text-sm font-medium">We haven&apos;t read your business yet</div>
+            <p className="text-sm text-muted-foreground">
+              Campaigns are targeted from what we understand about you. Build it once and every
+              campaign starts with a real audience.
+            </p>
+          </div>
+          <Button onClick={() => refresh.mutate()} disabled={refresh.isPending}>
+            {refresh.isPending ? "Reading…" : "Read my business"}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const conflicts = profile.conflicts ?? [];
+
+  return (
+    <Card>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CardContent className="py-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-sm font-medium">What we understand about your business</div>
+              <p className="text-sm text-muted-foreground">
+                Every campaign is targeted from this. Tell us where we&apos;re wrong.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => refresh.mutate()}
+                disabled={refresh.isPending}
+              >
+                <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${refresh.isPending ? "animate-spin" : ""}`} />
+                {refresh.isPending ? "Reading…" : "Re-read"}
+              </Button>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  {open ? "Hide" : "Show"}
+                  <ChevronDown
+                    className={`ml-1.5 h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+          </div>
+
+          {/* ★CONFLICTS ARE ALWAYS VISIBLE, collapsed or not. They are the most
+              interesting thing the engine found and the thing a user is most
+              able to settle in one sentence. */}
+          {conflicts.length > 0 && (
+            <div className="mt-3 space-y-2">
+              {conflicts.map((conflict) => (
+                <div
+                  key={conflict.field}
+                  className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5 text-sm"
+                >
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+                  <div>
+                    <span className="font-medium">
+                      {FIELD_LABEL[conflict.field] ?? conflict.field}
+                    </span>
+                    :{" "}
+                    {conflict.note ??
+                      `you told us "${conflict.statedValue}", your content says "${conflict.observedValue}".`}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+
+        <CollapsibleContent>
+          <CardContent className="space-y-5 border-t pt-4">
+            <section>
+              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                The business
+              </h4>
+              <div className="divide-y">
+                <ClaimRow
+                  label={FIELD_LABEL["classification.industry"]!}
+                  value={profile.classification.industry?.value}
+                  sources={profile.classification.industry?.sources}
+                  onEdit={
+                    specFor("classification.industry")
+                      ? () =>
+                          startEdit(
+                            "classification.industry",
+                            profile.classification.industry?.value ?? "",
+                          )
+                      : undefined
+                  }
+                />
+                <ClaimRow
+                  label={FIELD_LABEL["classification.subIndustry"]!}
+                  value={profile.classification.subIndustry?.value}
+                  sources={profile.classification.subIndustry?.sources}
+                  onEdit={
+                    specFor("classification.subIndustry")
+                      ? () =>
+                          startEdit(
+                            "classification.subIndustry",
+                            profile.classification.subIndustry?.value ?? "",
+                          )
+                      : undefined
+                  }
+                />
+                <ClaimRow
+                  label={FIELD_LABEL["classification.marketType"]!}
+                  value={
+                    profile.classification.marketType
+                      ? (MARKET_TYPE_LABEL[profile.classification.marketType.value] ??
+                        profile.classification.marketType.value)
+                      : undefined
+                  }
+                  sources={profile.classification.marketType?.sources}
+                  onEdit={
+                    specFor("classification.marketType")
+                      ? () =>
+                          startEdit(
+                            "classification.marketType",
+                            profile.classification.marketType?.value ?? "",
+                          )
+                      : undefined
+                  }
+                />
+                <ClaimRow
+                  label={FIELD_LABEL["classification.lifecycleStage"]!}
+                  value={profile.classification.lifecycleStage?.value}
+                  sources={profile.classification.lifecycleStage?.sources}
+                  onEdit={
+                    specFor("classification.lifecycleStage")
+                      ? () =>
+                          startEdit(
+                            "classification.lifecycleStage",
+                            profile.classification.lifecycleStage?.value ?? "",
+                          )
+                      : undefined
+                  }
+                />
+                <ClaimRow
+                  label={FIELD_LABEL["classification.regionalPresence"]!}
+                  value={profile.classification.regionalPresence?.map((r) => r.value).join(", ")}
+                  sources={profile.classification.regionalPresence?.[0]?.sources}
+                  onEdit={
+                    specFor("classification.regionalPresence")
+                      ? () =>
+                          startEdit(
+                            "classification.regionalPresence",
+                            profile.classification.regionalPresence?.map((r) => r.value).join(", ") ??
+                              "",
+                          )
+                      : undefined
+                  }
+                />
+              </div>
+            </section>
+
+            <ListSection
+              title={FIELD_LABEL.icp!}
+              field="icp"
+              spec={specFor("icp")}
+              items={profile.icp.map((i) => ({
+                key: i.label,
+                primary: i.label,
+                secondary: i.description,
+                sources: i.sources,
+              }))}
+              onEdit={() => startEdit("icp", profile.icp.map((i) => i.label))}
+            />
+
+            <ListSection
+              title={FIELD_LABEL.decisionMakers!}
+              field="decisionMakers"
+              spec={specFor("decisionMakers")}
+              items={profile.decisionMakers.map((d) => ({
+                key: d.titleFamily,
+                primary: d.titleFamily,
+                secondary: d.seniority,
+                sources: d.sources,
+              }))}
+              onEdit={() =>
+                startEdit("decisionMakers", profile.decisionMakers.map((d) => d.titleFamily))
+              }
+            />
+
+            <ListSection
+              title={FIELD_LABEL.painPoints!}
+              field="painPoints"
+              spec={specFor("painPoints")}
+              items={profile.painPoints.map((p) => ({
+                key: p.statement,
+                primary: p.statement,
+                sources: p.sources,
+              }))}
+              onEdit={() => startEdit("painPoints", profile.painPoints.map((p) => p.statement))}
+            />
+
+            <ListSection
+              title={FIELD_LABEL.personas!}
+              field="personas"
+              spec={specFor("personas")}
+              items={profile.personas.map((p) => ({
+                key: p.label,
+                primary: p.label,
+                secondary: [p.role, p.seniority].filter(Boolean).join(" · ") || undefined,
+                sources: p.sources,
+              }))}
+              onEdit={() => startEdit("personas", profile.personas.map((p) => p.label))}
+            />
+
+            <p className="text-xs text-muted-foreground">
+              Version {profile.profileVersion}
+              {profile.corrections.length > 0 &&
+                ` · ${profile.corrections.length} correction${profile.corrections.length === 1 ? "" : "s"} from you`}
+            </p>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {editing && (
+        <CardContent className="border-t pt-4">
+          <CorrectionEditor
+            editing={editing}
+            setEditing={setEditing}
+            onSubmit={submitEdit}
+            pending={correct.isPending}
+          />
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+function ListSection({
+  title,
+  field,
+  spec,
+  items,
+  onEdit,
+}: {
+  title: string;
+  field: string;
+  spec?: CorrectableFieldSpec;
+  items: Array<{ key: string; primary: string; secondary?: string; sources?: ProfileSource[] }>;
+  onEdit: () => void;
+}) {
+  return (
+    <section>
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h4>
+        {spec && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2"
+            onClick={onEdit}
+            aria-label={`Correct ${title}`}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground italic">
+          {/* Deliberately not "none" — we may simply not have worked it out. */}
+          Nothing here yet.
+        </p>
+      ) : (
+        <ul className="space-y-1.5">
+          {items.map((item) => (
+            <li key={`${field}:${item.key}`} className="flex flex-wrap items-center gap-2 text-sm">
+              <span>{item.primary}</span>
+              {item.secondary && (
+                <span className="text-muted-foreground">— {item.secondary}</span>
+              )}
+              <EvidenceBadge sources={item.sources} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/**
+ * The correction editor. One field at a time.
+ *
+ * ★IT RENDERS FROM THE SPEC. Shape decides scalar-vs-list, `values` decides
+ * whether it is a select, `maxLength`/`maxItems` are enforced here so the user
+ * hits a disabled button rather than a 400 they will read as "my answer was
+ * wrong". Every one of those came from the server, so this control cannot
+ * offer something the server refuses.
+ */
+function CorrectionEditor({
+  editing,
+  setEditing,
+  onSubmit,
+  pending,
+}: {
+  editing: NonNullable<Editing>;
+  setEditing: (e: Editing) => void;
+  onSubmit: () => void;
+  pending: boolean;
+}) {
+  const { spec, value, list } = editing;
+  const [draft, setDraft] = useState("");
+  const label = FIELD_LABEL[spec.field] ?? spec.field;
+  const atItemCap = spec.maxItems !== undefined && list.length >= spec.maxItems;
+  const draftTooLong = draft.trim().length > spec.maxLength;
+
+  const addDraft = () => {
+    const v = draft.trim();
+    if (!v || draftTooLong || atItemCap) return;
+    // Case-insensitive, because the server dedupes that way and a log that
+    // disagrees with the field it produced teaches the engine the wrong thing.
+    if (list.some((x) => x.toLowerCase() === v.toLowerCase())) {
+      setDraft("");
+      return;
+    }
+    setEditing({ ...editing, list: [...list, v] });
+    setDraft("");
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-sm font-medium">Correct: {label}</Label>
+        <Button variant="ghost" size="sm" onClick={() => setEditing(null)} aria-label="Cancel">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {spec.shape === "list" ? (
+        <div className="space-y-2">
+          <ul className="flex flex-wrap gap-1.5">
+            {list.map((item, i) => (
+              <li key={`${item}-${i}`}>
+                <Badge variant="secondary" className="gap-1 py-1 pr-1">
+                  <span className="max-w-[28rem] truncate">{item}</span>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${item}`}
+                    className="rounded-sm p-0.5 hover:bg-muted"
+                    onClick={() =>
+                      setEditing({ ...editing, list: list.filter((_, j) => j !== i) })
+                    }
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              </li>
+            ))}
+          </ul>
+          <div className="flex gap-2">
+            {spec.maxLength > 300 ? (
+              <Textarea
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder={`Add — up to ${spec.maxLength} characters`}
+                rows={2}
+                className="text-sm"
+              />
+            ) : (
+              <Input
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    addDraft();
+                  }
+                }}
+                placeholder="Add"
+              />
+            )}
+            <Button variant="outline" onClick={addDraft} disabled={!draft.trim() || draftTooLong || atItemCap}>
+              Add
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {draftTooLong
+              ? `Too long — keep each one under ${spec.maxLength} characters.`
+              : atItemCap
+                ? `That's the maximum of ${spec.maxItems}.`
+                : // The clear case, said plainly: an empty list is a real answer,
+                  // not a way of cancelling.
+                  "Remove everything and save to tell us none of these apply."}
+          </p>
+        </div>
+      ) : spec.values ? (
+        <Select
+          value={value}
+          onValueChange={(v) => setEditing({ ...editing, value: v })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Choose" />
+          </SelectTrigger>
+          <SelectContent>
+            {spec.values.map((v) => (
+              <SelectItem key={v} value={v}>
+                {MARKET_TYPE_LABEL[v] ?? v}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <div className="space-y-1">
+          <Input
+            value={value}
+            onChange={(e) => setEditing({ ...editing, value: e.target.value })}
+            placeholder={
+              spec.csv === "iso2" ? "Two-letter country codes, e.g. IN, SG, AE" : "Your answer"
+            }
+            aria-invalid={value.trim().length > spec.maxLength}
+          />
+          {spec.csv === "iso2" && (
+            <p className="text-xs text-muted-foreground">
+              Country codes only{spec.maxCount ? `, up to ${spec.maxCount}` : ""} — this is what we
+              target, so it decides where your budget goes.
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={() => setEditing(null)} disabled={pending}>
+          Cancel
+        </Button>
+        <Button
+          onClick={onSubmit}
+          disabled={
+            pending ||
+            (spec.shape === "scalar" &&
+              (!value.trim() || value.trim().length > spec.maxLength))
+          }
+        >
+          {pending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/ads/_components/audience-profile-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-profile-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { toastUnhandledApiError } from "@/lib/toast-errors";
@@ -140,7 +140,7 @@ function ClaimRow({
   label: string;
   value?: string;
   sources?: ProfileSource[];
-  onEdit?: () => void;
+  onEdit?: (opener: HTMLElement) => void;
 }) {
   return (
     <div className="flex items-start justify-between gap-3 py-2">
@@ -161,7 +161,7 @@ function ClaimRow({
           variant="ghost"
           size="sm"
           className="h-7 shrink-0 px-2"
-          onClick={onEdit}
+          onClick={(e) => onEdit(e.currentTarget)}
           aria-label={`Correct ${label}`}
         >
           <Pencil className="h-3.5 w-3.5" />
@@ -190,6 +190,16 @@ export function AudienceProfilePanel() {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<Editing>(null);
+  /** The control that opened the editor, so focus can go back to it on close.
+   *  Without this the editor unmounts and focus falls to `<body>` — the
+   *  keyboard user is dropped at the top of the document. */
+  const openerRef = useRef<HTMLElement | null>(null);
+  /** Set when the reconcile above closed an editor out from under the user. */
+  const [closedByRefresh, setClosedByRefresh] = useState(false);
+  const closeEditor = useCallback(() => {
+    setEditing(null);
+    openerRef.current?.focus();
+  }, []);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["audience-profile"],
@@ -242,7 +252,7 @@ export function AudienceProfilePanel() {
           correctableFields: old?.correctableFields ?? specs,
         }),
       );
-      setEditing(null);
+      closeEditor();
       toast.success("Thanks — we'll use that from now on.");
       // The audience is built from this profile, so a correction changes what
       // the next campaign would target.
@@ -251,7 +261,9 @@ export function AudienceProfilePanel() {
     onError: (err) => toastUnhandledApiError(err, "save that correction"),
   });
 
-  const startEdit = (field: string, current: string | string[]) => {
+  const startEdit = (field: string, current: string | string[], opener?: HTMLElement | null) => {
+    openerRef.current = opener ?? null;
+    setClosedByRefresh(false);
     const spec = specFor(field);
     if (!spec || !profile) return;
     const original = {
@@ -270,7 +282,11 @@ export function AudienceProfilePanel() {
     // ones the user never made — and append a null delta to the log. The
     // server cannot tell the difference; only this can.
     if (correctionIsNoop(spec, editing.original, { value: editing.value, list: editing.list })) {
-      setEditing(null);
+      // Said out loud. Closing silently is indistinguishable from Cancel, and
+      // the list hint invites exactly this on an already-empty list — a user
+      // who follows it would believe they made a statement they did not.
+      toast.info("That's what we already have — nothing to save.");
+      closeEditor();
       return;
     }
     // Every limit the server enforces, checked here first — with the server's
@@ -291,14 +307,31 @@ export function AudienceProfilePanel() {
   };
 
   // ★THE SNAPSHOT IS RECONCILED, not trusted. react-query refetches on window
-  // focus, `switchBusiness` clears the whole cache without unmounting this
-  // panel, and either one replaces the profile under an open editor. Saving
-  // then writes a list the user never saw — and after a business switch, writes
-  // business A's ICP onto business B, which is the wrong-business class of bug
-  // the server is business-scoped to prevent. If the profile moved or went
-  // away, the editor goes with it.
+  // focus and `switchBusiness` clears the whole cache without unmounting this
+  // panel, so the profile can move or vanish under an open editor. Saving then
+  // writes a list the user never saw — and after a business switch, writes
+  // business A's ICP onto business B, the wrong-business class of bug the
+  // server is business-scoped to prevent.
+  //
+  // TWO DIFFERENT CHECKS, because they catch different things and only one of
+  // them is the version. `!profile` is what catches the business switch — two
+  // businesses are both `profileVersion: 1` far more often than not, since only
+  // a re-read increments it. The version catches a re-read from another tab.
+  // (A correction from another tab moves neither: PATCH does not bump the
+  // version. That case is not covered, and saying so is better than implying
+  // it is.)
+  //
+  // DURING RENDER, which is React's sanctioned "adjust state when the input
+  // changes" pattern — same component, conditional, and it converges because
+  // `editing` becomes null. An effect would be the obvious alternative and is
+  // lint-forbidden here for good reason: it would render one frame with a stale
+  // editor still on screen. The cost is that a toast cannot fire from render,
+  // so the explanation is a NOTICE instead — closing silently is what the last
+  // version did, and it is indistinguishable from the editor never having
+  // opened.
   if (editing && (!profile || profile.profileVersion !== editing.profileVersion)) {
     setEditing(null);
+    setClosedByRefresh(Boolean(profile));
   }
 
   if (isLoading) {
@@ -370,7 +403,9 @@ export function AudienceProfilePanel() {
                 variant="outline"
                 size="sm"
                 onClick={() => refresh.mutate()}
-                disabled={refresh.isPending}
+                // Also blocked while a correction is in flight: both writers
+                // $set the profile, so the loser is silently discarded.
+                disabled={refresh.isPending || correct.isPending}
               >
                 <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${refresh.isPending ? "animate-spin" : ""}`} />
                 {refresh.isPending ? "Reading…" : "Re-read"}
@@ -385,6 +420,13 @@ export function AudienceProfilePanel() {
               </CollapsibleTrigger>
             </div>
           </div>
+
+          {closedByRefresh && (
+            <p className="mt-3 rounded-md border border-dashed p-2.5 text-sm text-muted-foreground">
+              Your business profile changed while you were editing, so we closed the editor rather
+              than save something you couldn&apos;t see. Have another look.
+            </p>
+          )}
 
           {/* ★CONFLICTS ARE ALWAYS VISIBLE, collapsed or not. They are the most
               interesting thing the engine found and the thing a user is most
@@ -424,10 +466,11 @@ export function AudienceProfilePanel() {
                   sources={profile.classification.industry?.sources}
                   onEdit={
                     specFor("classification.industry")
-                      ? () =>
+                      ? (opener) =>
                           startEdit(
                             "classification.industry",
                             profile.classification.industry?.value ?? "",
+                            opener,
                           )
                       : undefined
                   }
@@ -438,10 +481,11 @@ export function AudienceProfilePanel() {
                   sources={profile.classification.subIndustry?.sources}
                   onEdit={
                     specFor("classification.subIndustry")
-                      ? () =>
+                      ? (opener) =>
                           startEdit(
                             "classification.subIndustry",
                             profile.classification.subIndustry?.value ?? "",
+                            opener,
                           )
                       : undefined
                   }
@@ -457,10 +501,11 @@ export function AudienceProfilePanel() {
                   sources={profile.classification.marketType?.sources}
                   onEdit={
                     specFor("classification.marketType")
-                      ? () =>
+                      ? (opener) =>
                           startEdit(
                             "classification.marketType",
                             profile.classification.marketType?.value ?? "",
+                            opener,
                           )
                       : undefined
                   }
@@ -471,10 +516,11 @@ export function AudienceProfilePanel() {
                   sources={profile.classification.lifecycleStage?.sources}
                   onEdit={
                     specFor("classification.lifecycleStage")
-                      ? () =>
+                      ? (opener) =>
                           startEdit(
                             "classification.lifecycleStage",
                             profile.classification.lifecycleStage?.value ?? "",
+                            opener,
                           )
                       : undefined
                   }
@@ -491,11 +537,12 @@ export function AudienceProfilePanel() {
                   )}
                   onEdit={
                     specFor("classification.regionalPresence")
-                      ? () =>
+                      ? (opener) =>
                           startEdit(
                             "classification.regionalPresence",
                             profile.classification.regionalPresence?.map((r) => r.value).join(", ") ??
                               "",
+                            opener,
                           )
                       : undefined
                   }
@@ -513,7 +560,7 @@ export function AudienceProfilePanel() {
                 secondary: i.description,
                 sources: i.sources,
               }))}
-              onEdit={() => startEdit("icp", profile.icp.map((i) => i.label))}
+              onEdit={(opener) => startEdit("icp", profile.icp.map((i) => i.label), opener)}
             />
 
             <ListSection
@@ -526,8 +573,12 @@ export function AudienceProfilePanel() {
                 secondary: d.seniority,
                 sources: d.sources,
               }))}
-              onEdit={() =>
-                startEdit("decisionMakers", profile.decisionMakers.map((d) => d.titleFamily))
+              onEdit={(opener) =>
+                startEdit(
+                  "decisionMakers",
+                  profile.decisionMakers.map((d) => d.titleFamily),
+                  opener,
+                )
               }
             />
 
@@ -540,7 +591,9 @@ export function AudienceProfilePanel() {
                 primary: p.statement,
                 sources: p.sources,
               }))}
-              onEdit={() => startEdit("painPoints", profile.painPoints.map((p) => p.statement))}
+              onEdit={(opener) =>
+                startEdit("painPoints", profile.painPoints.map((p) => p.statement), opener)
+              }
             />
 
             <ListSection
@@ -553,7 +606,7 @@ export function AudienceProfilePanel() {
                 secondary: [p.role, p.seniority].filter(Boolean).join(" · ") || undefined,
                 sources: p.sources,
               }))}
-              onEdit={() => startEdit("personas", profile.personas.map((p) => p.label))}
+              onEdit={(opener) => startEdit("personas", profile.personas.map((p) => p.label), opener)}
             />
 
             {!classified && (
@@ -581,6 +634,7 @@ export function AudienceProfilePanel() {
             key={editing.spec.field}
             editing={editing}
             setEditing={setEditing}
+            onClose={closeEditor}
             onSubmit={submitEdit}
             pending={correct.isPending}
           />
@@ -601,7 +655,7 @@ function ListSection({
   field: string;
   spec?: CorrectableFieldSpec;
   items: Array<{ key: string; primary: string; secondary?: string; sources?: ProfileSource[] }>;
-  onEdit: () => void;
+  onEdit: (opener: HTMLElement) => void;
 }) {
   return (
     <section>
@@ -614,7 +668,7 @@ function ListSection({
             variant="ghost"
             size="sm"
             className="h-7 px-2"
-            onClick={onEdit}
+            onClick={(e) => onEdit(e.currentTarget)}
             aria-label={`Correct ${title}`}
           >
             <Pencil className="h-3.5 w-3.5" />
@@ -655,11 +709,15 @@ function ListSection({
 function CorrectionEditor({
   editing,
   setEditing,
+  onClose,
   onSubmit,
   pending,
 }: {
   editing: NonNullable<Editing>;
   setEditing: (e: Editing) => void;
+  /** Closes AND returns focus to the control that opened it — the editor
+   *  unmounts, so without this a keyboard user is dropped at `<body>`. */
+  onClose: () => void;
   onSubmit: () => void;
   pending: boolean;
 }) {
@@ -667,6 +725,7 @@ function CorrectionEditor({
   const [draft, setDraft] = useState("");
   const inputId = useId();
   const hintId = useId();
+  const reasonId = useId();
   const firstFieldRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
 
   // ★FOCUS MOVES TO THE EDITOR. It renders BELOW the collapsible while focus
@@ -677,7 +736,9 @@ function CorrectionEditor({
     firstFieldRef.current?.focus();
   }, []);
   const label = FIELD_LABEL[spec.field] ?? spec.field;
-  const atItemCap = spec.maxItems !== undefined && list.length >= spec.maxItems;
+  // Deduped, matching the rule Save uses. Counting raw entries meant Add was
+  // disabled while Save was enabled on the same screen, at 21 raw / 20 unique.
+  const atItemCap = spec.maxItems !== undefined && dedupeLabels(list).length >= spec.maxItems;
   const draftTooLong = draft.trim().length > spec.maxLength;
   const blockedReason = correctionBlockedReason(spec, { value, list });
 
@@ -703,7 +764,7 @@ function CorrectionEditor({
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => setEditing(null)}
+          onClick={onClose}
           disabled={pending}
           aria-label="Cancel"
         >
@@ -740,7 +801,7 @@ function CorrectionEditor({
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
                 placeholder={`Add — up to ${spec.maxLength} characters`}
-                aria-describedby={hintId}
+                aria-describedby={blockedReason ? `${hintId} ${reasonId}` : hintId}
                 rows={2}
                 className="text-sm"
               />
@@ -750,7 +811,7 @@ function CorrectionEditor({
                 ref={firstFieldRef as React.RefObject<HTMLInputElement>}
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
-                aria-describedby={hintId}
+                aria-describedby={blockedReason ? `${hintId} ${reasonId}` : hintId}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     e.preventDefault();
@@ -769,14 +830,27 @@ function CorrectionEditor({
               ? `Too long — keep each one under ${spec.maxLength} characters.`
               : atItemCap
                 ? `That's the maximum of ${spec.maxItems}.`
-                : // The clear case, said plainly: an empty list is a real answer,
-                  // not a way of cancelling.
-                  "Remove everything and save to tell us none of these apply."}
+                : list.length > 0
+                  ? // The clear case, said plainly: an empty list is a real
+                    // answer, not a way of cancelling.
+                    "Remove everything and save to tell us none of these apply."
+                  : // …and NOT offered when the list is already empty, where
+                    // following it would send nothing and leave the user
+                    // believing they had made a statement.
+                    "Add what we've missed."}
           </p>
         </div>
       ) : spec.values ? (
         <Select value={value} onValueChange={(v) => setEditing({ ...editing, value: v })}>
-          <SelectTrigger id={inputId} aria-label={`Correct ${label}`}>
+          <SelectTrigger
+            id={inputId}
+            // The market-type editor is the one branch with no text input, so
+            // without a ref here the pencil still did nothing for a keyboard
+            // user — the a11y fix covered eight of the nine fields.
+            ref={firstFieldRef as unknown as React.RefObject<HTMLButtonElement>}
+            aria-label={`Correct ${label}`}
+            aria-describedby={blockedReason ? reasonId : undefined}
+          >
             <SelectValue placeholder="Choose" />
           </SelectTrigger>
           <SelectContent>
@@ -800,7 +874,16 @@ function CorrectionEditor({
             // Every reason the value is unusable, not only the length one —
             // a malformed country list was silently valid to assistive tech.
             aria-invalid={blockedReason !== undefined}
-            aria-describedby={hintId}
+            // Only what actually exists: the hint renders for the ISO-2 field
+            // alone, and pointing at a missing id is worse than pointing at
+            // nothing. The blocked reason is included because a live region's
+            // INITIAL content is not announced — and a scalar editor opened on
+            // an absent claim is blocked from the first frame.
+            aria-describedby={
+              [spec.csv === "iso2" ? hintId : null, blockedReason ? reasonId : null]
+                .filter(Boolean)
+                .join(" ") || undefined
+            }
           />
           {spec.csv === "iso2" && (
             <p id={hintId} className="text-xs text-muted-foreground">
@@ -816,13 +899,13 @@ function CorrectionEditor({
           numbers in it are the server's own, so this is what the server would
           have said. `aria-live` because it appears in response to typing. */}
       {blockedReason && (
-        <p className="text-xs text-destructive" role="status" aria-live="polite">
+        <p id={reasonId} className="text-xs text-destructive" aria-live="polite">
           {blockedReason}
         </p>
       )}
 
       <div className="flex justify-end gap-2">
-        <Button variant="ghost" onClick={() => setEditing(null)} disabled={pending}>
+        <Button variant="ghost" onClick={onClose} disabled={pending}>
           Cancel
         </Button>
         <Button

--- a/src/app/(site)/dashboard/ads/_components/audience-profile-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-profile-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { toastUnhandledApiError } from "@/lib/toast-errors";
@@ -10,6 +10,14 @@ import {
   type EvidenceTier,
   type ProfileSource,
 } from "@/lib/api/audiences";
+import {
+  correctionBlockedReason,
+  correctionIsNoop,
+  dedupeLabels,
+  highestTier,
+  mergeSources,
+  topSource,
+} from "@/lib/audience-profile-rules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -95,26 +103,30 @@ const MARKET_TYPE_LABEL: Record<string, string> = {
 };
 
 function EvidenceBadge({ sources }: { sources?: ProfileSource[] }) {
-  // The HIGHEST tier present, because that is what the claim rests on: a
-  // segment the business declared AND we then measured is stated, not observed.
-  const tier: EvidenceTier | undefined = sources?.some((s) => s.tier === "stated")
-    ? "stated"
-    : sources?.some((s) => s.tier === "observed")
-      ? "observed"
-      : sources?.some((s) => s.tier === "inferred")
-        ? "inferred"
-        : undefined;
+  const tier: EvidenceTier | undefined = highestTier(sources);
   if (!tier) return null;
-  const detail = sources?.find((s) => s.detail)?.detail;
   return (
     <span
       className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${TIER_CLASS[tier]}`}
-      // The evidence itself, for anyone who wants to check our working.
-      title={detail ? `${TIER_LABEL[tier]} — ${detail}` : TIER_LABEL[tier]}
     >
+      {/* The tier is carried as TEXT, not colour alone — the badge has to mean
+          the same thing to a colour-blind reader and a screen reader. */}
       {TIER_LABEL[tier]}
     </span>
   );
+}
+
+/** The evidence itself, rendered rather than hidden in a `title`.
+ *
+ *  ★NOT A TOOLTIP. A `title` is invisible to keyboard users and to touch, and
+ *  this is the panel's whole argument — "here is what we think AND why". Copy
+ *  a user cannot reach is copy that does not exist. */
+function EvidenceDetail({ sources }: { sources?: ProfileSource[] }) {
+  // From the WINNING tier's own source. "the first source with a detail" put a
+  // measurement's detail under a stated badge.
+  const detail = topSource(sources)?.detail;
+  if (!detail) return null;
+  return <p className="mt-0.5 text-xs text-muted-foreground">{detail}</p>;
 }
 
 /** A claim and its evidence, with an edit affordance when the server says the
@@ -142,6 +154,7 @@ function ClaimRow({
           </span>
           <EvidenceBadge sources={sources} />
         </div>
+        <EvidenceDetail sources={sources} />
       </div>
       {onEdit && (
         <Button
@@ -160,7 +173,18 @@ function ClaimRow({
 
 /** Editing state: one field at a time, so a half-finished correction can never
  *  be submitted alongside a finished one. */
-type Editing = { spec: CorrectableFieldSpec; value: string; list: string[] } | null;
+type Editing = {
+  spec: CorrectableFieldSpec;
+  value: string;
+  list: string[];
+  /** What the profile said when the editor opened — so a no-op save can be
+   *  refused, and so the delta the log records is one the user actually made. */
+  original: { value: string; list: string[] };
+  /** The profile this snapshot came from. If the underlying profile moves —
+   *  a refetch on window focus, a re-read, a business switch — the snapshot is
+   *  stale and saving it would write values the user never saw. */
+  profileVersion: number;
+} | null;
 
 export function AudienceProfilePanel() {
   const queryClient = useQueryClient();
@@ -179,10 +203,22 @@ export function AudienceProfilePanel() {
   const refresh = useMutation({
     mutationFn: () => audiencesApi.refreshProfile(),
     onSuccess: (res) => {
-      queryClient.setQueryData(["audience-profile"], {
-        profile: res.profile,
-        correctableFields: specs,
-      });
+      // ★UPDATER FORM, so the specs come from whatever the cache already holds
+      // rather than from this render's closure. If the initial GET had failed,
+      // `specs` here is [] — and writing that back would leave the freshly
+      // refreshed profile with no edit controls at all, which reads as "this
+      // is not correctable" rather than "we lost the spec list".
+      queryClient.setQueryData(
+        ["audience-profile"],
+        (old: { correctableFields?: CorrectableFieldSpec[] } | undefined) => ({
+          profile: res.profile,
+          correctableFields: old?.correctableFields ?? specs,
+        }),
+      );
+      // A re-read replaces the profile underneath any open editor, so the
+      // snapshot in it describes a profile that no longer exists. Closing is
+      // the honest move — saving it would write values the user never saw.
+      setEditing(null);
       toast.success(
         res.classified
           ? "Refreshed what we understand about your business."
@@ -199,10 +235,13 @@ export function AudienceProfilePanel() {
     mutationFn: (corrections: Parameters<typeof audiencesApi.correctProfile>[0]) =>
       audiencesApi.correctProfile(corrections),
     onSuccess: (res) => {
-      queryClient.setQueryData(["audience-profile"], {
-        profile: res.profile,
-        correctableFields: specs,
-      });
+      queryClient.setQueryData(
+        ["audience-profile"],
+        (old: { correctableFields?: CorrectableFieldSpec[] } | undefined) => ({
+          profile: res.profile,
+          correctableFields: old?.correctableFields ?? specs,
+        }),
+      );
       setEditing(null);
       toast.success("Thanks — we'll use that from now on.");
       // The audience is built from this profile, so a correction changes what
@@ -214,30 +253,53 @@ export function AudienceProfilePanel() {
 
   const startEdit = (field: string, current: string | string[]) => {
     const spec = specFor(field);
-    if (!spec) return;
-    setEditing({
-      spec,
+    if (!spec || !profile) return;
+    const original = {
       value: typeof current === "string" ? current : "",
       list: Array.isArray(current) ? current : [],
-    });
+    };
+    setEditing({ spec, ...original, original, profileVersion: profile.profileVersion });
   };
 
   const submitEdit = () => {
     if (!editing) return;
     const { spec } = editing;
+    // ★A NO-OP SAVE IS NOT HARMLESS. Every entry a list correction names is
+    // rewritten as `stated / user_correction`, so opening the editor, changing
+    // nothing and pressing Save would turn inferred claims into "You told us"
+    // ones the user never made — and append a null delta to the log. The
+    // server cannot tell the difference; only this can.
+    if (correctionIsNoop(spec, editing.original, { value: editing.value, list: editing.list })) {
+      setEditing(null);
+      return;
+    }
+    // Every limit the server enforces, checked here first — with the server's
+    // own numbers, which arrived in the spec. A user should never learn a
+    // limit by being refused.
+    const blocked = correctionBlockedReason(spec, { value: editing.value, list: editing.list });
+    if (blocked) {
+      toast.error(blocked);
+      return;
+    }
     if (spec.shape === "list") {
-      correct.mutate([{ field: spec.field, toList: editing.list }]);
+      // Deduped exactly as the server dedupes, so the correction log and the
+      // field it produces cannot disagree.
+      correct.mutate([{ field: spec.field, toList: dedupeLabels(editing.list) }]);
       return;
     }
-    const value = editing.value.trim();
-    // The server refuses a blank scalar, and it is right to — but bouncing off
-    // a 400 to learn that is a worse experience than not offering it.
-    if (!value) {
-      toast.error("Give us something to go on, or cancel.");
-      return;
-    }
-    correct.mutate([{ field: spec.field, to: value }]);
+    correct.mutate([{ field: spec.field, to: editing.value.trim() }]);
   };
+
+  // ★THE SNAPSHOT IS RECONCILED, not trusted. react-query refetches on window
+  // focus, `switchBusiness` clears the whole cache without unmounting this
+  // panel, and either one replaces the profile under an open editor. Saving
+  // then writes a list the user never saw — and after a business switch, writes
+  // business A's ICP onto business B, which is the wrong-business class of bug
+  // the server is business-scoped to prevent. If the profile moved or went
+  // away, the editor goes with it.
+  if (editing && (!profile || profile.profileVersion !== editing.profileVersion)) {
+    setEditing(null);
+  }
 
   if (isLoading) {
     return (
@@ -252,7 +314,10 @@ export function AudienceProfilePanel() {
 
   // A failed READ is not "no profile" — offering the build button here would
   // invite a user to rebuild something that may already exist.
-  if (isError) {
+  // `isError && !data`: a BACKGROUND refetch failure must not throw away a
+  // perfectly good cached profile. Replacing it with an error card would hide
+  // the user's own data because a refresh blinked.
+  if (isError && !data) {
     return (
       <Card>
         <CardContent className="py-4 text-sm text-muted-foreground">
@@ -282,6 +347,12 @@ export function AudienceProfilePanel() {
   }
 
   const conflicts = profile.conflicts ?? [];
+  // ★"NOTHING HERE YET" vs "WE COULDN'T WORK IT OUT" — the same empty list, two
+  // completely different facts, and rendering them identically is how an
+  // absence gets read as a finding. `GET /profile` does not return the refresh
+  // route's `classified` flag, but the profile itself records which classifier
+  // produced it, and its absence means the deeper read has never succeeded.
+  const classified = Boolean(profile.skillVersions?.understand_business_for_ads);
 
   return (
     <Card>
@@ -325,7 +396,7 @@ export function AudienceProfilePanel() {
                   key={conflict.field}
                   className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5 text-sm"
                 >
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
                   <div>
                     <span className="font-medium">
                       {FIELD_LABEL[conflict.field] ?? conflict.field}
@@ -411,7 +482,13 @@ export function AudienceProfilePanel() {
                 <ClaimRow
                   label={FIELD_LABEL["classification.regionalPresence"]!}
                   value={profile.classification.regionalPresence?.map((r) => r.value).join(", ")}
-                  sources={profile.classification.regionalPresence?.[0]?.sources}
+                  // Every entry's evidence, not the first entry's: the line is
+                  // one sentence built from many claims, and badging it from
+                  // [0] calls the whole list "You told us" because one country
+                  // came from the business record.
+                  sources={mergeSources(
+                    (profile.classification.regionalPresence ?? []).map((r) => r.sources),
+                  )}
                   onEdit={
                     specFor("classification.regionalPresence")
                       ? () =>
@@ -479,10 +556,20 @@ export function AudienceProfilePanel() {
               onEdit={() => startEdit("personas", profile.personas.map((p) => p.label))}
             />
 
+            {!classified && (
+              <p className="rounded-md border border-dashed p-2.5 text-sm text-muted-foreground">
+                These are the facts we can measure. The deeper read — who buys, who signs, what
+                you solve — hasn&apos;t run for this business yet, so the lists above being empty
+                doesn&apos;t mean there&apos;s nothing there. Re-read to try it.
+              </p>
+            )}
+
             <p className="text-xs text-muted-foreground">
               Version {profile.profileVersion}
               {profile.corrections.length > 0 &&
-                ` · ${profile.corrections.length} correction${profile.corrections.length === 1 ? "" : "s"} from you`}
+                // "recent", because the server caps the log at 200 and trims
+                // the oldest — a bare count would quietly stop going up.
+                ` · ${profile.corrections.length} recent correction${profile.corrections.length === 1 ? "" : "s"} from you`}
             </p>
           </CardContent>
         </CollapsibleContent>
@@ -491,6 +578,7 @@ export function AudienceProfilePanel() {
       {editing && (
         <CardContent className="border-t pt-4">
           <CorrectionEditor
+            key={editing.spec.field}
             editing={editing}
             setEditing={setEditing}
             onSubmit={submitEdit}
@@ -540,8 +628,8 @@ function ListSection({
         </p>
       ) : (
         <ul className="space-y-1.5">
-          {items.map((item) => (
-            <li key={`${field}:${item.key}`} className="flex flex-wrap items-center gap-2 text-sm">
+          {items.map((item, index) => (
+            <li key={`${field}:${index}:${item.key}`} className="flex flex-wrap items-center gap-2 text-sm">
               <span>{item.primary}</span>
               {item.secondary && (
                 <span className="text-muted-foreground">— {item.secondary}</span>
@@ -577,9 +665,21 @@ function CorrectionEditor({
 }) {
   const { spec, value, list } = editing;
   const [draft, setDraft] = useState("");
+  const inputId = useId();
+  const hintId = useId();
+  const firstFieldRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  // ★FOCUS MOVES TO THE EDITOR. It renders BELOW the collapsible while focus
+  // stays on the pencil that opened it, so to a keyboard or screen-reader user
+  // the pencil appeared to do nothing at all. The component is keyed by field,
+  // so this fires once per open rather than on every keystroke.
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
   const label = FIELD_LABEL[spec.field] ?? spec.field;
   const atItemCap = spec.maxItems !== undefined && list.length >= spec.maxItems;
   const draftTooLong = draft.trim().length > spec.maxLength;
+  const blockedReason = correctionBlockedReason(spec, { value, list });
 
   const addDraft = () => {
     const v = draft.trim();
@@ -597,8 +697,16 @@ function CorrectionEditor({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-2">
-        <Label className="text-sm font-medium">Correct: {label}</Label>
-        <Button variant="ghost" size="sm" onClick={() => setEditing(null)} aria-label="Cancel">
+        <Label htmlFor={inputId} className="text-sm font-medium">
+          Correct: {label}
+        </Label>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setEditing(null)}
+          disabled={pending}
+          aria-label="Cancel"
+        >
           <X className="h-4 w-4" />
         </Button>
       </div>
@@ -627,16 +735,22 @@ function CorrectionEditor({
           <div className="flex gap-2">
             {spec.maxLength > 300 ? (
               <Textarea
+                id={inputId}
+                ref={firstFieldRef as React.RefObject<HTMLTextAreaElement>}
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
                 placeholder={`Add — up to ${spec.maxLength} characters`}
+                aria-describedby={hintId}
                 rows={2}
                 className="text-sm"
               />
             ) : (
               <Input
+                id={inputId}
+                ref={firstFieldRef as React.RefObject<HTMLInputElement>}
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
+                aria-describedby={hintId}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     e.preventDefault();
@@ -650,7 +764,7 @@ function CorrectionEditor({
               Add
             </Button>
           </div>
-          <p className="text-xs text-muted-foreground">
+          <p id={hintId} className="text-xs text-muted-foreground">
             {draftTooLong
               ? `Too long — keep each one under ${spec.maxLength} characters.`
               : atItemCap
@@ -661,11 +775,8 @@ function CorrectionEditor({
           </p>
         </div>
       ) : spec.values ? (
-        <Select
-          value={value}
-          onValueChange={(v) => setEditing({ ...editing, value: v })}
-        >
-          <SelectTrigger>
+        <Select value={value} onValueChange={(v) => setEditing({ ...editing, value: v })}>
+          <SelectTrigger id={inputId} aria-label={`Correct ${label}`}>
             <SelectValue placeholder="Choose" />
           </SelectTrigger>
           <SelectContent>
@@ -679,20 +790,35 @@ function CorrectionEditor({
       ) : (
         <div className="space-y-1">
           <Input
+            id={inputId}
+            ref={firstFieldRef as React.RefObject<HTMLInputElement>}
             value={value}
             onChange={(e) => setEditing({ ...editing, value: e.target.value })}
             placeholder={
               spec.csv === "iso2" ? "Two-letter country codes, e.g. IN, SG, AE" : "Your answer"
             }
-            aria-invalid={value.trim().length > spec.maxLength}
+            // Every reason the value is unusable, not only the length one —
+            // a malformed country list was silently valid to assistive tech.
+            aria-invalid={blockedReason !== undefined}
+            aria-describedby={hintId}
           />
           {spec.csv === "iso2" && (
-            <p className="text-xs text-muted-foreground">
+            <p id={hintId} className="text-xs text-muted-foreground">
               Country codes only{spec.maxCount ? `, up to ${spec.maxCount}` : ""} — this is what we
               target, so it decides where your budget goes.
             </p>
           )}
         </div>
+      )}
+
+      {/* The reason is SHOWN, not only used to disable. A disabled button with
+          no explanation is a dead end the user cannot reason about — and the
+          numbers in it are the server's own, so this is what the server would
+          have said. `aria-live` because it appears in response to typing. */}
+      {blockedReason && (
+        <p className="text-xs text-destructive" role="status" aria-live="polite">
+          {blockedReason}
+        </p>
       )}
 
       <div className="flex justify-end gap-2">
@@ -701,11 +827,7 @@ function CorrectionEditor({
         </Button>
         <Button
           onClick={onSubmit}
-          disabled={
-            pending ||
-            (spec.shape === "scalar" &&
-              (!value.trim() || value.trim().length > spec.maxLength))
-          }
+          disabled={pending || blockedReason !== undefined}
         >
           {pending ? "Saving…" : "Save"}
         </Button>

--- a/src/app/(site)/dashboard/ads/page.tsx
+++ b/src/app/(site)/dashboard/ads/page.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { OAuthConnectResult } from "@/components/integrations/oauth-connect-result";
+import { AudienceProfilePanel } from "./_components/audience-profile-panel";
 import { LinkedInAdsPanel } from "./_components/linkedin-ads-panel";
 import { XAdsPanel } from "./_components/x-ads-panel";
 import {
@@ -200,6 +201,15 @@ function AdsHub() {
       />
 
       <HubHeader description={channel?.description} />
+
+      {/* ★ABOVE THE CHANNEL TABS, ON PURPOSE. What we understand about a
+          business is channel-NEUTRAL — the same profile decides who a LinkedIn
+          campaign and an X campaign target — so putting it inside a channel
+          panel would make it look like a LinkedIn setting and would need
+          copying for every channel added afterwards. It lives here for the same
+          reason the hub owns the header: one surface, channels select into it.
+          Not a new route either (ads-hub-single-surface). */}
+      <AudienceProfilePanel />
 
       {/* <Tabs> renders only once a channel is known, so it stays controlled
           for its whole life — a value that starts undefined and later becomes

--- a/src/lib/api/audiences.test.ts
+++ b/src/lib/api/audiences.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * The audiences client's REQUEST SHAPES.
+ *
+ * Thin by design, so what is worth pinning is the thing a thin client gets
+ * wrong: the paths and the body the server actually accepts. `PATCH /profile`
+ * takes `{corrections: [...]}` where each correction carries `to` OR `toList`
+ * — the FIELD decides which, and sending the wrong one is a 400 the user reads
+ * as "my correction was wrong".
+ */
+
+const h = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({ api: { get: h.get, post: h.post, patch: h.patch } }));
+
+const { audiencesApi } = await import("./audiences");
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("audiencesApi", () => {
+  it("reads the profile from the platform-agnostic path", async () => {
+    h.get.mockResolvedValue({ profile: null, correctableFields: [] });
+    await audiencesApi.getProfile();
+    // Platform is a PARAMETER on this surface, never a path segment — adding
+    // Meta must not need a second client.
+    expect(h.get).toHaveBeenCalledWith("/v1/audiences/profile");
+  });
+
+  it("refreshes with a body, because the api rejects a bodiless POST", async () => {
+    h.post.mockResolvedValue({ profile: {}, classified: true });
+    await audiencesApi.refreshProfile();
+    expect(h.post).toHaveBeenCalledWith("/v1/audiences/profile/refresh", {});
+  });
+
+  it("sends a scalar correction as `to`", async () => {
+    h.patch.mockResolvedValue({ profile: {} });
+    await audiencesApi.correctProfile([{ field: "classification.industry", to: "Travel" }]);
+    expect(h.patch).toHaveBeenCalledWith("/v1/audiences/profile", {
+      corrections: [{ field: "classification.industry", to: "Travel" }],
+    });
+  });
+
+  it("★sends an EMPTY list as an empty array, not by omitting the key", async () => {
+    // "None of these apply" is a real correction and clearing the list is the
+    // only way to say it. Dropping the key would make the server read the
+    // request as a shape error instead.
+    h.patch.mockResolvedValue({ profile: {} });
+    await audiencesApi.correctProfile([{ field: "painPoints", toList: [] }]);
+    expect(h.patch).toHaveBeenCalledWith("/v1/audiences/profile", {
+      corrections: [{ field: "painPoints", toList: [] }],
+    });
+  });
+
+  it("sends several corrections in one request, in order", async () => {
+    // The server applies them in order and the last one for a field wins, so
+    // the client must not reorder or batch them into a map.
+    h.patch.mockResolvedValue({ profile: {} });
+    await audiencesApi.correctProfile([
+      { field: "icp", toList: ["A"] },
+      { field: "painPoints", toList: ["B"] },
+    ]);
+    const body = h.patch.mock.calls[0]![1] as { corrections: Array<{ field: string }> };
+    expect(body.corrections.map((c) => c.field)).toEqual(["icp", "painPoints"]);
+  });
+});

--- a/src/lib/api/audiences.test.ts
+++ b/src/lib/api/audiences.test.ts
@@ -3,11 +3,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 /**
  * The audiences client's REQUEST SHAPES.
  *
- * Thin by design, so what is worth pinning is the thing a thin client gets
- * wrong: the paths and the body the server actually accepts. `PATCH /profile`
- * takes `{corrections: [...]}` where each correction carries `to` OR `toList`
- * — the FIELD decides which, and sending the wrong one is a 400 the user reads
- * as "my correction was wrong".
+ * ⚠️ THIS FILE IS THIN, AND SO IS WHAT IT CAN PROVE. `audiences.ts` is a
+ * pass-through, so the body assertions below are close to `x => x` — they pin
+ * the PATHS and the wrapper shape, which is what a hand-written client actually
+ * gets wrong, and nothing more. The judgement worth testing lives in
+ * `audience-profile-rules.test.ts`, where the panel's decisions are pure
+ * functions: which evidence tier a claim rests on, whether a correction is safe
+ * to send, whether it changes anything at all.
+ *
+ * The panel itself has no test: this repo is vitest `environment: "node"` with
+ * no jsdom by design (see vitest.config.ts), and adding a DOM stack is a
+ * bigger change than this PR should carry. Extracting the decisions was the
+ * trade — and it is the half that would have been wrong silently.
  */
 
 const h = vi.hoisted(() => ({
@@ -31,7 +38,10 @@ describe("audiencesApi", () => {
     expect(h.get).toHaveBeenCalledWith("/v1/audiences/profile");
   });
 
-  it("refreshes with a body, because the api rejects a bodiless POST", async () => {
+  it("refreshes with an explicit empty body", async () => {
+    // Not because the route needs one — it reads nothing — but because
+    // `api.post(path)` and `api.post(path, {})` differ in whether a
+    // Content-Type is sent, and pinning the call keeps that stable.
     h.post.mockResolvedValue({ profile: {}, classified: true });
     await audiencesApi.refreshProfile();
     expect(h.post).toHaveBeenCalledWith("/v1/audiences/profile/refresh", {});

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -1,0 +1,152 @@
+import { api } from "@/lib/api";
+
+/**
+ * /v1/audiences — the Autonomous Audience Engine's client.
+ *
+ * ★THE FIRST ONE. Until this file, `grep -rn "/v1/audiences" src` returned
+ * nothing: the engine reads a business, classifies it, resolves a servable
+ * audience and puts it on every boosted campaign — entirely invisibly. Three
+ * things followed from that, and this client exists to end all three:
+ *
+ *   - the profile could not be seen, so Phase 1's exit criterion ("it is
+ *     recognisably right, and its errors are correctable") was untestable;
+ *   - it could not be CORRECTED, and a correction is the best learning signal
+ *     this engine will ever get — better than anything the content side has,
+ *     because it says WHAT was wrong rather than merely that something was;
+ *   - `targetingProvenance` was write-only.
+ *
+ * Platform is a PARAMETER on this surface, never a path segment — same rule as
+ * the ads hub, so adding Meta is a registry row and an adapter rather than a
+ * new client.
+ */
+
+/** Where a claim came from. `stated` (a human typed it) beats `observed` (we
+ *  measured it) beats `inferred` (the model's judgement), and the UI shows the
+ *  difference because a strategist who tells you which is which is the
+ *  product. */
+export type EvidenceTier = "stated" | "observed" | "inferred";
+
+export interface ProfileSource {
+  tier: EvidenceTier;
+  /** Machine-readable origin — "org_businesses.valueProposition", "gsc.queries". */
+  kind: string;
+  /** Human-readable pointer: a page title, a query, a count. */
+  detail?: string;
+}
+
+export interface ProfileClaim {
+  value: string;
+  confidence: number;
+  sources?: ProfileSource[];
+}
+
+export interface AudienceProfile {
+  classification: {
+    industry?: ProfileClaim;
+    subIndustry?: ProfileClaim;
+    marketType?: { value: string; confidence: number; sources?: ProfileSource[] };
+    lifecycleStage?: ProfileClaim;
+    regionalPresence?: ProfileClaim[];
+  };
+  icp: Array<{
+    label: string;
+    description?: string;
+    confidence: number;
+    sources?: ProfileSource[];
+  }>;
+  personas: Array<{
+    label: string;
+    role?: string;
+    seniority?: string;
+    buyingRole?: string;
+    confidence: number;
+    sources?: ProfileSource[];
+  }>;
+  decisionMakers: Array<{
+    titleFamily: string;
+    seniority?: string;
+    confidence: number;
+    sources?: ProfileSource[];
+  }>;
+  painPoints: Array<{ statement: string; confidence: number; sources?: ProfileSource[] }>;
+  intentSignals: Array<{ signal: string; strength: number; sources?: ProfileSource[] }>;
+  /**
+   * Where a stated fact and an observed one disagree. NOT an error to resolve:
+   * a business that says it sells to enterprises while its content only ever
+   * addresses freelancers is the most interesting thing the engine noticed, and
+   * flattening it into one answer throws that away.
+   */
+  conflicts: Array<{ field: string; statedValue?: string; observedValue?: string; note?: string }>;
+  corrections: Array<{
+    field: string;
+    from?: string;
+    to?: string;
+    fromList?: string[];
+    toList?: string[];
+    byUserId: string;
+    at: string;
+  }>;
+  profileVersion: number;
+  status: "active" | "stale" | "building" | "failed";
+  computedAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * What the server will accept as a correction, per field.
+ *
+ * ★SENT BY THE SERVER, never hardcoded here. A client offering a control the
+ * server refuses is a dead control; a client sending a scalar where the server
+ * wants a list is a 400 the user reads as "my correction was wrong". The panel
+ * renders whatever this list says and nothing else.
+ */
+export interface CorrectableFieldSpec {
+  field: string;
+  shape: "scalar" | "list";
+  maxLength: number;
+  maxItems?: number;
+  /** Closed vocabulary, when the field has one (market type). */
+  values?: readonly string[];
+  /** Comma-separated ISO-3166 alpha-2 — the one list-shaped field that stays a
+   *  scalar, because a two-character vocabulary cannot contain a comma. */
+  csv?: "iso2";
+  maxCount?: number;
+}
+
+export interface ProfileResponse {
+  profile: AudienceProfile | null;
+  correctableFields: CorrectableFieldSpec[];
+}
+
+export interface RefreshResponse {
+  profile: AudienceProfile;
+  /** False when only the EVIDENCED half is present — the model read failed or
+   *  was skipped. The panel says the deeper read is unavailable rather than
+   *  presenting gaps as findings. */
+  classified: boolean;
+}
+
+/** One correction. Carries `to` OR `toList` — the FIELD decides which, and the
+ *  spec above says. */
+export interface CorrectionInput {
+  field: string;
+  to?: string;
+  toList?: string[];
+}
+
+export const audiencesApi = {
+  /** What we understand about this business. `profile: null` is a first-class
+   *  answer — nobody has asked for audiences yet — not an error. */
+  getProfile: () => api.get<ProfileResponse>("/v1/audiences/profile"),
+
+  /** Rebuild from current signals. Expensive (site graph, content, a strong
+   *  model call), so the panel makes it an explicit action rather than
+   *  something that happens on mount. */
+  refreshProfile: () => api.post<RefreshResponse>("/v1/audiences/profile/refresh", {}),
+
+  /** Corrections are APPENDED to a log, never written over the field: the
+   *  delta is what teaches the engine, and storing only the result would let a
+   *  later rebuild silently revert it. */
+  correctProfile: (corrections: CorrectionInput[]) =>
+    api.patch<{ profile: AudienceProfile }>("/v1/audiences/profile", { corrections }),
+};

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -87,6 +87,10 @@ export interface AudienceProfile {
     at: string;
   }>;
   profileVersion: number;
+  /** Which skill instance produced each stage. ★The panel reads
+   *  `understand_business_for_ads` to tell "we found nothing" from "the deeper
+   *  read never ran" — two very different facts behind the same empty list. */
+  skillVersions?: Record<string, string>;
   status: "active" | "stale" | "building" | "failed";
   computedAt?: string;
   updatedAt?: string;

--- a/src/lib/audience-profile-rules.test.ts
+++ b/src/lib/audience-profile-rules.test.ts
@@ -65,6 +65,16 @@ describe("correctionBlockedReason", () => {
     expect(correctionBlockedReason(listSpec, { value: "", list: [] })).toBeUndefined();
   });
 
+  it("★says an over-cap list is OUR limit, not the user's mistake", () => {
+    // `personas` is evidence-built from declared segments plus up to 25 tagged
+    // ones against a cap of 20, so a content-rich business opens the editor
+    // already over it having done nothing.
+    const over = Array.from({ length: 27 }, (_, i) => `Segment ${i}`);
+    const reason = correctionBlockedReason(listSpec, { value: "", list: over });
+    expect(reason).toContain("We can only store 20");
+    expect(reason).toContain("remove 7");
+  });
+
   it("blocks a list entry over the field's own cap", () => {
     expect(
       correctionBlockedReason(listSpec, { value: "", list: ["x".repeat(257)] }),
@@ -158,10 +168,47 @@ describe("correctionIsNoop — saving nothing must not restate everything", () =
     ).toBe(false);
   });
 
-  it("a case-only retype is a no-op, because the server would collapse it anyway", () => {
+  it("★removing a DUPLICATE the server actually holds is a real correction", () => {
+    // The evidence layer does not dedupe — `taxonomy.audienceSegments` is
+    // mapped verbatim and tagged segments merge with a CASE-SENSITIVE check —
+    // so a profile can hold ["A", "a"] and the panel renders both. Deduping
+    // BOTH sides made removing the duplicate a no-op: the editor closed,
+    // nothing was sent, and the duplicate stayed on screen forever with no way
+    // for the user to tell why.
     expect(
       correctionIsNoop(listSpec, { value: "", list: ["A", "a"] }, { value: "", list: ["A"] }),
+    ).toBe(false);
+    expect(
+      correctionIsNoop(listSpec, { value: "", list: ["A", "A"] }, { value: "", list: ["A"] }),
+    ).toBe(false);
+  });
+
+  it("a case-only RETYPE is a real change, because the stored casing moves", () => {
+    // dedupeLabels keeps the first occurrence's casing, so these differ and
+    // the server stores the new one. Naming it a no-op would be a false claim
+    // about the system.
+    expect(
+      correctionIsNoop(
+        listSpec,
+        { value: "", list: ["Head of Travel"] },
+        { value: "", list: ["head of travel"] },
+      ),
+    ).toBe(false);
+  });
+
+  it("★a CSV whitespace edit is a no-op, because the server parses it the same", () => {
+    // "IN, SG" → "IN,SG" is the same audience. A plain string compare called
+    // it a change and appended a null delta to the log.
+    expect(
+      correctionIsNoop(geoSpec, { value: "IN, SG", list: [] }, { value: "IN,SG", list: [] }),
     ).toBe(true);
+    expect(
+      correctionIsNoop(geoSpec, { value: "IN, SG", list: [] }, { value: "in, sg ", list: [] }),
+    ).toBe(true);
+    // …and a real change still reads as one.
+    expect(
+      correctionIsNoop(geoSpec, { value: "IN, SG", list: [] }, { value: "IN, AE", list: [] }),
+    ).toBe(false);
   });
 
   it("clearing a non-empty list is a real correction", () => {

--- a/src/lib/audience-profile-rules.test.ts
+++ b/src/lib/audience-profile-rules.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  highestTier,
+  dedupeLabels,
+  correctionBlockedReason,
+  correctionIsNoop,
+  mergeSources,
+  topSource,
+} from "./audience-profile-rules";
+import type { CorrectableFieldSpec } from "@/lib/api/audiences";
+
+const listSpec: CorrectableFieldSpec = {
+  field: "icp",
+  shape: "list",
+  maxLength: 256,
+  maxItems: 20,
+};
+const geoSpec: CorrectableFieldSpec = {
+  field: "classification.regionalPresence",
+  shape: "scalar",
+  maxLength: 512,
+  csv: "iso2",
+  maxCount: 50,
+};
+const enumSpec: CorrectableFieldSpec = {
+  field: "classification.marketType",
+  shape: "scalar",
+  maxLength: 16,
+  values: ["b2b", "b2c", "b2b2c", "unknown"],
+};
+
+describe("highestTier", () => {
+  it("★takes the HIGHEST tier, not the first", () => {
+    // A segment the business declared AND that we then measured is a stated
+    // fact with corroboration. Showing it as "we measured" understates what we
+    // know, and the whole panel is an argument that the difference matters.
+    expect(highestTier([{ tier: "observed", kind: "x" }, { tier: "stated", kind: "y" }])).toBe(
+      "stated",
+    );
+    expect(highestTier([{ tier: "inferred", kind: "x" }, { tier: "observed", kind: "y" }])).toBe(
+      "observed",
+    );
+  });
+
+  it("says nothing rather than guessing when there is no evidence", () => {
+    expect(highestTier([])).toBeUndefined();
+    expect(highestTier(undefined)).toBeUndefined();
+  });
+});
+
+describe("dedupeLabels — the client must collapse what the server collapses", () => {
+  it("removes case-colliding entries, first occurrence winning", () => {
+    expect(dedupeLabels(["ICP A", "icp a", "ICP B"])).toEqual(["ICP A", "ICP B"]);
+  });
+
+  it("trims and drops blanks", () => {
+    expect(dedupeLabels(["  Kept  ", "   ", ""])).toEqual(["Kept"]);
+  });
+});
+
+describe("correctionBlockedReason", () => {
+  it("★never blocks an EMPTY list — that is how a user says 'none of these apply'", () => {
+    // The server treats an explicitly-empty list as a statement. A client that
+    // refused to send one would make the clear unreachable.
+    expect(correctionBlockedReason(listSpec, { value: "", list: [] })).toBeUndefined();
+  });
+
+  it("blocks a list entry over the field's own cap", () => {
+    expect(
+      correctionBlockedReason(listSpec, { value: "", list: ["x".repeat(257)] }),
+    ).toContain("256");
+  });
+
+  it("counts the DEDUPED list against maxItems", () => {
+    // 21 raw entries that collapse to 1 is a legal correction; counting the
+    // raw list would refuse it.
+    const list = Array.from({ length: 21 }, (_, i) => (i % 2 ? "same" : "SAME"));
+    expect(correctionBlockedReason(listSpec, { value: "", list })).toBeUndefined();
+  });
+
+  it("blocks a blank scalar rather than letting the server refuse it", () => {
+    expect(correctionBlockedReason(enumSpec, { value: "   ", list: [] })).toBeTruthy();
+  });
+
+  it("blocks a value outside a closed vocabulary — including the right word in the wrong case", () => {
+    expect(correctionBlockedReason(enumSpec, { value: "B2B", list: [] })).toBeTruthy();
+    expect(correctionBlockedReason(enumSpec, { value: "b2b", list: [] })).toBeUndefined();
+  });
+
+  it("★names the offending country code rather than saying 'invalid'", () => {
+    const reason = correctionBlockedReason(geoSpec, { value: "IN, United States", list: [] });
+    expect(reason).toContain("United States");
+  });
+
+  it("accepts lowercase codes, because the server uppercases them", () => {
+    expect(correctionBlockedReason(geoSpec, { value: "in, sg", list: [] })).toBeUndefined();
+  });
+
+  it("blocks more countries than the server will apply", () => {
+    const many = Array.from({ length: 60 }, () => "IN").join(",");
+    expect(correctionBlockedReason(geoSpec, { value: many, list: [] })).toContain("50");
+  });
+});
+
+describe("topSource — the detail must belong to the tier that won", () => {
+  it("★never attributes a measurement's detail to a stated claim", () => {
+    // Live in the server's own data: a segment the business DECLARED and that
+    // we then tagged carries a stated source with no detail and an observed
+    // one reading "tagged on 12 pieces". "First source with a detail" renders
+    // "You told us — tagged on 12 pieces": a measurement presented as the
+    // provenance of a stated fact, on a panel whose thesis is that the
+    // difference matters.
+    const sources = [
+      { tier: "stated" as const, kind: "org_businesses.taxonomy.audienceSegments" },
+      { tier: "observed" as const, kind: "cnt_content_tags", detail: "tagged on 12 pieces" },
+    ];
+    expect(highestTier(sources)).toBe("stated");
+    expect(topSource(sources)?.detail).toBeUndefined();
+  });
+
+  it("prefers a detailed source WITHIN the winning tier", () => {
+    const sources = [
+      { tier: "observed" as const, kind: "a" },
+      { tier: "observed" as const, kind: "b", detail: "seen on 41 pages" },
+    ];
+    expect(topSource(sources)?.detail).toBe("seen on 41 pages");
+  });
+});
+
+describe("mergeSources", () => {
+  it("badges a multi-entry line from ALL its entries, not the first", () => {
+    // The geography line is one sentence built from many claims; taking [0]
+    // calls the whole list "You told us" because one country came from the
+    // business record.
+    const merged = mergeSources([
+      [{ tier: "stated", kind: "org_businesses.location.country" }],
+      [{ tier: "inferred", kind: "llm" }],
+    ]);
+    expect(merged).toHaveLength(2);
+    expect(highestTier(merged)).toBe("stated");
+  });
+});
+
+describe("correctionIsNoop — saving nothing must not restate everything", () => {
+  it("★an unchanged list is a no-op", () => {
+    // Every entry a list correction names is rewritten as stated/user_correction,
+    // so a no-op save turns inferred claims into "You told us" ones the user
+    // never made — and appends a null delta to the learning log. The server
+    // cannot tell the difference.
+    expect(
+      correctionIsNoop(listSpec, { value: "", list: ["A", "B"] }, { value: "", list: ["A", "B"] }),
+    ).toBe(true);
+  });
+
+  it("reordering IS a change, because order is meaningful", () => {
+    expect(
+      correctionIsNoop(listSpec, { value: "", list: ["A", "B"] }, { value: "", list: ["B", "A"] }),
+    ).toBe(false);
+  });
+
+  it("a case-only retype is a no-op, because the server would collapse it anyway", () => {
+    expect(
+      correctionIsNoop(listSpec, { value: "", list: ["A", "a"] }, { value: "", list: ["A"] }),
+    ).toBe(true);
+  });
+
+  it("clearing a non-empty list is a real correction", () => {
+    expect(correctionIsNoop(listSpec, { value: "", list: ["A"] }, { value: "", list: [] })).toBe(
+      false,
+    );
+  });
+
+  it("whitespace-only scalar edits are no-ops", () => {
+    expect(correctionIsNoop(enumSpec, { value: "b2b", list: [] }, { value: " b2b ", list: [] })).toBe(
+      true,
+    );
+  });
+});

--- a/src/lib/audience-profile-rules.ts
+++ b/src/lib/audience-profile-rules.ts
@@ -1,0 +1,143 @@
+import type { CorrectableFieldSpec, EvidenceTier, ProfileSource } from "@/lib/api/audiences";
+
+/**
+ * The decisions the profile panel makes, extracted so they can be tested.
+ *
+ * This repo has no DOM test environment on purpose (`vitest.config.ts`:
+ * node-only until a primitive genuinely needs jsdom), so rendering is not what
+ * gets asserted here. What CAN be got wrong without a DOM — and what would be
+ * invisible in review — is the judgement: which evidence tier a claim rests on,
+ * whether a correction is safe to send, and whether the client's idea of "the
+ * same entry" matches the server's. Those live here.
+ */
+
+/**
+ * The tier a claim RESTS ON: the highest present, not the first.
+ *
+ * A persona the business declared AND that we then measured carries both
+ * `stated` and `observed`; it is a stated fact with corroboration, and showing
+ * it as "we measured" would understate what we actually know. The ordering is
+ * §5.1's, and the whole panel is an argument that the difference matters.
+ */
+export function highestTier(sources?: ProfileSource[]): EvidenceTier | undefined {
+  return topSource(sources)?.tier;
+}
+
+/**
+ * The winning tier's OWN source, so a detail can never be attributed to a tier
+ * that did not produce it.
+ *
+ * ★THE BUG THIS EXISTS TO PREVENT is live in the server's own data. A segment
+ * the business declared AND that we then tagged carries two sources: a STATED
+ * one naming `org_businesses.taxonomy.audienceSegments` with no detail, and an
+ * OBSERVED one carrying "tagged on 12 pieces". Taking "the first source with a
+ * detail" renders "You told us — tagged on 12 pieces": a measurement presented
+ * as the provenance of a stated fact, on a panel whose entire thesis is that
+ * the difference matters.
+ */
+export function topSource(sources?: ProfileSource[]): ProfileSource | undefined {
+  if (!sources?.length) return undefined;
+  for (const tier of ["stated", "observed", "inferred"] as const) {
+    const withDetail = sources.find((s) => s.tier === tier && s.detail);
+    if (withDetail) return withDetail;
+    const any = sources.find((s) => s.tier === tier);
+    if (any) return any;
+  }
+  return undefined;
+}
+
+/** One claim's worth of evidence assembled from SEVERAL entries — the geography
+ *  line is one sentence built from many claims, and badging it with the first
+ *  entry's tier would call the whole list stated because one country was. */
+export function mergeSources(lists: Array<ProfileSource[] | undefined>): ProfileSource[] {
+  return lists.flatMap((l) => l ?? []);
+}
+
+/**
+ * Did this correction actually change anything?
+ *
+ * ★SAVING A NO-OP IS NOT HARMLESS, and the server cannot detect it. Every entry
+ * a list correction names is rewritten as `stated / user_correction` — so
+ * opening the ICP editor, changing nothing and pressing Save turns four
+ * inferred ICPs into four "You told us" claims the user never made, and appends
+ * a null delta to the log that §12.4 calls the best learning signal this engine
+ * will ever get. The panel is the only place this can be caught.
+ */
+export function correctionIsNoop(
+  spec: CorrectableFieldSpec,
+  original: { value: string; list: string[] },
+  draft: { value: string; list: string[] },
+): boolean {
+  if (spec.shape === "list") {
+    const a = dedupeLabels(original.list);
+    const b = dedupeLabels(draft.list);
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  }
+  return original.value.trim() === draft.value.trim();
+}
+
+/**
+ * Collapse a list the way the SERVER collapses it — trim, drop blanks, and
+ * remove case-colliding duplicates, first occurrence winning.
+ *
+ * Matching the server exactly is the point. `applyCorrections` dedupes
+ * case-insensitively, so a client that sent both "ICP A" and "icp a" would
+ * have the log record two entries and the profile hold one — a log that
+ * disagrees with the field it produced, teaching the learning loop about an
+ * entry that never existed.
+ */
+export function dedupeLabels(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of values) {
+    const v = raw.trim();
+    if (v.length === 0) continue;
+    const key = v.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(v);
+  }
+  return out;
+}
+
+/** Why a correction cannot be sent, or undefined when it can. The message is
+ *  user-facing: the point of checking here is that the user never learns a
+ *  limit by being refused. */
+export function correctionBlockedReason(
+  spec: CorrectableFieldSpec,
+  draft: { value: string; list: string[] },
+): string | undefined {
+  if (spec.shape === "list") {
+    const clean = dedupeLabels(draft.list);
+    if (spec.maxItems !== undefined && clean.length > spec.maxItems) {
+      return `That's more than the maximum of ${spec.maxItems}.`;
+    }
+    const tooLong = clean.find((v) => v.length > spec.maxLength);
+    if (tooLong) return `Keep each one under ${spec.maxLength} characters.`;
+    // ★AN EMPTY LIST IS NOT BLOCKED. "None of these apply" is a real
+    // correction and clearing the list is the only way to say it — the server
+    // treats an explicitly-empty list as a statement, and a client that
+    // refused to send one would make that unreachable.
+    return undefined;
+  }
+  const value = draft.value.trim();
+  if (!value) return "Give us something to go on.";
+  if (value.length > spec.maxLength) return `Keep it under ${spec.maxLength} characters.`;
+  if (spec.values && !spec.values.includes(value)) return "Choose one of the options.";
+  if (spec.csv === "iso2") {
+    const parts = value
+      .split(",")
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0);
+    const bad = parts.find((x) => !/^[A-Za-z]{2}$/.test(x));
+    if (parts.length === 0 || bad) {
+      return bad
+        ? `"${bad}" isn't a two-letter country code.`
+        : "Give us at least one two-letter country code.";
+    }
+    if (spec.maxCount !== undefined && parts.length > spec.maxCount) {
+      return `That's more than ${spec.maxCount} countries.`;
+    }
+  }
+  return undefined;
+}

--- a/src/lib/audience-profile-rules.ts
+++ b/src/lib/audience-profile-rules.ts
@@ -69,9 +69,29 @@ export function correctionIsNoop(
   draft: { value: string; list: string[] },
 ): boolean {
   if (spec.shape === "list") {
-    const a = dedupeLabels(original.list);
-    const b = dedupeLabels(draft.list);
-    return a.length === b.length && a.every((v, i) => v === b[i]);
+    // ★THE ORIGINAL IS COMPARED AS THE SERVER HOLDS IT, NOT DEDUPED. The
+    // evidence layer does not dedupe: `taxonomy.audienceSegments` is mapped
+    // verbatim and tagged segments are merged with a CASE-SENSITIVE check, so
+    // a profile can legitimately hold ["Travel Buyers", "travel buyers"] and
+    // the panel renders both. Deduping both sides made removing that duplicate
+    // a no-op — the editor closed, nothing was sent, and the duplicate stayed
+    // on screen FOREVER, with no way for the user to tell why.
+    const before = original.list.map((v) => v.trim()).filter((v) => v.length > 0);
+    const after = dedupeLabels(draft.list);
+    return before.length === after.length && before.every((v, i) => v === after[i]);
+  }
+  // ★CSV IS COMPARED AS THE SERVER PARSES IT. "IN, SG" → "IN,SG" is the same
+  // audience: the server splits on commas and uppercases, so the profile does
+  // not move — but a plain string compare called it a change and appended a
+  // null delta to the log this function exists to keep honest.
+  if (spec.csv === "iso2") {
+    const codes = (v: string) =>
+      v
+        .split(",")
+        .map((x) => x.trim().toUpperCase())
+        .filter((x) => x.length > 0)
+        .join(",");
+    return codes(original.value) === codes(draft.value);
   }
   return original.value.trim() === draft.value.trim();
 }
@@ -110,7 +130,12 @@ export function correctionBlockedReason(
   if (spec.shape === "list") {
     const clean = dedupeLabels(draft.list);
     if (spec.maxItems !== undefined && clean.length > spec.maxItems) {
-      return `That's more than the maximum of ${spec.maxItems}.`;
+      // ★THIS CAN BE OUR FAULT, NOT THEIRS, and the copy has to admit it.
+      // `personas` is evidence-built from declared segments plus up to 25
+      // tagged ones against a cap of 20, so a content-rich business opens the
+      // editor already over the limit having done nothing. Blaming the user
+      // for a list we produced is the wrong sentence.
+      return `We can only store ${spec.maxItems} of these — remove ${clean.length - spec.maxItems} to save.`;
     }
     const tooLong = clean.find((v) => v.length > spec.maxLength);
     if (tooLong) return `Keep each one under ${spec.maxLength} characters.`;


### PR DESCRIPTION
**A1.** Before this, `grep -rn "/v1/audiences" src` over this repo returned **zero hits**. The Audience Engine reads a business, classifies it, resolves a servable audience and puts it on every boosted campaign — entirely invisibly. Three things followed, and all three end here: Phase 1's exit criterion (*"the profile is recognisably right, and its errors are correctable"*) was untestable; the correction — §12.4's best-learning-signal-this-engine-will-ever-get — was being discarded daily; and the nine correctable fields A2b shipped had no client at all.

### Why the panel looks like this
A tidy summary would be indistinguishable from a black box guessing. What makes it a strategist is that every line says **where it came from** and **can be told it is wrong**. So every claim carries its evidence tier (you told us / we measured / we inferred), **conflicts are surfaced and never resolved** (and render even while collapsed — a business that says it sells to enterprises while its content addresses freelancers is the most interesting thing the engine noticed), and an unavailable deeper read is said to be unavailable rather than rendered as "you have no ICP".

**The correctable fields come from the server** — shape, length cap, item cap, closed vocabulary, the ISO-2 rule. Hardcoding that list is how a client comes to offer a control the server refuses.

It mounts **above the channel tabs**: the profile is channel-neutral, and inside a panel it would look like a LinkedIn setting. No new route.

---

## Review round 1 found four real defects

**★ One click could manufacture "You told us".** Open a list editor, change nothing, Save — every entry got rewritten as `stated / user_correction`. Four inferred ICPs became four claims the user never made, plus a null delta in the learning log. The server cannot tell a no-op from a correction; only the panel can.

**★ The spec-driven validation this PR advertises was half-built** — `disabled` covered scalars only, so an over-cap list and a country *name* in the ISO-2 field both reached a 400, which the toast layer maps to "permanent" and renders as an **infinite** toast telling the user to contact support with a reference. For typing "India". Reachable: `personas` is built from declared segments plus up to 25 tagged ones, against a `maxItems` of 20.

**★ The evidence badge could attribute one tier's detail to another tier's claim** — and the breaking data is in the server today. A declared-and-then-tagged segment rendered *"You told us — tagged on 12 pieces"*: a measurement presented as the provenance of a stated fact, on a panel whose thesis is that the difference matters.

**★ An open editor was a snapshot nobody reconciled.** A focus refetch, a "Re-read", or `switchBusiness` (which clears the cache without unmounting this panel) each leave an editor holding a list the user can no longer see. After a business switch, saving writes business A's ICP onto business B — the wrong-business bug the server is business-scoped to prevent, reintroduced in the client.

Plus: a background refetch failure discarded a good cached profile; "nothing here yet" was indistinguishable from "the deeper read never ran"; the evidence detail was a mouse-only `title`; no focus management, orphan `<Label>`, placeholder-only accessible names; a draft leaked across field switches; a dark-on-dark warning icon.

**Tests:** the client test was `x => x` with `api.patch` mocked, so it could not prove what its comment claimed. It now says what it can, and the judgement moved to `audience-profile-rules.ts` — tier selection, server-matching dedupe, every validation limit, the no-op check. 24 pure tests, no DOM stack added (this repo is node-only by design; the trade is recorded in the file).

**169 green, tsc clean, eslint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)