### PR TITLE
feat(audience): the library gets a screen — /dashboard/growth/audiences (G1)

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/audience-card.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-card.tsx
@@ -5,6 +5,12 @@ import { toast } from "sonner";
 import { toastUnhandledApiError } from "@/lib/toast-errors";
 import { linkedInAdsApi, type ManagedCampaign } from "@/lib/api/linkedin-ads";
 import { audienceClaim, reachLine } from "@/lib/audience-card-rules";
+// ★THE LIBRARY'S MAP, NOT A NINE-KEY COPY. This card carried its own, and it
+// covered nine of the vocabulary's thirty-one attributes — so a campaign
+// targeting `purchase_intent` rendered the raw identifier here and "Purchase
+// intent" on /dashboard/growth/audiences, in the same session, for the same
+// audience.
+import { attributeLabel } from "@/lib/audience-library-rules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Check, Sparkles } from "lucide-react";
@@ -33,21 +39,6 @@ import { Check, Sparkles } from "lucide-react";
  * `verified` comes from the api because it depends on a fingerprint comparison
  * the client cannot make.
  */
-
-/** Business-language attribute names. An unknown attribute renders under its
- *  own id rather than vanishing — a silent omission would make a narrower
- *  audience look complete, which is the one thing this card must not do. */
-const ATTRIBUTE_LABEL: Record<string, string> = {
-  geo: "Location",
-  company_industry: "Industry",
-  company_size: "Company size",
-  job_title: "Job title",
-  seniority: "Seniority",
-  job_function: "Job function",
-  member_interest: "Interests",
-  company_name: "Companies",
-  skill: "Skills",
-};
 
 export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
   const queryClient = useQueryClient();
@@ -111,7 +102,7 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
         {prov.basis.map((b) => (
           <li key={b.attribute} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             <span className="text-xs text-muted-foreground">
-              {ATTRIBUTE_LABEL[b.attribute] ?? b.attribute}
+              {attributeLabel(b.attribute)}
             </span>
             {/* Readable chips, never URNs — "Mumbai", not urn:li:geo:1. */}
             {b.values.map((v, i) => (

--- a/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Sparkles, History, PencilLine } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import type { AudienceSet } from "@/lib/api/audiences";
+import {
+  audienceShape,
+  channelNote,
+  historyLine,
+  originIsOurs,
+  originLabel,
+  outcomeLine,
+  platformLabel,
+  reachReading,
+  unaskedChannels,
+} from "@/lib/audience-library-rules";
+
+/**
+ * One audience, as a person reads it.
+ *
+ * ★THE ROW IS MOSTLY ABOUT WHAT WE DO NOT KNOW, and every one of those is a
+ * different sentence:
+ *
+ *   - a channel with a number → the number;
+ *   - a channel without one → "no size from X", never a zero and never a blank;
+ *   - a channel NOBODY HAS ASKED → said outright, because "we haven't looked"
+ *     is not "it doesn't work there";
+ *   - attributes a channel could not express → counted here, named in the
+ *     per-channel view.
+ *
+ * The decisions all live in `audience-library-rules.ts` so they can be tested
+ * without a DOM; this file is the arrangement.
+ */
+
+const ORIGIN_ICON = {
+  suggested: Sparkles,
+  imported: History,
+  authored: PencilLine,
+} as const;
+
+export function AudienceSetCard({ set }: { set: AudienceSet }) {
+  const shape = audienceShape(set);
+  const history = historyLine(set);
+  const outcome = outcomeLine(set.outcome);
+  const unasked = unaskedChannels(set);
+  const ours = originIsOurs(set.source);
+  const OriginIcon =
+    set.source === "imported"
+      ? ORIGIN_ICON.imported
+      : set.source === "user_defined"
+        ? ORIGIN_ICON.authored
+        : ORIGIN_ICON.suggested;
+
+  return (
+    <Card className={set.status === "discarded" ? "opacity-70" : undefined}>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="font-semibold break-words">{set.name}</h3>
+            {set.description && (
+              <p className="mt-0.5 text-sm text-muted-foreground break-words">{set.description}</p>
+            )}
+          </div>
+          {/* ★THE ORIGIN BADGE IS THE BRIEF'S OWN DISTINCTION AND IT LEADS.
+              "Peakhour suggested" and "you built this" are the difference
+              between a suggestion and a fact about the business, and a library
+              that renders them alike is one undifferentiated pile. */}
+          <Badge variant={ours ? "outline" : "secondary"} className="shrink-0 gap-1">
+            <OriginIcon className="size-3" aria-hidden="true" />
+            {originLabel(set.source)}
+          </Badge>
+        </div>
+
+        {shape.length > 0 ? (
+          <ul className="space-y-1">
+            {shape.map((row) => (
+              <li key={row.attribute} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span className="text-xs text-muted-foreground">{row.label}</span>
+                {row.values.map((v, i) => (
+                  // Keyed by index as well as value: two distinct entities can
+                  // share a display name, and only the label survives here.
+                  <Badge
+                    key={`${row.attribute}:${i}:${v}`}
+                    variant="outline"
+                    className="font-normal whitespace-normal"
+                  >
+                    {v}
+                  </Badge>
+                ))}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          // ★AN IMPORTED SET HAS NO HYPOTHESIS AND SAYING SO IS THE POINT. Its
+          // targeting is the platform's own, read off a campaign they ran — so
+          // there is no business-language description to show, and inventing
+          // one out of URNs would be a sentence we made up.
+          <p className="text-sm text-muted-foreground">
+            Read off the campaign as it ran, so we don&apos;t have a plain-language
+            description of who it targets.
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+          {set.channels.map((channel) => {
+            const reach = reachReading(channel);
+            const note = channelNote(channel);
+            return (
+              <span key={channel.platform} className="flex items-center gap-1.5">
+                <span
+                  className={
+                    reach.kind === "counted" ? "font-medium" : "text-muted-foreground italic"
+                  }
+                >
+                  {reach.text}
+                </span>
+                {note && <span className="text-muted-foreground">· {note}</span>}
+              </span>
+            );
+          })}
+          {/* ★NOT A BLANK, AND NOT "DOESN'T WORK THERE". Nobody has asked this
+              channel about this audience; the honest thing is to say so, and
+              it is also where the next action is. */}
+          {unasked.length > 0 && (
+            <span className="text-muted-foreground">
+              Not checked on {unasked.map(platformLabel).join(" or ")} yet
+            </span>
+          )}
+        </div>
+
+        {(history || outcome) && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t pt-2 text-xs text-muted-foreground">
+            {history && <span>{history}</span>}
+            {history && outcome && <span aria-hidden="true">·</span>}
+            {/* Copied from the campaigns that ran it, never independently
+                measured — the api's own `basis` says so on every row. */}
+            {outcome && <span>{outcome}</span>}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import type { AudienceSet } from "@/lib/api/audiences";
 import {
   audienceShape,
-  channelNote,
+  channelNotes,
   historyLine,
   originIsOurs,
   originLabel,
@@ -105,7 +105,7 @@ export function AudienceSetCard({ set }: { set: AudienceSet }) {
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
           {set.channels.map((channel) => {
             const reach = reachReading(channel);
-            const note = channelNote(channel);
+            const notes = channelNotes(channel);
             return (
               <span key={channel.platform} className="flex items-center gap-1.5">
                 <span
@@ -115,7 +115,11 @@ export function AudienceSetCard({ set }: { set: AudienceSet }) {
                 >
                   {reach.text}
                 </span>
-                {note && <span className="text-muted-foreground">· {note}</span>}
+                {notes.map((note) => (
+                  <span key={note} className="text-muted-foreground">
+                    · {note}
+                  </span>
+                ))}
               </span>
             );
           })}

--- a/src/app/(site)/dashboard/growth/audiences/filters.ts
+++ b/src/app/(site)/dashboard/growth/audiences/filters.ts
@@ -1,0 +1,49 @@
+import type { AudienceSource, AudienceSetStatus } from "@/lib/api/audiences";
+
+/**
+ * The library's filter vocabulary — extracted from the page so it can be
+ * asserted against the api's enums.
+ *
+ * ★THE SEAM NOTHING COVERED, AND WHERE A REAL DEFECT LIVED. `GET /sets` takes
+ * ONE `source` value from a four-member enum, and a first cut offered three:
+ * the `fallback` set every plan carries was badged identically to the rows the
+ * filter returned and reachable from no option in any dropdown. A filter that
+ * is accepted and then quietly excludes something is a list a customer reads as
+ * "I have no audiences" — which is the exact failure the api's own strict enums
+ * exist to prevent, one layer up.
+ *
+ * These live in a module of their own rather than in `page.tsx` because a
+ * client component cannot be imported by a node-environment test.
+ */
+
+/** `all` rather than an empty string: a Radix Select item may not have an empty
+ *  value, and the query simply omits the key. */
+export const ALL = "all";
+
+export const SOURCES: ReadonlyArray<{ value: AudienceSource; label: string }> = [
+  { value: "generated", label: "Peakhour suggested" },
+  // The deterministic geography × industry set every plan carries — the one the
+  // strategist's ideas are MEASURED AGAINST. Its own label, because the api
+  // takes one value and a shared one makes it unreachable.
+  { value: "fallback", label: "Peakhour baseline" },
+  { value: "imported", label: "From past campaigns" },
+  { value: "user_defined", label: "You built" },
+];
+
+export const STATUSES: ReadonlyArray<{ value: AudienceSetStatus; label: string }> = [
+  { value: "proposed", label: "Suggested" },
+  { value: "applied", label: "On a campaign" },
+  { value: "discarded", label: "Discarded" },
+  { value: "superseded", label: "Replaced" },
+];
+
+export const PAGE_SIZE = 20;
+
+/** The api's own `q` bound. A longer string is a 400, and a 400 on this route
+ *  renders as an error state whose only action refetches the same invalid
+ *  query — so the input refuses the character rather than the request. */
+export const SEARCH_MAX = 80;
+
+/** The api caps `offset` at 1000 and 400s past it, so the last page a customer
+ *  can reach is the last one the server will serve. */
+export const MAX_OFFSET = 1000;

--- a/src/app/(site)/dashboard/growth/audiences/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Users } from "lucide-react";
+import { ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -17,6 +18,7 @@ import { useAudienceSets } from "@/hooks/use-audience-library";
 import { platformLabel, LIBRARY_CHANNELS } from "@/lib/audience-library-rules";
 import type { AudienceSetsQuery } from "@/lib/api/audiences";
 import { AudienceSetCard } from "./_components/audience-set-card";
+import { ALL, MAX_OFFSET, PAGE_SIZE, SEARCH_MAX, SOURCES, STATUSES } from "./filters";
 
 /**
  * The audience library (G1).
@@ -33,24 +35,16 @@ import { AudienceSetCard } from "./_components/audience-set-card";
  * customer reads as "I have no audiences".
  */
 
-/** `all` rather than an empty string: a Radix Select item may not have an empty
- *  value, and the query simply omits the key. */
-const ALL = "all";
-
-const SOURCES = [
-  { value: "generated", label: "Peakhour suggested" },
-  { value: "imported", label: "From past campaigns" },
-  { value: "user_defined", label: "You built" },
-] as const;
-
-const STATUSES = [
-  { value: "proposed", label: "Suggested" },
-  { value: "applied", label: "On a campaign" },
-  { value: "discarded", label: "Discarded" },
-  { value: "superseded", label: "Replaced" },
-] as const;
-
-const PAGE_SIZE = 20;
+/** Debounce a value. Same shape as the targeting dialog's, kept local rather
+ *  than shared until a third caller wants it. */
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
 
 export default function AudienceLibraryPage() {
   const [q, setQ] = useState("");
@@ -59,10 +53,17 @@ export default function AudienceLibraryPage() {
   const [platform, setPlatform] = useState<string>(ALL);
   const [offset, setOffset] = useState(0);
 
+  // ★DEBOUNCED, BECAUSE EVERY KEYSTROKE IS A COLLECTION SCAN. `GET /sets`
+  // cannot use an index for `createdAt` ordering once a channel filter exists
+  // (the api says so itself), and it pairs the page with a `countDocuments`.
+  // Typing "enterprise travel" undebounced is seventeen double-scans of a
+  // customer's library.
+  const search = useDebounced(q.trim(), 350);
+
   const query: AudienceSetsQuery = {
     limit: PAGE_SIZE,
     offset,
-    ...(q.trim() ? { q: q.trim() } : {}),
+    ...(search ? { q: search } : {}),
     ...(source !== ALL ? { source: source as AudienceSetsQuery["source"] } : {}),
     ...(status !== ALL ? { status: status as AudienceSetsQuery["status"] } : {}),
     ...(platform !== ALL ? { platform } : {}),
@@ -80,7 +81,20 @@ export default function AudienceLibraryPage() {
 
   const rows = sets.data?.sets ?? [];
   const total = sets.data?.total ?? 0;
-  const filtered = q.trim() !== "" || source !== ALL || status !== ALL || platform !== ALL;
+  const filtered = search !== "" || source !== ALL || status !== ALL || platform !== ALL;
+  /** ★A PAGE PAST THE END IS A THIRD EMPTY STATE. A customer on page 3 whose
+   *  library shrinks — a discard, a business switch — would otherwise be told
+   *  "No audiences yet" with no way back, because the pagination lives in the
+   *  branch the empty state replaces. */
+  const pastTheEnd = rows.length === 0 && offset > 0;
+
+  function clearFilters() {
+    setQ("");
+    setSource(ALL);
+    setStatus(ALL);
+    setPlatform(ALL);
+    setOffset(0);
+  }
 
   return (
     <div className="space-y-6">
@@ -96,9 +110,10 @@ export default function AudienceLibraryPage() {
         <Input
           value={q}
           onChange={(e) => {
-            setQ(e.target.value);
+            setQ(e.target.value.slice(0, SEARCH_MAX));
             setOffset(0);
           }}
+          maxLength={SEARCH_MAX}
           placeholder="Search names and descriptions…"
           className="w-full sm:max-w-xs"
           aria-label="Search audiences"
@@ -154,11 +169,24 @@ export default function AudienceLibraryPage() {
           <Skeleton className="h-32 w-full" />
         </div>
       ) : sets.isError ? (
+        // ★NOT EVERY FAILURE IS OURS, AND A RETRY BUTTON ON THE ONES THAT ARE
+        // NOT IS A LOOP. `GET /sets` answers 403 FORBIDDEN when no business is
+        // active — retrying never fixes that — and the api carries a sentence
+        // of its own on every error. A first cut showed "that's on us, try
+        // again" over both.
         <EmptyState
           icon={Users}
           title="We couldn't load your audiences"
-          description="That's on us. Try again in a moment — nothing has been changed."
-          action={{ label: "Try again", onClick: () => void sets.refetch() }}
+          description={
+            sets.error instanceof ApiError && sets.error.code === "FORBIDDEN"
+              ? "Pick a business first — audiences belong to one business at a time."
+              : sets.error instanceof ApiError && sets.error.message
+                ? sets.error.message
+                : "That's on us. Try again in a moment — nothing has been changed."
+          }
+          {...(sets.error instanceof ApiError && sets.error.code === "FORBIDDEN"
+            ? {}
+            : { action: { label: "Try again", onClick: () => void sets.refetch() } })}
         />
       ) : rows.length === 0 ? (
         // ★TWO DIFFERENT EMPTIES, AND THEY ARE NOT THE SAME SENTENCE. A filter
@@ -167,26 +195,25 @@ export default function AudienceLibraryPage() {
         // typed a word — is the accepted-then-ignored failure one layer up.
         <EmptyState
           icon={Users}
-          title={filtered ? "No audiences match that" : "No audiences yet"}
-          description={
-            filtered
-              ? "Try a different search, or clear the filters to see everything in your library."
-              : "When Peakhour suggests an audience for a campaign, or reads the ones you've already run, they'll be kept here so you can use them again."
+          title={
+            pastTheEnd
+              ? "Nothing on this page"
+              : filtered
+                ? "No audiences match that"
+                : "No audiences yet"
           }
-          {...(filtered
-            ? {
-                action: {
-                  label: "Clear filters",
-                  onClick: () => {
-                    setQ("");
-                    setSource(ALL);
-                    setStatus(ALL);
-                    setPlatform(ALL);
-                    setOffset(0);
-                  },
-                },
-              }
-            : {})}
+          description={
+            pastTheEnd
+              ? "There are fewer audiences than there were — something was discarded, or you switched business."
+              : filtered
+                ? "Try a different search, or clear the filters to see everything in your library."
+                : "When Peakhour suggests an audience for a campaign, or reads the ones you've already run, they'll be kept here so you can use them again."
+          }
+          {...(pastTheEnd
+            ? { action: { label: "Back to the start", onClick: () => setOffset(0) } }
+            : filtered
+              ? { action: { label: "Clear filters", onClick: clearFilters } }
+              : {})}
         />
       ) : (
         <>
@@ -194,7 +221,7 @@ export default function AudienceLibraryPage() {
             {/* The api's own total, not the page length — a count that silently
                 equals the page size is a number we did not source. */}
             {total} audience{total === 1 ? "" : "s"}
-            {filtered ? " match this filter" : ""}
+            {filtered ? (total === 1 ? " matches this filter" : " match this filter") : ""}
           </p>
           <div className="space-y-3">
             {rows.map((set) => (
@@ -217,7 +244,10 @@ export default function AudienceLibraryPage() {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={offset + PAGE_SIZE >= total}
+                // The api caps `offset` at 1000 and 400s past it, so the last
+                // reachable page is the last one it will serve. Walking into
+                // that would be a dead end wearing an error message.
+                disabled={offset + PAGE_SIZE >= total || offset + PAGE_SIZE > MAX_OFFSET}
                 onClick={() => setOffset((o) => o + PAGE_SIZE)}
               >
                 Next

--- a/src/app/(site)/dashboard/growth/audiences/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+import { Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { useAudienceSets } from "@/hooks/use-audience-library";
+import { platformLabel, LIBRARY_CHANNELS } from "@/lib/audience-library-rules";
+import type { AudienceSetsQuery } from "@/lib/api/audiences";
+import { AudienceSetCard } from "./_components/audience-set-card";
+
+/**
+ * The audience library (G1).
+ *
+ * ★THE WHOLE POINT OF THE PLAN THIS PR BELONGS TO. `biz_audience_sets` has held
+ * named, reusable, per-channel audiences since B2 — planned portfolios, the
+ * campaigns a business actually ran, scores, critiques, outcomes — and until
+ * this page nothing rendered a single row of it. The standing rule is that
+ * "built" means a caller can reach it.
+ *
+ * ★AND THE FILTERS ARE THE SERVER'S. A value it does not recognise is a 400
+ * rather than a silently empty list, which is why the selects offer exactly the
+ * enums the api takes: an accepted-then-ignored filter returns a list a
+ * customer reads as "I have no audiences".
+ */
+
+/** `all` rather than an empty string: a Radix Select item may not have an empty
+ *  value, and the query simply omits the key. */
+const ALL = "all";
+
+const SOURCES = [
+  { value: "generated", label: "Peakhour suggested" },
+  { value: "imported", label: "From past campaigns" },
+  { value: "user_defined", label: "You built" },
+] as const;
+
+const STATUSES = [
+  { value: "proposed", label: "Suggested" },
+  { value: "applied", label: "On a campaign" },
+  { value: "discarded", label: "Discarded" },
+  { value: "superseded", label: "Replaced" },
+] as const;
+
+const PAGE_SIZE = 20;
+
+export default function AudienceLibraryPage() {
+  const [q, setQ] = useState("");
+  const [source, setSource] = useState<string>(ALL);
+  const [status, setStatus] = useState<string>(ALL);
+  const [platform, setPlatform] = useState<string>(ALL);
+  const [offset, setOffset] = useState(0);
+
+  const query: AudienceSetsQuery = {
+    limit: PAGE_SIZE,
+    offset,
+    ...(q.trim() ? { q: q.trim() } : {}),
+    ...(source !== ALL ? { source: source as AudienceSetsQuery["source"] } : {}),
+    ...(status !== ALL ? { status: status as AudienceSetsQuery["status"] } : {}),
+    ...(platform !== ALL ? { platform } : {}),
+  };
+  const sets = useAudienceSets(query);
+
+  /** Any filter change returns to the first page. Leaving the offset would show
+   *  "no audiences" for a filter that has plenty, three pages in. */
+  function onFilterChange(setter: (v: string) => void) {
+    return (value: string) => {
+      setter(value);
+      setOffset(0);
+    };
+  }
+
+  const rows = sets.data?.sets ?? [];
+  const total = sets.data?.total ?? 0;
+  const filtered = q.trim() !== "" || source !== ALL || status !== ALL || platform !== ALL;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Audiences</h2>
+        <p className="text-muted-foreground">
+          Every audience we&apos;ve suggested, read off your past campaigns, or you&apos;ve
+          built by hand — reusable on any campaign, on any channel.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Input
+          value={q}
+          onChange={(e) => {
+            setQ(e.target.value);
+            setOffset(0);
+          }}
+          placeholder="Search names and descriptions…"
+          className="w-full sm:max-w-xs"
+          aria-label="Search audiences"
+        />
+        <Select value={source} onValueChange={onFilterChange(setSource)}>
+          <SelectTrigger className="w-45" aria-label="Filter by where it came from">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Anywhere from</SelectItem>
+            {SOURCES.map((s) => (
+              <SelectItem key={s.value} value={s.value}>
+                {s.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={status} onValueChange={onFilterChange(setStatus)}>
+          <SelectTrigger className="w-40" aria-label="Filter by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Any status</SelectItem>
+            {STATUSES.map((s) => (
+              <SelectItem key={s.value} value={s.value}>
+                {s.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={platform} onValueChange={onFilterChange(setPlatform)}>
+          <SelectTrigger className="w-40" aria-label="Filter by channel">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {/* ★"WORKS ON THIS CHANNEL", NOT "WAS BORN ON IT". The api asks
+                whether the audience carries a shape for the channel, so an
+                idea planned on LinkedIn and since resolved for X appears under
+                both — which is the whole point of a channel-neutral library. */}
+            <SelectItem value={ALL}>Any channel</SelectItem>
+            {LIBRARY_CHANNELS.map((p) => (
+              <SelectItem key={p} value={p}>
+                Works on {platformLabel(p)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {sets.isPending ? (
+        <div className="space-y-3">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : sets.isError ? (
+        <EmptyState
+          icon={Users}
+          title="We couldn't load your audiences"
+          description="That's on us. Try again in a moment — nothing has been changed."
+          action={{ label: "Try again", onClick: () => void sets.refetch() }}
+        />
+      ) : rows.length === 0 ? (
+        // ★TWO DIFFERENT EMPTIES, AND THEY ARE NOT THE SAME SENTENCE. A filter
+        // that matched nothing is not a library with nothing in it, and telling
+        // a customer with forty audiences that they have none — because they
+        // typed a word — is the accepted-then-ignored failure one layer up.
+        <EmptyState
+          icon={Users}
+          title={filtered ? "No audiences match that" : "No audiences yet"}
+          description={
+            filtered
+              ? "Try a different search, or clear the filters to see everything in your library."
+              : "When Peakhour suggests an audience for a campaign, or reads the ones you've already run, they'll be kept here so you can use them again."
+          }
+          {...(filtered
+            ? {
+                action: {
+                  label: "Clear filters",
+                  onClick: () => {
+                    setQ("");
+                    setSource(ALL);
+                    setStatus(ALL);
+                    setPlatform(ALL);
+                    setOffset(0);
+                  },
+                },
+              }
+            : {})}
+        />
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground">
+            {/* The api's own total, not the page length — a count that silently
+                equals the page size is a number we did not source. */}
+            {total} audience{total === 1 ? "" : "s"}
+            {filtered ? " match this filter" : ""}
+          </p>
+          <div className="space-y-3">
+            {rows.map((set) => (
+              <AudienceSetCard key={set.id} set={set} />
+            ))}
+          </div>
+          {total > PAGE_SIZE && (
+            <div className="flex items-center justify-between">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset === 0}
+                onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+              >
+                Previous
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset + PAGE_SIZE >= total}
+                onClick={() => setOffset((o) => o + PAGE_SIZE)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/growth/audiences/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/page.tsx
@@ -35,6 +35,40 @@ import { ALL, MAX_OFFSET, PAGE_SIZE, SEARCH_MAX, SOURCES, STATUSES } from "./fil
  * customer reads as "I have no audiences".
  */
 
+/**
+ * What to show when the list will not load, and whether a retry can possibly
+ * help.
+ *
+ * ★THE SERVER'S OWN SENTENCE IS NOT ALWAYS THE CUSTOMER'S. On this route a 400
+ * reads "Check the query parameters." — true, and addressed to whoever wrote
+ * the client. Only the codes whose message is written FOR a customer are
+ * passed through, and the two that a retry cannot fix do not get the button.
+ */
+function errorState(
+  error: unknown,
+  actions: { onClear: () => void; onRetry: () => void },
+): { title: string; description: string; action?: { label: string; onClick: () => void } } {
+  const code = error instanceof ApiError ? error.code : undefined;
+  if (code === "FORBIDDEN") {
+    return {
+      title: "Pick a business first",
+      description: "Audiences belong to one business at a time — choose one and they'll load.",
+    };
+  }
+  if (code === "VALIDATION_ERROR") {
+    return {
+      title: "We couldn't load your audiences",
+      description: "Something about those filters isn't right. Clearing them should fix it.",
+      action: { label: "Clear filters", onClick: actions.onClear },
+    };
+  }
+  return {
+    title: "We couldn't load your audiences",
+    description: "That's on us. Try again in a moment — nothing has been changed.",
+    action: { label: "Try again", onClick: actions.onRetry },
+  };
+}
+
 /** Debounce a value. Same shape as the targeting dialog's, kept local rather
  *  than shared until a third caller wants it. */
 function useDebounced<T>(value: T, ms: number): T {
@@ -82,10 +116,30 @@ export default function AudienceLibraryPage() {
   const rows = sets.data?.sets ?? [];
   const total = sets.data?.total ?? 0;
   const filtered = search !== "" || source !== ALL || status !== ALL || platform !== ALL;
+  /**
+   * ★THE ROWS ON SCREEN ARE THE PREVIOUS QUERY'S WHILE THE NEW ONE IS IN
+   * FLIGHT, and everything else on this page is current component state.
+   * `keepPreviousData` is what stops the library vanishing into skeletons on
+   * every keystroke — and, unguarded, it is what puts "45 audiences match this
+   * filter" above twenty rows that do not match it, or flips the range to
+   * "21–40" above page one's cards. `GET /sets` is a blocking-sort collection
+   * scan plus a countDocuments by the api's own admission, so that window is
+   * not a frame.
+   *
+   * The rows stay (they are still real audiences, and losing them is worse);
+   * every number and control that would DESCRIBE them is withheld until they
+   * are the ones being described.
+   */
+  const settling = sets.isPlaceholderData;
+  /** The debounce has not applied the typed search yet. Paging now would send
+   *  the OLD filter's offset with the NEW filter — landing past the end of a
+   *  result the customer has not seen, and blaming a discard for it. */
+  const searchPending = q.trim() !== search;
+  const stale = settling || searchPending;
   /** ★A PAGE PAST THE END IS A THIRD EMPTY STATE. A customer on page 3 whose
-   *  library shrinks — a discard, a business switch — would otherwise be told
-   *  "No audiences yet" with no way back, because the pagination lives in the
-   *  branch the empty state replaces. */
+   *  library shrinks would otherwise be told "No audiences yet" with no way
+   *  back, because the pagination lives in the branch the empty state
+   *  replaces. */
   const pastTheEnd = rows.length === 0 && offset > 0;
 
   function clearFilters() {
@@ -171,22 +225,15 @@ export default function AudienceLibraryPage() {
       ) : sets.isError ? (
         // ★NOT EVERY FAILURE IS OURS, AND A RETRY BUTTON ON THE ONES THAT ARE
         // NOT IS A LOOP. `GET /sets` answers 403 FORBIDDEN when no business is
-        // active — retrying never fixes that — and the api carries a sentence
-        // of its own on every error. A first cut showed "that's on us, try
-        // again" over both.
+        // active and 400 VALIDATION_ERROR on a query it will not take — and
+        // retrying either one refetches the same request forever. A first cut
+        // showed "that's on us, try again" over all three; the fix after that
+        // put the api's OWN sentence in front of the customer, which on this
+        // route is "Check the query parameters." — written for whoever built
+        // the client, and still under a Try again that cannot help.
         <EmptyState
           icon={Users}
-          title="We couldn't load your audiences"
-          description={
-            sets.error instanceof ApiError && sets.error.code === "FORBIDDEN"
-              ? "Pick a business first — audiences belong to one business at a time."
-              : sets.error instanceof ApiError && sets.error.message
-                ? sets.error.message
-                : "That's on us. Try again in a moment — nothing has been changed."
-          }
-          {...(sets.error instanceof ApiError && sets.error.code === "FORBIDDEN"
-            ? {}
-            : { action: { label: "Try again", onClick: () => void sets.refetch() } })}
+          {...errorState(sets.error, { onClear: clearFilters, onRetry: () => void sets.refetch() })}
         />
       ) : rows.length === 0 ? (
         // ★TWO DIFFERENT EMPTIES, AND THEY ARE NOT THE SAME SENTENCE. A filter
@@ -204,7 +251,7 @@ export default function AudienceLibraryPage() {
           }
           description={
             pastTheEnd
-              ? "There are fewer audiences than there were — something was discarded, or you switched business."
+              ? "This page is past the end of your library now."
               : filtered
                 ? "Try a different search, or clear the filters to see everything in your library."
                 : "When Peakhour suggests an audience for a campaign, or reads the ones you've already run, they'll be kept here so you can use them again."
@@ -219,9 +266,18 @@ export default function AudienceLibraryPage() {
         <>
           <p className="text-sm text-muted-foreground">
             {/* The api's own total, not the page length — a count that silently
-                equals the page size is a number we did not source. */}
-            {total} audience{total === 1 ? "" : "s"}
-            {filtered ? (total === 1 ? " matches this filter" : " match this filter") : ""}
+                equals the page size is a number we did not source. And not
+                shown at all while the rows below it belong to a different
+                query: a number describing something other than what is on
+                screen is worse than no number. */}
+            {stale ? (
+              "Updating…"
+            ) : (
+              <>
+                {total} audience{total === 1 ? "" : "s"}
+                {filtered ? (total === 1 ? " matches this filter" : " match this filter") : ""}
+              </>
+            )}
           </p>
           <div className="space-y-3">
             {rows.map((set) => (
@@ -233,13 +289,13 @@ export default function AudienceLibraryPage() {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={offset === 0}
+                disabled={offset === 0 || stale}
                 onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
               >
                 Previous
               </Button>
               <span className="text-xs text-muted-foreground">
-                {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+                {stale ? "…" : `${offset + 1}–${Math.min(offset + PAGE_SIZE, total)} of ${total}`}
               </span>
               <Button
                 variant="outline"
@@ -247,7 +303,11 @@ export default function AudienceLibraryPage() {
                 // The api caps `offset` at 1000 and 400s past it, so the last
                 // reachable page is the last one it will serve. Walking into
                 // that would be a dead end wearing an error message.
-                disabled={offset + PAGE_SIZE >= total || offset + PAGE_SIZE > MAX_OFFSET}
+                // ★AND NOT WHILE `stale`: `total` is then the PREVIOUS query's,
+                // so this guard would be comparing the new page against the old
+                // library — which is how a customer pages into an empty result
+                // and is told something was discarded.
+                disabled={stale || offset + PAGE_SIZE >= total || offset + PAGE_SIZE > MAX_OFFSET}
                 onClick={() => setOffset((o) => o + PAGE_SIZE)}
               >
                 Next

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -147,6 +147,11 @@ const NAV_GROUPS: NavGroup[] = [
         label: "Growth",
         icon: TrendingUp,
         subItems: [
+          // Audiences leads because it is the durable object the rest reads:
+          // an audience is planned or imported once and put on campaigns for
+          // months afterwards, on any channel. Ads is where money is spent;
+          // this is what it is spent on.
+          { href: "/dashboard/growth/audiences", label: "Audiences" },
           { href: "/dashboard/ads", label: "Ads" },
           { href: "/dashboard/outcomes", label: "Outcomes" },
           { href: "/dashboard/optimizer", label: "Optimizer" },

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -226,6 +226,12 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Scans recently-sent content vs. the AI draft and promotes phrases your team kept (signatures) or edited out (avoid) onto the matching voice card.",
   },
+  "skill-tuning": {
+    label: "Learn from what worked",
+    frequency: "Runs weekly (Monday 8 AM UTC)",
+    description:
+      "Rescores each skill from the feedback and outcomes it collected, and writes back what it learned — the loop that stops the same suggestion being made twice.",
+  },
   "sync-ai-models": {
     label: "Sync AI model catalog",
     frequency: "Runs daily at 3 AM UTC",

--- a/src/hooks/use-audience-library.ts
+++ b/src/hooks/use-audience-library.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  audienceLibraryApi,
+  type AudienceSetsQuery,
+  type AudienceSetsResponse,
+} from "@/lib/api/audiences";
+
+/**
+ * The audience library (G1).
+ *
+ * ★THE FIRST READER `biz_audience_sets` HAS EVER HAD FROM A SCREEN. The engine
+ * has been planning portfolios, importing the audiences a business actually
+ * ran, scoring them and resolving them per channel since B2 — every row of it
+ * API-only. "Built" means a caller can reach it.
+ */
+export function useAudienceSets(query: AudienceSetsQuery = {}) {
+  return useQuery<AudienceSetsResponse>({
+    // The filters are part of the key: a cache shared across filters would
+    // show the previous filter's rows under the new filter's heading, which is
+    // a list that lies about what it is showing.
+    queryKey: ["audience-sets", query],
+    queryFn: () => audienceLibraryApi.listSets(query),
+    // A library is a durable object, not a feed — it changes when somebody
+    // plans, imports or discards, all of which happen on this surface and
+    // invalidate it directly.
+    staleTime: 30_000,
+  });
+}
+
+/** Every query this feature owns, for a caller that has just changed one. */
+export const AUDIENCE_LIBRARY_KEY = ["audience-sets"] as const;

--- a/src/hooks/use-audience-library.ts
+++ b/src/hooks/use-audience-library.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   audienceLibraryApi,
   type AudienceSetsQuery,
@@ -22,12 +22,10 @@ export function useAudienceSets(query: AudienceSetsQuery = {}) {
     // a list that lies about what it is showing.
     queryKey: ["audience-sets", query],
     queryFn: () => audienceLibraryApi.listSets(query),
-    // A library is a durable object, not a feed — it changes when somebody
-    // plans, imports or discards, all of which happen on this surface and
-    // invalidate it directly.
-    staleTime: 30_000,
+    // ★THE PREVIOUS PAGE STAYS ON SCREEN WHILE THE NEXT LOADS. Without it
+    // every filter keystroke and every page turn replaces the list with
+    // skeletons, because a new key is `isPending` — so a customer refining a
+    // search watches their library disappear and come back on each character.
+    placeholderData: keepPreviousData,
   });
 }
-
-/** Every query this feature owns, for a caller that has just changed one. */
-export const AUDIENCE_LIBRARY_KEY = ["audience-sets"] as const;

--- a/src/hooks/use-audience-library.ts
+++ b/src/hooks/use-audience-library.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/providers/auth-provider";
 import {
   audienceLibraryApi,
   type AudienceSetsQuery,
@@ -16,11 +17,17 @@ import {
  * API-only. "Built" means a caller can reach it.
  */
 export function useAudienceSets(query: AudienceSetsQuery = {}) {
+  const { business } = useAuth();
   return useQuery<AudienceSetsResponse>({
     // The filters are part of the key: a cache shared across filters would
     // show the previous filter's rows under the new filter's heading, which is
     // a list that lies about what it is showing.
-    queryKey: ["audience-sets", query],
+    // ★AND SO IS THE BUSINESS, which every other business-scoped hook in this
+    // directory pins. `switchBusiness` clears the whole cache today, so this is
+    // belt on top of braces — but the route is business-scoped server-side, and
+    // a key that does not say which business is one `clear()` away from
+    // rendering another one's audiences.
+    queryKey: ["audience-sets", business?._id ?? "none", query],
     queryFn: () => audienceLibraryApi.listSets(query),
     // ★THE PREVIOUS PAGE STAYS ON SCREEN WHILE THE NEXT LOADS. Without it
     // every filter keystroke and every page turn replaces the list with

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -202,3 +202,125 @@ export const audiencesApi = {
   correctProfile: (corrections: CorrectionInput[]) =>
     api.patch<{ profile: AudienceProfile }>("/v1/audiences/profile", { corrections }),
 };
+
+// ── The library ─────────────────────────────────────────────────────────
+//
+// ★EVERYTHING BELOW IS THE FIRST CALLER E1–F4 HAS EVER HAD. The engine has
+// planned portfolios, imported the audiences a business actually ran, scored
+// them, argued against them and resolved them per channel — all of it API-only,
+// with this client calling exactly four profile endpoints. "Built" means a
+// caller can reach it, and until now nothing did.
+
+/** Where an audience came from — the brief's own distinction, and the one the
+ *  list has to make visible. */
+export type AudienceSource = "generated" | "fallback" | "imported" | "user_defined";
+
+export type AudienceSetStatus = "proposed" | "applied" | "discarded" | "superseded";
+
+/**
+ * One channel this audience is KNOWN to work on, as `GET /sets` reports it.
+ *
+ * ★A CHANNEL MISSING FROM THE LIST HAS NOT BEEN ASKED. That is a different
+ * statement from "it doesn't work there", and a client that renders them the
+ * same is making a claim about a customer's reach on a channel nobody has
+ * queried. The list is what is already stored; asking a channel costs a
+ * typeahead round and lives behind `GET /sets/:id/resolutions/:platform`.
+ */
+export interface AudienceChannel {
+  platform: string;
+  /** The entry is real but cannot be shown to be current — the adapter build
+   *  that produced it has moved, or none was recorded. */
+  stale: boolean;
+  /** False for an audience with no business-language hypothesis to re-express
+   *  — an imported set. Its criteria are a record of what was RUN, so `stale`
+   *  on such a row would invite an action that does not exist. */
+  rematerialisable: boolean;
+  /** True only when we HAVE a number. False covers both "the channel publishes
+   *  no count" and "we could not get one", which the api collapses on purpose:
+   *  from the customer's side both are "we don't have a size". Neither is a
+   *  zero. */
+  reachSupported: boolean;
+  reachValue?: number;
+  /** The platform masked the count because the audience is under its serving
+   *  floor. Carries NO figure, deliberately. */
+  belowFloor: boolean;
+  /** How many attributes this channel could not express at all. The names live
+   *  behind the per-channel view. */
+  droppedAttributes: number;
+  resolvedAt?: string;
+}
+
+/** The business-language shape of an audience — no URNs, no platform enums.
+ *  This IS the audience; a channel's criteria are a cache of it. */
+export interface AudienceHypothesisAttribute {
+  attribute: string;
+  variant: string;
+  values: string[];
+}
+
+export interface AudienceSet {
+  id: string;
+  name: string;
+  description?: string;
+  source: AudienceSource;
+  status: AudienceSetStatus;
+  archetype?: string;
+  hypothesis?: {
+    attributes: AudienceHypothesisAttribute[];
+    rationale?: string;
+    cites?: string[];
+  };
+  channels: AudienceChannel[];
+  /** Every hand-correction to this audience's targeting. The count is the
+   *  interesting figure on a list: an audience corrected four times is one we
+   *  keep getting wrong. */
+  userEdits?: Array<{ at: string; attribute?: string; from?: string[]; to?: string[] }>;
+  /** Copied from the campaigns that ran it, never independently measured. */
+  outcome?: {
+    campaignIds: string[];
+    impressions: number;
+    clicks: number;
+    ctr?: number;
+    conversions?: number;
+    spend?: number;
+    currency?: string;
+    note?: string;
+    syncedAt: string;
+  };
+  discardReason?: string;
+  createdAt: string;
+}
+
+export interface AudienceSetsQuery {
+  platform?: string;
+  status?: AudienceSetStatus;
+  source?: AudienceSource;
+  q?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AudienceSetsResponse {
+  sets: AudienceSet[];
+  /** The true total, not the page size — so the header can say "23 audiences"
+   *  rather than a number that silently equals the page. */
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export const audienceLibraryApi = {
+  /**
+   * The library. Filters are SERVER-SIDE and the enums are the server's: a
+   * value it does not recognise is a 400, not a silently empty list.
+   */
+  listSets: (query: AudienceSetsQuery = {}) => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === "") continue;
+      params.set(key, String(value));
+    }
+    const qs = params.toString();
+    return api.get<AudienceSetsResponse>(`/v1/audiences/sets${qs ? `?${qs}` : ""}`);
+  },
+};

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import type { AudienceChannel, AudienceSet } from "@/lib/api/audiences";
+import {
+  audienceShape,
+  channelNote,
+  historyLine,
+  originIsOurs,
+  originLabel,
+  outcomeLine,
+  reachReading,
+  unaskedChannels,
+} from "./audience-library-rules";
+
+/**
+ * The library's judgement, which is almost entirely about ABSENCES.
+ *
+ * Every test below is one collapse this surface is not allowed to make. They
+ * are here rather than in a render test because this repo is vitest
+ * `environment: "node"` by design — and because these are the decisions that
+ * would be wrong SILENTLY.
+ */
+
+const channel = (over: Partial<AudienceChannel> = {}): AudienceChannel => ({
+  platform: "linkedin",
+  stale: false,
+  rematerialisable: true,
+  reachSupported: true,
+  reachValue: 2_400_000,
+  belowFloor: false,
+  droppedAttributes: 0,
+  ...over,
+});
+
+describe("originLabel", () => {
+  it("tells our suggestion from their fact", () => {
+    // The brief's own distinction. `generated` is something we thought of;
+    // `imported` is something they ran with their own money; `user_defined` is
+    // something they wrote, usually while disagreeing with us.
+    expect(originLabel("generated")).toBe("Peakhour suggested");
+    expect(originLabel("fallback")).toBe("Peakhour suggested");
+    expect(originLabel("imported")).toBe("From your past campaigns");
+    expect(originLabel("user_defined")).toBe("You built this");
+    expect(originIsOurs("generated")).toBe(true);
+    expect(originIsOurs("imported")).toBe(false);
+    expect(originIsOurs("user_defined")).toBe(false);
+  });
+});
+
+describe("reachReading", () => {
+  it("gives the number when the channel gave us one", () => {
+    expect(reachReading(channel())).toEqual({
+      kind: "counted",
+      text: "2,400,000 on LinkedIn",
+    });
+  });
+
+  it("never renders a missing size as zero", () => {
+    // X publishes no audience count. "We don't know" and "zero" must look
+    // different — and this reading may not blame the channel either, because
+    // the api reports "the platform has no endpoint" and "our call failed"
+    // identically on purpose.
+    const reading = reachReading(channel({ platform: "x", reachSupported: false, reachValue: undefined }));
+    expect(reading.kind).toBe("unknown");
+    expect(reading.text).toBe("No size from X");
+    expect(reading.text).not.toMatch(/\b0\b/);
+  });
+
+  it("treats a literal zero as the serving floor rather than printing it", () => {
+    // LinkedIn's masked `total: 0` means "fewer than 300". The api maps it to
+    // belowFloor with no number, so a zero arriving here means something
+    // upstream changed — and "0 people" is the sentence this file exists to
+    // prevent.
+    expect(reachReading(channel({ reachValue: 0 })).kind).toBe("below_floor");
+    expect(reachReading(channel({ reachValue: 0 })).text).not.toMatch(/\b0\b/);
+  });
+
+  it("carries no figure beside a below-floor audience", () => {
+    const reading = reachReading(channel({ belowFloor: true, reachSupported: false, reachValue: undefined }));
+    expect(reading.kind).toBe("below_floor");
+    expect(reading.text).not.toMatch(/\d/);
+  });
+});
+
+describe("channelNote", () => {
+  it("names what a channel could not express, in the plural a person would use", () => {
+    expect(channelNote(channel({ platform: "x", droppedAttributes: 1 }))).toBe(
+      "1 thing X can't express",
+    );
+    expect(channelNote(channel({ platform: "x", droppedAttributes: 2 }))).toBe(
+      "2 things X can't express",
+    );
+  });
+
+  it("★never calls an IMPORTED audience out of date", () => {
+    // An imported set has no hypothesis: its criteria are a record of what
+    // somebody actually ran, so there is nothing to re-derive and nothing it
+    // could be out of date WITH. "May be out of date" over it invites an
+    // action that does not exist — the exact collapse `rematerialisable`
+    // exists to prevent, and one the api has already made once.
+    expect(channelNote(channel({ stale: true, rematerialisable: false }))).toBeNull();
+    expect(channelNote(channel({ stale: true, rematerialisable: true }))).toBe("May be out of date");
+  });
+
+  it("leads with what was lost rather than with staleness", () => {
+    // A dropped attribute is a fact about the audience the customer would be
+    // buying; staleness is a fact about our cache.
+    expect(channelNote(channel({ stale: true, droppedAttributes: 1 }))).toBe(
+      "1 thing LinkedIn can't express",
+    );
+  });
+});
+
+describe("unaskedChannels", () => {
+  it("★reports the channels nobody has asked, which is not 'it doesn't work there'", () => {
+    expect(unaskedChannels({ channels: [channel()] })).toEqual(["x"]);
+    expect(unaskedChannels({ channels: [channel(), channel({ platform: "x" })] })).toEqual([]);
+    // An audience nobody has resolved anywhere has not failed anywhere either.
+    expect(unaskedChannels({ channels: [] })).toEqual(["linkedin", "x"]);
+  });
+});
+
+describe("audienceShape", () => {
+  it("renders the hypothesis, which is the audience", () => {
+    const shape = audienceShape({
+      hypothesis: {
+        attributes: [
+          { attribute: "geo", variant: "any", values: ["India"] },
+          { attribute: "job_title", variant: "current", values: ["Head of Corporate Travel"] },
+        ],
+      },
+    });
+    expect(shape).toEqual([
+      { attribute: "geo", label: "Location", values: ["India"] },
+      { attribute: "job_title", label: "Job title", values: ["Head of Corporate Travel"] },
+    ]);
+  });
+
+  it("shows an unknown attribute rather than dropping it", () => {
+    // A silent omission makes a narrower audience look complete.
+    const shape = audienceShape({
+      hypothesis: { attributes: [{ attribute: "brand_new_facet", variant: "any", values: ["x"] }] },
+    });
+    expect(shape).toHaveLength(1);
+    expect(shape[0]!.label).toBe("brand new facet");
+  });
+
+  it("is empty for an imported set, which has no hypothesis at all", () => {
+    // Its criteria are the platform's own. An empty shape is the true answer,
+    // and the caller says so rather than drawing nothing.
+    expect(audienceShape({})).toEqual([]);
+    expect(
+      audienceShape({ hypothesis: { attributes: [{ attribute: "geo", variant: "any", values: [] }] } }),
+    ).toEqual([]);
+  });
+});
+
+describe("historyLine", () => {
+  it("★leads with the discard, even on an audience that ran", () => {
+    // A discarded audience that once ran is a rejection with history; leading
+    // with its performance would read as a recommendation.
+    expect(historyLine({ status: "discarded", discardReason: "too broad" })).toBe(
+      'You discarded this — "too broad"',
+    );
+    expect(historyLine({ status: "discarded" })).toBe("You discarded this");
+  });
+
+  it("counts the corrections, because an audience corrected four times is one we keep getting wrong", () => {
+    expect(historyLine({ status: "proposed", userEdits: [{ at: "x" }] })).toBe(
+      "Suggested, corrected 1 time",
+    );
+    expect(historyLine({ status: "applied", userEdits: [{ at: "x" }, { at: "y" }] })).toBe(
+      "On a campaign, corrected 2 times",
+    );
+  });
+
+  it("says nothing about an audience nothing has happened to", () => {
+    // A row that manufactures a sentence for every audience makes the ones
+    // with real history invisible.
+    expect(historyLine({ status: "proposed" })).toBeNull();
+  });
+});
+
+describe("outcomeLine", () => {
+  const outcome = (over: Partial<NonNullable<AudienceSet["outcome"]>> = {}) => ({
+    campaignIds: ["1"],
+    impressions: 10_000,
+    clicks: 120,
+    ctr: 0.012,
+    basis: "campaign_performance" as const,
+    syncedAt: "2026-08-01T00:00:00Z",
+    ...over,
+  });
+
+  it("says nothing at all about an audience that has never run", () => {
+    expect(outcomeLine(undefined)).toBeNull();
+  });
+
+  it("★never invents a click-through rate over zero impressions", () => {
+    // The api omits `ctr` when nothing served, so a set whose campaign never
+    // delivered is not ranked below one that genuinely underperformed. A
+    // client filling in "0.00%" undoes that in the one number a customer reads
+    // as a verdict.
+    const line = outcomeLine(outcome({ impressions: 0, clicks: 0, ctr: undefined }))!;
+    expect(line).toContain("never served");
+    expect(line).not.toContain("0.00%");
+  });
+
+  it("shows spend only with its currency", () => {
+    // The two travel together or neither is written — a figure with no unit is
+    // one every reader will nonetheless treat as money.
+    expect(outcomeLine(outcome({ spend: 4210, currency: "INR" }))).toContain("INR 4,210 spent");
+    expect(outcomeLine(outcome({ spend: 4210 }))).not.toContain("4,210 spent");
+  });
+});

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -1,22 +1,30 @@
 import { describe, it, expect } from "vitest";
 import type { AudienceChannel, AudienceSet, AudienceSource, AudienceSetStatus } from "@/lib/api/audiences";
 
-/** The api's own enums, restated so a change to either side is a failing test
- *  rather than a filter option nobody can reach. Kept as literal tuples: a
- *  `satisfies` against the union catches a value that leaves the api, and the
- *  comparisons below catch one that joins it. */
-const SOURCE_VALUES = [
-  "generated",
-  "fallback",
-  "imported",
-  "user_defined",
-] as const satisfies readonly AudienceSource[];
-const STATUS_VALUES = [
-  "proposed",
-  "applied",
-  "discarded",
-  "superseded",
-] as const satisfies readonly AudienceSetStatus[];
+/**
+ * The api's own enums, derived so that a change on EITHER side breaks.
+ *
+ * ★A TUPLE WITH `satisfies readonly AudienceSource[]` DOES NOT CATCH AN ADDED
+ * MEMBER, which is the direction that matters — assignability still holds when
+ * the union grows, so the parity test below would have compared one hand-written
+ * list against another and stayed green while a row became unreachable. That is
+ * the exact defect this test was written for, one level up.
+ *
+ * An exhaustive `Record` is a COMPILE error the day the api adds a source: the
+ * object literal no longer satisfies it, and `tsc --noEmit` covers this file.
+ */
+const SOURCE_VALUES = Object.keys({
+  generated: true,
+  fallback: true,
+  imported: true,
+  user_defined: true,
+} satisfies Record<AudienceSource, true>) as AudienceSource[];
+const STATUS_VALUES = Object.keys({
+  proposed: true,
+  applied: true,
+  discarded: true,
+  superseded: true,
+} satisfies Record<AudienceSetStatus, true>) as AudienceSetStatus[];
 import { SOURCES, STATUSES, SEARCH_MAX } from "@/app/(site)/dashboard/growth/audiences/filters";
 import {
   audienceShape,
@@ -284,9 +292,20 @@ describe("outcomeLine", () => {
     expect(outcomeLine(outcome({ spend: 4210 }))).not.toContain("4,210 spent");
   });
 
-  it("never rounds real spend down to zero", () => {
+  it("never rounds real spend down to zero, at any size", () => {
     // `Math.round(0.49)` is 0, and "INR 0 spent" beside a campaign that did
-    // spend is exactly the confident-wrong number this file refuses.
+    // spend is exactly the confident-wrong number this file refuses. A first
+    // fix used `toFixed(2)` below 1 — which prints "0.00" for four tenths of a
+    // cent, the same lie in more decimal places.
     expect(outcomeLine(outcome({ spend: 0.49, currency: "USD" }))).toContain("USD 0.49 spent");
+    expect(outcomeLine(outcome({ spend: 0.004, currency: "USD" }))).toContain("under USD 0.01");
+    expect(outcomeLine(outcome({ spend: 12_345.6, currency: "INR" }))).toContain("INR 12,346 spent");
+  });
+
+  it("shows no spend at all for a figure the schema forbids", () => {
+    // `spend` is `min(0)` server-side, so a negative is impossible — and
+    // `Math.round(-0.4)` is JavaScript's `-0`, which renders as "-0". A number
+    // we cannot explain is one we do not show.
+    expect(outcomeLine(outcome({ spend: -1, currency: "USD" }))).not.toContain("spent");
   });
 });

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -1,8 +1,26 @@
 import { describe, it, expect } from "vitest";
-import type { AudienceChannel, AudienceSet } from "@/lib/api/audiences";
+import type { AudienceChannel, AudienceSet, AudienceSource, AudienceSetStatus } from "@/lib/api/audiences";
+
+/** The api's own enums, restated so a change to either side is a failing test
+ *  rather than a filter option nobody can reach. Kept as literal tuples: a
+ *  `satisfies` against the union catches a value that leaves the api, and the
+ *  comparisons below catch one that joins it. */
+const SOURCE_VALUES = [
+  "generated",
+  "fallback",
+  "imported",
+  "user_defined",
+] as const satisfies readonly AudienceSource[];
+const STATUS_VALUES = [
+  "proposed",
+  "applied",
+  "discarded",
+  "superseded",
+] as const satisfies readonly AudienceSetStatus[];
+import { SOURCES, STATUSES, SEARCH_MAX } from "@/app/(site)/dashboard/growth/audiences/filters";
 import {
   audienceShape,
-  channelNote,
+  channelNotes,
   historyLine,
   originIsOurs,
   originLabel,
@@ -37,12 +55,40 @@ describe("originLabel", () => {
     // `imported` is something they ran with their own money; `user_defined` is
     // something they wrote, usually while disagreeing with us.
     expect(originLabel("generated")).toBe("Peakhour suggested");
-    expect(originLabel("fallback")).toBe("Peakhour suggested");
     expect(originLabel("imported")).toBe("From your past campaigns");
     expect(originLabel("user_defined")).toBe("You built this");
     expect(originIsOurs("generated")).toBe(true);
+    expect(originIsOurs("fallback")).toBe(true);
     expect(originIsOurs("imported")).toBe(false);
     expect(originIsOurs("user_defined")).toBe(false);
+  });
+
+  it("★gives every source its OWN label, because the filter sends one value", () => {
+    // `fallback` shared "Peakhour suggested" with `generated` in a first cut,
+    // and the api's `source` filter takes ONE enum member — so the baseline set
+    // every plan carries was badged identically to the rows the filter returned
+    // and reachable from no option in any dropdown. Two sources, one label, is
+    // an accepted-then-ignored filter with extra steps.
+    const labels = SOURCE_VALUES.map(originLabel);
+    expect(new Set(labels).size).toBe(SOURCE_VALUES.length);
+  });
+});
+
+describe("the filter options and the api's enums", () => {
+  it("★offers every source the api accepts", () => {
+    // The seam nothing covered, and where the fallback defect lived. A value
+    // the api takes and the UI never offers is a row a customer cannot reach.
+    expect([...SOURCES].map((s) => s.value).sort()).toEqual([...SOURCE_VALUES].sort());
+  });
+
+  it("offers every status the api accepts", () => {
+    expect([...STATUSES].map((s) => s.value).sort()).toEqual([...STATUS_VALUES].sort());
+  });
+
+  it("never sends a search longer than the api will take", () => {
+    // `q` is `.min(1).max(80)` server-side, and an over-long one is a 400 whose
+    // only offered action refetches the same invalid query.
+    expect(SEARCH_MAX).toBeLessThanOrEqual(80);
   });
 });
 
@@ -62,7 +108,12 @@ describe("reachReading", () => {
     const reading = reachReading(channel({ platform: "x", reachSupported: false, reachValue: undefined }));
     expect(reading.kind).toBe("unknown");
     expect(reading.text).toBe("No size from X");
-    expect(reading.text).not.toMatch(/\b0\b/);
+    // And a stale VALUE left on the row cannot leak into the sentence when the
+    // channel says it has no count — which is how a number nobody sourced
+    // reaches a screen.
+    expect(
+      reachReading(channel({ platform: "x", reachSupported: false, reachValue: 4_200_000 })).text,
+    ).toBe("No size from X");
   });
 
   it("treats a literal zero as the serving floor rather than printing it", () => {
@@ -81,14 +132,14 @@ describe("reachReading", () => {
   });
 });
 
-describe("channelNote", () => {
+describe("channelNotes", () => {
   it("names what a channel could not express, in the plural a person would use", () => {
-    expect(channelNote(channel({ platform: "x", droppedAttributes: 1 }))).toBe(
+    expect(channelNotes(channel({ platform: "x", droppedAttributes: 1 }))).toEqual([
       "1 thing X can't express",
-    );
-    expect(channelNote(channel({ platform: "x", droppedAttributes: 2 }))).toBe(
+    ]);
+    expect(channelNotes(channel({ platform: "x", droppedAttributes: 2 }))).toEqual([
       "2 things X can't express",
-    );
+    ]);
   });
 
   it("★never calls an IMPORTED audience out of date", () => {
@@ -97,16 +148,26 @@ describe("channelNote", () => {
     // could be out of date WITH. "May be out of date" over it invites an
     // action that does not exist — the exact collapse `rematerialisable`
     // exists to prevent, and one the api has already made once.
-    expect(channelNote(channel({ stale: true, rematerialisable: false }))).toBeNull();
-    expect(channelNote(channel({ stale: true, rematerialisable: true }))).toBe("May be out of date");
+    expect(channelNotes(channel({ stale: true, rematerialisable: false }))).toEqual([]);
+    expect(channelNotes(channel({ stale: true, rematerialisable: true }))).toEqual([
+      "May be out of date",
+    ]);
   });
 
-  it("leads with what was lost rather than with staleness", () => {
-    // A dropped attribute is a fact about the audience the customer would be
-    // buying; staleness is a fact about our cache.
-    expect(channelNote(channel({ stale: true, droppedAttributes: 1 }))).toBe(
+  it("★says BOTH when a channel is stale and lossy, leading with what was lost", () => {
+    // A first cut returned one string and stopped at the dropped-attribute
+    // case, so a stale AND lossy channel rendered byte-identically to a fresh
+    // one. What was lost is a fact about the audience the customer would be
+    // buying; staleness is a fact about our copy of it. Two facts, two
+    // sentences — the order says which matters more.
+    expect(channelNotes(channel({ stale: true, droppedAttributes: 1 }))).toEqual([
       "1 thing LinkedIn can't express",
-    );
+      "May be out of date",
+    ]);
+  });
+
+  it("says nothing about a channel with nothing to report", () => {
+    expect(channelNotes(channel())).toEqual([]);
   });
 });
 
@@ -164,6 +225,17 @@ describe("historyLine", () => {
     expect(historyLine({ status: "discarded" })).toBe("You discarded this");
   });
 
+  it("★keeps the correction count on a discard, which is where it matters most", () => {
+    // "Discarded after being corrected four times" is the most informative row
+    // in a library: an audience we kept getting wrong until they gave up on it.
+    // A first cut computed the figure and then dropped it on exactly the sets
+    // most likely to carry one. Suppressing the OUTCOME on a discard is the
+    // rule; suppressing this was an accident of ordering.
+    expect(
+      historyLine({ status: "discarded", userEdits: [{ at: "a" }, { at: "b" }] }),
+    ).toBe("You discarded this (corrected 2 times)");
+  });
+
   it("counts the corrections, because an audience corrected four times is one we keep getting wrong", () => {
     expect(historyLine({ status: "proposed", userEdits: [{ at: "x" }] })).toBe(
       "Suggested, corrected 1 time",
@@ -210,5 +282,11 @@ describe("outcomeLine", () => {
     // one every reader will nonetheless treat as money.
     expect(outcomeLine(outcome({ spend: 4210, currency: "INR" }))).toContain("INR 4,210 spent");
     expect(outcomeLine(outcome({ spend: 4210 }))).not.toContain("4,210 spent");
+  });
+
+  it("never rounds real spend down to zero", () => {
+    // `Math.round(0.49)` is 0, and "INR 0 spent" beside a campaign that did
+    // spend is exactly the confident-wrong number this file refuses.
+    expect(outcomeLine(outcome({ spend: 0.49, currency: "USD" }))).toContain("USD 0.49 spent");
   });
 });

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -64,10 +64,20 @@ export function originIsOurs(source: AudienceSource): boolean {
   return source === "generated" || source === "fallback";
 }
 
-/** Business-language attribute names. An unknown attribute renders under its
- *  own id rather than vanishing — a silent omission makes a narrower audience
- *  look complete, which is the one thing this surface must not do. Same map as
- *  the campaign audience card, kept in step deliberately. */
+/**
+ * Business-language attribute names, from the collection's own
+ * `zTargetingAttribute` enum.
+ *
+ * An unknown attribute renders under its own id rather than vanishing — a
+ * silent omission makes a narrower audience look complete, which is the one
+ * thing this surface must not do.
+ *
+ * ★AND THE CAMPAIGN AUDIENCE CARD READS THIS ONE. It used to carry its own
+ * nine-key copy, and a comment here claimed the two were "kept in step" while
+ * this map grew to thirty-one — so the same attribute rendered "Purchase
+ * intent" in the library and the raw identifier `purchase_intent` on the ads
+ * page, in the same session. One map, or the claim is decoration.
+ */
 const ATTRIBUTE_LABEL: Record<string, string> = {
   // person / professional
   job_title: "Job title",
@@ -103,8 +113,12 @@ const ATTRIBUTE_LABEL: Record<string, string> = {
   lookalike_seed: "Lookalike seed",
   retargeting_audience: "Retargeting",
   // delivery
-  device: "Platform",
-  device_model: "Device",
+  // ★NOT "Platform", WHICH ON THIS SURFACE ALREADY MEANS THE AD CHANNEL. The
+  // schema's `device` is the operating system or form factor (iOS, Android,
+  // desktop); a chip row reading "Platform · iOS" beside "Not checked on X yet"
+  // uses one word for two things.
+  device: "Device type",
+  device_model: "Device model",
   placement: "Placement",
 };
 
@@ -301,15 +315,23 @@ export function outcomeLine(outcome: AudienceSet["outcome"]): string | null {
     // clicked" are different facts about an audience.
     parts.push("never served");
   }
-  if (typeof outcome.spend === "number" && outcome.currency) {
+  if (typeof outcome.spend === "number" && outcome.spend >= 0 && outcome.currency) {
     // ★ROUNDED TO WHOLE UNITS EXCEPT WHERE THAT WOULD PRINT A ZERO OVER REAL
-    // SPEND. `Math.round(0.49)` is 0, and "INR 0 spent" beside a campaign that
-    // did spend is the confident-wrong number this file exists to refuse.
-    const spend =
-      outcome.spend > 0 && outcome.spend < 1
-        ? outcome.spend.toFixed(2)
-        : REACH_FORMAT.format(Math.round(outcome.spend));
-    parts.push(`${outcome.currency} ${spend} spent`);
+    // SPEND, AT EITHER SCALE. `Math.round(0.49)` is 0; `(0.004).toFixed(2)` is
+    // "0.00", which is the same lie with more decimal places. Below a cent the
+    // only honest rendering is a bound.
+    // ★AND A NEGATIVE IS NOT RENDERED AT ALL. The schema forbids one (`min: 0`),
+    // and `Math.round(-0.4)` is JavaScript's `-0` — "USD -0 spent" is a
+    // sentence about money that nobody can act on.
+    if (outcome.spend > 0 && outcome.spend < 0.01) {
+      parts.push(`under ${outcome.currency} 0.01 spent`);
+    } else {
+      const spend =
+        outcome.spend > 0 && outcome.spend < 1
+          ? outcome.spend.toFixed(2)
+          : REACH_FORMAT.format(Math.round(outcome.spend));
+      parts.push(`${outcome.currency} ${spend} spent`);
+    }
   }
   return parts.join(" · ");
 }

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -40,6 +40,18 @@ export function originLabel(source: AudienceSource): string {
     case "user_defined":
       return "You built this";
     case "fallback":
+      // ★NOT "Peakhour suggested", AND THE REASON IS THE FILTER. The api takes
+      // ONE `source` value, so a badge that says the same thing for two enum
+      // members leaves the second reachable from no option in any dropdown: a
+      // customer filtering to "Peakhour suggested" loses a row badged
+      // "Peakhour suggested", which is the accepted-then-ignored-filter failure
+      // this surface exists to avoid.
+      //
+      // It is also a real distinction rather than a workaround. `fallback` is
+      // the deterministic geography × industry set every plan carries — the
+      // one the strategist's ideas are MEASURED AGAINST — so saying which one
+      // it is tells the customer more, not less.
+      return "Peakhour baseline";
     case "generated":
     default:
       return "Peakhour suggested";
@@ -57,22 +69,43 @@ export function originIsOurs(source: AudienceSource): boolean {
  *  look complete, which is the one thing this surface must not do. Same map as
  *  the campaign audience card, kept in step deliberately. */
 const ATTRIBUTE_LABEL: Record<string, string> = {
-  geo: "Location",
-  company_industry: "Industry",
-  company_size: "Company size",
+  // person / professional
   job_title: "Job title",
   seniority: "Seniority",
   job_function: "Job function",
-  member_interest: "Interests",
-  company_name: "Companies",
-  school: "Schools",
   skill: "Skills",
-  degree: "Degrees",
   years_experience: "Years of experience",
-  member_behaviour: "Behaviour",
-  company_follower: "Followers",
+  education_degree: "Degrees",
+  field_of_study: "Fields of study",
+  group_membership: "Groups",
+  member_interest: "Interests",
+  // company / firmographic
+  company_industry: "Industry",
+  company_size: "Company size",
+  company_name: "Companies",
+  company_follower: "Company followers",
+  company_category: "Company category",
+  company_growth_rate: "Company growth",
+  company_revenue: "Company revenue",
+  school: "Schools",
+  // demographic, place, language
+  age_range: "Age",
+  gender: "Gender",
+  geo: "Location",
+  language: "Language",
+  // behavioural / intent
+  behaviour: "Behaviour",
+  purchase_intent: "Purchase intent",
+  life_event: "Life events",
+  search_keyword: "Search terms",
+  // audience objects
   custom_audience: "Your own lists",
-  lookalike: "Lookalikes",
+  lookalike_seed: "Lookalike seed",
+  retargeting_audience: "Retargeting",
+  // delivery
+  device: "Platform",
+  device_model: "Device",
+  placement: "Placement",
 };
 
 export function attributeLabel(attribute: string): string {
@@ -170,18 +203,33 @@ export function reachReading(channel: AudienceChannel): ReachReading {
  * does not exist — which is exactly the collapse the api's own
  * `rematerialisable` flag was added to prevent.
  */
-export function channelNote(channel: AudienceChannel): string | null {
+export function channelNotes(channel: AudienceChannel): string[] {
+  const notes: string[] = [];
   if (channel.droppedAttributes > 0) {
     const n = channel.droppedAttributes;
-    return `${n} thing${n === 1 ? "" : "s"} ${platformLabel(channel.platform)} can't express`;
+    notes.push(`${n} thing${n === 1 ? "" : "s"} ${platformLabel(channel.platform)} can't express`);
   }
-  if (channel.stale && channel.rematerialisable) return "May be out of date";
-  return null;
+  // ★BOTH, NOT THE FIRST. A first cut returned one string and stopped at the
+  // dropped-attribute case — so a channel that was stale AND lossy rendered
+  // byte-identically to one that was merely lossy. They are two true and
+  // different facts: one is about the audience the customer would be buying,
+  // the other about how old our copy of it is, and this file's whole argument
+  // is that collapsing two facts into one sentence is the failure.
+  if (channel.stale && channel.rematerialisable) notes.push("May be out of date");
+  return notes;
 }
 
-/** Every channel this business can advertise on, whether or not this audience
- *  has been resolved against it. The library's own rows carry only the ones
- *  that HAVE been asked. */
+/**
+ * Every channel this business can advertise on, whether or not this audience
+ * has been resolved against it. A row carries only the ones that HAVE been
+ * asked, so this is what makes "nobody has asked X" sayable at all.
+ *
+ * ⚠️ HAND-MIRRORED FROM THE API'S ADAPTER REGISTRY, and said here rather than
+ * discovered: `listAudiencePlatforms()` is the authority and this client cannot
+ * import it. The consequence of drift is bounded and one-directional — a third
+ * channel would simply never be offered as "not checked yet" until somebody
+ * edits this line — but it is drift, and `GET /sets` does not publish the list.
+ */
 export const LIBRARY_CHANNELS = ["linkedin", "x"] as const;
 
 /**
@@ -212,9 +260,16 @@ export function historyLine(set: Pick<AudienceSet, "status" | "userEdits" | "dis
   const edits = set.userEdits?.length ?? 0;
   const corrected = edits > 0 ? `corrected ${edits} time${edits === 1 ? "" : "s"}` : null;
   if (set.status === "discarded") {
-    return set.discardReason
+    // ★THE COUNT SURVIVES THE DISCARD. "Discarded after being corrected four
+    // times" is the most informative row in the library — it is an audience we
+    // kept getting wrong and they finally gave up on — and a first cut computed
+    // the figure and then dropped it on exactly the sets most likely to carry
+    // one. Suppressing the OUTCOME on a discard is the rule; suppressing the
+    // correction count was an accident of ordering.
+    const base = set.discardReason
       ? `You discarded this — "${set.discardReason}"`
       : "You discarded this";
+    return corrected ? `${base} (${corrected})` : base;
   }
   if (set.status === "superseded") {
     return corrected ? `Replaced by a newer audience, ${corrected}` : "Replaced by a newer audience";
@@ -247,7 +302,14 @@ export function outcomeLine(outcome: AudienceSet["outcome"]): string | null {
     parts.push("never served");
   }
   if (typeof outcome.spend === "number" && outcome.currency) {
-    parts.push(`${outcome.currency} ${REACH_FORMAT.format(Math.round(outcome.spend))} spent`);
+    // ★ROUNDED TO WHOLE UNITS EXCEPT WHERE THAT WOULD PRINT A ZERO OVER REAL
+    // SPEND. `Math.round(0.49)` is 0, and "INR 0 spent" beside a campaign that
+    // did spend is the confident-wrong number this file exists to refuse.
+    const spend =
+      outcome.spend > 0 && outcome.spend < 1
+        ? outcome.spend.toFixed(2)
+        : REACH_FORMAT.format(Math.round(outcome.spend));
+    parts.push(`${outcome.currency} ${spend} spent`);
   }
   return parts.join(" · ");
 }

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -1,0 +1,253 @@
+import type {
+  AudienceChannel,
+  AudienceHypothesisAttribute,
+  AudienceSet,
+  AudienceSource,
+} from "@/lib/api/audiences";
+
+/**
+ * The decisions the audience library makes, extracted so they can be tested.
+ *
+ * This repo has no DOM test environment on purpose (`vitest.config.ts`:
+ * node-only until a primitive genuinely needs jsdom), so rendering is not what
+ * gets asserted. What CAN be got wrong without a DOM — and what would be
+ * invisible in review — is the judgement, and on this surface the judgement is
+ * almost entirely about ABSENCES:
+ *
+ *   - a channel nobody has asked, versus one that cannot express the audience;
+ *   - a reach we do not have, versus a reach of zero;
+ *   - an audience the engine suggested, versus one the customer told us.
+ *
+ * Collapsing any of those is the failure this whole engine is built not to
+ * commit, and each collapse is one line of JSX away.
+ */
+
+/**
+ * Where an audience came from, in the customer's terms.
+ *
+ * ★THE BRIEF'S OWN DISTINCTION AND IT MUST BE VISIBLE. "Peakhour inferred" and
+ * "user inferred" are the difference between a suggestion and a fact about the
+ * business: `generated`/`fallback` is something we thought of, `imported` is
+ * something they actually ran with their own money, and `user_defined` is
+ * something they sat down and wrote — usually while disagreeing with a
+ * proposal we had just shown them, which the design calls the best signal this
+ * engine ever gets.
+ */
+export function originLabel(source: AudienceSource): string {
+  switch (source) {
+    case "imported":
+      return "From your past campaigns";
+    case "user_defined":
+      return "You built this";
+    case "fallback":
+    case "generated":
+    default:
+      return "Peakhour suggested";
+  }
+}
+
+/** Whether the origin is OURS. Drives the badge's tone: a suggestion is not
+ *  the same kind of thing as a record of what they did. */
+export function originIsOurs(source: AudienceSource): boolean {
+  return source === "generated" || source === "fallback";
+}
+
+/** Business-language attribute names. An unknown attribute renders under its
+ *  own id rather than vanishing — a silent omission makes a narrower audience
+ *  look complete, which is the one thing this surface must not do. Same map as
+ *  the campaign audience card, kept in step deliberately. */
+const ATTRIBUTE_LABEL: Record<string, string> = {
+  geo: "Location",
+  company_industry: "Industry",
+  company_size: "Company size",
+  job_title: "Job title",
+  seniority: "Seniority",
+  job_function: "Job function",
+  member_interest: "Interests",
+  company_name: "Companies",
+  school: "Schools",
+  skill: "Skills",
+  degree: "Degrees",
+  years_experience: "Years of experience",
+  member_behaviour: "Behaviour",
+  company_follower: "Followers",
+  custom_audience: "Your own lists",
+  lookalike: "Lookalikes",
+};
+
+export function attributeLabel(attribute: string): string {
+  return ATTRIBUTE_LABEL[attribute] ?? attribute.replace(/_/g, " ");
+}
+
+/** Channel display names. Unknown platforms render under their own key rather
+ *  than being hidden — a channel we cannot name is still a channel this
+ *  audience works on. */
+const PLATFORM_LABEL: Record<string, string> = {
+  linkedin: "LinkedIn",
+  x: "X",
+  meta: "Meta",
+  google_ads: "Google Ads",
+};
+
+export function platformLabel(platform: string): string {
+  return PLATFORM_LABEL[platform] ?? platform;
+}
+
+/**
+ * The shape of the audience, in business language, ready to render as chips.
+ *
+ * ★THE HYPOTHESIS, NEVER A RESOLUTION. A channel's `basis` holds what THAT
+ * channel managed to bind — so rendering it would shrink the audience to
+ * whatever LinkedIn happened to match, and an audience narrowing by being
+ * looked at is the exact failure the channel-neutral shape exists to end.
+ *
+ * An imported set has no hypothesis at all (its criteria are the platform's
+ * own), and that is a real answer rather than an empty one: the caller says so
+ * instead of drawing nothing.
+ */
+export function audienceShape(
+  set: Pick<AudienceSet, "hypothesis">,
+): Array<{ attribute: string; label: string; values: string[] }> {
+  return (set.hypothesis?.attributes ?? [])
+    .filter((a: AudienceHypothesisAttribute) => a.values?.length)
+    .map((a) => ({ attribute: a.attribute, label: attributeLabel(a.attribute), values: a.values }));
+}
+
+/**
+ * ★A FIXED LOCALE, not the ambient one, for the reason `audience-card-rules`
+ * gives at length: `toLocaleString()` groups by whatever locale the runtime
+ * has, so the same number renders differently on the server and in the browser
+ * and React reports a hydration mismatch.
+ */
+const REACH_FORMAT = new Intl.NumberFormat("en-US");
+
+/** How big this audience is on a channel — or WHY there is no number. */
+export type ReachReading =
+  | { kind: "counted"; text: string }
+  /** The platform masked the count because the audience is under its serving
+   *  floor. There is no figure to show and there never was one. */
+  | { kind: "below_floor"; text: string }
+  /** We do not have a size. NOT zero, and NOT a claim about the channel —
+   *  "the platform publishes no count" and "our call for it failed" are the
+   *  same fact from the customer's side, and the api reports them identically
+   *  on purpose. */
+  | { kind: "unknown"; text: string };
+
+export function reachReading(channel: AudienceChannel): ReachReading {
+  // Order matters: "we have no number" outranks any reading of one, so a
+  // `{reachSupported: false, reachValue: 0}` can never claim a floor.
+  if (!channel.reachSupported || typeof channel.reachValue !== "number") {
+    return {
+      kind: channel.belowFloor ? "below_floor" : "unknown",
+      text: channel.belowFloor
+        ? `Too small for ${platformLabel(channel.platform)} to count`
+        : `No size from ${platformLabel(channel.platform)}`,
+    };
+  }
+  if (channel.belowFloor || channel.reachValue === 0) {
+    // ★A LITERAL ZERO IS THE FLOOR, NOT A COUNT. LinkedIn's masked `total: 0`
+    // means "fewer than 300"; the api maps it to `belowFloor` with no number,
+    // so a zero arriving here means something upstream changed — and "0
+    // people" is the exact sentence this file exists to prevent.
+    return {
+      kind: "below_floor",
+      text: `Too small for ${platformLabel(channel.platform)} to count`,
+    };
+  }
+  return {
+    kind: "counted",
+    text: `${REACH_FORMAT.format(channel.reachValue)} on ${platformLabel(channel.platform)}`,
+  };
+}
+
+/**
+ * What a channel row should say beyond its reach, or null.
+ *
+ * ★`stale` IS ONLY ACTIONABLE WHEN THE AUDIENCE CAN BE RE-EXPRESSED. An
+ * imported set carries no hypothesis: its criteria are a record of what somebody
+ * actually ran, there is nothing to re-derive, and nothing it could be out of
+ * date WITH. Showing "may be out of date" over it would invite an action that
+ * does not exist — which is exactly the collapse the api's own
+ * `rematerialisable` flag was added to prevent.
+ */
+export function channelNote(channel: AudienceChannel): string | null {
+  if (channel.droppedAttributes > 0) {
+    const n = channel.droppedAttributes;
+    return `${n} thing${n === 1 ? "" : "s"} ${platformLabel(channel.platform)} can't express`;
+  }
+  if (channel.stale && channel.rematerialisable) return "May be out of date";
+  return null;
+}
+
+/** Every channel this business can advertise on, whether or not this audience
+ *  has been resolved against it. The library's own rows carry only the ones
+ *  that HAVE been asked. */
+export const LIBRARY_CHANNELS = ["linkedin", "x"] as const;
+
+/**
+ * The channels nobody has asked about this audience.
+ *
+ * ★THIS IS A FIRST-CLASS ANSWER AND NOT AN EMPTY ONE. "We haven't looked at X
+ * for this audience" is a different sentence from "it doesn't work on X", and
+ * rendering the second when the first is true claims something about a
+ * customer's reach on a channel nobody has queried. It is also the affordance:
+ * the unasked channel is exactly the one worth offering to check.
+ */
+export function unaskedChannels(
+  set: Pick<AudienceSet, "channels">,
+  known: readonly string[] = LIBRARY_CHANNELS,
+): string[] {
+  const asked = new Set(set.channels.map((c) => c.platform));
+  return known.filter((p) => !asked.has(p));
+}
+
+/**
+ * What has HAPPENED to this audience, in one line, or null when nothing has.
+ *
+ * ★`discarded` OUTRANKS EVERYTHING, INCLUDING AN OUTCOME. A discarded audience
+ * that once ran is a rejection with history, and leading with its click-through
+ * rate would read as a recommendation.
+ */
+export function historyLine(set: Pick<AudienceSet, "status" | "userEdits" | "discardReason">): string | null {
+  const edits = set.userEdits?.length ?? 0;
+  const corrected = edits > 0 ? `corrected ${edits} time${edits === 1 ? "" : "s"}` : null;
+  if (set.status === "discarded") {
+    return set.discardReason
+      ? `You discarded this — "${set.discardReason}"`
+      : "You discarded this";
+  }
+  if (set.status === "superseded") {
+    return corrected ? `Replaced by a newer audience, ${corrected}` : "Replaced by a newer audience";
+  }
+  if (set.status === "applied") {
+    return corrected ? `On a campaign, ${corrected}` : "On a campaign";
+  }
+  return corrected ? `Suggested, ${corrected}` : null;
+}
+
+/**
+ * The one-line performance summary, or null when the audience has never run.
+ *
+ * ★A RATIO OVER ZERO IMPRESSIONS IS NOT ZERO. The api omits `ctr` when nothing
+ * served, precisely so a set whose campaign never delivered is not ranked below
+ * one that genuinely underperformed — and a client that filled in "0.0%" would
+ * undo that in the one number a customer reads as a verdict.
+ *
+ * ★AND THE FIGURES ARE COPIED FROM THE CAMPAIGNS, NOT MEASURED HERE. The
+ * caller says so; this only decides what may be shown.
+ */
+export function outcomeLine(outcome: AudienceSet["outcome"]): string | null {
+  if (!outcome) return null;
+  const parts: string[] = [`${REACH_FORMAT.format(outcome.impressions)} impressions`];
+  if (typeof outcome.ctr === "number") {
+    parts.push(`${(outcome.ctr * 100).toFixed(2)}% clicked`);
+  } else if (outcome.impressions === 0) {
+    // Said rather than left blank: "it never served" and "it served and nobody
+    // clicked" are different facts about an audience.
+    parts.push("never served");
+  }
+  if (typeof outcome.spend === "number" && outcome.currency) {
+    parts.push(`${outcome.currency} ${REACH_FORMAT.format(Math.round(outcome.spend))} spent`);
+  }
+  return parts.join(" · ");
+}


### PR DESCRIPTION
**The customer can finally see any of this.**

`biz_audience_sets` has held named, reusable, per-channel audiences since B2 — planned portfolios, the campaigns a business actually ran, scores, critiques, outcomes, hand-corrections — and until this page nothing rendered a single row of it. Four merged PRs (E1, F1, F2, F3) built the channel-neutral shape underneath and did not change that. The standing rule is that **"built" means a caller can reach it.**

## The row is mostly about what we do not know

Each absence is a different sentence, and every one has a test:

- a channel with a number → the number;
- a channel without one → "No size from X" — never a zero and never a blank. It does not blame the channel either: the api reports "the platform publishes no count" and "our call for it failed" identically on purpose, because from the customer's side they are the same fact;
- a channel **nobody has asked** → said outright. "We haven't looked at X for this audience" is not "it doesn't work on X", and rendering the second when the first is true claims something about a customer's reach on a channel nobody has queried;
- attributes a channel could not express → counted here, named in G3's per-channel view.

**The origin badge leads**, because it is the brief's own distinction: "Peakhour suggested" is a suggestion, "From your past campaigns" is what they ran with their own money, "You built this" is what they wrote — usually while disagreeing with a proposal we had just shown them.

Three more collapses refused, each pinned by a test:
- an **imported** set is never called "may be out of date". It has no hypothesis: its criteria are a record of what somebody actually ran, so there is nothing to re-derive and nothing it could be out of date *with*.
- a literal reach of 0 is the serving floor, not a count.
- an outcome over zero impressions says "never served" rather than inventing 0.00%.

The judgement lives in `audience-library-rules.ts` and is tested — this repo is vitest node-only by design, so extracting the decisions is what makes them assertable at all. The page is the arrangement.

## What review changed

Round 1 found the filter labelled **"Peakhour suggested"** was hiding a row badged **"Peakhour suggested"**: the api's `source` enum has four members, the filter offered three, and `originLabel` gave `generated` and `fallback` the same badge — so the baseline set every plan carries was reachable from no option in any dropdown. The filter vocabulary moved to `filters.ts` so a test can assert it against the api's enums; that seam had no coverage at all, and it is where the defect lived.

Plus: an 81-character search was a permanent error state (a 400 whose only action refetches the same invalid query); every error read as ours including a 403 a retry can never fix; a page past the end rendered "No audiences yet" with the pagination gone; `Next` could walk past the api's own offset cap; a stale+lossy channel rendered identically to a merely-lossy one; the correction count was dropped on discarded sets, which are the ones most likely to have one; the attribute label map had three keys the api cannot send and was missing fifteen it can.

Every fix mutation-checked — reverted, and the test confirmed failing.

Also adds the missing `skill-tuning` cron label: unrelated, but the cron-metadata drift guard has been red on master since the api added that cron, and it is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)