### PR TITLE
feat(peaks): a wallet page you can actually buy from

### DIFF
--- a/src/app/(site)/dashboard/peaks/page.tsx
+++ b/src/app/(site)/dashboard/peaks/page.tsx
@@ -256,10 +256,14 @@ function BuyPeaks() {
           toast.success(
             res.credits ? `${res.credits.toLocaleString()} Peaks added.` : "Your Peaks have been added.",
           );
-        } else if (res.reason === "not_found") {
-          // The id isn't a pack session of ours. Saying "payment received"
-          // for any `cs_…` in the address bar would be an affirmative money
-          // claim we cannot support.
+        } else if (res.reason !== "pending") {
+          // ★ALLOWLIST, not a denylist. Only "pending" means "this really is
+          // your purchase and the money is still settling". Everything else —
+          // a retrieve that threw, a session that isn't ours, Stripe unwired,
+          // or a charge nobody credited — establishes nothing, and an
+          // affirmative money claim is the wrong default when we don't know.
+          // Reporting the benign case by elimination is how
+          // `?session_id=cs_anything` came to say "Payment received".
           void 0;
         } else {
           // NOT silence. `credited:false` means the session is still finalising

--- a/src/app/(site)/dashboard/peaks/page.tsx
+++ b/src/app/(site)/dashboard/peaks/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import { Zap, History, ArrowUpRight, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
 import {
   Sheet,
   SheetContent,
@@ -22,6 +24,8 @@ import {
 } from "@/components/ui/table";
 import Link from "next/link";
 import { useCreditsBalance, useCreditsRateCard, useCreditsHistory } from "@/hooks/use-credits";
+import { usePeaksPacks, buyPack, confirmPackPurchase } from "@/hooks/use-peaks-packs";
+import { PaymentModal, type CheckoutResult } from "@/components/upgrade/payment-modal";
 
 // ── Formatting helpers ────────────────────────────────────────────────────
 
@@ -100,6 +104,131 @@ function UsageHistorySheet({ open, onOpenChange }: { open: boolean; onOpenChange
         </div>
       </SheetContent>
     </Sheet>
+  );
+}
+
+// ── Buy more Peaks ─────────────────────────────────────────────────────────
+
+/** Card-level copy when nothing is buyable, so the section leads with one
+ *  message and a way forward instead of repeating itself per pack. */
+function blockedCopy(reason: "plan_required" | "unlimited" | null): string | null {
+  if (reason === "unlimited") return "Your plan already includes unlimited Peaks.";
+  if (reason === "plan_required") return "Peaks packs need an active paid plan.";
+  return null;
+}
+
+function BuyPeaks() {
+  const qc = useQueryClient();
+  const search = useSearchParams();
+  const { data, isLoading } = usePeaksPacks();
+  const [checkout, setCheckout] = useState<CheckoutResult | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  // The pack a link-out asked for (Shopify and the WordPress plugin both send
+  // `?pack=`), highlighted so a merchant who already chose doesn't have to
+  // choose again.
+  const wanted = search.get("pack");
+
+  // Stripe returns the buyer here with `?purchase=success&session_id=cs_…`.
+  // Confirm synchronously so the new Peaks are visible on this paint rather
+  // than whenever the webhook happens to land. Runs ONCE per session id.
+  const confirmed = useRef<string | null>(null);
+  useEffect(() => {
+    const sessionId = search.get("session_id");
+    if (!sessionId || confirmed.current === sessionId) return;
+    confirmed.current = sessionId;
+    void (async () => {
+      try {
+        const res = await confirmPackPurchase(sessionId);
+        if (res.credited) {
+          toast.success(
+            res.credits ? `${res.credits.toLocaleString()} Peaks added.` : "Your Peaks have been added.",
+          );
+        }
+      } catch {
+        // The webhook is the backstop — never turn a successful payment into an
+        // error message on the buyer's return page.
+      } finally {
+        void qc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] });
+      }
+    })();
+  }, [search, qc]);
+
+  const start = async (packKey: string) => {
+    setBusyKey(packKey);
+    try {
+      setCheckout(await buyPack(packKey));
+    } catch {
+      toast.error("We couldn't start checkout. Please try again.");
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  // Dormant by design: no public priced pack means nothing to show at all,
+  // rather than an empty card that reads like a fault.
+  if (isLoading || !data || data.packs.length === 0) return null;
+
+  const cardBlocked = data.packs.some((p) => p.purchasable)
+    ? null
+    : blockedCopy(data.packs[0].blockedReason);
+
+  return (
+    <>
+      <PaymentModal
+        checkout={checkout}
+        onOpenChange={(open) => {
+          if (!open) setCheckout(null);
+        }}
+        onSuccess={() => {
+          // Razorpay's overlay reports success in-page; the webhook does the
+          // crediting, so refetch rather than assuming a number.
+          toast.success("Payment received — your Peaks are on the way.");
+          void qc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] });
+        }}
+      />
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Buy more Peaks</CardTitle>
+          <CardDescription className="mt-1">
+            {cardBlocked ??
+              "One-time top-ups. Bought Peaks don't expire and are used after your monthly allowance."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {data.packs.map((p) => (
+              <div
+                key={p.key}
+                className={`flex flex-col gap-3 rounded-xl border p-4 ${
+                  p.key === wanted ? "border-primary ring-primary/20 ring-2" : ""
+                }`}
+              >
+                <div>
+                  <p className="font-medium">{p.name}</p>
+                  <p className="text-muted-foreground text-sm">
+                    {fmtPeaks(p.credits)} Peaks
+                  </p>
+                </div>
+                <div className="mt-auto flex items-end justify-between gap-2">
+                  <span className="text-lg font-semibold tabular-nums">
+                    {p.currency} {p.amount}
+                  </span>
+                  <Button
+                    size="sm"
+                    disabled={!p.purchasable || busyKey !== null}
+                    onClick={() => void start(p.key)}
+                  >
+                    {busyKey === p.key ? "Opening…" : "Buy"}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </>
   );
 }
 
@@ -211,6 +340,13 @@ export default function PeaksPage() {
             )}
           </CardContent>
         </Card>
+
+        {/* ── Buy more Peaks ────────────────────────────────────────── */}
+        {/* Suspense: BuyPeaks reads useSearchParams (the ?pack= deep link and
+            Stripe's ?session_id= return), which Next requires a boundary for. */}
+        <Suspense fallback={null}>
+          <BuyPeaks />
+        </Suspense>
 
         {/* ── Rate card ─────────────────────────────────────────────── */}
         <Card>

--- a/src/app/(site)/dashboard/peaks/page.tsx
+++ b/src/app/(site)/dashboard/peaks/page.tsx
@@ -24,7 +24,13 @@ import {
 } from "@/components/ui/table";
 import Link from "next/link";
 import { useCreditsBalance, useCreditsRateCard, useCreditsHistory } from "@/hooks/use-credits";
-import { usePeaksPacks, buyPack, confirmPackPurchase } from "@/hooks/use-peaks-packs";
+import {
+  usePeaksPacks,
+  buyPack,
+  confirmPackPurchase,
+  type PeaksPack,
+  type PackBlockedReason,
+} from "@/hooks/use-peaks-packs";
 import { PaymentModal, type CheckoutResult } from "@/components/upgrade/payment-modal";
 
 // ── Formatting helpers ────────────────────────────────────────────────────
@@ -33,6 +39,19 @@ function fmtPeaks(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return n.toLocaleString();
+}
+
+/** One formatter for a pack price, so the card and the payment overlay cannot
+ *  quote the same purchase differently (the api sends "49.00" to one and 49 to
+ *  the other). Falls back to the raw string if the currency code is unknown. */
+function fmtPrice(amount: string, currency: string): string {
+  const n = Number(amount);
+  if (!Number.isFinite(n)) return `${currency} ${amount}`;
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(n);
+  } catch {
+    return `${currency} ${amount}`;
+  }
 }
 
 function fmtDate(iso: string): string {
@@ -109,18 +128,40 @@ function UsageHistorySheet({ open, onOpenChange }: { open: boolean; onOpenChange
 
 // ── Buy more Peaks ─────────────────────────────────────────────────────────
 
-/** Card-level copy when nothing is buyable, so the section leads with one
- *  message and a way forward instead of repeating itself per pack. */
-function blockedCopy(reason: "plan_required" | "unlimited" | null): string | null {
-  if (reason === "unlimited") return "Your plan already includes unlimited Peaks.";
-  if (reason === "plan_required") return "Peaks packs need an active paid plan.";
-  return null;
+/** Why a pack can't be bought, in the buyer's words. EVERY reason the api can
+ *  return is named — an unexplained row of greyed-out Buy buttons under a sales
+ *  pitch is worse than not showing the section at all. */
+function blockedCopy(reason: PackBlockedReason | null): string | null {
+  switch (reason) {
+    case "unlimited":
+      return "Your plan already includes unlimited Peaks.";
+    case "plan_required":
+      return "Peaks packs need an active paid plan.";
+    case "not_priced_here":
+      // Real, not hypothetical: a pack priced only in USD viewed by an Indian
+      // org resolves a currency the gateway for that country can't charge.
+      return "These packs aren't priced for your region yet.";
+    case "no_wallet":
+      return "We couldn't load your Peaks wallet. Please contact support.";
+    default:
+      return null;
+  }
+}
+
+/** The card-level reason, only when NOTHING is buyable. A real reduction, not
+ *  `packs[0]` — `planRequired` and the pricing row are both per-pack, so a
+ *  catalogue mixing two reasons would otherwise show copy for neither. */
+function cardBlockedCopy(packs: PeaksPack[]): string | null {
+  if (packs.length === 0 || packs.some((p) => p.purchasable)) return null;
+  const reasons = new Set(packs.map((p) => p.blockedReason));
+  if (reasons.size === 1) return blockedCopy(packs[0].blockedReason);
+  return "None of these packs is available on your account right now.";
 }
 
 function BuyPeaks() {
   const qc = useQueryClient();
   const search = useSearchParams();
-  const { data, isLoading } = usePeaksPacks();
+  const { data, isLoading, isError } = usePeaksPacks();
   const [checkout, setCheckout] = useState<CheckoutResult | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
 
@@ -131,12 +172,28 @@ function BuyPeaks() {
 
   // Stripe returns the buyer here with `?purchase=success&session_id=cs_…`.
   // Confirm synchronously so the new Peaks are visible on this paint rather
-  // than whenever the webhook happens to land. Runs ONCE per session id.
-  const confirmed = useRef<string | null>(null);
+  // than whenever the webhook happens to land.
+  //
+  // ★AND STRIP THE PARAMS AFTERWARDS — the same thing the billing page does,
+  // for the same reason. The ref guard survives StrictMode's double-effect but
+  // NOT a remount, and nothing else removes the query string: a refresh or a
+  // back-navigation re-fired the confirm and re-toasted "Peaks added", which on
+  // a money surface reads as a second charge. It also keeps a Stripe session id
+  // out of a URL the merchant might copy.
+  const confirmed = useRef(false);
   useEffect(() => {
-    const sessionId = search.get("session_id");
-    if (!sessionId || confirmed.current === sessionId) return;
-    confirmed.current = sessionId;
+    if (confirmed.current || typeof window === "undefined") return;
+    const sessionId = new URLSearchParams(window.location.search).get("session_id");
+    if (!sessionId) return;
+    confirmed.current = true;
+
+    const stripParams = () => {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("purchase");
+      url.searchParams.delete("session_id");
+      window.history.replaceState({}, "", url.toString());
+    };
+
     void (async () => {
       try {
         const res = await confirmPackPurchase(sessionId);
@@ -144,34 +201,89 @@ function BuyPeaks() {
           toast.success(
             res.credits ? `${res.credits.toLocaleString()} Peaks added.` : "Your Peaks have been added.",
           );
+        } else {
+          // NOT silence. `credited:false` means the session is still finalising
+          // (an async payment method, or Stripe's redirect beating its own
+          // bookkeeping) — the webhook will land. Saying nothing left a buyer
+          // looking at an unchanged balance having just paid, which is the exact
+          // failure this whole return path exists to prevent.
+          toast.success("Payment received — adding your Peaks…", {
+            description: "This can take a few seconds to reflect.",
+          });
+          // One follow-up refetch so a webhook landing moments later repaints
+          // without the buyer reloading.
+          setTimeout(
+            () => void qc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] }),
+            6000,
+          );
         }
       } catch {
         // The webhook is the backstop — never turn a successful payment into an
         // error message on the buyer's return page.
       } finally {
         void qc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] });
+        stripParams();
       }
     })();
-  }, [search, qc]);
+  }, [qc]);
 
   const start = async (packKey: string) => {
     setBusyKey(packKey);
     try {
       setCheckout(await buyPack(packKey));
-    } catch {
-      toast.error("We couldn't start checkout. Please try again.");
+    } catch (err) {
+      // The api's refusals are written FOR the buyer and are mostly terminal —
+      // wrong region, no paid plan, unlimited wallet, contact support. Replacing
+      // them all with "please try again" invites retrying something that can
+      // never succeed.
+      const message =
+        err && typeof err === "object" && "message" in err && typeof err.message === "string"
+          ? err.message
+          : "We couldn't start checkout. Please try again.";
+      toast.error(message);
     } finally {
       setBusyKey(null);
     }
   };
 
   // Dormant by design: no public priced pack means nothing to show at all,
-  // rather than an empty card that reads like a fault.
+  // rather than an empty card that reads like a fault. A FAILED read is a
+  // different thing and must not be indistinguishable from it — otherwise a 500
+  // silently removes the buy surface, including for someone who arrived on a
+  // `?pack=` deep link from Shopify or WordPress.
+  if (isError) {
+    return (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Buy more Peaks</CardTitle>
+          <CardDescription className="mt-1">
+            We couldn&apos;t load the top-up packs just now.{" "}
+            <button
+              type="button"
+              className="underline underline-offset-2"
+              onClick={() => void qc.invalidateQueries({ queryKey: ["/v1/billing/packs"] })}
+            >
+              Try again
+            </button>
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
   if (isLoading || !data || data.packs.length === 0) return null;
 
-  const cardBlocked = data.packs.some((p) => p.purchasable)
-    ? null
-    : blockedCopy(data.packs[0].blockedReason);
+  // The api reports the country gate on the READ and enforces it on the POST —
+  // so a surface that ignores it shows a live Buy button that can only 403.
+  // `resolveBillingCountry` returns "DEFAULT" for an org with no stored country,
+  // and DEFAULT is never live, so this is the common case rather than an edge.
+  const countryBlocked =
+    data.countryStatus === "blocked"
+      ? "Peaks packs aren't available in your country."
+      : data.countryStatus !== "live"
+        ? "Peaks packs are coming soon in your country."
+        : null;
+  const cardBlocked = countryBlocked ?? cardBlockedCopy(data.packs);
+  const canBuy = (p: PeaksPack) => p.purchasable && countryBlocked === null;
 
   return (
     <>
@@ -198,33 +310,49 @@ function BuyPeaks() {
         </CardHeader>
         <CardContent>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {data.packs.map((p) => (
-              <div
-                key={p.key}
-                className={`flex flex-col gap-3 rounded-xl border p-4 ${
-                  p.key === wanted ? "border-primary ring-primary/20 ring-2" : ""
-                }`}
-              >
-                <div>
-                  <p className="font-medium">{p.name}</p>
-                  <p className="text-muted-foreground text-sm">
-                    {fmtPeaks(p.credits)} Peaks
-                  </p>
+            {data.packs.map((p) => {
+              const reason = countryBlocked ?? blockedCopy(p.blockedReason);
+              const reasonId = `pack-reason-${p.key.replace(/[^a-z0-9]/gi, "-")}`;
+              return (
+                <div
+                  key={p.key}
+                  className={`flex flex-col gap-3 rounded-xl border p-4 ${
+                    p.key === wanted ? "border-primary ring-primary/20 ring-2" : ""
+                  }`}
+                >
+                  <div>
+                    <p className="font-medium">
+                      {p.name}
+                      {/* The pre-selection is otherwise conveyed by a ring only,
+                          which a screen reader cannot see. */}
+                      {p.key === wanted ? <span className="sr-only"> (the pack you chose)</span> : null}
+                    </p>
+                    <p className="text-muted-foreground text-sm">{fmtPeaks(p.credits)} Peaks</p>
+                  </div>
+                  <div className="mt-auto flex items-end justify-between gap-2">
+                    <span className="text-lg font-semibold tabular-nums">
+                      {fmtPrice(p.amount, p.currency)}
+                    </span>
+                    <Button
+                      size="sm"
+                      disabled={!canBuy(p) || busyKey !== null}
+                      aria-busy={busyKey === p.key}
+                      {...(reason && !canBuy(p) ? { "aria-describedby": reasonId } : {})}
+                      onClick={() => void start(p.key)}
+                    >
+                      {busyKey === p.key ? "Opening…" : "Buy"}
+                    </Button>
+                  </div>
+                  {/* Per-pack reason, so a mixed catalogue explains each greyed
+                      button rather than leaving the card copy to cover one. */}
+                  {reason && !canBuy(p) ? (
+                    <p id={reasonId} className="text-muted-foreground text-xs">
+                      {reason}
+                    </p>
+                  ) : null}
                 </div>
-                <div className="mt-auto flex items-end justify-between gap-2">
-                  <span className="text-lg font-semibold tabular-nums">
-                    {p.currency} {p.amount}
-                  </span>
-                  <Button
-                    size="sm"
-                    disabled={!p.purchasable || busyKey !== null}
-                    onClick={() => void start(p.key)}
-                  >
-                    {busyKey === p.key ? "Opening…" : "Buy"}
-                  </Button>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </CardContent>
       </Card>

--- a/src/app/(site)/dashboard/peaks/page.tsx
+++ b/src/app/(site)/dashboard/peaks/page.tsx
@@ -32,6 +32,31 @@ import {
   type PackBlockedReason,
 } from "@/hooks/use-peaks-packs";
 import { PaymentModal, type CheckoutResult } from "@/components/upgrade/payment-modal";
+import { ApiError } from "@/lib/api";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+
+/**
+ * Refusals from POST /v1/billing/packs/checkout whose `message` is written for
+ * the buyer and is the most useful thing we can show. Everything NOT on this
+ * list — transport failures, auth expiry, parse errors, config errors — goes
+ * through the shared handler, which never renders a raw message.
+ *
+ * An allowlist rather than a denylist on purpose: a new api error code should
+ * default to the safe generic copy, not to whatever string it happens to carry.
+ */
+const BUYER_FACING_CODES = new Set([
+  "ORG_NOT_BILLABLE",
+  "COUNTRY_UNAVAILABLE",
+  "COUNTRY_COMING_SOON",
+  "PACK_UNAVAILABLE",
+  "PACK_CURRENCY_UNAVAILABLE",
+  "PACK_TAX_CONFIG_INVALID",
+  "PACK_NOT_PURCHASABLE",
+  "WALLET_UNLIMITED",
+  "PLAN_REQUIRED",
+  "GATEWAY_UNAVAILABLE",
+  "BILLING_UNAVAILABLE",
+]);
 
 // ── Formatting helpers ────────────────────────────────────────────────────
 
@@ -45,6 +70,10 @@ function fmtPeaks(n: number): string {
  *  quote the same purchase differently (the api sends "49.00" to one and 49 to
  *  the other). Falls back to the raw string if the currency code is unknown. */
 function fmtPrice(amount: string, currency: string): string {
+  // `Number("")` and `Number(" ")` are BOTH 0 and pass Number.isFinite, so an
+  // empty amount rendered as a real price of zero — the worst possible output
+  // of a guard whose whole job is catching bad input on a money surface.
+  if (!amount.trim()) return `${currency} ${amount}`;
   const n = Number(amount);
   if (!Number.isFinite(n)) return `${currency} ${amount}`;
   try {
@@ -143,8 +172,16 @@ function blockedCopy(reason: PackBlockedReason | null): string | null {
       return "These packs aren't priced for your region yet.";
     case "no_wallet":
       return "We couldn't load your Peaks wallet. Please contact support.";
-    default:
+    case null:
       return null;
+    default: {
+      // A fifth reason added on the api side is a BUILD failure here, not a
+      // silent regression to the original defect (a greyed button with no
+      // explanation). The union is hand-mirrored from the api, so nothing else
+      // enforces that they stay in step.
+      const _exhaustive: never = reason;
+      return _exhaustive;
+    }
   }
 }
 
@@ -183,8 +220,12 @@ function BuyPeaks() {
   const confirmed = useRef(false);
   useEffect(() => {
     if (confirmed.current || typeof window === "undefined") return;
-    const sessionId = new URLSearchParams(window.location.search).get("session_id");
-    if (!sessionId) return;
+    const params = new URLSearchParams(window.location.search);
+    const sessionId = params.get("session_id");
+    // Gate on EITHER marker. A return that carries only `?purchase=success`
+    // (no session id substituted) previously left the param in the URL forever
+    // and said nothing at all.
+    if (!sessionId && params.get("purchase") !== "success") return;
     confirmed.current = true;
 
     const stripParams = () => {
@@ -193,6 +234,20 @@ function BuyPeaks() {
       url.searchParams.delete("session_id");
       window.history.replaceState({}, "", url.toString());
     };
+    // ★STRIPPED BEFORE THE AWAIT, not in the finally. The confirm round trip is
+    // a Stripe retrieve plus a wallet credit — comfortably seconds — and the
+    // ref guard is per-instance, so navigating away and back inside that window
+    // remounted with a fresh ref and a URL that still carried the session id.
+    // The double toast this was meant to stop simply moved.
+    stripParams();
+
+    if (!sessionId) {
+      toast.success("Payment received — adding your Peaks…", {
+        description: "This can take a few seconds to reflect.",
+      });
+      void qc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] });
+      return;
+    }
 
     void (async () => {
       try {
@@ -201,6 +256,11 @@ function BuyPeaks() {
           toast.success(
             res.credits ? `${res.credits.toLocaleString()} Peaks added.` : "Your Peaks have been added.",
           );
+        } else if (res.reason === "not_found") {
+          // The id isn't a pack session of ours. Saying "payment received"
+          // for any `cs_…` in the address bar would be an affirmative money
+          // claim we cannot support.
+          void 0;
         } else {
           // NOT silence. `credited:false` means the session is still finalising
           // (an async payment method, or Stripe's redirect beating its own
@@ -222,7 +282,6 @@ function BuyPeaks() {
         // error message on the buyer's return page.
       } finally {
         void qc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] });
-        stripParams();
       }
     })();
   }, [qc]);
@@ -232,15 +291,17 @@ function BuyPeaks() {
     try {
       setCheckout(await buyPack(packKey));
     } catch (err) {
-      // The api's refusals are written FOR the buyer and are mostly terminal —
-      // wrong region, no paid plan, unlimited wallet, contact support. Replacing
-      // them all with "please try again" invites retrying something that can
-      // never succeed.
-      const message =
-        err && typeof err === "object" && "message" in err && typeof err.message === "string"
-          ? err.message
-          : "We couldn't start checkout. Please try again.";
-      toast.error(message);
+      // The packs route authors its refusals FOR the buyer, so those messages
+      // are worth showing — but ONLY those. A duck-typed `err.message` admits
+      // everything else the api client can throw: "Failed to fetch" from an
+      // offline tab, "Missing authentication. Provide Authorization header…"
+      // from an expired session, even "NEXT_PUBLIC_API_URL is not configured".
+      // toast-errors.ts exists because of exactly this trap and says so.
+      if (err instanceof ApiError && BUYER_FACING_CODES.has(err.code)) {
+        toast.error(err.message);
+      } else {
+        toastUnhandledApiError(err, "start checkout");
+      }
     } finally {
       setBusyKey(null);
     }
@@ -311,7 +372,12 @@ function BuyPeaks() {
         <CardContent>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {data.packs.map((p) => {
-              const reason = countryBlocked ?? blockedCopy(p.blockedReason);
+              // Only when it ADDS something. When every pack is blocked for the
+              // same reason the card already says it once — repeating it under
+              // each button turned one message into N+1 identical sentences,
+              // which is what the card-level line existed to avoid.
+              const packReason = countryBlocked ?? blockedCopy(p.blockedReason);
+              const reason = packReason === cardBlocked ? null : packReason;
               const reasonId = `pack-reason-${p.key.replace(/[^a-z0-9]/gi, "-")}`;
               return (
                 <div

--- a/src/components/upgrade/payment-modal.tsx
+++ b/src/components/upgrade/payment-modal.tsx
@@ -105,15 +105,36 @@ function loadScript(src: string, id: string): Promise<void> {
   });
 }
 
+/** Locale currency formatting, with a raw fallback for an unknown code. */
+function fmtAmount(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(amount);
+  } catch {
+    return `${currency} ${amount}`;
+  }
+}
+
 function SummaryLine({ summary }: { summary: CheckoutSummary }) {
   return (
     <div className="rounded-xl border bg-muted/40 px-4 py-3 text-sm">
       <div className="flex items-baseline justify-between gap-3">
         <span className="font-medium truncate">
           {summary.tierLabel || summary.tier || summary.packKey}
+          {/* The Peaks count is the ONE number that tells the packs apart —
+              without it the overlay shows a name and a price and the buyer
+              cannot check they picked the right pack. */}
+          {summary.credits ? (
+            <span className="text-muted-foreground font-normal">
+              {" "}
+              · {summary.credits.toLocaleString()} Peaks
+            </span>
+          ) : null}
         </span>
         <span className="font-semibold whitespace-nowrap">
-          {summary.currency} {summary.amount}
+          {/* Formatted, not concatenated: the api sends "49.00" to the pack card
+              and 49 here, so raw interpolation quoted the same purchase two
+              different ways on two surfaces. */}
+          {fmtAmount(summary.amount, summary.currency)}
           {/* No suffix on a one-time pack — "/mo" beside a one-off price tells
               the buyer they are starting a subscription they are not. */}
           {summary.interval ? `/${summary.interval === "year" ? "yr" : "mo"}` : ""}

--- a/src/components/upgrade/payment-modal.tsx
+++ b/src/components/upgrade/payment-modal.tsx
@@ -28,12 +28,19 @@ import { Input } from "@/components/ui/input";
 /** Buyer-facing checkout summary from the api — the tax label is derived from
  *  the SAME plan flag that stamps the charge, so copy and money always agree. */
 export interface CheckoutSummary {
-  tier: string;
-  /** Human plan name (cfg_plans.name) — always prefer over the machine key. */
+  /** cfg_plans.key on a subscription. Absent on a one-time Peaks pack. */
+  tier?: string;
+  /** cfg_addons.key on a one-time Peaks pack. Absent on a subscription. */
+  packKey?: string;
+  /** Human plan or pack name — always prefer over the machine key. */
   tierLabel?: string;
+  /** Peaks granted, on a pack summary only. */
+  credits?: number;
   amount: number;
   currency: string;
-  interval: "month" | "year";
+  /** ABSENT on a one-time pack. Rendering "/mo" beside a one-off price would
+   *  tell the buyer they are starting a subscription they are not. */
+  interval?: "month" | "year";
   buyerCountry: string;
   taxIncluded: boolean;
   taxLabel: string;
@@ -52,7 +59,14 @@ export type CheckoutResult =
       gateway: "razorpay";
       embed: {
         kind: "razorpay";
-        subscriptionId: string;
+        /** Set for a SUBSCRIPTION (an e-mandate is authorised). */
+        subscriptionId?: string;
+        /** Set for a ONE-TIME pack purchase (an order is charged once).
+         *  Exactly one of the two is present; the launcher branches on it. */
+        orderId?: string;
+        /** Paise/cents — required by Checkout.js alongside `order_id`. */
+        amountMinor?: number;
+        currency?: string;
         keyId: string;
         prefill?: { name?: string; email?: string };
       };
@@ -95,9 +109,14 @@ function SummaryLine({ summary }: { summary: CheckoutSummary }) {
   return (
     <div className="rounded-xl border bg-muted/40 px-4 py-3 text-sm">
       <div className="flex items-baseline justify-between gap-3">
-        <span className="font-medium truncate">{summary.tierLabel || summary.tier}</span>
+        <span className="font-medium truncate">
+          {summary.tierLabel || summary.tier || summary.packKey}
+        </span>
         <span className="font-semibold whitespace-nowrap">
-          {summary.currency} {summary.amount}/{summary.interval === "year" ? "yr" : "mo"}
+          {summary.currency} {summary.amount}
+          {/* No suffix on a one-time pack — "/mo" beside a one-off price tells
+              the buyer they are starting a subscription they are not. */}
+          {summary.interval ? `/${summary.interval === "year" ? "yr" : "mo"}` : ""}
         </span>
       </div>
       <div className="text-muted-foreground mt-1 flex flex-wrap items-baseline justify-between gap-x-3 text-xs">
@@ -273,16 +292,29 @@ function GatewayLauncher({
     (async () => {
       try {
         if (checkout.gateway === "razorpay") {
-          const { subscriptionId, keyId, prefill } = checkout.embed;
+          const { subscriptionId, orderId, amountMinor, currency, keyId, prefill } = checkout.embed;
           await loadScript(RAZORPAY_SRC, "razorpay-checkout");
           if (!window.Razorpay) throw new Error("Razorpay SDK unavailable");
           const rzp = new window.Razorpay({
             key: keyId,
-            subscription_id: subscriptionId,
+            // An ORDER (one-time pack) and a SUBSCRIPTION are different
+            // Checkout.js modes. Sending both would be ambiguous; sending the
+            // wrong one silently opens an overlay that charges nothing.
+            ...(orderId
+              ? {
+                  order_id: orderId,
+                  ...(amountMinor !== undefined ? { amount: amountMinor } : {}),
+                  ...(currency ? { currency } : {}),
+                }
+              : { subscription_id: subscriptionId }),
             // Seller identity is data-driven from the billing entity's invoice
             // branding (Phase 6) — never hardcoded.
             name: summary?.sellerName || "Peakhour",
-            ...(summary ? { description: `${summary.tierLabel || summary.tier} — ${summary.taxLabel}` } : {}),
+            ...(summary
+              ? {
+                  description: `${summary.tierLabel || summary.tier || summary.packKey} — ${summary.taxLabel}`,
+                }
+              : {}),
             ...(prefill ? { prefill } : {}),
             handler: () => {
               onSuccess?.();

--- a/src/hooks/use-peaks-packs.ts
+++ b/src/hooks/use-peaks-packs.ts
@@ -14,6 +14,15 @@ import type { CheckoutResult } from "@/components/upgrade/payment-modal";
  * peakhour-mongodb/docs/idea/peaks-pack-hosted-checkout-plan.md.
  */
 
+/** Every reason the api's `blockedReason` can carry. `no_wallet` and
+ *  `not_priced_here` are hosted-rail states the POST also refuses; omitting them
+ *  from this union is how a blocked card ends up with no explanation. */
+export type PackBlockedReason =
+  | "plan_required"
+  | "unlimited"
+  | "no_wallet"
+  | "not_priced_here";
+
 export interface PeaksPack {
   key: string;
   name: string;
@@ -24,7 +33,7 @@ export interface PeaksPack {
   planRequired: boolean;
   purchasable: boolean;
   /** Why not, when `purchasable` is false. */
-  blockedReason: "plan_required" | "unlimited" | null;
+  blockedReason: PackBlockedReason | null;
 }
 
 export interface PeaksPacksResponse {

--- a/src/hooks/use-peaks-packs.ts
+++ b/src/hooks/use-peaks-packs.ts
@@ -84,9 +84,11 @@ export function confirmPackPurchase(
   credits?: number;
   packKey?: string;
   /** "pending" — ours, still settling (safe to reassure the buyer).
-   *  "not_found" — not a pack session of ours; affirming a payment for it
-   *  would be a money claim we cannot support. */
-  reason?: "pending" | "not_found" | "unconfigured";
+   *  Anything else means we established nothing ("unknown"), it isn't ours
+   *  ("not_found"), Stripe isn't wired ("unconfigured"), or the charge landed
+   *  and NOBODY credited ("not_credited"). None of those may be reported to
+   *  the buyer as a received payment. */
+  reason?: "pending" | "not_found" | "unknown" | "unconfigured" | "not_credited";
 }> {
   return api.post("/v1/billing/packs/confirm", { sessionId });
 }

--- a/src/hooks/use-peaks-packs.ts
+++ b/src/hooks/use-peaks-packs.ts
@@ -79,6 +79,14 @@ export function buyPack(packKey: string): Promise<CheckoutResult> {
  */
 export function confirmPackPurchase(
   sessionId: string,
-): Promise<{ credited: boolean; credits?: number; packKey?: string; reason?: string }> {
+): Promise<{
+  credited: boolean;
+  credits?: number;
+  packKey?: string;
+  /** "pending" — ours, still settling (safe to reassure the buyer).
+   *  "not_found" — not a pack session of ours; affirming a payment for it
+   *  would be a money claim we cannot support. */
+  reason?: "pending" | "not_found" | "unconfigured";
+}> {
   return api.post("/v1/billing/packs/confirm", { sessionId });
 }

--- a/src/hooks/use-peaks-packs.ts
+++ b/src/hooks/use-peaks-packs.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
+import type { CheckoutResult } from "@/components/upgrade/payment-modal";
+
+/**
+ * Peaks packs on peakhour.ai's own hosted rail.
+ *
+ * The Shopify embedded app and the WordPress plugin have listed packs for a
+ * long time; both linked out here to buy one, and until the hosted checkout
+ * shipped this page had nothing to sell. See
+ * peakhour-mongodb/docs/idea/peaks-pack-hosted-checkout-plan.md.
+ */
+
+export interface PeaksPack {
+  key: string;
+  name: string;
+  credits: number;
+  /** Decimal string, e.g. "999.00" — priced for the org's own country. */
+  amount: string;
+  currency: string;
+  planRequired: boolean;
+  purchasable: boolean;
+  /** Why not, when `purchasable` is false. */
+  blockedReason: "plan_required" | "unlimited" | null;
+}
+
+export interface PeaksPacksResponse {
+  country: string;
+  currency: string;
+  countryStatus: "live" | "coming_soon" | "blocked";
+  /** An unlimited wallet can't use a top-up, so none is offered. */
+  unlimited: boolean;
+  packs: PeaksPack[];
+}
+
+const PACKS_KEY = "/v1/billing/packs";
+
+/**
+ * The packs this org can buy. EMPTY until ops makes a pack public and prices
+ * it — the whole surface is dormant by default, matching every other reader of
+ * `getPeaksPacks`, so an empty array is a normal state and not an error.
+ */
+export function usePeaksPacks() {
+  const { isAuthenticated, org } = useAuth();
+  return useQuery<PeaksPacksResponse>({
+    queryKey: [PACKS_KEY, org?._id ?? null],
+    queryFn: () => api.get<PeaksPacksResponse>(PACKS_KEY),
+    enabled: isAuthenticated && !!org?._id,
+    // Pack catalogue + price change only when ops edits them.
+    staleTime: 5 * 60_000,
+  });
+}
+
+/** Mint a gateway overlay for one pack. The response is the SAME
+ *  `{ gateway, embed, summary }` envelope the plan checkout returns, so the
+ *  existing PaymentModal renders it unchanged. */
+export function buyPack(packKey: string): Promise<CheckoutResult> {
+  return api.post<CheckoutResult>("/v1/billing/packs/checkout", { packKey });
+}
+
+/**
+ * Reconcile-on-return for the Stripe overlay. Stripe sends the buyer back here
+ * the instant the session completes — routinely BEFORE the webhook lands — so
+ * without this call they would be looking at an unchanged balance having just
+ * paid. Safe to call twice: the api keys the grant on the session id, so
+ * whichever of this and the webhook arrives second no-ops.
+ */
+export function confirmPackPurchase(
+  sessionId: string,
+): Promise<{ credited: boolean; credits?: number; packKey?: string; reason?: string }> {
+  return api.post("/v1/billing/packs/confirm", { sessionId });
+}


### PR DESCRIPTION
PR-4 of `docs/idea/peaks-pack-hosted-checkout-plan.md` (travelxp/peakhour-mongodb#445). Depends on peakhour-api#1009 (mints the checkout) and #1010 (captures it).

## Why

`/dashboard/peaks` rendered a balance and a rate card and sold nothing — while the Shopify embedded app and the WordPress plugin have both been linking merchants *here* to buy a pack. This is the destination those links already assumed existed.

## Reusing PaymentModal, not adding a second one

The api returns the same `{ gateway, embed, summary }` envelope the plan checkout does, so the existing modal renders it. Two widenings were needed, and both exist because a pack is genuinely not a subscription:

- **`summary.interval` is now optional.** Rendering "/mo" beside a one-off price would tell the buyer they're starting a subscription they aren't.
- **The Razorpay embed carries either `orderId` or `subscriptionId`.** Those are different Checkout.js modes — sending the wrong one opens an overlay that charges nothing.

The India GSTIN pre-overlay step is inherited for free and applies to packs too.

## Reconcile on return

Stripe returns the buyer with `?session_id=`, routinely before the webhook lands. The page confirms synchronously so the new Peaks are visible on that paint — otherwise they're staring at an unchanged balance having just paid. Guarded to run once per session id; a failed confirm never becomes an error message on a successful payment, because the webhook is still the backstop.

`?pack=` — which both link-outs already send — highlights the chosen pack so a merchant who already decided doesn't decide again.

## Dormant by default

The section renders **nothing** when no pack is public and priced, matching every other reader of `getPeaksPacks`. An empty card would read like a fault; no card is the honest state.

## Verification

`tsc --noEmit` clean · eslint clean on the touched files · 192 tests passing.

One pre-existing eslint error remains in `payment-modal.tsx` (`set-state-in-effect` on the `mounted` gate, line unchanged by this branch) — verified present on master before this work, so it isn't introduced here. I also removed a dead `Progress` import in the peaks page while editing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
