### PR TITLE
feat(ads): show the audience before the money, and ask the one question (A4 b2c)

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-preview.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-preview.tsx
@@ -9,7 +9,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { reachLine } from "@/lib/audience-card-rules";
-import { parseCountryCodes, unusableCountryTokens } from "@/lib/audience-preview-rules";
+import {
+  MAX_COUNTRIES,
+  parseCountryCodes,
+  unusableCountryTokens,
+} from "@/lib/audience-preview-rules";
 import { Pencil } from "lucide-react";
 
 /**
@@ -35,27 +39,20 @@ import { Pencil } from "lucide-react";
  * can ask it.
  */
 
-export function AudiencePreview({
-  geo,
-  onGeoChange,
-  onOutcome,
-}: {
-  /** Confirmed ISO-2 codes, or undefined for "use what we inferred". */
-  geo: string[] | undefined;
-  onGeoChange: (next: string[] | undefined) => void;
-  /**
-   * Whether this boost will get an audience at all.
-   *
-   * ★THE DIALOG HAS TO KNOW. Without it the Boost button, the confirm copy and
-   * the success toast are identical whether the campaign gets a real audience
-   * or none — and an untargeted campaign that looks ready is the exact failure
-   * this screen exists to delete.
-   */
-  onOutcome: (willTarget: boolean) => void;
-}) {
-  const [editing, setEditing] = useState<{ draft: string } | null>(null);
-
-  const { data, isLoading, isError } = useQuery<ProposalResponse>({
+/**
+ * The proposal for a given confirmed geography.
+ *
+ * ★A HOOK, SO THE DIALOG CAN READ THE SAME ANSWER. The dialog needs to know
+ * whether the campaign will get an audience at all — the Boost button, its copy
+ * and its success toast are otherwise identical whether targeting was applied
+ * or not, and an untargeted campaign that looks ready is exactly the failure
+ * this screen exists to delete. A callback fired from the child's render would
+ * have been an update to a DIFFERENT component during render, which React warns
+ * about and which has no defensible ordering; react-query shares one cache
+ * entry between the two callers, so this costs no extra request.
+ */
+export function useAudienceProposal(geo: string[] | undefined) {
+  return useQuery<ProposalResponse>({
     // The geography is part of the key: a different confirmation is a
     // different audience, and reusing the cached one would show the user the
     // audience they just changed away from.
@@ -68,19 +65,30 @@ export function AudiencePreview({
     // user has to answer.
     retry: false,
   });
+}
+
+export function AudiencePreview({
+  geo,
+  onGeoChange,
+}: {
+  /** Confirmed ISO-2 codes, or undefined for "use what we inferred". */
+  geo: string[] | undefined;
+  onGeoChange: (next: string[] | undefined) => void;
+}) {
+  const [editing, setEditing] = useState<{ draft: string } | null>(null);
+  const { data, isLoading, isError } = useAudienceProposal(geo);
 
   const proposal = data?.proposal ?? null;
   const refusal = data?.refusal ?? null;
 
-  // Reported during render rather than from an effect (this repo's lint forbids
-  // setState in an effect, and the parent's own state is what changes). The
-  // parent guards on equality, so this cannot loop.
-  onOutcome(proposal !== null);
 
   // ★THE CODES, NOT THE LABELS. `basis[].values` are display names — "India",
   // never "IN" — so seeding them into a two-letter box turned the act of
   // CONFIRMING the inference into an act of deleting it. `geoCodes` is what the
   // audience was actually built from, and only what resolved.
+  // `?? []` is also the DEPLOY-SKEW guard: an api that predates `geoCodes`
+    // sends none, and pre-filling from the labels instead would put "India" in
+    // a two-letter box — the exact defect this field was added to remove.
   const inferredCodes = proposal?.geoCodes ?? [];
 
   // ★SEEDED AT OPEN, not in an effect. The editor's initial text is whatever is
@@ -98,12 +106,21 @@ export function AudiencePreview({
    * they tried to name a country and we could not read it, and treating THAT as
    * the same statement is how confirming an audience came to delete it.
    */
+  const overCap = editing !== null && parseCountryCodes(editing.draft).length >= MAX_COUNTRIES
+    && editing.draft.split(/[,\s]+/).filter((t) => /^[A-Za-z]{2}$/.test(t.trim())).length > MAX_COUNTRIES;
   const blocked =
-    editing !== null && draftCodes.length === 0 && editing.draft.trim().length > 0
-      ? draftUnusable.length > 0
-        ? `We need two-letter country codes — "${draftUnusable[0]}" isn't one. India is IN, Singapore is SG.`
-        : "Use two-letter country codes, like IN or SG."
-      : undefined;
+    editing === null
+      ? undefined
+      : overCap
+        ? // ★NAMED, NOT TRUNCATED. Silently dropping the 26th country is the
+          // same silent narrowing this screen exists to prevent, and neither
+          // the unusable-token hint nor the parser said a word about it.
+          `We can only target ${MAX_COUNTRIES} countries — take some out.`
+        : draftCodes.length === 0 && editing.draft.trim().length > 0
+          ? draftUnusable.length > 0
+            ? `We need two-letter country codes — "${draftUnusable[0]}" isn't one. India is IN, Singapore is SG.`
+            : "Use two-letter country codes, like IN or SG."
+          : undefined;
 
   const apply = () => {
     if (!editing || blocked) return;
@@ -116,16 +133,32 @@ export function AudiencePreview({
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium">Audience</span>
         {editing === null && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2"
-            onClick={openEditor}
-            aria-label="Change the countries this campaign targets"
-          >
-            <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
-          </Button>
+          <div className="flex items-center gap-1">
+            {geo !== undefined && (
+              // The way back to "use what we inferred". Without it, a user who
+              // confirmed a list — or emptied it — had no route back short of
+              // closing the dialog and losing everything else they typed.
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => onGeoChange(undefined)}
+              >
+                Use ours
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2"
+              onClick={openEditor}
+              aria-label="Change the countries this campaign targets"
+            >
+              <Pencil className="size-3.5" aria-hidden="true" />
+            </Button>
+          </div>
         )}
       </div>
 
@@ -200,22 +233,33 @@ export function AudiencePreview({
               aria-describedby={blocked ? "audience-geo-error" : "audience-geo-hint"}
               aria-invalid={blocked !== undefined}
               onKeyDown={(e) => {
-                // Escape closes the EDITOR, not the whole boost dialog — which
-                // would discard the name, budget and duration the user had
-                // already filled in. Enter applies, because a box with one
-                // affirmative action should take the obvious key.
-                if (e.key === "Escape") {
-                  e.stopPropagation();
-                  setEditing(null);
-                }
+                // Enter applies, because a box with one affirmative action
+                // should take the obvious key.
+                //
+                // ⚠️ ESCAPE IS NOT HANDLED HERE, and an earlier version's claim
+                // that it "closes the editor, not the dialog" was false: Radix
+                // listens for Escape with a DOCUMENT-LEVEL CAPTURE listener, so
+                // a bubble-phase stopPropagation never runs first. Escape
+                // closes the whole boost dialog — which is true of every field
+                // in it, not just this one, so Cancel is the exit this editor
+                // documents.
                 if (e.key === "Enter") {
                   e.preventDefault();
                   apply();
                 }
               }}
             />
-            <Button type="button" variant="outline" onClick={apply} disabled={blocked !== undefined}>
-              Use these
+            <Button
+              type="button"
+              variant="outline"
+              onClick={apply}
+              disabled={blocked !== undefined}
+            >
+              {/* ★THE EMPTY CASE SAYS WHAT IT DOES. "Use these" on an empty box
+                  means "create this campaign with no audience", which is a real
+                  thing to want and a terrible thing to do by accident — and the
+                  no_geography refusal literally invites the user to press it. */}
+              {editing.draft.trim().length === 0 ? "Create without an audience" : "Use these"}
             </Button>
             <Button type="button" variant="ghost" onClick={() => setEditing(null)}>
               Cancel

--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-preview.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-preview.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { audiencesApi, type ProposalResponse } from "@/lib/api/audiences";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { reachLine } from "@/lib/audience-card-rules";
+import { parseCountryCodes } from "@/lib/audience-preview-rules";
+import { Pencil } from "lucide-react";
+
+/**
+ * The audience this boost will get, shown BEFORE the money is committed — and
+ * the one inference the user is asked to confirm (decision D13).
+ *
+ * ★WHY GEOGRAPHY IS THE ONLY QUESTION. Objective alone does not determine an
+ * audience, and geography does more work than any other attribute: we cannot
+ * reliably infer it, LinkedIn will not serve without it, and against an
+ * India-first product a wrong guess puts the budget in the wrong hemisphere.
+ * `locale` must never be read as geography — it falls back to "en-US" meaning
+ * *unknown*. So the design's "one question" is deliberately relaxed by exactly
+ * one confirmable fact, and nothing else is asked: no facet picking, no
+ * seniority, no company size.
+ *
+ * ★AND THE CONFIRMATION IS SENT WITH THE BOOST. The parent lifts the confirmed
+ * codes and passes them to `/boost`, which resolves the audience server-side
+ * from the same input — otherwise this screen would show one audience and the
+ * campaign would get another, which is worse than showing nothing at all.
+ *
+ * A refusal is not an error here. "We don't know your country" is a question
+ * for the user, and the api answers 200 with a reason code precisely so this
+ * can ask it.
+ */
+
+export function AudiencePreview({
+  geo,
+  onGeoChange,
+  enabled,
+}: {
+  /** Confirmed ISO-2 codes, or undefined for "use what we inferred". */
+  geo: string[] | undefined;
+  onGeoChange: (next: string[] | undefined) => void;
+  /** False while the dialog is closed — no point asking LinkedIn for a count
+   *  nobody is looking at, and /propose costs a typeahead round trip per
+   *  country plus an audienceCounts call. */
+  enabled: boolean;
+}) {
+  const [editing, setEditing] = useState<{ draft: string } | null>(null);
+
+  const { data, isLoading, isError } = useQuery<ProposalResponse>({
+    // The geography is part of the key: a different confirmation is a
+    // different audience, and reusing the cached one would show the user the
+    // audience they just changed away from.
+    queryKey: ["audience-proposal", geo ?? null],
+    queryFn: () => audiencesApi.propose(geo ? { geo } : {}),
+    enabled,
+    // The answer depends on the business profile and LinkedIn's own counts,
+    // neither of which moves minute to minute.
+    staleTime: 5 * 60_000,
+    // A proposal is a read. Retrying a refusal would just re-ask a question the
+    // user has to answer.
+    retry: false,
+  });
+
+  const proposal = data?.proposal ?? null;
+  const refusal = data?.refusal ?? null;
+
+  const inferredCodes = useMemo(
+    () =>
+      proposal?.basis.find((b) => b.attribute === "geo")?.values ?? [],
+    [proposal],
+  );
+
+  // ★SEEDED AT OPEN, not in an effect. The editor's initial text is whatever is
+  // currently in force — the user's own confirmation if they made one, else
+  // what we inferred — and an effect that re-seeded it while open would
+  // overwrite what they are typing the moment a refetch changed the inference.
+  const openEditor = () => setEditing({ draft: (geo ?? inferredCodes).join(", ") });
+
+  const apply = () => {
+    if (!editing) return;
+    const codes = parseCountryCodes(editing.draft);
+    // An empty box means "none of these", which the api treats as a statement
+    // rather than a fallback — so it is sent as an empty array, not undefined.
+    onGeoChange(codes);
+    setEditing(null);
+  };
+
+  if (!enabled) return null;
+
+  return (
+    <div className="space-y-2 rounded-md border bg-muted/30 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-sm font-medium">Audience</Label>
+        {editing === null && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2"
+            onClick={openEditor}
+            aria-label="Change the countries this campaign targets"
+          >
+            <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+          </Button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-4 w-56" />
+      ) : isError ? (
+        // Not a blocker: the boost builds its own audience server-side, so a
+        // failed PREVIEW must not stop the campaign. Say what we can't do.
+        <p className="text-sm text-muted-foreground">
+          We couldn&apos;t work out the audience just now. Boosting still picks one from your
+          business profile.
+        </p>
+      ) : refusal ? (
+        <p className="text-sm text-muted-foreground">{refusal.message}</p>
+      ) : proposal ? (
+        <>
+          <ul className="space-y-1">
+            {proposal.basis.map((b) => (
+              <li key={b.attribute} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span className="text-xs text-muted-foreground">
+                  {b.attribute === "geo" ? "Where" : "Who"}
+                </span>
+                {b.values.map((v, i) => (
+                  <Badge
+                    key={`${b.attribute}:${i}:${v}`}
+                    variant="outline"
+                    className="font-normal whitespace-normal"
+                  >
+                    {v}
+                  </Badge>
+                ))}
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-muted-foreground">
+            {reachLine(proposal.reach) ?? "We couldn't get a size for this audience"}
+            {geo === undefined && " · inferred from your business — change it if it's wrong"}
+          </p>
+          {proposal.unresolved.length > 0 && (
+            // ★NAMED, NOT DROPPED. A campaign narrower than the profile — one
+            // country of three, no industry qualifier — is a DIFFERENT
+            // audience, and silently is the one way that must not happen.
+            <p className="text-xs text-muted-foreground">
+              We couldn&apos;t use:{" "}
+              {proposal.unresolved.map((u) => u.value).join(", ")}
+            </p>
+          )}
+        </>
+      ) : null}
+
+      {editing !== null && (
+        <div className="space-y-1.5">
+          <Label htmlFor="audience-geo" className="text-xs">
+            Countries — two-letter codes, comma separated
+          </Label>
+          <div className="flex gap-2">
+            <Input
+              id="audience-geo"
+              value={editing.draft}
+              onChange={(e) => setEditing({ draft: e.target.value })}
+              placeholder="IN, SG, AE"
+              autoFocus
+            />
+            <Button type="button" variant="outline" onClick={apply}>
+              Use these
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            This decides where the budget goes, so it&apos;s the one thing we ask you to check.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-preview.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-preview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { audiencesApi, type ProposalResponse } from "@/lib/api/audiences";
 import { Badge } from "@/components/ui/badge";
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { reachLine } from "@/lib/audience-card-rules";
-import { parseCountryCodes } from "@/lib/audience-preview-rules";
+import { parseCountryCodes, unusableCountryTokens } from "@/lib/audience-preview-rules";
 import { Pencil } from "lucide-react";
 
 /**
@@ -38,15 +38,20 @@ import { Pencil } from "lucide-react";
 export function AudiencePreview({
   geo,
   onGeoChange,
-  enabled,
+  onOutcome,
 }: {
   /** Confirmed ISO-2 codes, or undefined for "use what we inferred". */
   geo: string[] | undefined;
   onGeoChange: (next: string[] | undefined) => void;
-  /** False while the dialog is closed — no point asking LinkedIn for a count
-   *  nobody is looking at, and /propose costs a typeahead round trip per
-   *  country plus an audienceCounts call. */
-  enabled: boolean;
+  /**
+   * Whether this boost will get an audience at all.
+   *
+   * ★THE DIALOG HAS TO KNOW. Without it the Boost button, the confirm copy and
+   * the success toast are identical whether the campaign gets a real audience
+   * or none — and an untargeted campaign that looks ready is the exact failure
+   * this screen exists to delete.
+   */
+  onOutcome: (willTarget: boolean) => void;
 }) {
   const [editing, setEditing] = useState<{ draft: string } | null>(null);
 
@@ -56,7 +61,6 @@ export function AudiencePreview({
     // audience they just changed away from.
     queryKey: ["audience-proposal", geo ?? null],
     queryFn: () => audiencesApi.propose(geo ? { geo } : {}),
-    enabled,
     // The answer depends on the business profile and LinkedIn's own counts,
     // neither of which moves minute to minute.
     staleTime: 5 * 60_000,
@@ -68,11 +72,16 @@ export function AudiencePreview({
   const proposal = data?.proposal ?? null;
   const refusal = data?.refusal ?? null;
 
-  const inferredCodes = useMemo(
-    () =>
-      proposal?.basis.find((b) => b.attribute === "geo")?.values ?? [],
-    [proposal],
-  );
+  // Reported during render rather than from an effect (this repo's lint forbids
+  // setState in an effect, and the parent's own state is what changes). The
+  // parent guards on equality, so this cannot loop.
+  onOutcome(proposal !== null);
+
+  // ★THE CODES, NOT THE LABELS. `basis[].values` are display names — "India",
+  // never "IN" — so seeding them into a two-letter box turned the act of
+  // CONFIRMING the inference into an act of deleting it. `geoCodes` is what the
+  // audience was actually built from, and only what resolved.
+  const inferredCodes = proposal?.geoCodes ?? [];
 
   // ★SEEDED AT OPEN, not in an effect. The editor's initial text is whatever is
   // currently in force — the user's own confirmation if they made one, else
@@ -80,21 +89,32 @@ export function AudiencePreview({
   // overwrite what they are typing the moment a refetch changed the inference.
   const openEditor = () => setEditing({ draft: (geo ?? inferredCodes).join(", ") });
 
+  const draftCodes = editing ? parseCountryCodes(editing.draft) : [];
+  const draftUnusable = editing ? unusableCountryTokens(editing.draft) : [];
+  /**
+   * ★AN EMPTY BOX AND AN UNREADABLE BOX ARE NOT THE SAME ANSWER. Empty means
+   * "none of these", which the api treats as a statement and which produces an
+   * untargeted campaign — a real thing a user may want to say. "India" means
+   * they tried to name a country and we could not read it, and treating THAT as
+   * the same statement is how confirming an audience came to delete it.
+   */
+  const blocked =
+    editing !== null && draftCodes.length === 0 && editing.draft.trim().length > 0
+      ? draftUnusable.length > 0
+        ? `We need two-letter country codes — "${draftUnusable[0]}" isn't one. India is IN, Singapore is SG.`
+        : "Use two-letter country codes, like IN or SG."
+      : undefined;
+
   const apply = () => {
-    if (!editing) return;
-    const codes = parseCountryCodes(editing.draft);
-    // An empty box means "none of these", which the api treats as a statement
-    // rather than a fallback — so it is sent as an empty array, not undefined.
-    onGeoChange(codes);
+    if (!editing || blocked) return;
+    onGeoChange(draftCodes);
     setEditing(null);
   };
-
-  if (!enabled) return null;
 
   return (
     <div className="space-y-2 rounded-md border bg-muted/30 p-3">
       <div className="flex items-center justify-between gap-2">
-        <Label className="text-sm font-medium">Audience</Label>
+        <span className="text-sm font-medium">Audience</span>
         {editing === null && (
           <Button
             type="button"
@@ -115,8 +135,8 @@ export function AudiencePreview({
         // Not a blocker: the boost builds its own audience server-side, so a
         // failed PREVIEW must not stop the campaign. Say what we can't do.
         <p className="text-sm text-muted-foreground">
-          We couldn&apos;t work out the audience just now. Boosting still picks one from your
-          business profile.
+          We couldn&apos;t work out the audience just now, so we can&apos;t show you what this
+          campaign would target.
         </p>
       ) : refusal ? (
         <p className="text-sm text-muted-foreground">{refusal.message}</p>
@@ -142,7 +162,16 @@ export function AudiencePreview({
           </ul>
           <p className="text-xs text-muted-foreground">
             {reachLine(proposal.reach) ?? "We couldn't get a size for this audience"}
-            {geo === undefined && " · inferred from your business — change it if it's wrong"}
+            {geo === undefined &&
+              // ★"INFERRED" ONLY WHEN IT WAS. The geography usually comes from
+              // the business record or the user's own correction, both of which
+              // are STATED — calling a customer's typed fact a guess is the
+              // opposite of what the evidence tiers are for.
+              (proposal.basis
+                .find((b) => b.attribute === "geo")
+                ?.evidence.some((e) => e.tier === "stated")
+                ? " · from your business profile — change it if it's wrong"
+                : " · our best guess — change it if it's wrong")}
           </p>
           {proposal.unresolved.length > 0 && (
             // ★NAMED, NOT DROPPED. A campaign narrower than the profile — one
@@ -168,14 +197,43 @@ export function AudiencePreview({
               onChange={(e) => setEditing({ draft: e.target.value })}
               placeholder="IN, SG, AE"
               autoFocus
+              aria-describedby={blocked ? "audience-geo-error" : "audience-geo-hint"}
+              aria-invalid={blocked !== undefined}
+              onKeyDown={(e) => {
+                // Escape closes the EDITOR, not the whole boost dialog — which
+                // would discard the name, budget and duration the user had
+                // already filled in. Enter applies, because a box with one
+                // affirmative action should take the obvious key.
+                if (e.key === "Escape") {
+                  e.stopPropagation();
+                  setEditing(null);
+                }
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  apply();
+                }
+              }}
             />
-            <Button type="button" variant="outline" onClick={apply}>
+            <Button type="button" variant="outline" onClick={apply} disabled={blocked !== undefined}>
               Use these
             </Button>
+            <Button type="button" variant="ghost" onClick={() => setEditing(null)}>
+              Cancel
+            </Button>
           </div>
-          <p className="text-xs text-muted-foreground">
-            This decides where the budget goes, so it&apos;s the one thing we ask you to check.
-          </p>
+          {blocked ? (
+            <p id="audience-geo-error" className="text-xs text-destructive" aria-live="polite">
+              {blocked}
+            </p>
+          ) : (
+            <p id="audience-geo-hint" className="text-xs text-muted-foreground">
+              This decides where the budget goes, so it&apos;s the one thing we ask you to check.
+              {draftUnusable.length > 0 &&
+                ` We'll ignore: ${draftUnusable.join(", ")}.`}
+              {editing !== null && editing.draft.trim().length === 0 &&
+                " Leave it empty to tell us none of these — the campaign will be created without an audience."}
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -45,7 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Rocket } from "lucide-react";
-import { AudiencePreview } from "./audience-preview";
+import { AudiencePreview, useAudienceProposal } from "./audience-preview";
 
 /**
  * Boost-to-Campaign dialog (G1) — turns a ranked organic post into a
@@ -107,11 +107,24 @@ export function BoostCampaignDialog({
    * the two differently.
    */
   const [geo, setGeo] = useState<string[] | undefined>(undefined);
-  /** Whether the engine could actually build an audience for this boost. The
-   *  campaign is still creatable without one — that is deliberate, /boost never
-   *  fails over a missing audience — but the user must not be told a campaign
-   *  is ready when LinkedIn will refuse to deliver it. */
-  const [willTarget, setWillTarget] = useState(true);
+  /**
+   * Whether the engine could actually build an audience for this boost.
+   *
+   * Read from the SAME query the preview renders (react-query shares the cache,
+   * so there is one request) rather than reported up by a callback: a child
+   * setting a parent's state during render is an update to a different
+   * component mid-render, and the value is derived data that never needed to be
+   * state at all. The campaign is still creatable without an audience — /boost
+   * deliberately never fails over one — but the user must not be told a
+   * campaign is ready when LinkedIn will refuse to deliver it.
+   */
+  const proposal = useAudienceProposal(geo);
+  // ★A FAILED PREVIEW SAYS NOTHING ABOUT THE CAMPAIGN. `/boost` re-resolves the
+  // audience server-side, so a 502 on `/propose` has no bearing on whether the
+  // campaign gets targeting — and warning that it will not would be two
+  // contradictory sentences 40px apart, with the frightening one wrong.
+  const willTarget =
+    proposal.isPending || proposal.isError || proposal.data?.proposal != null;
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
@@ -382,13 +395,7 @@ export function BoostCampaignDialog({
 
           {/* The audience this boost will get, BEFORE the money is committed —
               and the single inference the user is asked to confirm. */}
-          <AudiencePreview
-            geo={geo}
-            onGeoChange={setGeo}
-            // Guarded on inequality: the child reports during render, and an
-            // unconditional setState there would loop.
-            onOutcome={(next) => setWillTarget((prev) => (prev === next ? prev : next))}
-          />
+          <AudiencePreview geo={geo} onGeoChange={setGeo} />
           {!willTarget && (
             <p className="text-xs text-muted-foreground">
               We can&apos;t build an audience for this one, so the campaign will be created without

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -107,6 +107,11 @@ export function BoostCampaignDialog({
    * the two differently.
    */
   const [geo, setGeo] = useState<string[] | undefined>(undefined);
+  /** Whether the engine could actually build an audience for this boost. The
+   *  campaign is still creatable without one — that is deliberate, /boost never
+   *  fails over a missing audience — but the user must not be told a campaign
+   *  is ready when LinkedIn will refuse to deliver it. */
+  const [willTarget, setWillTarget] = useState(true);
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
@@ -377,7 +382,19 @@ export function BoostCampaignDialog({
 
           {/* The audience this boost will get, BEFORE the money is committed —
               and the single inference the user is asked to confirm. */}
-          <AudiencePreview geo={geo} onGeoChange={setGeo} enabled={open} />
+          <AudiencePreview
+            geo={geo}
+            onGeoChange={setGeo}
+            // Guarded on inequality: the child reports during render, and an
+            // unconditional setState there would loop.
+            onOutcome={(next) => setWillTarget((prev) => (prev === next ? prev : next))}
+          />
+          {!willTarget && (
+            <p className="text-xs text-muted-foreground">
+              We can&apos;t build an audience for this one, so the campaign will be created without
+              targeting — LinkedIn won&apos;t deliver it until you set one from the Ads Manager.
+            </p>
+          )}
 
           <div className="grid grid-cols-3 gap-3">
             <div className="space-y-1.5">

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -45,6 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Rocket } from "lucide-react";
+import { AudiencePreview } from "./audience-preview";
 
 /**
  * Boost-to-Campaign dialog (G1) — turns a ranked organic post into a
@@ -99,6 +100,13 @@ export function BoostCampaignDialog({
   const queryClient = useQueryClient();
   const [name, setName] = useState(defaultName);
   const [objective, setObjective] = useState<BoostObjective>("engagement");
+  /**
+   * Decision D13's confirmed geography. `undefined` means "use what we inferred
+   * from the business", which is the default and today's behaviour; an array —
+   * INCLUDING an empty one — is the user's own statement, and `/boost` treats
+   * the two differently.
+   */
+  const [geo, setGeo] = useState<string[] | undefined>(undefined);
   const [dailyBudget, setDailyBudget] = useState("10");
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationDays, setDurationDays] = useState("14");
@@ -170,6 +178,10 @@ export function BoostCampaignDialog({
         currencyCode: currencyCode.trim().toUpperCase(),
         durationDays: durationNumber,
         notPolitical: vars.notPolitical,
+        // Sent so the campaign gets the audience the preview showed. Without
+        // it the boost would resolve from the profile's own countries and the
+        // preview would be a lie about its own effect.
+        ...(geo !== undefined ? { geo } : {}),
       }),
     onSuccess: async (_data, vars) => {
       // The Ads Manager list must show the new campaign even within
@@ -362,6 +374,10 @@ export function BoostCampaignDialog({
               </SelectContent>
             </Select>
           </div>
+
+          {/* The audience this boost will get, BEFORE the money is committed —
+              and the single inference the user is asked to confirm. */}
+          <AudiencePreview geo={geo} onGeoChange={setGeo} enabled={open} />
 
           <div className="grid grid-cols-3 gap-3">
             <div className="space-y-1.5">

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -138,6 +138,38 @@ export interface CorrectionInput {
   toList?: string[];
 }
 
+/** What the engine would target, without writing anything. */
+export interface ProposalResponse {
+  proposal: {
+    /** Platform-native criteria — opaque here; the campaign gets its own copy. */
+    criteria: Record<string, unknown>;
+    facets: Record<string, string[]>;
+    labels: Record<string, string>;
+    /** Why each attribute is in the audience, in business language. */
+    basis: Array<{
+      attribute: string;
+      values: string[];
+      evidence: Array<{ tier: EvidenceTier; kind: string; detail?: string }>;
+    }>;
+    /** Platform-sourced only; `belowFloor` carries NO number. */
+    reach?: { supported: boolean; value?: number; belowFloor?: boolean; fetchedAt?: string };
+    /** What we wanted to express and could not — surfaced, never dropped. */
+    unresolved: Array<{ attribute: string; value: string; reason: string }>;
+  } | null;
+  /** A refusal is a 200 with a REASON, because "we don't know your country" is
+   *  a question for the user rather than a failure of the request. */
+  refusal: {
+    reason:
+      | "no_profile"
+      | "no_geography"
+      | "geo_unresolved"
+      | "platform_unsupported"
+      | "registry_empty"
+      | "not_servable";
+    message: string;
+  } | null;
+}
+
 export const audiencesApi = {
   /** What we understand about this business. `profile: null` is a first-class
    *  answer — nobody has asked for audiences yet — not an error. */
@@ -151,6 +183,17 @@ export const audiencesApi = {
   /** Corrections are APPENDED to a log, never written over the field: the
    *  delta is what teaches the engine, and storing only the result would let a
    *  later rebuild silently revert it. */
+  /**
+   * What we WOULD target, resolved against the platform with a real reach
+   * number. Read-only: it writes nothing and touches no campaign.
+   *
+   * `geo` is decision D13's confirmed geography. Omitting it means "use what
+   * the profile says"; sending an EMPTY array is the user saying none of these,
+   * and the api treats the two differently.
+   */
+  propose: (body: { geo?: string[] } = {}) =>
+    api.post<ProposalResponse>("/v1/audiences/propose", body),
+
   correctProfile: (corrections: CorrectionInput[]) =>
     api.patch<{ profile: AudienceProfile }>("/v1/audiences/profile", { corrections }),
 };

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -157,7 +157,7 @@ export interface ProposalResponse {
      *  `basis`, whose values are display labels ("India", never "IN"). A
      *  client that pre-fills a codes box from the labels turns confirming the
      *  inference into deleting it. */
-    geoCodes: string[];
+    geoCodes?: string[];
     /** What we wanted to express and could not — surfaced, never dropped. */
     unresolved: Array<{ attribute: string; value: string; reason: string }>;
   } | null;

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -153,6 +153,11 @@ export interface ProposalResponse {
     }>;
     /** Platform-sourced only; `belowFloor` carries NO number. */
     reach?: { supported: boolean; value?: number; belowFloor?: boolean; fetchedAt?: string };
+    /** ★The ISO-2 codes this audience was built from — NOT derivable from
+     *  `basis`, whose values are display labels ("India", never "IN"). A
+     *  client that pre-fills a codes box from the labels turns confirming the
+     *  inference into deleting it. */
+    geoCodes: string[];
     /** What we wanted to express and could not — surfaced, never dropped. */
     unresolved: Array<{ attribute: string; value: string; reason: string }>;
   } | null;

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -171,6 +171,11 @@ export interface BoostCampaignInput {
   postUrn: string;
   name: string;
   objective: BoostObjective;
+  /** Decision D13's CONFIRMED geography, ISO-3166 alpha-2. Absent = use what
+   *  the business profile says. An EMPTY array is the user's own statement
+   *  ("none of these") and the api treats the two differently — so the audience
+   *  the preview showed is the audience the campaign gets. */
+  geo?: string[];
   dailyBudget: number;
   /** Must match the ad account's billing currency — the server rejects
    *  a mismatch with code CURRENCY_MISMATCH naming the expected code. */

--- a/src/lib/audience-preview-rules.test.ts
+++ b/src/lib/audience-preview-rules.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { parseCountryCodes, unusableCountryTokens } from "./audience-preview-rules";
+
+describe("parseCountryCodes", () => {
+  it("★a cleared box is 'none of these', not 'use your guess'", () => {
+    // The api distinguishes an ABSENT geo from an EMPTY one. Returning
+    // undefined here would hand the user back the inference they just deleted.
+    expect(parseCountryCodes("")).toEqual([]);
+    expect(parseCountryCodes("   ")).toEqual([]);
+  });
+
+  it("uppercases, dedupes and accepts spaces or commas", () => {
+    expect(parseCountryCodes("in, sg IN,ae")).toEqual(["IN", "SG", "AE"]);
+  });
+
+  it("drops what the api would reject rather than sending it", () => {
+    expect(parseCountryCodes("IN, India, S, SGP, AE")).toEqual(["IN", "AE"]);
+  });
+
+  it("caps at the server's own limit", () => {
+    const many = Array.from({ length: 40 }, (_, i) =>
+      String.fromCharCode(65 + Math.floor(i / 26)) + String.fromCharCode(65 + (i % 26)),
+    ).join(",");
+    expect(parseCountryCodes(many)).toHaveLength(25);
+  });
+});
+
+describe("unusableCountryTokens", () => {
+  it("names what was dropped, so a silent loss is impossible", () => {
+    expect(unusableCountryTokens("IN, India, SGP")).toEqual(["India", "SGP"]);
+  });
+
+  it("says nothing when everything was usable", () => {
+    expect(unusableCountryTokens("IN, sg")).toEqual([]);
+  });
+});

--- a/src/lib/audience-preview-rules.test.ts
+++ b/src/lib/audience-preview-rules.test.ts
@@ -17,7 +17,12 @@ describe("parseCountryCodes", () => {
     expect(parseCountryCodes("IN, India, S, SGP, AE")).toEqual(["IN", "AE"]);
   });
 
-  it("caps at the server's own limit", () => {
+  it("★caps at the limit BOTH routes accept", () => {
+    // The preview and the boost resolve the same audience from the same list.
+    // While /propose capped at 10 and /boost at 25, confirming eleven countries
+    // gave a 400 from one and a working campaign from the other — and this
+    // test, asserting 25, certified the mismatch rather than catching it. Both
+    // are 25 now.
     const many = Array.from({ length: 40 }, (_, i) =>
       String.fromCharCode(65 + Math.floor(i / 26)) + String.fromCharCode(65 + (i % 26)),
     ).join(",");
@@ -25,12 +30,37 @@ describe("parseCountryCodes", () => {
   });
 });
 
-describe("unusableCountryTokens", () => {
-  it("names what was dropped, so a silent loss is impossible", () => {
+describe("unusableCountryTokens — wired into the editor, not decorative", () => {
+  it("★names what was dropped, which the editor shows", () => {
+    // This was exported and imported by nobody, so the module's promise that a
+    // silent loss is impossible was false: the UI dropped every unusable token
+    // without a word. The editor now blocks on it or names it.
     expect(unusableCountryTokens("IN, India, SGP")).toEqual(["India", "SGP"]);
   });
 
   it("says nothing when everything was usable", () => {
     expect(unusableCountryTokens("IN, sg")).toEqual([]);
+  });
+});
+
+describe("the distinction the editor has to make", () => {
+  it("★an EMPTY box and an UNREADABLE box are different answers", () => {
+    // Empty is "none of these", a real statement that produces an untargeted
+    // campaign. "India" is somebody naming a country we could not read — and
+    // treating them the same is how confirming an audience came to delete it.
+    expect(parseCountryCodes("")).toEqual([]);
+    expect(unusableCountryTokens("")).toEqual([]);
+
+    expect(parseCountryCodes("India")).toEqual([]);
+    expect(unusableCountryTokens("India")).toEqual(["India"]);
+  });
+
+  it("a full country name never silently becomes 'none of these'", () => {
+    // The default path: the box is pre-filled, the user agrees, presses the one
+    // affirmative button. If that produced [] the audience would be deleted by
+    // the act of confirming it.
+    const typed = "India, Singapore";
+    expect(parseCountryCodes(typed)).toEqual([]);
+    expect(unusableCountryTokens(typed).length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/audience-preview-rules.test.ts
+++ b/src/lib/audience-preview-rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCountryCodes, unusableCountryTokens } from "./audience-preview-rules";
+import { MAX_COUNTRIES, parseCountryCodes, unusableCountryTokens } from "./audience-preview-rules";
 
 describe("parseCountryCodes", () => {
   it("★a cleared box is 'none of these', not 'use your guess'", () => {
@@ -17,7 +17,11 @@ describe("parseCountryCodes", () => {
     expect(parseCountryCodes("IN, India, S, SGP, AE")).toEqual(["IN", "AE"]);
   });
 
-  it("★caps at the limit BOTH routes accept", () => {
+  it("caps at the limit both routes accept", () => {
+    // ⚠️ This asserts the CLIENT's constant only. Nothing here can see either
+    // route's zod, so if /propose regressed to 10 this would stay green — the
+    // cross-check lives in the api's own tests, and saying so is better than
+    // implying this file guards it.
     // The preview and the boost resolve the same audience from the same list.
     // While /propose capped at 10 and /boost at 25, confirming eleven countries
     // gave a 400 from one and a working campaign from the other — and this
@@ -55,12 +59,26 @@ describe("the distinction the editor has to make", () => {
     expect(unusableCountryTokens("India")).toEqual(["India"]);
   });
 
-  it("a full country name never silently becomes 'none of these'", () => {
-    // The default path: the box is pre-filled, the user agrees, presses the one
-    // affirmative button. If that produced [] the audience would be deleted by
-    // the act of confirming it.
+  it("a full country name is DISTINGUISHABLE from an empty box", () => {
+    // Both parse to [], and the editor must not treat them the same: empty is
+    // "none of these", a real statement, while "India, Singapore" is somebody
+    // naming countries we could not read. The parser cannot tell them apart on
+    // its own — `unusableCountryTokens` is what the editor blocks on, and this
+    // pins that the two inputs differ THERE.
     const typed = "India, Singapore";
-    expect(parseCountryCodes(typed)).toEqual([]);
-    expect(unusableCountryTokens(typed).length).toBeGreaterThan(0);
+    expect(parseCountryCodes(typed)).toEqual(parseCountryCodes(""));
+    expect(unusableCountryTokens(typed)).not.toEqual(unusableCountryTokens(""));
+  });
+
+  it("★names the 26th country instead of dropping it", () => {
+    // 26 well-formed codes are all "usable", so the unusable-token hint says
+    // nothing — the editor has to block on the COUNT, or a country vanishes
+    // with no word at all.
+    const codes = Array.from({ length: 26 }, (_, i) =>
+      String.fromCharCode(65 + Math.floor(i / 26)) + String.fromCharCode(65 + (i % 26)),
+    );
+    expect(unusableCountryTokens(codes.join(","))).toEqual([]);
+    expect(parseCountryCodes(codes.join(","))).toHaveLength(MAX_COUNTRIES);
+    expect(codes.length).toBeGreaterThan(MAX_COUNTRIES);
   });
 });

--- a/src/lib/audience-preview-rules.ts
+++ b/src/lib/audience-preview-rules.ts
@@ -1,0 +1,33 @@
+/**
+ * Parsing the one input the audience preview asks for.
+ *
+ * ★AN EMPTY RESULT IS A STATEMENT, NOT A MISSING ANSWER. The api distinguishes
+ * an ABSENT `geo` ("use what the profile says") from an EMPTY one ("none of
+ * these"), and treating a cleared box as absent would hand the user back the
+ * guess they had just rejected — the same explicitly-empty rule the proposer
+ * applies server-side. So this always returns an array.
+ */
+export function parseCountryCodes(input: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input.split(/[,\s]+/)) {
+    const code = raw.trim().toUpperCase();
+    // Two letters or nothing. The api rejects anything else, and refusing here
+    // means the user does not learn that from a 400.
+    if (!/^[A-Z]{2}$/.test(code)) continue;
+    if (seen.has(code)) continue;
+    seen.add(code);
+    out.push(code);
+  }
+  // The server caps a boost's geo at 25.
+  return out.slice(0, 25);
+}
+
+/** What the user typed that we could not use — so the box can say so rather
+ *  than silently dropping half of it. */
+export function unusableCountryTokens(input: string): string[] {
+  return input
+    .split(/[,\s]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0 && !/^[A-Za-z]{2}$/.test(t));
+}

--- a/src/lib/audience-preview-rules.ts
+++ b/src/lib/audience-preview-rules.ts
@@ -7,6 +7,11 @@
  * guess they had just rejected — the same explicitly-empty rule the proposer
  * applies server-side. So this always returns an array.
  */
+/** What both `/propose` and `/boost` accept. The proposer may use FEWER — its
+ *  own cap comes from the capability registry and is editable at runtime — so
+ *  it reports the overflow rather than this pretending to know. */
+export const MAX_COUNTRIES = 25;
+
 export function parseCountryCodes(input: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
@@ -19,8 +24,11 @@ export function parseCountryCodes(input: string): string[] {
     seen.add(code);
     out.push(code);
   }
-  // The server caps a boost's geo at 25.
-  return out.slice(0, 25);
+  // Truncation here is a LAST RESORT, not the user-facing rule: the editor
+  // blocks and says so before it can happen, because silently dropping the
+  // 26th country is the same quiet narrowing this whole screen exists to
+  // prevent.
+  return out.slice(0, MAX_COUNTRIES);
 }
 
 /** What the user typed that we could not use — so the box can say so rather


### PR DESCRIPTION
**A4's b2c half.** `POST /v1/audiences/propose` had existed since api#981 with **no client**: the boost dialog committed a budget to an audience the user never saw, and the engine's one honest question — which country — was never asked.

Nothing else is asked. No facet picking, no seniority, no company size. The confirmation is sent with the boost, so the audience shown is the audience created.

### Two review rounds, nine confirmed defects
**★ The default path destroyed the audience.** The editor seeded display labels into a codes-only box, so opening it to *check* the inference and pressing the one affirmative button sent "India" → parsed to nothing → read as "none of these" → **untargeted campaign, with a success toast**. The 2026-07-30 shape, reintroduced through the screen built to delete it.

**★ The child updated the parent during render**, and on the first frame told the user the campaign would have no targeting *while the skeleton was still spinning*. **★ A failed preview claimed the campaign would be untargeted** — two contradictory sentences 40px apart, the frightening one wrong. **★ The 26th country vanished without a word.** **★ The Escape comment was false** — Radix captures at the document, so Escape closed the whole dialog and discarded everything typed.

Plus: `unusableCountryTokens` was exported and imported by nobody, so the module's promise that "a silent loss is impossible" was false; the dialog could not tell whether the campaign would get an audience at all; "inferred from your business" called the user's own typed fact a guess.

**192 green, tsc clean, eslint clean.**

⚠️ **Deploy order: peakhour-api#1000 must ship first.** It adds `geoCodes` and the `/boost` `geo` field; without them the editor pre-fills from labels again and `/boost` silently strips the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)