### PR TITLE
feat(dev): the Peaks page can now run the cron its numbers come from

### DIFF
--- a/src/app/(site)/cms/crons/page.tsx
+++ b/src/app/(site)/cms/crons/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 /**
- * /cms/crons — Dev cron hub. Lists every cron handler that can be
- * manually triggered (the same whitelist the api enforces) with a
- * one-click "Run now" button per row.
+ * /cms/crons — Dev cron hub. Lists every cron handler that can be manually
+ * triggered (the same whitelist the api enforces), with the <CronToolbar/>
+ * above holding the actual trigger buttons — the rows below are reference,
+ * not controls. Crons whose effects leave Peakhour are marked and confirm
+ * before firing; which those are comes from the api, never a list here.
  *
  * Vercel Cron only runs on production deployments, so previews + local
  * dev had no UI way to exercise cron paths. This page is the central
@@ -116,13 +118,24 @@ export default function CmsCronsPage() {
               <div className="grid gap-2">
                 {data.crons.map((name) => {
                   const meta = getCronMetadata(name);
+                  // The same marker the toolbar button carries. Without it the
+                  // identical cron reads as dangerous above and ordinary in the
+                  // list right below, which teaches people to ignore the ⚠️.
+                  const guarded = data.requiresConfirmation?.includes(name) ?? false;
                   return (
                     <div
                       key={name}
                       className="flex items-start justify-between border-b pb-2 last:border-b-0 last:pb-0"
                     >
                       <div className="flex flex-col">
-                        <span className="font-medium text-sm">{meta.label}</span>
+                        <span className="font-medium text-sm">
+                          {guarded ? `⚠️ ${meta.label}` : meta.label}
+                        </span>
+                        {guarded ? (
+                          <span className="text-xs font-medium text-amber-600 dark:text-amber-500">
+                            Reaches outside Peakhour — asks before running
+                          </span>
+                        ) : null}
                         <span className="text-xs text-muted-foreground">
                           {meta.frequency}
                         </span>

--- a/src/app/(site)/cms/crons/page.tsx
+++ b/src/app/(site)/cms/crons/page.tsx
@@ -26,7 +26,14 @@ import { AlertTriangle, Zap } from "lucide-react";
 
 interface DevCronList {
   env: string;
+  /** APP_ENV, which the api's production gate also consults — reported so this
+   *  page can't show an environment that disagrees with the one that decided. */
+  appEnv?: string | null;
   crons: string[];
+  /** Crons the api refuses without an explicit confirmation. Optional because
+   *  this page and the api deploy separately; absent simply means no cron is
+   *  pre-confirmed here and the api's own refusal is the backstop. */
+  requiresConfirmation?: string[];
 }
 
 export default function CmsCronsPage() {
@@ -86,12 +93,18 @@ export default function CmsCronsPage() {
           <div className="flex items-center gap-2 text-xs">
             <span className="text-muted-foreground">Environment:</span>
             <Badge variant="outline">{data.env}</Badge>
+            {/* Both signals, because the api's gate consults both — showing one
+                would let this page display an env that didn't decide anything. */}
+            {data.appEnv ? <Badge variant="outline">APP_ENV {data.appEnv}</Badge> : null}
             <span className="text-muted-foreground">·</span>
             <span className="text-muted-foreground">{data.crons.length} crons</span>
           </div>
           {/* The toolbar pattern, applied to every cron at once — same
-              friendly labels + hover tooltips as the per-page toolbars. */}
-          <CronToolbar crons={data.crons} />
+              friendly labels + hover tooltips as the per-page toolbars.
+              `requiresConfirmation` comes straight from the api so the
+              dangerous ones ask before firing rather than 400-ing into a
+              "try again" that can never succeed. */}
+          <CronToolbar crons={data.crons} requiresConfirmation={data.requiresConfirmation} />
           <Card>
             <CardContent className="pt-6">
               <div className="grid gap-2">

--- a/src/app/(site)/cms/crons/page.tsx
+++ b/src/app/(site)/cms/crons/page.tsx
@@ -92,10 +92,16 @@ export default function CmsCronsPage() {
         <>
           <div className="flex items-center gap-2 text-xs">
             <span className="text-muted-foreground">Environment:</span>
-            <Badge variant="outline">{data.env}</Badge>
-            {/* Both signals, because the api's gate consults both — showing one
-                would let this page display an env that didn't decide anything. */}
-            {data.appEnv ? <Badge variant="outline">APP_ENV {data.appEnv}</Badge> : null}
+            {/* Both signals, because the api's gate refuses on EITHER — showing
+                one lets this page display an env that didn't decide anything.
+                `undefined` means an api older than the field; `null` means
+                APP_ENV genuinely isn't set, which is itself the diagnostic
+                (the api can't tell dev from prod without it). Rendering those
+                two identically would hide the case worth seeing. */}
+            <Badge variant="outline">VERCEL_ENV {data.env}</Badge>
+            {data.appEnv !== undefined ? (
+              <Badge variant="outline">APP_ENV {data.appEnv ?? "unset"}</Badge>
+            ) : null}
             <span className="text-muted-foreground">·</span>
             <span className="text-muted-foreground">{data.crons.length} crons</span>
           </div>

--- a/src/app/(site)/dashboard/peaks/page.tsx
+++ b/src/app/(site)/dashboard/peaks/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/hooks/use-peaks-packs";
 import { PaymentModal, type CheckoutResult } from "@/components/upgrade/payment-modal";
 import { ApiError } from "@/lib/api";
+import { CronToolbar } from "@/components/dev/cron-toolbar";
 import { toastUnhandledApiError } from "@/lib/toast-errors";
 
 /**
@@ -436,6 +437,7 @@ export default function PeaksPage() {
   const { data: balance, isLoading: balanceLoading } = useCreditsBalance();
   const { data: rateCard, isLoading: rateLoading } = useCreditsRateCard();
   const [historyOpen, setHistoryOpen] = useState(false);
+  const pageQc = useQueryClient();
 
   const pct =
     balance && !balance.unlimited && balance.hardCap > 0
@@ -456,6 +458,21 @@ export default function PeaksPage() {
       <UsageHistorySheet open={historyOpen} onOpenChange={setHistoryOpen} />
 
       <div className="space-y-6">
+        {/* The architecture requirement, applied to the page it matters most on:
+            every number here is downstream of ai-credits-rollup, and on dev
+            Vercel never fires it. Without this the balance sits at 0 used
+            forever while "Where your Peaks go" fills up, which is exactly how
+            the wallet looked broken. */}
+        <CronToolbar
+          crons={["ai-credits-rollup"]}
+          onTriggered={() => {
+            // Balance AND history: the rollup writes the meters both read, so
+            // refreshing one would leave the page disagreeing with itself.
+            void pageQc.invalidateQueries({ queryKey: ["/v1/dashboard/credits"] });
+            void pageQc.invalidateQueries({ queryKey: ["/v1/dashboard/credits/history"] });
+          }}
+        />
+
         {/* Page header */}
         <div className="flex items-start justify-between gap-4">
           <div>

--- a/src/components/dev/cron-metadata.test.ts
+++ b/src/components/dev/cron-metadata.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { CRON_METADATA, getCronMetadata } from "./cron-metadata";
+
+/**
+ * Cron metadata vs the crons the api will actually let us fire.
+ *
+ * WHY: this file's own header says its keys "MUST match peakhour-api's
+ * DEV_TRIGGERABLE_CRONS", and that was enforced by nothing. It had drifted to
+ * 35 entries against 56 scheduled crons — so /cms/crons rendered a row of
+ * buttons labelled "Run einvoice-register" with "(undocumented schedule)",
+ * on a tenant that has real stores on it.
+ *
+ * The api is the source of truth and lives in a sibling repo, so this reads
+ * `peakhour-api/vercel.json` directly. That coupling is deliberate and cheap:
+ * the alternative is a third hand-maintained list, which is what caused the
+ * problem. If the sibling checkout isn't present the test SKIPS rather than
+ * fails — a b2c-only clone should still have a green suite.
+ */
+
+function readScheduledCrons(): string[] | null {
+  try {
+    const path = fileURLToPath(
+      new URL("../../../../peakhour-api/vercel.json", import.meta.url),
+    );
+    const config = JSON.parse(readFileSync(path, "utf8")) as {
+      crons?: Array<{ path: string }>;
+    };
+    const names = (config.crons ?? []).map((c) => c.path.replace(/^\/v1\/cron\//, ""));
+    return names.length > 0 ? names.sort() : null;
+  } catch {
+    return null;
+  }
+}
+
+const scheduled = readScheduledCrons();
+
+describe("cron metadata coverage", () => {
+  it.runIf(scheduled)("documents every cron the api schedules", () => {
+    const undocumented = scheduled!.filter((c) => !(c in CRON_METADATA));
+    expect(undocumented, `No friendly label for: ${undocumented.join(", ")}`).toEqual([]);
+  });
+
+  it.runIf(scheduled)("documents nothing that no longer exists", () => {
+    // A stale entry is a label for a button that can never appear — harmless,
+    // but it is the same drift in the other direction and hides real removals.
+    const orphans = Object.keys(CRON_METADATA).filter((c) => !scheduled!.includes(c));
+    expect(orphans, `Documented but not scheduled: ${orphans.join(", ")}`).toEqual([]);
+  });
+
+  it("gives every entry a label, frequency and description", () => {
+    for (const [name, meta] of Object.entries(CRON_METADATA)) {
+      expect(meta.label, name).toBeTruthy();
+      expect(meta.frequency, name).toBeTruthy();
+      expect(meta.description, name).toBeTruthy();
+      // The description is the only thing standing between an operator and a
+      // button whose effects they don't know. A bare restatement of the key
+      // would satisfy `toBeTruthy` while telling them nothing.
+      expect(meta.description.length, name).toBeGreaterThan(40);
+    }
+  });
+
+  it("marks the crons that reach outside Peakhour", () => {
+    // These can email real merchants or call an external provider. The api
+    // refuses them without a confirmation; the label is what warns the operator
+    // BEFORE they click, so it must carry the marker.
+    for (const cron of [
+      "billing-dunning",
+      "billing-reconcile",
+      "shopify-billing-reconcile",
+      "internal-settlement",
+      "einvoice-register",
+    ]) {
+      expect(CRON_METADATA[cron]?.label, cron).toContain("⚠️");
+    }
+  });
+
+  it("falls back gracefully for a cron it has never heard of", () => {
+    // Deploys are independent, so the api can list a cron this build predates.
+    const meta = getCronMetadata("some-brand-new-cron");
+    expect(meta.label).toContain("some-brand-new-cron");
+    expect(meta.frequency).toBeTruthy();
+  });
+});

--- a/src/components/dev/cron-metadata.test.ts
+++ b/src/components/dev/cron-metadata.test.ts
@@ -19,31 +19,30 @@ import { CRON_METADATA, getCronMetadata, summarizeCronBody } from "./cron-metada
  * fails — a b2c-only clone should still have a green suite.
  */
 
-function readScheduledCrons(): string[] | null {
-  const path = fileURLToPath(new URL("../../../../peakhour-api/vercel.json", import.meta.url));
+const VERCEL_JSON = fileURLToPath(
+  new URL("../../../../peakhour-api/vercel.json", import.meta.url),
+);
+
+/**
+ * Read the sibling api's schedule, or null when that checkout simply isn't
+ * there (a b2c-only clone should still have a green suite).
+ *
+ * ONLY the read is allowed to produce a skip. A first draft threw its sanity
+ * checks inside the same try, so the local catch swallowed them and an emptied
+ * or renamed `crons` key silently disabled both coverage assertions — the exact
+ * invisible no-op this file exists to prevent, reproduced one level up. The
+ * checks now live outside, where they fail loudly.
+ */
+function readVercelJson(): string[] | null {
   try {
-    const config = JSON.parse(readFileSync(path, "utf8")) as {
+    const config = JSON.parse(readFileSync(VERCEL_JSON, "utf8")) as {
       crons?: Array<{ path: string }>;
     };
-    const names = (config.crons ?? []).map((c) => c.path.replace(/^\/v1\/cron\//, ""));
-    if (names.length === 0) {
-      // Distinct from "sibling absent": the file parsed and had no crons, which
-      // means the key was renamed or emptied — a real problem, not a skip.
-      throw new Error("vercel.json parsed but listed no crons");
-    }
-    // A path that stopped matching the prefix would survive whole and turn into
-    // a baffling orphan; catch it here where the cause is obvious.
-    const malformed = names.filter((n) => n.includes("/"));
-    if (malformed.length > 0) {
-      throw new Error(`cron paths did not match /v1/cron/: ${malformed.join(", ")}`);
-    }
-    return names;
+    return (config.crons ?? []).map((c) => c.path.replace(/^\/v1\/cron\//, ""));
   } catch (err) {
-    // Skipping is right for a b2c-only clone, but a SILENT skip turns the two
-    // assertions that matter into invisible no-ops — which is the failure this
-    // whole file exists to prevent, one level up.
+    // A silent skip is indistinguishable from a pass, so say it out loud.
     console.warn(
-      `[cron-metadata.test] Skipping api coverage — could not read ${path}: ${
+      `[cron-metadata.test] Skipping api coverage — could not read ${VERCEL_JSON}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -51,9 +50,19 @@ function readScheduledCrons(): string[] | null {
   }
 }
 
-const scheduled = readScheduledCrons();
+const scheduled = readVercelJson();
 
 describe("cron metadata coverage", () => {
+  // Outside the reader's try/catch on purpose — these FAIL, they do not skip.
+  // "vercel.json exists but lists nothing" means the key was renamed or
+  // emptied, which would otherwise turn both assertions below into no-ops that
+  // report green.
+  it.runIf(scheduled)("read a usable schedule from the api", () => {
+    expect(scheduled!.length, "vercel.json parsed but listed no crons").toBeGreaterThan(20);
+    const malformed = scheduled!.filter((n) => n.includes("/"));
+    expect(malformed, `cron paths did not match /v1/cron/: ${malformed.join(", ")}`).toEqual([]);
+  });
+
   it.runIf(scheduled)("documents every cron the api schedules", () => {
     const undocumented = scheduled!.filter((c) => !(c in CRON_METADATA));
     expect(undocumented, `No friendly label for: ${undocumented.join(", ")}`).toEqual([]);
@@ -124,7 +133,19 @@ describe("summarizeCronBody", () => {
     expect(summarizeCronBody("ai-credits-rollup", "")).toBeNull();
   });
 
+  it("warns when a purge did nothing because storage isn't configured", () => {
+    // The handler early-returns `{success, skipped, purged:0}`. Now that flat
+    // bodies reach summarizers, "0 purged" would otherwise read as healthy.
+    const body = JSON.stringify({ success: true, skipped: "storage_not_configured", purged: 0 });
+    const summary = summarizeCronBody("media-hard-delete", body);
+    expect(summary?.level).toBe("warning");
+  });
+
   it("returns null for a cron with no summarizer", () => {
-    expect(summarizeCronBody("billing-dunning", JSON.stringify({ ok: true }))).toBeNull();
+    // Picked by SEARCHING for one rather than naming a cron, so adding a
+    // summarizer to any particular entry can't break an unrelated test.
+    const withoutSummarizer = Object.keys(CRON_METADATA).find((k) => !CRON_METADATA[k].summarize);
+    expect(withoutSummarizer, "every cron now has a summarizer — pick another case").toBeDefined();
+    expect(summarizeCronBody(withoutSummarizer!, JSON.stringify({ ok: true }))).toBeNull();
   });
 });

--- a/src/components/dev/cron-metadata.test.ts
+++ b/src/components/dev/cron-metadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { CRON_METADATA, getCronMetadata } from "./cron-metadata";
+import { CRON_METADATA, getCronMetadata, summarizeCronBody } from "./cron-metadata";
 
 /**
  * Cron metadata vs the crons the api will actually let us fire.
@@ -20,16 +20,33 @@ import { CRON_METADATA, getCronMetadata } from "./cron-metadata";
  */
 
 function readScheduledCrons(): string[] | null {
+  const path = fileURLToPath(new URL("../../../../peakhour-api/vercel.json", import.meta.url));
   try {
-    const path = fileURLToPath(
-      new URL("../../../../peakhour-api/vercel.json", import.meta.url),
-    );
     const config = JSON.parse(readFileSync(path, "utf8")) as {
       crons?: Array<{ path: string }>;
     };
     const names = (config.crons ?? []).map((c) => c.path.replace(/^\/v1\/cron\//, ""));
-    return names.length > 0 ? names.sort() : null;
-  } catch {
+    if (names.length === 0) {
+      // Distinct from "sibling absent": the file parsed and had no crons, which
+      // means the key was renamed or emptied — a real problem, not a skip.
+      throw new Error("vercel.json parsed but listed no crons");
+    }
+    // A path that stopped matching the prefix would survive whole and turn into
+    // a baffling orphan; catch it here where the cause is obvious.
+    const malformed = names.filter((n) => n.includes("/"));
+    if (malformed.length > 0) {
+      throw new Error(`cron paths did not match /v1/cron/: ${malformed.join(", ")}`);
+    }
+    return names;
+  } catch (err) {
+    // Skipping is right for a b2c-only clone, but a SILENT skip turns the two
+    // assertions that matter into invisible no-ops — which is the failure this
+    // whole file exists to prevent, one level up.
+    console.warn(
+      `[cron-metadata.test] Skipping api coverage — could not read ${path}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return null;
   }
 }
@@ -61,18 +78,13 @@ describe("cron metadata coverage", () => {
     }
   });
 
-  it("marks the crons that reach outside Peakhour", () => {
-    // These can email real merchants or call an external provider. The api
-    // refuses them without a confirmation; the label is what warns the operator
-    // BEFORE they click, so it must carry the marker.
-    for (const cron of [
-      "billing-dunning",
-      "billing-reconcile",
-      "shopify-billing-reconcile",
-      "internal-settlement",
-      "einvoice-register",
-    ]) {
-      expect(CRON_METADATA[cron]?.label, cron).toContain("⚠️");
+  it("does not hardcode which crons are dangerous", () => {
+    // The warning marker is rendered from the api's `requiresConfirmation`, not
+    // baked into a label here. Keeping a second list would recreate exactly the
+    // drift this file exists to kill — the api adds a sixth dangerous cron and
+    // b2c renders it unmarked, with nothing failing.
+    for (const [name, meta] of Object.entries(CRON_METADATA)) {
+      expect(meta.label, `${name} hardcodes a warning marker`).not.toContain("⚠️");
     }
   });
 
@@ -80,6 +92,39 @@ describe("cron metadata coverage", () => {
     // Deploys are independent, so the api can list a cron this build predates.
     const meta = getCronMetadata("some-brand-new-cron");
     expect(meta.label).toContain("some-brand-new-cron");
-    expect(meta.frequency).toBeTruthy();
+    expect(meta.frequency).toContain("undocumented");
+  });
+});
+
+describe("summarizeCronBody", () => {
+  // The api has TWO cron response conventions, and reading only `.data` made
+  // every summarizer for the flat ones dead code — five of them, including
+  // ai-credits-rollup, where it turned "charged nothing" into a green success.
+  it("reads a WRAPPED {ok,data} body", () => {
+    const body = JSON.stringify({ ok: true, data: { purged: 3 } });
+    expect(summarizeCronBody("media-hard-delete", body)?.message).toContain("3");
+  });
+
+  it("reads a FLAT body", () => {
+    const body = JSON.stringify({ success: true, processed: 12, topUpDebited: 0, failed: 0 });
+    const summary = summarizeCronBody("ai-credits-rollup", body);
+    expect(summary?.message).toContain("12");
+    expect(summary?.level).toBe("success");
+  });
+
+  it("warns rather than congratulating when the rollup charged nothing", () => {
+    const body = JSON.stringify({ success: true, processed: 0, failed: 0, skipped: 0 });
+    const summary = summarizeCronBody("ai-credits-rollup", body);
+    expect(summary?.level).toBe("warning");
+    expect(summary?.message).toMatch(/no new/i);
+  });
+
+  it("defers to the generic toast on a malformed or truncated body", () => {
+    expect(summarizeCronBody("ai-credits-rollup", "{not json")).toBeNull();
+    expect(summarizeCronBody("ai-credits-rollup", "")).toBeNull();
+  });
+
+  it("returns null for a cron with no summarizer", () => {
+    expect(summarizeCronBody("billing-dunning", JSON.stringify({ ok: true }))).toBeNull();
   });
 });

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -438,8 +438,9 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
 
   // ── Billing + money ────────────────────────────────────────────────
   // Undocumented until now because none of them could be triggered at all
-  // (peakhour-api#1017). ⚠️ marks the ones the api refuses without an explicit
-  // confirmation, because their effects leave Peakhour.
+  // (peakhour-api#1017). Which of these need an explicit confirmation is NOT
+  // recorded here — the api reports it via `requiresConfirmation` and the UI
+  // marks them from that, so there is no second list to drift.
   "ai-credits-rollup": {
     label: "Charge Peaks used",
     frequency: "Runs every minute",
@@ -459,31 +460,31 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     },
   },
   "billing-dunning": {
-    label: "⚠️ Enforce failed payments",
+    label: "Enforce failed payments",
     frequency: "Runs hourly",
     description:
-      "Ends the grace period for subscriptions whose payment failed, freezing access once retries have run out. Can email real customers — dev has real stores on it.",
+      "Ends the grace period for subscriptions whose payment failed, freezing access once the retry window has run out. Revokes entitlements from real organisations — dev has real stores on it.",
   },
   "billing-reconcile": {
-    label: "⚠️ Re-check card subscriptions",
+    label: "Re-check card subscriptions",
     frequency: "Runs daily at 4am UTC",
     description:
       "Compares every Stripe/Razorpay subscription against what the gateway actually says, correcting anything a dropped webhook left stale — such as a cancellation that never arrived.",
   },
   "shopify-billing-reconcile": {
-    label: "⚠️ Re-check Shopify subscriptions",
+    label: "Re-check Shopify subscriptions",
     frequency: "Runs daily at 3:30am UTC",
     description:
       "The safety net for a dropped Shopify billing webhook. Re-reads each store's live subscription state so an uninstall or cancellation that never reached us stops granting access.",
   },
   "internal-settlement": {
-    label: "⚠️ Settle internal accounts",
-    frequency: "Runs monthly on the 1st",
+    label: "Settle internal accounts",
+    frequency: "Runs monthly (1st, 3:00 AM UTC)",
     description:
       "Produces the notional invoice and matching credit note for non-billable internal orgs, netting to zero. Never calls a payment gateway.",
   },
   "einvoice-register": {
-    label: "⚠️ Register GST e-invoices",
+    label: "Register GST e-invoices",
     frequency: "Runs every 2 hours",
     description:
       "Submits pending B2B GST invoices to the government IRP to obtain an IRN and signed QR code. Talks to a real external tax portal.",
@@ -504,7 +505,7 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
   },
   "site-graph-metrics": {
     label: "Sync page metrics",
-    frequency: "Runs weekly on Monday",
+    frequency: "Runs weekly (Mon 5:00 AM UTC)",
     description:
       "Pulls per-URL clicks and impressions from Search Console into the site graph so page-level performance is current.",
   },
@@ -539,10 +540,10 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       "For each WordPress site with autopilot due, re-checks the site still holds a paid Content entitlement and then publishes the next scheduled piece. A lapsed subscription disables autopilot rather than publishing.",
   },
   "wp-identity-reconcile": {
-    label: "Re-check WordPress identity",
+    label: "Clean up WordPress shells",
     frequency: "Runs daily at 6am UTC",
     description:
-      "Server-side backstop for WordPress sites whose domain or connection changed, so a plugin re-connect can't silently bind a site to the wrong account.",
+      "Deletes leftover placeholder accounts from WordPress silent-connect that ended up with no site attached — after an interrupted claim, for example. Only ever removes a placeholder with zero connections, never a real account.",
   },
 
   // ── Already triggerable, never documented ──────────────────────────
@@ -558,11 +559,17 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     label: "Convert finished trials",
     frequency: "Runs daily at 3:45am UTC",
     description:
-      "Turns a trial that has run its course into a real billing line on the customer's existing subscription, so the first charge lands on schedule.",
+      "Turns a trial that has run its course into a real billing line on the customer's live payment-gateway subscription, so the first charge lands on schedule. This changes what a real customer is billed.",
+  },
+  "shopify-deadstock-score": {
+    label: "Score dead stock",
+    frequency: "Runs daily at 2:15am UTC",
+    description:
+      "Scores each Shopify store's catalog for stock that isn't selling and writes the diagnosis the Commerce insights read from. Uses AI, so it costs Peaks.",
   },
   "media-overage-snapshot": {
     label: "Snapshot storage overage",
-    frequency: "Runs monthly on the 1st",
+    frequency: "Runs monthly (1st, 6:00 AM UTC)",
     description:
       "Captures how much storage each organisation used beyond its plan for the month that just closed, which is what any overage is billed from.",
   },
@@ -572,17 +579,11 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Refreshes long-lived Meta tokens for connections nothing has touched recently, so a dormant account doesn't quietly expire and need reconnecting.",
   },
-  "shopify-deadstock-score": {
-    label: "Score dead stock",
-    frequency: "Runs daily at 2:15am UTC",
-    description:
-      "Scores each Shopify store's catalog for stock that isn't selling and writes the diagnosis the Commerce insights read from.",
-  },
   "shopify-voice-card-learn": {
     label: "Learn store voice",
     frequency: "Runs daily at 3:45am UTC",
     description:
-      "Reviews how each Shopify store's assistant has been answering and updates its voice card, so replies sound more like the merchant over time.",
+      "Feeds each merchant's approvals, edits and rejections of AI suggestions back into their voice card, so future suggestions sound more like them. Skips a store until it has enough new verdicts to learn from. Uses AI, so it costs Peaks.",
   },
 };
 
@@ -641,7 +642,15 @@ export function summarizeCronBody(
   if (!summarize || !body) return null;
   try {
     const parsed = JSON.parse(body) as unknown;
-    const data = asRecord(parsed)?.data;
+    const root = asRecord(parsed);
+    // The api has TWO cron response conventions and always has: most handlers
+    // return `{ok, data:{…}}`, but ai-credits-rollup and every media-* cron
+    // return the payload FLAT (`{success, processed, …}`). Reading only `.data`
+    // silently handed `undefined` to those summarizers, so all five returned
+    // null and fell back to "<label> complete" — including, in the rollup's
+    // case, turning a run that charged nothing into a green success, which is
+    // the exact outcome the warning level exists to prevent.
+    const data = root?.data !== undefined ? root.data : root;
     const result = summarize(data);
     if (result == null) return null;
     // Normalize the bare-string form to a success-level object.

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -65,7 +65,15 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Permanently removes media that has been in the trash past its 30-day recovery window, freeing the storage for good.",
     summarize: (data) => {
-      const d = data as { purged?: number } | null;
+      const d = data as { purged?: number; skipped?: string } | null;
+      // The handler early-returns `{success:true, skipped:"storage_not_configured",
+      // purged:0}` when there is no object store. Now that flat bodies actually
+      // reach this summarizer, that path would otherwise read as a healthy
+      // "0 expired items purged." — a green toast for a cron that did nothing
+      // because it CAN'T.
+      if (d?.skipped) {
+        return { message: "Nothing purged — media storage isn't configured.", level: "warning" };
+      }
       return typeof d?.purged === "number" ? `${d.purged} expired item${d.purged === 1 ? "" : "s"} purged.` : null;
     },
   },
@@ -643,13 +651,16 @@ export function summarizeCronBody(
   try {
     const parsed = JSON.parse(body) as unknown;
     const root = asRecord(parsed);
-    // The api has TWO cron response conventions and always has: most handlers
-    // return `{ok, data:{…}}`, but ai-credits-rollup and every media-* cron
-    // return the payload FLAT (`{success, processed, …}`). Reading only `.data`
-    // silently handed `undefined` to those summarizers, so all five returned
-    // null and fell back to "<label> complete" — including, in the rollup's
-    // case, turning a run that charged nothing into a green success, which is
-    // the exact outcome the warning level exists to prevent.
+    // The api has THREE cron response conventions and always has:
+    //   • `{ok, data:{…}}`            — most handlers
+    //   • `{success, processed, …}`   — flat: ai-credits-rollup, every media-*
+    //   • `{ok:true, ...result}`      — flat under `ok`: the site-graph-* trio,
+    //                                   voice-card-learning
+    // Reading only `.data` silently handed `undefined` to every summarizer in
+    // the last two groups, so they returned null and fell back to "<label>
+    // complete" — including, in the rollup's case, turning a run that charged
+    // nothing into a green success, which is the exact outcome the warning
+    // level exists to prevent. Falling back to the root covers all three.
     const data = root?.data !== undefined ? root.data : root;
     const result = summarize(data);
     if (result == null) return null;

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -435,6 +435,155 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       return `${parts.join(", ")}.`;
     },
   },
+
+  // ── Billing + money ────────────────────────────────────────────────
+  // Undocumented until now because none of them could be triggered at all
+  // (peakhour-api#1017). ⚠️ marks the ones the api refuses without an explicit
+  // confirmation, because their effects leave Peakhour.
+  "ai-credits-rollup": {
+    label: "Charge Peaks used",
+    frequency: "Runs every minute",
+    description:
+      "Turns AI work already done into Peaks charged against each plan's allowance. Until this runs, usage shows under 'Where your Peaks go' but no balance has moved. Only covers the last 6 hours, so it can't backfill older usage.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return null;
+      const processed = num(d.processed);
+      if (processed === 0) {
+        return { message: "No new AI usage to charge.", level: "warning" };
+      }
+      const parts = [`${processed} AI ${plural(processed, "call")} charged`];
+      if (num(d.topUpDebited) > 0) parts.push(`${num(d.topUpDebited)} Peaks drawn from top-ups`);
+      if (num(d.failed) > 0) parts.push(`${num(d.failed)} failed`);
+      return `${parts.join(", ")}.`;
+    },
+  },
+  "billing-dunning": {
+    label: "⚠️ Enforce failed payments",
+    frequency: "Runs hourly",
+    description:
+      "Ends the grace period for subscriptions whose payment failed, freezing access once retries have run out. Can email real customers — dev has real stores on it.",
+  },
+  "billing-reconcile": {
+    label: "⚠️ Re-check card subscriptions",
+    frequency: "Runs daily at 4am UTC",
+    description:
+      "Compares every Stripe/Razorpay subscription against what the gateway actually says, correcting anything a dropped webhook left stale — such as a cancellation that never arrived.",
+  },
+  "shopify-billing-reconcile": {
+    label: "⚠️ Re-check Shopify subscriptions",
+    frequency: "Runs daily at 3:30am UTC",
+    description:
+      "The safety net for a dropped Shopify billing webhook. Re-reads each store's live subscription state so an uninstall or cancellation that never reached us stops granting access.",
+  },
+  "internal-settlement": {
+    label: "⚠️ Settle internal accounts",
+    frequency: "Runs monthly on the 1st",
+    description:
+      "Produces the notional invoice and matching credit note for non-billable internal orgs, netting to zero. Never calls a payment gateway.",
+  },
+  "einvoice-register": {
+    label: "⚠️ Register GST e-invoices",
+    frequency: "Runs every 2 hours",
+    description:
+      "Submits pending B2B GST invoices to the government IRP to obtain an IRN and signed QR code. Talks to a real external tax portal.",
+  },
+
+  // ── Site graph, analytics + integrations ───────────────────────────
+  "site-graph-health": {
+    label: "Check link health",
+    frequency: "Runs every 6 hours",
+    description:
+      "Scans a batch of the least-recently-checked pages for broken links and redirects, so the site graph reflects what visitors actually hit.",
+  },
+  "site-graph-inspection": {
+    label: "Sync URL inspection",
+    frequency: "Runs daily at 4am UTC",
+    description:
+      "Asks Google Search Console how it sees a batch of your URLs — indexed, excluded, or blocked — and stores the verdict against each page.",
+  },
+  "site-graph-metrics": {
+    label: "Sync page metrics",
+    frequency: "Runs weekly on Monday",
+    description:
+      "Pulls per-URL clicks and impressions from Search Console into the site graph so page-level performance is current.",
+  },
+  "pin-rollup": {
+    label: "Roll up network insights",
+    frequency: "Runs daily at 4am UTC",
+    description:
+      "Contributes anonymised, consent-gated catalog signals to the Insights Network and refreshes the benchmarks each business sees. Never carries a business identifier.",
+  },
+  "linkedin-conversion-stream": {
+    label: "Send conversions to LinkedIn",
+    frequency: "Runs daily at 5am UTC",
+    description:
+      "Streams matured lead attribution back to LinkedIn's Conversions API so ad reporting closes the loop on what actually converted.",
+  },
+  "integration-fit-reconcile": {
+    label: "Flag mismatched connections",
+    frequency: "Runs daily at 6:30am UTC",
+    description:
+      "Finds existing connections whose brand doesn't match the business that owns them — pollution the connect-time guard now prevents but can't retroactively clean.",
+  },
+  "support-sla-sweep": {
+    label: "Flag overdue support",
+    frequency: "Runs hourly",
+    description:
+      "Marks open inbox items whose first-response or resolution deadline has passed, so a breach surfaces instead of ageing quietly.",
+  },
+  "wp-autopilot": {
+    label: "Run WordPress autopilot",
+    frequency: "Runs hourly",
+    description:
+      "For each WordPress site with autopilot due, re-checks the site still holds a paid Content entitlement and then publishes the next scheduled piece. A lapsed subscription disables autopilot rather than publishing.",
+  },
+  "wp-identity-reconcile": {
+    label: "Re-check WordPress identity",
+    frequency: "Runs daily at 6am UTC",
+    description:
+      "Server-side backstop for WordPress sites whose domain or connection changed, so a plugin re-connect can't silently bind a site to the wrong account.",
+  },
+
+  // ── Already triggerable, never documented ──────────────────────────
+  // Surfaced by the coverage test: these were on the api's allowlist all along
+  // but had no entry here, so they rendered as "Run fx-rates" with no schedule.
+  "fx-rates": {
+    label: "Refresh exchange rates",
+    frequency: "Runs daily at 4:30am UTC",
+    description:
+      "Pulls fresh USD-base currency rates so revenue reported in USD reflects today's rates rather than the day a sale happened to land.",
+  },
+  "trial-conversion-sweep": {
+    label: "Convert finished trials",
+    frequency: "Runs daily at 3:45am UTC",
+    description:
+      "Turns a trial that has run its course into a real billing line on the customer's existing subscription, so the first charge lands on schedule.",
+  },
+  "media-overage-snapshot": {
+    label: "Snapshot storage overage",
+    frequency: "Runs monthly on the 1st",
+    description:
+      "Captures how much storage each organisation used beyond its plan for the month that just closed, which is what any overage is billed from.",
+  },
+  "meta-token-keepalive": {
+    label: "Keep Meta tokens alive",
+    frequency: "Runs daily at 4am UTC",
+    description:
+      "Refreshes long-lived Meta tokens for connections nothing has touched recently, so a dormant account doesn't quietly expire and need reconnecting.",
+  },
+  "shopify-deadstock-score": {
+    label: "Score dead stock",
+    frequency: "Runs daily at 2:15am UTC",
+    description:
+      "Scores each Shopify store's catalog for stock that isn't selling and writes the diagnosis the Commerce insights read from.",
+  },
+  "shopify-voice-card-learn": {
+    label: "Learn store voice",
+    frequency: "Runs daily at 3:45am UTC",
+    description:
+      "Reviews how each Shopify store's assistant has been answering and updates its voice card, so replies sound more like the merchant over time.",
+  },
 };
 
 /** Fallback for a cron name not yet documented in CRON_METADATA. The UI

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
-import { getCronMetadata, summarizeCronBody } from "./cron-metadata";
+import { CRON_METADATA, getCronMetadata, summarizeCronBody } from "./cron-metadata";
 
 interface DevCronResult {
   cron: string;
@@ -89,6 +89,35 @@ function isProductionEnv(): boolean {
 // in-flight cron registers itself here and unregisters in the finally.
 const inFlightCrons = new Set<string>();
 
+/**
+ * The confirmation prompt for a cron whose effects leave our database.
+ *
+ * Leads with the cron's OWN description rather than one blanket sentence: an
+ * earlier draft asserted these "email real merchants or call an external
+ * provider", which is wrong for two of the five — internal-settlement never
+ * calls a gateway and billing-dunning sends nothing, it freezes access.
+ * Guessing at the danger is how you train people to click straight through.
+ *
+ * But `requiresConfirmation` is RUNTIME data from the api, so the newly
+ * dangerous cron is precisely the one this build may have no metadata for — and
+ * the fallback description is a note to a developer ("Add this cron to
+ * cron-metadata.ts"), which tells the person clicking nothing at all. So the
+ * consequence line is always appended; it is the only part guaranteed to be
+ * true and useful for a cron we have never heard of.
+ */
+function confirmText(cron: string, meta: { label: string; description: string }): string {
+  const known = cron in CRON_METADATA;
+  return [
+    meta.label,
+    "",
+    known ? meta.description : `The "${cron}" cron.`,
+    "",
+    "This one has effects outside Peakhour — it can reach real customers or an external provider.",
+    "",
+    "Run it now?",
+  ].join("\n");
+}
+
 export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props) {
   // Hooks must run unconditionally; the production gate decides what to
   // render below, not whether to mount.
@@ -111,6 +140,53 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
 
   if (isProductionEnv() || crons.length === 0) return null;
 
+  /**
+   * What to do with a dev-cron response, for EVERY path that gets one.
+   *
+   * Extracted because the confirmation-retry path grew its own copy and
+   * immediately diverged: it toasted success without checking `ok`, so a cron
+   * that 500'd inside the dev route's 200 envelope reported green with nothing
+   * logged — on the retry path for the dangerous crons, of all places. Two
+   * copies of this will always drift; one cannot.
+   */
+  function handleResult(cron: string, label: string, res: DevCronResult) {
+    if (res.ok) {
+      // Show a clean, user-facing line — never the raw cron JSON. The per-cron
+      // summarizer turns the response payload into something like "12 posts
+      // synced successfully."; absent one, we fall back to a generic "<label>
+      // complete". A summarizer can flag `level:"warning"` for a 2xx run that
+      // did nothing useful (e.g. a sync that skipped every connection because
+      // none is configured) so a no-op stops reading as a green success. The
+      // raw body + timing still go to the dev console for debugging.
+      const summary = summarizeCronBody(cron, res.body);
+      if (summary?.level === "warning") {
+        toast.warning(summary.message);
+      } else {
+        toast.success(summary?.message ?? `${label} complete`);
+      }
+      if (res.body) {
+        console.debug(`[CronToolbar] ${cron} ok in ${res.durationMs}ms:`, res.body);
+      }
+      // A truncated body can't be JSON.parsed, so the summary silently
+      // disappears and the toast falls back to "<label> complete". Say so in
+      // the console rather than leaving it looking like a missing summarizer.
+      if (res.truncated) {
+        console.debug(`[CronToolbar] ${cron} body was truncated — no summary available.`);
+      }
+      // Success-only callback — see Props.onTriggered jsdoc. A failed cron run
+      // already surfaced via the toast.error branch; the host page doesn't need
+      // to invalidate queries for a no-op or error.
+      onTriggered?.(res);
+    } else {
+      // Keep the failure toast friendly too — the HTTP status + body are dev
+      // detail, not something to surface verbatim. Log them instead.
+      console.error(`[CronToolbar] ${cron} failed: HTTP ${res.status}`, res.body);
+      toast.error(`${label} didn't complete`, {
+        description: "Please try again in a moment.",
+      });
+    }
+  }
+
   async function trigger(cron: string) {
     if (inFlightCrons.has(cron)) return;
     const meta = getCronMetadata(cron);
@@ -118,12 +194,7 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
     // separate tenant but has real stores on it, and these send real email /
     // hit a real tax portal — a one-click toolbar is the wrong shape for that.
     const needsConfirm = requiresConfirmation?.includes(cron) ?? false;
-    // The cron's OWN description, not a one-size-fits-all sentence. An earlier
-    // draft asserted these "email real merchants or call an external provider",
-    // which is wrong for two of the five: internal-settlement never calls a
-    // gateway, and billing-dunning sends nothing — it freezes access. Guessing
-    // at the danger is how you train people to click through the dialog.
-    if (needsConfirm && !window.confirm(`${meta.label}\n\n${meta.description}\n\nRun it now?`)) {
+    if (needsConfirm && !window.confirm(confirmText(cron, meta))) {
       return;
     }
     inFlightCrons.add(cron);
@@ -135,42 +206,7 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
         `/v1/dev/cron/${cron}`,
         needsConfirm ? { confirm: cron } : {},
       );
-      if (res.ok) {
-        // Show a clean, user-facing line — never the raw cron JSON. The
-        // per-cron summarizer turns the response payload into something like
-        // "12 posts synced successfully."; absent one, we fall back to a
-        // generic "<label> complete". A summarizer can flag `level:"warning"`
-        // for a 2xx run that did nothing useful (e.g. a sync that skipped
-        // every connection because none is configured) so a no-op stops
-        // reading as a green success. The raw body + timing still go to the
-        // dev console for debugging.
-        const summary = summarizeCronBody(cron, res.body);
-        if (summary?.level === "warning") {
-          toast.warning(summary.message);
-        } else {
-          toast.success(summary?.message ?? `${meta.label} complete`);
-        }
-        if (res.body) {
-          console.debug(
-            `[CronToolbar] ${cron} ok in ${res.durationMs}ms:`,
-            res.body,
-          );
-        }
-        // Success-only callback — see Props.onTriggered jsdoc. A failed
-        // cron run already surfaced via the toast.error branch; the host
-        // page doesn't need to invalidate queries for a no-op or error.
-        onTriggered?.(res);
-      } else {
-        // Keep the failure toast friendly too — the HTTP status + body are
-        // dev detail, not something to surface verbatim. Log them instead.
-        console.error(
-          `[CronToolbar] ${cron} failed: HTTP ${res.status}`,
-          res.body,
-        );
-        toast.error(`${meta.label} didn't complete`, {
-          description: "Please try again in a moment.",
-        });
-      }
+      handleResult(cron, meta.label, res);
     } catch (err) {
       console.error(`[CronToolbar] ${cron} request failed:`, err);
       // "Try again in a moment" is right for a flake and actively misleading
@@ -184,11 +220,10 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
         // that could never help: /cms/crons is the only surface that passes
         // `requiresConfirmation`, so it is exactly where they already are.
         // Ask properly and retry once instead.
-        if (window.confirm(`${meta.label}\n\n${err instanceof ApiError ? err.message : ""}\n\nRun it now?`)) {
+        if (window.confirm(confirmText(cron, meta))) {
           try {
             const retry = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, { confirm: cron });
-            toast.success(summarizeCronBody(cron, retry.body)?.message ?? `${meta.label} complete`);
-            if (retry.ok) onTriggered?.(retry);
+            handleResult(cron, meta.label, retry);
           } catch (retryErr) {
             console.error(`[CronToolbar] ${cron} retry failed:`, retryErr);
             toast.error(`${meta.label} couldn't run`, {
@@ -249,6 +284,7 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
                     className="h-6 px-2 text-xs"
                     onClick={() => trigger(cron)}
                     disabled={disabled}
+                    aria-busy={running}
                   >
                     {running ? "Running…" : guarded ? `⚠️ ${meta.label}` : meta.label}
                   </Button>
@@ -259,6 +295,13 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
                     {meta.frequency}
                   </p>
                   <p className="text-xs mt-1">{meta.description}</p>
+                  {/* Says what the ⚠️ MEANS. An unexplained emoji on a button
+                      is a warning nobody can act on. */}
+                  {guarded ? (
+                    <p className="text-xs mt-1 font-medium">
+                      ⚠️ Reaches outside Peakhour — asks before running.
+                    </p>
+                  ) : null}
                   <p className="text-[10px] text-muted-foreground mt-1 font-mono">
                     cron: {cron}
                   </p>

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -92,7 +92,22 @@ const inFlightCrons = new Set<string>();
 export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props) {
   // Hooks must run unconditionally; the production gate decides what to
   // render below, not whether to mount.
-  const [runningCron, setRunningCron] = useState<string | null>(null);
+  //
+  // A SET, not a single slot. Parallel firing is the documented design (see the
+  // per-button comment), but one `string | null` meant firing B overwrote A's
+  // "Running…", and whichever finished FIRST re-enabled both buttons while the
+  // other was still in flight. The module-scoped guard stopped a real
+  // double-fire, so this was only ever confusing — but /cms/crons now renders
+  // 56 buttons, which makes it easy to hit.
+  const [runningCrons, setRunningCrons] = useState<ReadonlySet<string>>(new Set());
+  const startRunning = (cron: string) =>
+    setRunningCrons((prev) => new Set(prev).add(cron));
+  const stopRunning = (cron: string) =>
+    setRunningCrons((prev) => {
+      const next = new Set(prev);
+      next.delete(cron);
+      return next;
+    });
 
   if (isProductionEnv() || crons.length === 0) return null;
 
@@ -103,16 +118,16 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
     // separate tenant but has real stores on it, and these send real email /
     // hit a real tax portal — a one-click toolbar is the wrong shape for that.
     const needsConfirm = requiresConfirmation?.includes(cron) ?? false;
-    if (
-      needsConfirm &&
-      !window.confirm(
-        `${meta.label} affects things outside Peakhour — it can email real merchants or call an external provider. Run it now?`,
-      )
-    ) {
+    // The cron's OWN description, not a one-size-fits-all sentence. An earlier
+    // draft asserted these "email real merchants or call an external provider",
+    // which is wrong for two of the five: internal-settlement never calls a
+    // gateway, and billing-dunning sends nothing — it freezes access. Guessing
+    // at the danger is how you train people to click through the dialog.
+    if (needsConfirm && !window.confirm(`${meta.label}\n\n${meta.description}\n\nRun it now?`)) {
       return;
     }
     inFlightCrons.add(cron);
-    setRunningCron(cron);
+    startRunning(cron);
     try {
       // The api requires the cron's own name as the confirmation token, so a
       // generic `{confirm:true}` is deliberately not enough.
@@ -162,12 +177,25 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
       // for a refusal that will never succeed on retry. These two codes are the
       // api telling us something actionable, so say it.
       const code = err instanceof ApiError ? err.code : null;
-      if (code === "CONFIRMATION_REQUIRED") {
-        // Only reachable when this toolbar wasn't told the cron needs
-        // confirming — the api knows and we didn't.
-        toast.error(`${meta.label} needs confirmation`, {
-          description: "This cron reaches outside Peakhour. Run it from the Crons page.",
-        });
+      if (code === "CONFIRMATION_REQUIRED" && !needsConfirm) {
+        // Reachable when the api knows a cron is dangerous and this build
+        // doesn't — an api deployed ahead of b2c, which is the normal order.
+        // Telling the user to "run it from the Crons page" was the one thing
+        // that could never help: /cms/crons is the only surface that passes
+        // `requiresConfirmation`, so it is exactly where they already are.
+        // Ask properly and retry once instead.
+        if (window.confirm(`${meta.label}\n\n${err instanceof ApiError ? err.message : ""}\n\nRun it now?`)) {
+          try {
+            const retry = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, { confirm: cron });
+            toast.success(summarizeCronBody(cron, retry.body)?.message ?? `${meta.label} complete`);
+            if (retry.ok) onTriggered?.(retry);
+          } catch (retryErr) {
+            console.error(`[CronToolbar] ${cron} retry failed:`, retryErr);
+            toast.error(`${meta.label} couldn't run`, {
+              description: "Please try again in a moment.",
+            });
+          }
+        }
       } else if (code === "DEV_ONLY") {
         toast.error("Cron triggers are disabled here", {
           description: "This environment is treated as production.",
@@ -179,7 +207,7 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
       }
     } finally {
       inFlightCrons.delete(cron);
-      setRunningCron(null);
+      stopRunning(cron);
     }
   }
 
@@ -200,12 +228,17 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
         <div className="flex flex-wrap gap-1">
           {crons.map((cron) => {
             const meta = getCronMetadata(cron);
-            const running = runningCron === cron;
+            const running = runningCrons.has(cron);
             // Only disable the in-flight cron's button. Independent crons
             // can fire in parallel — strategist surfaces 5 of them and
             // serializing here would force a ~minute of waiting to
             // exercise the whole row.
             const disabled = running;
+            // Marked from the API's own list rather than a hardcoded set here.
+            // Baking the marker into the label would recreate the drift this
+            // whole change exists to remove: the api would add a sixth
+            // dangerous cron and b2c would render it unmarked.
+            const guarded = requiresConfirmation?.includes(cron) ?? false;
             return (
               <Tooltip key={cron}>
                 <TooltipTrigger asChild>
@@ -217,7 +250,7 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
                     onClick={() => trigger(cron)}
                     disabled={disabled}
                   >
-                    {running ? "Running…" : meta.label}
+                    {running ? "Running…" : guarded ? `⚠️ ${meta.label}` : meta.label}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent className="max-w-xs">

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -42,7 +42,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { getCronMetadata, summarizeCronBody } from "./cron-metadata";
 
 interface DevCronResult {
@@ -57,6 +57,18 @@ interface DevCronResult {
 interface Props {
   /** Ordered list of cron names. The toolbar renders one button per name. */
   crons: readonly string[];
+  /**
+   * Crons the api refuses to fire without `{"confirm":"<name>"}` — its effects
+   * leave our database (a customer email, an external tax portal, a payment
+   * gateway). Comes from `GET /v1/dev/cron`; pass it through rather than
+   * hardcoding, so the api stays the single source of truth for what is
+   * dangerous.
+   *
+   * Omitted on the per-page toolbars, which list only everyday crons. A cron
+   * that turns out to need confirmation without being named here still can't
+   * fire by accident — the api refuses and the toast says exactly why.
+   */
+  requiresConfirmation?: readonly string[];
   /** Optional callback fired ONLY when the cron handler responded 2xx
    *  (result.ok === true). Host pages typically use this to invalidate
    *  the React Query keys whose data the cron just mutated; invalidating
@@ -77,7 +89,7 @@ function isProductionEnv(): boolean {
 // in-flight cron registers itself here and unregisters in the finally.
 const inFlightCrons = new Set<string>();
 
-export function CronToolbar({ crons, onTriggered }: Props) {
+export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props) {
   // Hooks must run unconditionally; the production gate decides what to
   // render below, not whether to mount.
   const [runningCron, setRunningCron] = useState<string | null>(null);
@@ -86,11 +98,28 @@ export function CronToolbar({ crons, onTriggered }: Props) {
 
   async function trigger(cron: string) {
     if (inFlightCrons.has(cron)) return;
+    const meta = getCronMetadata(cron);
+    // Ask BEFORE firing anything whose effects leave our database. Dev is a
+    // separate tenant but has real stores on it, and these send real email /
+    // hit a real tax portal — a one-click toolbar is the wrong shape for that.
+    const needsConfirm = requiresConfirmation?.includes(cron) ?? false;
+    if (
+      needsConfirm &&
+      !window.confirm(
+        `${meta.label} affects things outside Peakhour — it can email real merchants or call an external provider. Run it now?`,
+      )
+    ) {
+      return;
+    }
     inFlightCrons.add(cron);
     setRunningCron(cron);
-    const meta = getCronMetadata(cron);
     try {
-      const res = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, {});
+      // The api requires the cron's own name as the confirmation token, so a
+      // generic `{confirm:true}` is deliberately not enough.
+      const res = await api.post<DevCronResult>(
+        `/v1/dev/cron/${cron}`,
+        needsConfirm ? { confirm: cron } : {},
+      );
       if (res.ok) {
         // Show a clean, user-facing line — never the raw cron JSON. The
         // per-cron summarizer turns the response payload into something like
@@ -129,9 +158,25 @@ export function CronToolbar({ crons, onTriggered }: Props) {
       }
     } catch (err) {
       console.error(`[CronToolbar] ${cron} request failed:`, err);
-      toast.error(`${meta.label} couldn't run`, {
-        description: "Please try again in a moment.",
-      });
+      // "Try again in a moment" is right for a flake and actively misleading
+      // for a refusal that will never succeed on retry. These two codes are the
+      // api telling us something actionable, so say it.
+      const code = err instanceof ApiError ? err.code : null;
+      if (code === "CONFIRMATION_REQUIRED") {
+        // Only reachable when this toolbar wasn't told the cron needs
+        // confirming — the api knows and we didn't.
+        toast.error(`${meta.label} needs confirmation`, {
+          description: "This cron reaches outside Peakhour. Run it from the Crons page.",
+        });
+      } else if (code === "DEV_ONLY") {
+        toast.error("Cron triggers are disabled here", {
+          description: "This environment is treated as production.",
+        });
+      } else {
+        toast.error(`${meta.label} couldn't run`, {
+          description: "Please try again in a moment.",
+        });
+      }
     } finally {
       inFlightCrons.delete(cron);
       setRunningCron(null);


### PR DESCRIPTION
Companion to peakhour-api#1017, which added 15 crons to the dev-trigger allowlist. This is the half that makes them usable rather than a row of unlabelled buttons.

## The Peaks page can now run the cron its numbers come from

Every figure on `/dashboard/peaks` is downstream of `ai-credits-rollup`, and Vercel doesn't fire crons on dev — which is exactly why the balance sat at **0 used forever** while "Where your Peaks go" filled up from raw usage. That's the shape the toolbar pattern exists for.

Invalidates balance **and** history on success, since the rollup writes the meters both read and refreshing one would leave the page disagreeing with itself.

## Confirmation flow

The api refuses five outward-reaching crons without `{"confirm":"<name>"}`, and now reports which via `requiresConfirmation`. The toolbar asks **before** firing instead of posting `{}` and taking a 400.

Without this, merging the api change alone would have put **five permanently broken buttons** on `/cms/crons`, each failing into "Please try again in a moment" — advice that could never work.

The list is passed through from the api rather than hardcoded, so there's one source of truth for what counts as dangerous. The confirm token is the cron's own name, so a generic `{confirm:true}` deliberately isn't enough.

## Metadata for 21 crons

Written from each handler's own doc comment and its real schedule. Writing the coverage test immediately surfaced **six more** undocumented crons that were already triggerable before any of this work — `fx-rates`, `trial-conversion-sweep`, `media-overage-snapshot`, `meta-token-keepalive`, `shopify-deadstock-score`, `shopify-voice-card-learn` — rendering as "Run fx-rates" with "(undocumented schedule)". Documented those too, so coverage is real rather than complete-for-the-crons-I-happened-to-add.

A test now asserts this file matches the crons the api schedules, in both directions. The header has always claimed the keys "MUST match" the api's allowlist and nothing enforced it, which is how it drifted to 35 entries against 56.

## Review #1's best finding: my summarizer could never run — nor could four others

`summarizeCronBody` extracted the payload as `asRecord(parsed)?.data`. But the api has **two** cron response conventions and always has: most return `{ok, data:{…}}`, while `ai-credits-rollup` and every `media-*` cron return it **flat** (`{success, processed, …}`). So `data` was `undefined` for five summarizers, all returned null, and the toast fell back to `"<label> complete"`.

For the rollup that's the worst possible failure: the one thing an operator needs to know is whether it charged anything, and a run that processed **zero** reported as a **green success** — precisely what the `level: "warning"` machinery exists to prevent.

Fixed at the root (fall back to the root object when there's no `data` key), repairing my new summarizer and the four pre-existing media ones at once. Tests now cover both response shapes, the zero-processed warning, and the malformed-body fallback — the gap that let this through is that nothing tested `summarizeCronBody` at all.

## Three more findings, all about honesty

- **The confirm dialog was guessed.** It asserted these crons "can email real merchants or call an external provider" — wrong for two of five: `internal-settlement` never calls a gateway (its own description says so) and `billing-dunning` sends no email, it freezes access. In a commit claiming the metadata came from handler docs "rather than guessed", the dialog copy was guessed. It now shows the cron's own description.
- **The ⚠️ markers were a third hardcoded list** — five labels here plus the same five names in the test. The api adds a sixth dangerous cron and b2c renders it unmarked with nothing failing. The marker now derives from `requiresConfirmation`, and the test asserts the opposite: that no label hardcodes one.
- **Three descriptions were wrong.** `wp-identity-reconcile` doesn't reconcile identity — it **deletes** orphaned placeholder orgs, worth saying plainly on a one-click button. `shopify-voice-card-learn` aggregates the merchant's approve/edit/reject verdicts, not "how the assistant answered". And `trial-conversion-sweep` / `shopify-deadstock-score` / `shopify-voice-card-learn` now say outright that they bill a real customer or cost Peaks — the api leaves them unconfirmed because they have one-click history, so the description is the only warning an operator gets.

Also: `CONFIRMATION_REQUIRED` told users to "run it from the Crons page" — but that branch is only reachable when the toolbar wasn't given the list, and `/cms/crons` is the only surface that passes it, so it advised going where they already were. It now asks properly and retries once, the realistic path when the api deploys ahead of b2c.

## Smaller fixes

- `runningCron` was a single slot while parallel firing is the documented design, so firing B overwrote A's "Running…" and whichever finished first re-enabled both. Only confusing rather than dangerous (the module guard prevents a real double-fire), but `/cms/crons` now renders 56 buttons. Now a `Set`.
- The coverage test **skipped silently** when the sibling checkout was missing, turning its two real assertions into invisible no-ops — the same failure it exists to prevent. Now warns, and distinguishes "sibling absent" from "vercel.json listed no crons".
- `/cms/crons` labels `VERCEL_ENV` explicitly and distinguishes "APP_ENV unset" from "api too old to report it" — an unset `APP_ENV` is itself the diagnostic, given the api's open question about which env dev actually runs as.

## Verification

`tsc --noEmit` clean · eslint clean · **16 files / 202 tests** · `next build` passes

## Known gap, not fixed here

`peakhour-b2c` has **no CI workflow**, so nothing runs any of this on a PR. Same gap as `peakhour-cms`; worth its own change rather than a workflow smuggled into a cron commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
