### PR TITLE
feat(ads): show the audience a campaign actually has (A3 b2c)

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/audience-card.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-card.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+import { linkedInAdsApi, type ManagedCampaign } from "@/lib/api/linkedin-ads";
+import { audienceClaim, reachLine } from "@/lib/audience-card-rules";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Check, Sparkles } from "lucide-react";
+
+/**
+ * The audience a campaign actually has, said out loud.
+ *
+ * ★THE FIELD THIS READS WAS WRITE-ONLY. mig 208 records who chose a campaign's
+ * audience, on what evidence, and whether a human ever agreed — and until this
+ * card, nothing rendered any of it. The engine had been picking audiences and
+ * labelling them "you can change this" in a comment, to nobody.
+ *
+ * Three states, and conflating any two of them is the failure this exists to
+ * prevent:
+ *
+ *   - AUTO-SELECTED, UNCONFIRMED — ours, nobody has looked. Say so, and offer
+ *     the one-click agreement. This is the state every boosted campaign starts
+ *     in, and the state the 2026-07-30 outage was invisible inside.
+ *   - CONFIRMED / USER-SET — a human decided. Never label a person's own choice
+ *     "auto-selected from your business".
+ *   - UNVERIFIED — the provenance no longer matches the targeting, so we
+ *     genuinely cannot say who chose it. Show the audience, claim nothing.
+ *     "We cannot tell" rendering as "we chose this" is the same class of lie as
+ *     a row claiming an audience the platform does not have.
+ *
+ * `verified` comes from the api because it depends on a fingerprint comparison
+ * the client cannot make.
+ */
+
+/** Business-language attribute names. An unknown attribute renders under its
+ *  own id rather than vanishing — a silent omission would make a narrower
+ *  audience look complete, which is the one thing this card must not do. */
+const ATTRIBUTE_LABEL: Record<string, string> = {
+  geo: "Location",
+  company_industry: "Industry",
+  company_size: "Company size",
+  job_title: "Job title",
+  seniority: "Seniority",
+  job_function: "Job function",
+  member_interest: "Interests",
+  company_name: "Companies",
+  skill: "Skills",
+};
+
+export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
+  const queryClient = useQueryClient();
+  const prov = campaign.targetingProvenance;
+  const origin = campaign.audienceOrigin;
+
+  const confirm = useMutation({
+    mutationFn: () => linkedInAdsApi.confirmAudience(campaign._id),
+    onSuccess: (res) => {
+      toast.success(
+        res.alreadyConfirmed
+          ? "Already noted — thanks."
+          : "Noted. We'll stop calling this one unreviewed.",
+      );
+      void queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+    },
+    onError: (err) => toastUnhandledApiError(err, "record that you approved this audience"),
+  });
+
+  if (!prov?.basis?.length) return null;
+
+  const claim = audienceClaim(origin);
+  const unconfirmed = claim === "auto_unconfirmed";
+  const unverified = claim === "unverified";
+  const reach = reachLine(prov.reach);
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 text-sm">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {unverified ? (
+          // No claim about WHO — we cannot tell, and the honest sentence is the
+          // one that says nothing rather than the one that guesses.
+          <Badge variant="outline">Audience</Badge>
+        ) : unconfirmed ? (
+          <Badge variant="outline" className="gap-1">
+            <Sparkles className="h-3 w-3" />
+            Auto-selected from your business
+          </Badge>
+        ) : (
+          <Badge variant="secondary" className="gap-1">
+            <Check className="h-3 w-3" />
+            {claim === "user_set" ? "You chose this" : "You approved this"}
+          </Badge>
+        )}
+        {reach && <span className="text-xs text-muted-foreground">{reach}</span>}
+      </div>
+
+      <ul className="space-y-1">
+        {prov.basis.map((b) => (
+          <li key={b.attribute} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span className="text-xs text-muted-foreground">
+              {ATTRIBUTE_LABEL[b.attribute] ?? b.attribute}
+            </span>
+            {/* Readable chips, never URNs — "Mumbai", not urn:li:geo:1. */}
+            {b.values.map((v) => (
+              <Badge key={`${b.attribute}:${v}`} variant="outline" className="font-normal">
+                {v}
+              </Badge>
+            ))}
+          </li>
+        ))}
+      </ul>
+
+      {unverified && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          This is what we last recorded. The audience has changed since, so we can&apos;t say who
+          chose the current one — open the audience editor to see it.
+        </p>
+      )}
+
+      {unconfirmed && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <p className="text-xs text-muted-foreground">
+            You can change it — or tell us it&apos;s right and we&apos;ll learn from that.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7"
+            onClick={() => confirm.mutate()}
+            disabled={confirm.isPending}
+          >
+            {confirm.isPending ? "Saving…" : "Looks right"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/ads/_components/audience-card.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-card.tsx
@@ -72,7 +72,13 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
   const claim = audienceClaim(origin);
   const unconfirmed = claim === "auto_unconfirmed";
   const unverified = claim === "unverified";
-  const reach = reachLine(prov.reach);
+  // ★REACH IS SUPPRESSED WHEN WE CANNOT VERIFY THE RECORD. The api $unsets the
+  // engine's reach the moment a human edits an audience, for a reason it states
+  // plainly: "reach is the number a customer divides their budget by, so a
+  // stale one is worse than none". A record that no longer matches the
+  // targeting is exactly that stale number, and rendering it above a paragraph
+  // saying we can't confirm the audience would be the worst of both.
+  const reach = unverified ? null : reachLine(prov.reach);
 
   return (
     // `whitespace-normal`: TableCell's base class sets `whitespace-nowrap` and
@@ -81,9 +87,11 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
     // nine-column table.
     <div className="rounded-md border bg-muted/30 p-3 text-sm whitespace-normal">
       <div className="mb-2 flex flex-wrap items-center gap-2">
-        {unverified ? (
-          // No claim about WHO — we cannot tell, and the honest sentence is the
-          // one that says nothing rather than the one that guesses.
+        {unverified || claim === "unclaimed" ? (
+          // No claim about WHO. For `unverified` we cannot tell; for
+          // `unclaimed` the record IS current and simply nobody has approved
+          // it. Both are honest as a bare label; neither may borrow the other's
+          // sentence.
           <Badge variant="outline">Audience</Badge>
         ) : unconfirmed ? (
           <Badge variant="outline" className="gap-1">
@@ -106,8 +114,17 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
               {ATTRIBUTE_LABEL[b.attribute] ?? b.attribute}
             </span>
             {/* Readable chips, never URNs — "Mumbai", not urn:li:geo:1. */}
-            {b.values.map((v) => (
-              <Badge key={`${b.attribute}:${v}`} variant="outline" className="font-normal">
+            {b.values.map((v, i) => (
+              // Keyed by index as well as value: two distinct URNs can share a
+              // display name (LinkedIn has several "Cambridge"), and the label
+              // is all that survives into the basis.
+              <Badge
+                key={`${b.attribute}:${i}:${v}`}
+                variant="outline"
+                // Badge is `whitespace-nowrap` by default, so a long job title
+                // would overflow the cell the same way the prose did.
+                className="font-normal whitespace-normal"
+              >
                 {v}
               </Badge>
             ))}

--- a/src/app/(site)/dashboard/ads/_components/audience-card.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-card.tsx
@@ -75,7 +75,11 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
   const reach = reachLine(prov.reach);
 
   return (
-    <div className="rounded-md border bg-muted/30 p-3 text-sm">
+    // `whitespace-normal`: TableCell's base class sets `whitespace-nowrap` and
+    // white-space INHERITS, so every paragraph below would render as one
+    // unbreakable line and push a horizontal scrollbar onto the whole
+    // nine-column table.
+    <div className="rounded-md border bg-muted/30 p-3 text-sm whitespace-normal">
       <div className="mb-2 flex flex-wrap items-center gap-2">
         {unverified ? (
           // No claim about WHO — we cannot tell, and the honest sentence is the
@@ -83,12 +87,12 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
           <Badge variant="outline">Audience</Badge>
         ) : unconfirmed ? (
           <Badge variant="outline" className="gap-1">
-            <Sparkles className="h-3 w-3" />
+    <Sparkles className="h-3 w-3" aria-hidden="true" />
             Auto-selected from your business
           </Badge>
         ) : (
           <Badge variant="secondary" className="gap-1">
-            <Check className="h-3 w-3" />
+            <Check className="h-3 w-3" aria-hidden="true" />
             {claim === "user_set" ? "You chose this" : "You approved this"}
           </Badge>
         )}
@@ -113,8 +117,9 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
 
       {unverified && (
         <p className="mt-2 text-xs text-muted-foreground">
-          This is what we last recorded. The audience has changed since, so we can&apos;t say who
-          chose the current one — open the audience editor to see it.
+          This is what we last recorded. We can&apos;t confirm it still describes the campaign&apos;s
+          current audience, so we&apos;re not saying who chose it — open the audience editor to see
+          what it is now.
         </p>
       )}
 

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -488,7 +488,7 @@ function CampaignRow({
   // ★THE AUDIENCE GETS ITS OWN ROW, not a tooltip. It is the thing that decides
   // who sees the ad and where the money goes, and for a year it was recorded in
   // a column nothing rendered. A second row rather than a cell because the
-  // basis is a list of readable chips and this table is already ten columns
+  // basis is a list of readable chips and this table is already nine columns
   // wide.
   const showAudience = Boolean(campaign.targetingProvenance?.basis?.length);
 

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -46,6 +46,7 @@ import {
 import { AdvertisingDeclarationCard } from "@/components/ads/advertising-declaration-card";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { AlertTriangle, Archive, Megaphone, Pause, Play, RefreshCw, Rocket, Target } from "lucide-react";
+import { AudienceCard } from "./audience-card";
 import { TargetingDialog, editorTargeting } from "./targeting-dialog";
 
 /**
@@ -484,9 +485,16 @@ function CampaignRow({
   // object instead — feature-detected by the shared helper).
   const hasAudience =
     (editorTargeting(campaign.targeting)?.facets?.locations?.length ?? 0) > 0;
+  // ★THE AUDIENCE GETS ITS OWN ROW, not a tooltip. It is the thing that decides
+  // who sees the ad and where the money goes, and for a year it was recorded in
+  // a column nothing rendered. A second row rather than a cell because the
+  // basis is a list of readable chips and this table is already ten columns
+  // wide.
+  const showAudience = Boolean(campaign.targetingProvenance?.basis?.length);
 
   return (
-    <TableRow>
+    <>
+    <TableRow className={showAudience ? "border-b-0" : undefined}>
       <TableCell className="max-w-[260px]">
         <p className="truncate text-sm font-medium" title={campaign.name}>
           {campaign.name}
@@ -671,5 +679,15 @@ function CampaignRow({
         </AlertDialog>
       </TableCell>
     </TableRow>
+      {showAudience ? (
+        <TableRow className="hover:bg-transparent">
+          {/* Spans the whole row: the audience describes the campaign, not any
+              one of its numbers. */}
+          <TableCell colSpan={9} className="pt-0">
+            <AudienceCard campaign={campaign} />
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </>
   );
 }

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -97,6 +97,46 @@ export interface ManagedCampaign {
    *  carry a legacy free-form object here instead — always feature-
    *  detect `targeting.facets` before treating it as editor state. */
   targeting?: CampaignTargeting | Record<string, unknown>;
+  /**
+   * WHO chose this audience, on what evidence, and whether a human has ever
+   * looked at it (mig 208).
+   *
+   * ★`confirmedAt` ABSENT is what earns the phrase "auto-selected from your
+   * business — you can change this". The moment it is set, the campaign is a
+   * reviewed one and must stop being described as unreviewed.
+   */
+  targetingProvenance?: {
+    source?: "auto_proposed" | "user_set" | "platform_set";
+    proposedAt?: string;
+    engineVersion?: string;
+    /** Why each attribute is in the audience, in BUSINESS language — "India",
+     *  never `urn:li:geo:1` — with the profile's own evidence tiers. */
+    basis?: Array<{
+      attribute: string;
+      values: string[];
+      evidence: Array<{ tier: "stated" | "observed" | "inferred"; kind: string; detail?: string }>;
+    }>;
+    /** Platform-sourced ONLY. `belowFloor` carries NO number, because
+     *  LinkedIn's `total: 0` means "fewer than 300" — rendering it as
+     *  "0 people" would be a false statement about the customer's market. */
+    reach?: { supported: boolean; value?: number; belowFloor?: boolean; fetchedAt?: string };
+    confirmedAt?: string;
+    confirmedByUserId?: string;
+  };
+  /**
+   * The api's own read of the provenance, derived per request — the UI must
+   * use THIS rather than re-deriving, because `verified` depends on a
+   * fingerprint comparison the client cannot make.
+   */
+  audienceOrigin?: {
+    source: string;
+    confirmed: boolean;
+    /** False when the provenance may no longer describe `targeting`. The UI
+     *  then shows the audience WITHOUT claiming who chose it. */
+    verified: boolean;
+    /** The one flag to act on: ours, and nobody has looked at it yet. */
+    autoSelectedUnconfirmed: boolean;
+  };
   performance?: ManagedCampaignPerformance;
   /**
    * SPEND ALARM — set by the api (derived, never stored) when this campaign
@@ -193,6 +233,21 @@ export const linkedInAdsApi = {
       `/v1/linkedin/ads/targeting/entities?${qs.toString()}`,
     );
   },
+
+  /**
+   * Record that a human read the auto-selected audience and agreed with it.
+   *
+   * Cannot spend and cannot retarget: it sets `confirmedAt` on a row whose
+   * audience LinkedIn already has. It is also the ACCEPTED-as-proposed half of
+   * the learning signal — the targeting PATCH only ever records edits, and an
+   * engine that hears about nothing but its mistakes learns a pessimistic
+   * lesson.
+   */
+  confirmAudience: (id: string) =>
+    api.post<{ campaignId: string; confirmedAt: string; alreadyConfirmed: boolean }>(
+      `/v1/linkedin/ads/managed-campaigns/${id}/confirm-audience`,
+      {},
+    ),
 
   /**
    * Replace a campaign's audience targeting (platform first, then the

--- a/src/lib/audience-card-rules.test.ts
+++ b/src/lib/audience-card-rules.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { reachLine, audienceClaim } from "./audience-card-rules";
+
+/**
+ * The two sentences the audience card is allowed to say about a campaign.
+ * Both have a way of being confidently wrong, and both were unrenderable
+ * before A3 — so what is pinned here is what the card must NEVER claim.
+ */
+
+describe("reachLine — the number a customer divides their budget by", () => {
+  it("★never renders LinkedIn's masked 0 as a number", () => {
+    // `total: 0` means "fewer than 300", not zero. "0 people" would be a false
+    // statement about the customer's market — and the honest sentence predicts
+    // non-delivery, which is worth more than the number would have been.
+    const line = reachLine({ supported: true, belowFloor: true });
+    expect(line).toContain("300");
+    expect(line).not.toMatch(/\b0\b/);
+  });
+
+  it("says the size is unavailable rather than inventing one", () => {
+    expect(reachLine({ supported: false })).toContain("didn't give us");
+    // supported, but no number came back — same honest absence.
+    expect(reachLine({ supported: true })).toContain("didn't give us");
+  });
+
+  it("renders a real number when the platform gave one", () => {
+    expect(reachLine({ supported: true, value: 2_400_000 })).toContain("2,400,000");
+  });
+
+  it("says nothing at all when reach was never fetched", () => {
+    expect(reachLine(undefined)).toBeNull();
+  });
+});
+
+describe("audienceClaim — who chose this", () => {
+  it("★claims nobody when the provenance no longer matches the audience", () => {
+    // "We cannot tell" rendering as "we chose this" is the same class of lie
+    // as a row claiming an audience the platform does not have.
+    expect(
+      audienceClaim({ source: "auto_proposed", confirmed: false, verified: false, autoSelectedUnconfirmed: false }),
+    ).toBe("unverified");
+  });
+
+  it("labels an unlooked-at proposal as ours", () => {
+    expect(
+      audienceClaim({ source: "auto_proposed", confirmed: false, verified: true, autoSelectedUnconfirmed: true }),
+    ).toBe("auto_unconfirmed");
+  });
+
+  it("★never calls a person's own choice auto-selected", () => {
+    expect(
+      audienceClaim({ source: "user_set", confirmed: true, verified: true, autoSelectedUnconfirmed: false }),
+    ).toBe("user_set");
+    expect(
+      audienceClaim({ source: "auto_proposed", confirmed: true, verified: true, autoSelectedUnconfirmed: false }),
+    ).toBe("approved");
+  });
+
+  it("claims nothing when the api sent no reading", () => {
+    expect(audienceClaim(undefined)).toBe("unverified");
+  });
+});

--- a/src/lib/audience-card-rules.test.ts
+++ b/src/lib/audience-card-rules.test.ts
@@ -74,6 +74,11 @@ describe("audienceClaim — who chose this", () => {
     // `platform_set` — an audience targeted in Campaign Manager, which the
     // schema allows — is confirmed by nobody. A fallback that ignored
     // `confirmed` would give it a green check reading "You approved this".
+    //
+    // ★AND IT IS NOT `unverified` EITHER. That bucket's copy says we cannot
+    // confirm the record describes the current audience — which would be false
+    // here, because the api verified exactly that. Two different untrue
+    // sentences are not an improvement on one.
     expect(
       audienceClaim({
         source: "platform_set",
@@ -81,6 +86,12 @@ describe("audienceClaim — who chose this", () => {
         verified: true,
         autoSelectedUnconfirmed: false,
       }),
-    ).toBe("unverified");
+    ).toBe("unclaimed");
+  });
+
+  it("says nothing about the platform's silence being a floor", () => {
+    // `{supported: false, value: 0}` is "LinkedIn told us nothing", not "fewer
+    // than 300 people". Order of checks decides which sentence appears.
+    expect(reachLine({ supported: false, value: 0 })).toContain("didn't give us");
   });
 });

--- a/src/lib/audience-card-rules.test.ts
+++ b/src/lib/audience-card-rules.test.ts
@@ -30,6 +30,16 @@ describe("reachLine — the number a customer divides their budget by", () => {
   it("says nothing at all when reach was never fetched", () => {
     expect(reachLine(undefined)).toBeNull();
   });
+
+  it("★a literal 0 is the floor, never 'About 0 people'", () => {
+    // The api maps LinkedIn's masked total:0 to belowFloor with no number, so
+    // a zero arriving here means something upstream changed — and the sentence
+    // it would have produced is the one this function exists to forbid.
+    // Guarded here rather than trusted from two repos away.
+    const line = reachLine({ supported: true, value: 0 });
+    expect(line).toContain("300");
+    expect(line).not.toContain("About 0");
+  });
 });
 
 describe("audienceClaim — who chose this", () => {
@@ -58,5 +68,19 @@ describe("audienceClaim — who chose this", () => {
 
   it("claims nothing when the api sent no reading", () => {
     expect(audienceClaim(undefined)).toBe("unverified");
+  });
+
+  it("★never puts 'You approved this' on something nobody approved", () => {
+    // `platform_set` — an audience targeted in Campaign Manager, which the
+    // schema allows — is confirmed by nobody. A fallback that ignored
+    // `confirmed` would give it a green check reading "You approved this".
+    expect(
+      audienceClaim({
+        source: "platform_set",
+        confirmed: false,
+        verified: true,
+        autoSelectedUnconfirmed: false,
+      }),
+    ).toBe("unverified");
   });
 });

--- a/src/lib/audience-card-rules.ts
+++ b/src/lib/audience-card-rules.ts
@@ -1,0 +1,52 @@
+import type { ManagedCampaign } from "@/lib/api/linkedin-ads";
+
+/** The claim the audience card is allowed to make about who chose an audience. */
+export type AudienceClaim = "auto_unconfirmed" | "approved" | "user_set" | "unverified";
+
+/**
+ * ★"WE CANNOT TELL" IS ITS OWN ANSWER. `verified` is false when the provenance
+ * fingerprint no longer matches the campaign's targeting, which means the
+ * record may describe an audience that has since been replaced. Rendering that
+ * as "auto-selected from your business" would be the same class of lie as a row
+ * claiming an audience the platform does not have — so it claims nothing, and
+ * the card shows the audience without a byline.
+ *
+ * `verified` is computed by the api because it needs a fingerprint comparison
+ * the client cannot make.
+ */
+export function audienceClaim(origin: ManagedCampaign["audienceOrigin"]): AudienceClaim {
+  if (!origin || !origin.verified) return "unverified";
+  if (origin.autoSelectedUnconfirmed) return "auto_unconfirmed";
+  if (origin.source === "user_set") return "user_set";
+  return "approved";
+}
+
+/**
+ * The reach sentence, or nothing.
+ *
+ * ★LINKEDIN'S `total: 0` MEANS "FEWER THAN 300", so the number is deliberately
+ * absent and `belowFloor` arrives instead. Rendering "0 people" would be a
+ * false statement about the customer's market; saying the campaign will not
+ * deliver is both true and more useful than the number would have been.
+ */
+/**
+ * ★A FIXED LOCALE, not the ambient one. `toLocaleString()` groups by whatever
+ * locale the runtime has — "2,400,000" in Node's default, "24,00,000" under
+ * en-IN — so the same number renders differently on the server and in the
+ * browser, which is a React hydration mismatch on a component that SSRs. The
+ * sibling `formatMoney` passes `undefined` deliberately (a currency belongs in
+ * the reader's own format); a bare count does not have that excuse, and a
+ * number that changes between renders is worse than one grouped unfamiliarly.
+ */
+const REACH_FORMAT = new Intl.NumberFormat("en-US");
+
+export function reachLine(
+  reach: NonNullable<ManagedCampaign["targetingProvenance"]>["reach"],
+): string | null {
+  if (!reach) return null;
+  if (reach.belowFloor) return "Under LinkedIn's 300-member minimum — this won't deliver";
+  if (!reach.supported || typeof reach.value !== "number") {
+    return "LinkedIn didn't give us a size for this audience";
+  }
+  return `About ${REACH_FORMAT.format(reach.value)} people on LinkedIn`;
+}

--- a/src/lib/audience-card-rules.ts
+++ b/src/lib/audience-card-rules.ts
@@ -18,17 +18,15 @@ export function audienceClaim(origin: ManagedCampaign["audienceOrigin"]): Audien
   if (!origin || !origin.verified) return "unverified";
   if (origin.autoSelectedUnconfirmed) return "auto_unconfirmed";
   if (origin.source === "user_set") return "user_set";
-  return "approved";
+  // ★`confirmed` IS READ, and the fallback is not "approved". A
+  // `platform_set` audience — one targeted in Campaign Manager, which the
+  // schema allows — is confirmed by nobody, and falling through would put a
+  // green check reading "You approved this" on a decision no user made.
+  // Nothing writes `platform_set` today; a claim that depends on that staying
+  // true is a claim waiting to become false.
+  return origin.confirmed ? "approved" : "unverified";
 }
 
-/**
- * The reach sentence, or nothing.
- *
- * ★LINKEDIN'S `total: 0` MEANS "FEWER THAN 300", so the number is deliberately
- * absent and `belowFloor` arrives instead. Rendering "0 people" would be a
- * false statement about the customer's market; saying the campaign will not
- * deliver is both true and more useful than the number would have been.
- */
 /**
  * ★A FIXED LOCALE, not the ambient one. `toLocaleString()` groups by whatever
  * locale the runtime has — "2,400,000" in Node's default, "24,00,000" under
@@ -40,11 +38,25 @@ export function audienceClaim(origin: ManagedCampaign["audienceOrigin"]): Audien
  */
 const REACH_FORMAT = new Intl.NumberFormat("en-US");
 
+/**
+ * The reach sentence, or nothing.
+ *
+ * ★LINKEDIN'S `total: 0` MEANS "FEWER THAN 300", so the number is deliberately
+ * absent and `belowFloor` arrives instead. Rendering "0 people" would be a
+ * false statement about the customer's market; saying the campaign will not
+ * deliver is both true and more useful than the number would have been.
+ */
 export function reachLine(
   reach: NonNullable<ManagedCampaign["targetingProvenance"]>["reach"],
 ): string | null {
   if (!reach) return null;
   if (reach.belowFloor) return "Under LinkedIn's 300-member minimum — this won't deliver";
+  // ★A LITERAL ZERO IS TREATED AS THE FLOOR, not printed. The api maps
+  // LinkedIn's masked `total: 0` to `belowFloor` with no number, so a zero
+  // reaching here means something upstream changed — and "About 0 people" is
+  // the exact sentence this function's whole reason for existing forbids.
+  // Guarding it here rather than trusting a convention two repos away.
+  if (reach.value === 0) return "Under LinkedIn's 300-member minimum — this won't deliver";
   if (!reach.supported || typeof reach.value !== "number") {
     return "LinkedIn didn't give us a size for this audience";
   }

--- a/src/lib/audience-card-rules.ts
+++ b/src/lib/audience-card-rules.ts
@@ -1,7 +1,16 @@
 import type { ManagedCampaign } from "@/lib/api/linkedin-ads";
 
 /** The claim the audience card is allowed to make about who chose an audience. */
-export type AudienceClaim = "auto_unconfirmed" | "approved" | "user_set" | "unverified";
+export type AudienceClaim =
+  | "auto_unconfirmed"
+  | "approved"
+  | "user_set"
+  /** We verified the record describes the current audience, but nobody has
+   *  approved it and nobody claims to have chosen it. Distinct from
+   *  `unverified`, whose copy says we cannot confirm the record is current —
+   *  which would be FALSE here, because we did. */
+  | "unclaimed"
+  | "unverified";
 
 /**
  * ★"WE CANNOT TELL" IS ITS OWN ANSWER. `verified` is false when the provenance
@@ -24,7 +33,7 @@ export function audienceClaim(origin: ManagedCampaign["audienceOrigin"]): Audien
   // green check reading "You approved this" on a decision no user made.
   // Nothing writes `platform_set` today; a claim that depends on that staying
   // true is a claim waiting to become false.
-  return origin.confirmed ? "approved" : "unverified";
+  return origin.confirmed ? "approved" : "unclaimed";
 }
 
 /**
@@ -50,6 +59,9 @@ export function reachLine(
   reach: NonNullable<ManagedCampaign["targetingProvenance"]>["reach"],
 ): string | null {
   if (!reach) return null;
+  // Order matters: "the platform told us nothing" outranks any reading of the
+  // number, so `{supported: false, value: 0}` must not claim a floor.
+  if (!reach.supported) return "LinkedIn didn't give us a size for this audience";
   if (reach.belowFloor) return "Under LinkedIn's 300-member minimum — this won't deliver";
   // ★A LITERAL ZERO IS TREATED AS THE FLOOR, not printed. The api maps
   // LinkedIn's masked `total: 0` to `belowFloor` with no number, so a zero
@@ -57,7 +69,7 @@ export function reachLine(
   // the exact sentence this function's whole reason for existing forbids.
   // Guarding it here rather than trusting a convention two repos away.
   if (reach.value === 0) return "Under LinkedIn's 300-member minimum — this won't deliver";
-  if (!reach.supported || typeof reach.value !== "number") {
+  if (typeof reach.value !== "number") {
     return "LinkedIn didn't give us a size for this audience";
   }
   return `About ${REACH_FORMAT.format(reach.value)} people on LinkedIn`;

--- a/src/lib/toast-errors.ts
+++ b/src/lib/toast-errors.ts
@@ -69,6 +69,15 @@ const USER_FIXABLE = new Set([
   "RATE_LIMITED",
   "FORBIDDEN",
   "INVALID_TRANSITION",
+  // ★The api authors an actionable sentence for each of these and, without
+  // this list, none of it reached anyone: a 409 falls through to "permanent",
+  // which renders a non-dismissable "contact support and quote a reference"
+  // toast. Telling a user to open a ticket because their audience moved in
+  // another tab is exactly the failure this file exists to prevent.
+  "PROVENANCE_STALE",
+  "NO_PROVENANCE",
+  "NOT_A_PROPOSAL",
+  "CONFIRM_FAILED",
 ]);
 
 const USER_FIXABLE_COPY: Record<string, string> = {
@@ -78,6 +87,11 @@ const USER_FIXABLE_COPY: Record<string, string> = {
   RATE_LIMITED: "The platform is rate-limiting us — give it a minute and try again.",
   FORBIDDEN: "Pick a business first.",
   INVALID_TRANSITION: "That change isn't possible from the campaign's current state.",
+  PROVENANCE_STALE:
+    "This audience has changed since we described it — reload, or open the audience editor to see what it is now.",
+  NO_PROVENANCE: "There's no audience record on this campaign to approve.",
+  NOT_A_PROPOSAL: "You set this audience yourself, so there's nothing for us to record.",
+  CONFIRM_FAILED: "Couldn't record that just now — try again.",
 };
 
 function dispositionOf(code: string, status: number): Disposition {

--- a/src/lib/toast-errors.ts
+++ b/src/lib/toast-errors.ts
@@ -78,6 +78,11 @@ const USER_FIXABLE = new Set([
   "NO_PROVENANCE",
   "NOT_A_PROPOSAL",
   "CONFIRM_FAILED",
+  // ★AND `NOT_FOUND`, which is the one that would have fired most often. It is
+  // also what `app.onError`'s unknown-route handler returns, so if b2c ships
+  // ahead of the api EVERY click on a new endpoint tells the user to open a
+  // support ticket — a deploy-order hazard, not a hypothetical.
+  "NOT_FOUND",
 ]);
 
 const USER_FIXABLE_COPY: Record<string, string> = {
@@ -92,6 +97,7 @@ const USER_FIXABLE_COPY: Record<string, string> = {
   NO_PROVENANCE: "There's no audience record on this campaign to approve.",
   NOT_A_PROPOSAL: "You set this audience yourself, so there's nothing for us to record.",
   CONFIRM_FAILED: "Couldn't record that just now — try again.",
+  NOT_FOUND: "That's gone — reload the page to see what's there now.",
 };
 
 function dispositionOf(code: string, status: number): Disposition {


### PR DESCRIPTION
**A3's b2c half.** mig 208 records who chose a campaign's audience, on what evidence, and whether a human ever agreed — and **nothing rendered any of it**. The engine had been picking audiences and labelling them "you can change this" in a code comment, to nobody.

Three states, and conflating any two is the failure this exists to prevent: **auto-selected/unconfirmed** (every boosted campaign starts here — the state the 2026-07-30 outage was invisible inside), **confirmed/user-set** (never label a person's own choice "auto-selected"), and **unverified** — the fingerprint no longer matches, so it shows the audience and claims *nothing*. "We cannot tell" rendering as "we chose this" is the same class of lie as a row claiming an audience the platform lacks.

Reach is rendered or honestly absent: LinkedIn masks anything under 300 as `total: 0`, so "0 people" would be a false statement about the customer's market.

### Review round 1
**★ Every failure went to `toastUnhandledApiError`**, and a 409 falls through to "permanent" — a non-dismissable *"contact support and quote reference…"* toast. The api's actionable *"open the audience editor and apply it instead"* reached nobody. **★ `whitespace-nowrap` inherits** from `TableCell`, so the card's paragraphs rendered as unbreakable lines and pushed a horizontal scrollbar onto the whole table. **★ `audienceClaim` never read `confirmed`**, so a `platform_set` audience would show "You approved this" for a decision nobody made. **★ `reachLine` could still say "About 0 people"** — the sentence its own docstring forbids.

Extracting the two sentences into testable rules also caught a **hydration mismatch**: `toLocaleString()` groups by ambient locale, so the same number rendered differently on the server and in the browser.

**182 green, tsc clean, eslint clean.** Pairs with peakhour-api#998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)