### PR TITLE
feat(audience): what this audience looks like on each channel (G3)

### DIFF
--- a/src/app/(site)/dashboard/growth/audiences/[id]/_components/channel-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/_components/channel-card.tsx
@@ -19,7 +19,9 @@ import {
 } from "@/lib/api/audiences";
 import {
   attributeLabel,
+  channelNotes,
   gapSentence,
+  reachReading,
   platformLabel,
   refreshability,
   resolutionReach,
@@ -78,8 +80,20 @@ export function ChannelCard({ set, platform }: { set: AudienceSet; platform: str
   async function refresh() {
     setRefreshing(true);
     try {
+      // ★CANCEL FIRST. A focus refetch is in flight exactly when the cached
+      // answer is older than `staleTime` — which is the state a customer is in
+      // when they press this — and it would land AFTER the forced write with a
+      // response carrying no `refreshFailed`: the toast says the refresh failed
+      // and the card shows a clean cache hit.
+      await queryClient.cancelQueries({ queryKey });
       const fresh = await audienceLibraryApi.getResolution(set.id, platform, { refresh: true });
       queryClient.setQueryData(queryKey, fresh);
+      // The forced call WRITES the resolution back server-side, so the parent
+      // set's `channels[]` — its staleness, its reach — is now behind. Without
+      // this the library list keeps showing the old number and a remount
+      // decides whether to ask using flags that have moved.
+      void queryClient.invalidateQueries({ queryKey: ["audience-set"] });
+      void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
       if (fresh.available && fresh.refreshFailed) {
         toast.warning(`We couldn't ask ${platformLabel(platform)} again.`, {
           description: fresh.refreshFailed.message,
@@ -107,22 +121,51 @@ export function ChannelCard({ set, platform }: { set: AudienceSet; platform: str
           {!asked ? (
             <Button size="sm" variant="outline" onClick={() => setAsked(true)}>
               <Search className="mr-1.5 size-3.5" aria-hidden="true" />
-              Check this channel
+              {known ? "Check again" : "Check this channel"}
             </Button>
           ) : (
             <RefreshControl data={data} platform={platform} onRefresh={refresh} busy={refreshing} />
           )}
         </div>
 
-        {/* ★NOBODY HAS ASKED IS ITS OWN ANSWER. Not "it doesn't work here", and
-            not a blank — a claim about a customer's reach on a channel nobody
-            has queried is the thing this surface exists not to make. */}
-        {!asked ? (
+        {/* ★TWO DIFFERENT UNASKED STATES, AND A FIRST CUT RENDERED BOTH AS THE
+            SECOND. `known` present means we HAVE a stored answer and are simply
+            not re-asking for a fresh one — so withholding its reach and its
+            gaps made this page know LESS than the library row that links to it,
+            which is the opposite of the page's entire premise. `known` absent
+            is the real "nobody has asked", which is its own answer and not
+            "it doesn't work here". */}
+        {!asked && known ? (
+          <div className="space-y-2">
+            {(() => {
+              const reach = reachReading(known);
+              const notes = channelNotes(known);
+              return (
+                <>
+                  <p
+                    className={
+                      reach.kind === "counted" ? "text-sm font-medium" : "text-sm text-muted-foreground"
+                    }
+                  >
+                    {reach.text}
+                  </p>
+                  {notes.length > 0 && (
+                    <p className="text-xs text-muted-foreground">{notes.join(" · ")}</p>
+                  )}
+                </>
+              );
+            })()}
+            <p className="text-xs text-muted-foreground">
+              This is what we worked out last time. Checking asks{" "}
+              {platformLabel(platform)} again — it puts nothing on a campaign and spends no
+              budget.
+            </p>
+          </div>
+        ) : !asked ? (
           <p className="text-sm text-muted-foreground">
             We haven&apos;t worked out what this audience looks like on{" "}
-            {platformLabel(platform)}
-            {known?.stale ? " recently" : ""}. Checking asks {platformLabel(platform)} directly
-            — it puts nothing on a campaign and spends no budget.
+            {platformLabel(platform)}. Checking asks {platformLabel(platform)} directly — it
+            puts nothing on a campaign and spends no budget.
           </p>
         ) : resolution.isPending ? (
           <div className="space-y-2">
@@ -130,14 +173,29 @@ export function ChannelCard({ set, platform }: { set: AudienceSet; platform: str
             <Skeleton className="h-3 w-full max-w-sm" />
           </div>
         ) : resolution.isError ? (
-          <p className="text-sm text-muted-foreground">
-            {resolution.error instanceof ApiError && resolution.error.code === "RATE_LIMITED"
-              ? "We're still working out the last one — give it a moment and ask again."
-              : resolution.error instanceof ApiError &&
-                  resolution.error.code === "PLATFORM_UNSUPPORTED"
-                ? `We can't build audiences for ${platformLabel(platform)} yet.`
-                : "We couldn't ask just now. Nothing was changed."}
-          </p>
+          // ★AND A CONTROL, BECAUSE THE COPY PROMISES ONE. `asked` is one-way
+          // and `RefreshControl` renders nothing without data, so a rate-limited
+          // card told the customer to "ask again" with nothing to press and
+          // stayed inert until a full page reload — on the state they reach by
+          // doing what the page just told them to.
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              {resolution.error instanceof ApiError && resolution.error.code === "RATE_LIMITED"
+                ? "We're still working out the last one — give it a moment and ask again."
+                : resolution.error instanceof ApiError &&
+                    resolution.error.code === "PLATFORM_UNSUPPORTED"
+                  ? `We can't build audiences for ${platformLabel(platform)} yet.`
+                  : "We couldn't ask just now. Nothing was changed."}
+            </p>
+            {!(
+              resolution.error instanceof ApiError &&
+              resolution.error.code === "PLATFORM_UNSUPPORTED"
+            ) && (
+              <Button size="sm" variant="ghost" onClick={() => void resolution.refetch()}>
+                Ask again
+              </Button>
+            )}
+          </div>
         ) : !data ? null : !data.available ? (
           // ★A REFUSAL IS THE ANSWER, RENDERED AS ONE. The api returns 200 with
           // a reason precisely so this is not a broken screen: "this audience
@@ -221,14 +279,33 @@ export function ChannelCard({ set, platform }: { set: AudienceSet; platform: str
             {data.stale && data.rematerialisable && (
               <p className="text-xs text-muted-foreground">
                 This was worked out by an older version of us, so we can&apos;t promise it&apos;s
-                today&apos;s answer — ask again for a fresh one.
+                today&apos;s answer
+                {/* ★AND NO IMPERATIVE TO PRESS A BUTTON WE KNOW WILL FAIL. When
+                    the refresh failed for a reason nothing on this card can fix,
+                    "ask again for a fresh one" is an instruction to repeat what
+                    just did not work. */}
+                {data.refreshFailed ? "." : " — ask again for a fresh one."}
               </p>
             )}
             {data.refreshFailed && (
-              <p className="text-xs text-muted-foreground">
-                We couldn&apos;t ask {platformLabel(platform)} again just now, so this is what we
-                had. {data.refreshFailed.message}
-              </p>
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  We couldn&apos;t ask {platformLabel(platform)} again just now, so this is what
+                  we had. {data.refreshFailed.message}
+                </p>
+                {/* ★THE SAME CONNECTION CODES ARRIVE ON THIS PATH TOO, AND A
+                    FIRST CUT LOOKED FOR THEM ONLY ON `available: false`. The api
+                    returns the CACHED entry whenever one exists — so a business
+                    that resolved LinkedIn once and later lost the token got a
+                    "reconnect" sentence with no route to Integrations, while a
+                    business that had never resolved it got the link. The more
+                    common case had the worse answer. */}
+                {CONNECTION_CODES.has(data.refreshFailed.code) && (
+                  <Button asChild size="sm" variant="outline">
+                    <Link href="/dashboard/integrations">Go to integrations</Link>
+                  </Button>
+                )}
+              </div>
             )}
           </div>
         )}

--- a/src/app/(site)/dashboard/growth/audiences/[id]/_components/channel-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/_components/channel-card.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { RefreshCw, Search } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ApiError } from "@/lib/api";
+import {
+  audienceLibraryApi,
+  type AudienceChannelGap,
+  type AudienceSet,
+} from "@/lib/api/audiences";
+import {
+  attributeLabel,
+  gapSentence,
+  platformLabel,
+  refreshability,
+  resolutionReach,
+} from "@/lib/audience-library-rules";
+
+/**
+ * What this audience looks like on ONE channel (G3).
+ *
+ * ★THE SEAM, MADE VISIBLE TO A CUSTOMER INSTEAD OF CLAIMED IN A DOC. "On
+ * LinkedIn: 2.4M people. On X: we can't get a count, and these two things can't
+ * be expressed there" is the sentence this whole track exists to be able to
+ * say.
+ *
+ * ★AND IT ASKS ONLY WHEN ASKED. `GET /sets/:id/resolutions/:platform` runs a
+ * typeahead round and a reach call, and it WRITES the answer back — so firing
+ * it on mount for every channel would spend a customer's rate limit rendering a
+ * page. The card opens with what is already stored and offers the question.
+ */
+export function ChannelCard({
+  set,
+  platform,
+}: {
+  set: AudienceSet;
+  platform: string;
+}) {
+  const known = set.channels.find((c) => c.platform === platform);
+  /** Nobody asks a channel by accident: the query is disabled until they do,
+   *  or until the channel is one we have already resolved (where the answer is
+   *  a cache read on the api's side and costs nothing). */
+  const [asked, setAsked] = useState(Boolean(known));
+  const [refreshing, setRefreshing] = useState(false);
+
+  const resolution = useQuery({
+    queryKey: ["audience-resolution", set.id, platform],
+    queryFn: () => audienceLibraryApi.getResolution(set.id, platform),
+    enabled: asked,
+    // The answer is cached server-side into the set; re-asking on every focus
+    // would re-run a typeahead round for a page that has not changed.
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+
+  async function refresh() {
+    setRefreshing(true);
+    try {
+      await audienceLibraryApi.getResolution(set.id, platform, { refresh: true });
+    } finally {
+      setRefreshing(false);
+      void resolution.refetch();
+    }
+  }
+
+  const data = resolution.data;
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-semibold">{platformLabel(platform)}</h3>
+          {!asked ? (
+            <Button size="sm" variant="outline" onClick={() => setAsked(true)}>
+              <Search className="mr-1.5 size-3.5" aria-hidden="true" />
+              Check this channel
+            </Button>
+          ) : data?.available ? (
+            (() => {
+              const { canRefresh, reason } = refreshability(data.resolution, {
+                rematerialisable: data.rematerialisable,
+              });
+              return canRefresh ? (
+                <Button size="sm" variant="ghost" onClick={() => void refresh()} disabled={refreshing}>
+                  <RefreshCw
+                    className={`mr-1.5 size-3.5 ${refreshing ? "animate-spin" : ""}`}
+                    aria-hidden="true"
+                  />
+                  {refreshing ? "Asking…" : "Ask again"}
+                </Button>
+              ) : (
+                <span className="text-xs text-muted-foreground">{reason}</span>
+              );
+            })()
+          ) : null}
+        </div>
+
+        {/* ★NOBODY HAS ASKED IS ITS OWN ANSWER. Not "it doesn't work here", and
+            not a blank — a claim about a customer's reach on a channel nobody
+            has queried is the thing this surface exists not to make. */}
+        {!asked ? (
+          <p className="text-sm text-muted-foreground">
+            We haven&apos;t worked out what this audience looks like on{" "}
+            {platformLabel(platform)}. Checking asks {platformLabel(platform)} directly — it
+            changes nothing and spends nothing.
+          </p>
+        ) : resolution.isPending ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-56" />
+            <Skeleton className="h-3 w-full max-w-sm" />
+          </div>
+        ) : resolution.isError ? (
+          <p className="text-sm text-muted-foreground">
+            {resolution.error instanceof ApiError && resolution.error.code === "RATE_LIMITED"
+              ? "We're still working out the last one — give it a moment and ask again."
+              : resolution.error instanceof ApiError &&
+                  resolution.error.code === "PLATFORM_UNSUPPORTED"
+                ? `We can't build audiences for ${platformLabel(platform)} yet.`
+                : "We couldn't ask just now. Nothing was changed."}
+          </p>
+        ) : !data ? null : !data.available ? (
+          // ★A REFUSAL IS THE ANSWER, RENDERED AS ONE. The api returns 200 with
+          // a reason precisely so this is not a broken screen: "this audience
+          // is a geography and nothing else, so there's nothing to translate
+          // for X" is what the customer asked to know.
+          <div className="space-y-2">
+            <p className="text-sm">{data.message}</p>
+            <GapList gaps={data.gaps} platform={platform} />
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {(() => {
+              const reach = resolutionReach(data.resolution, platform);
+              return (
+                <p className={reach.sourced ? "text-sm font-medium" : "text-sm text-muted-foreground"}>
+                  {reach.text}
+                </p>
+              );
+            })()}
+
+            {/* What the channel actually bound, in its own words — the readable
+                half of the criteria. The criteria themselves are the
+                platform's and are deliberately not rendered: a customer cannot
+                act on a URN. */}
+            {(data.resolution.basis ?? []).length > 0 && (
+              <ul className="space-y-1">
+                {data.resolution.basis!.map((b) => (
+                  <li key={b.attribute} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className="text-xs text-muted-foreground">
+                      {attributeLabel(b.attribute)}
+                    </span>
+                    {b.values.map((v, i) => (
+                      <Badge
+                        key={`${b.attribute}:${i}:${v}`}
+                        variant="outline"
+                        className="font-normal whitespace-normal"
+                      >
+                        {v}
+                      </Badge>
+                    ))}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <GapList gaps={data.gaps} platform={platform} />
+
+            {/* ★"WE COULDN'T RE-ASK" IS NOT "THIS IS CURRENT". Without saying
+                so, a failed refresh is indistinguishable from a cache hit —
+                which is why the api reports it separately from `stale`. */}
+            {data.refreshFailed && (
+              <p className="text-xs text-muted-foreground">
+                We couldn&apos;t ask {platformLabel(platform)} again just now, so this is what we
+                had. {data.refreshFailed.message}
+              </p>
+            )}
+            {data.stale && !data.refreshFailed && data.rematerialisable && (
+              <p className="text-xs text-muted-foreground">
+                This was worked out by an older version of us — ask again for today&apos;s answer.
+              </p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * What the channel could not express — by name, never as a count.
+ *
+ * ★TWO KINDS OF GAP, KEPT APART. "X can't target seniority at all" is a fact
+ * about the channel; "X matched 3 of your 5 job titles" is a fact about those
+ * values, and it names them. A customer can act on the second and can only
+ * plan around the first.
+ */
+function GapList({ gaps, platform }: { gaps: AudienceChannelGap[]; platform: string }) {
+  if (gaps.length === 0) return null;
+  return (
+    <div className="space-y-1 rounded-md border border-dashed p-2.5">
+      <p className="text-xs font-medium">What {platformLabel(platform)} couldn&apos;t express</p>
+      <ul className="space-y-1">
+        {gaps.map((gap) => (
+          <li key={`${gap.attribute}:${gap.variant}`} className="text-xs text-muted-foreground">
+            {gapSentence(gap, platform)}
+            {gap.values.length > 0 && (
+              <span className="block pl-3">
+                {gap.values.map((v) => `“${v.value}” — ${v.reason}`).join("; ")}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/growth/audiences/[id]/_components/channel-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/_components/channel-card.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { RefreshCw, Search } from "lucide-react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError } from "@/lib/api";
+import { useAuth } from "@/providers/auth-provider";
 import {
   audienceLibraryApi,
   type AudienceChannelGap,
+  type AudienceResolutionResponse,
   type AudienceSet,
 } from "@/lib/api/audiences";
 import {
@@ -19,6 +23,7 @@ import {
   platformLabel,
   refreshability,
   resolutionReach,
+  shouldAskOnMount,
 } from "@/lib/audience-library-rules";
 
 /**
@@ -29,27 +34,26 @@ import {
  * be expressed there" is the sentence this whole track exists to be able to
  * say.
  *
- * ★AND IT ASKS ONLY WHEN ASKED. `GET /sets/:id/resolutions/:platform` runs a
- * typeahead round and a reach call, and it WRITES the answer back — so firing
- * it on mount for every channel would spend a customer's rate limit rendering a
- * page. The card opens with what is already stored and offers the question.
+ * ★AND IT ASKS ONLY WHEN THE ANSWER IS ALREADY PAID FOR. The route is a cache
+ * read when the stored entry is CURRENT; on a stale one it takes an org-wide
+ * rate-limit token and runs a full typeahead round, a reach call and a write.
+ * `shouldAskOnMount` is that distinction, and it is a tested function rather
+ * than a `Boolean(known)` — the first cut fired a metered resolution for every
+ * pre-E1 entry (stale by construction) just by opening the page.
  */
-export function ChannelCard({
-  set,
-  platform,
-}: {
-  set: AudienceSet;
-  platform: string;
-}) {
+export function ChannelCard({ set, platform }: { set: AudienceSet; platform: string }) {
+  const { business } = useAuth();
+  const queryClient = useQueryClient();
   const known = set.channels.find((c) => c.platform === platform);
-  /** Nobody asks a channel by accident: the query is disabled until they do,
-   *  or until the channel is one we have already resolved (where the answer is
-   *  a cache read on the api's side and costs nothing). */
-  const [asked, setAsked] = useState(Boolean(known));
+  const [asked, setAsked] = useState(() => shouldAskOnMount(known));
   const [refreshing, setRefreshing] = useState(false);
 
+  // The business is in the key like every other business-scoped query here:
+  // the route is business-scoped server-side, and a key that does not say which
+  // business is one cache `clear()` away from rendering another one's answer.
+  const queryKey = ["audience-resolution", business?._id ?? "none", set.id, platform] as const;
   const resolution = useQuery({
-    queryKey: ["audience-resolution", set.id, platform],
+    queryKey,
     queryFn: () => audienceLibraryApi.getResolution(set.id, platform),
     enabled: asked,
     // The answer is cached server-side into the set; re-asking on every focus
@@ -58,13 +62,38 @@ export function ChannelCard({
     retry: false,
   });
 
+  /**
+   * Ask the channel again.
+   *
+   * ★THE FORCED CALL'S OWN ANSWER IS WHAT GETS RENDERED. A first cut awaited it,
+   * THREW THE PAYLOAD AWAY and then issued a second, unforced GET — so
+   * `refreshFailed`, which only the attempting call produces, was unreachable
+   * on the one path that can produce it, and a stale entry paid for two
+   * resolutions per button press.
+   *
+   * ★AND A FAILURE IS SAID OUT LOUD. With no `catch`, a 429 left the spinner
+   * stopping over byte-identical data and nothing else happening — on the one
+   * control that can actually trip an org-wide bucket.
+   */
   async function refresh() {
     setRefreshing(true);
     try {
-      await audienceLibraryApi.getResolution(set.id, platform, { refresh: true });
+      const fresh = await audienceLibraryApi.getResolution(set.id, platform, { refresh: true });
+      queryClient.setQueryData(queryKey, fresh);
+      if (fresh.available && fresh.refreshFailed) {
+        toast.warning(`We couldn't ask ${platformLabel(platform)} again.`, {
+          description: fresh.refreshFailed.message,
+        });
+      }
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : undefined;
+      toast.error(
+        code === "RATE_LIMITED"
+          ? "We're still working out the last one — give it a moment."
+          : `We couldn't ask ${platformLabel(platform)} again just now. Nothing was changed.`,
+      );
     } finally {
       setRefreshing(false);
-      void resolution.refetch();
     }
   }
 
@@ -80,24 +109,9 @@ export function ChannelCard({
               <Search className="mr-1.5 size-3.5" aria-hidden="true" />
               Check this channel
             </Button>
-          ) : data?.available ? (
-            (() => {
-              const { canRefresh, reason } = refreshability(data.resolution, {
-                rematerialisable: data.rematerialisable,
-              });
-              return canRefresh ? (
-                <Button size="sm" variant="ghost" onClick={() => void refresh()} disabled={refreshing}>
-                  <RefreshCw
-                    className={`mr-1.5 size-3.5 ${refreshing ? "animate-spin" : ""}`}
-                    aria-hidden="true"
-                  />
-                  {refreshing ? "Asking…" : "Ask again"}
-                </Button>
-              ) : (
-                <span className="text-xs text-muted-foreground">{reason}</span>
-              );
-            })()
-          ) : null}
+          ) : (
+            <RefreshControl data={data} platform={platform} onRefresh={refresh} busy={refreshing} />
+          )}
         </div>
 
         {/* ★NOBODY HAS ASKED IS ITS OWN ANSWER. Not "it doesn't work here", and
@@ -106,8 +120,9 @@ export function ChannelCard({
         {!asked ? (
           <p className="text-sm text-muted-foreground">
             We haven&apos;t worked out what this audience looks like on{" "}
-            {platformLabel(platform)}. Checking asks {platformLabel(platform)} directly — it
-            changes nothing and spends nothing.
+            {platformLabel(platform)}
+            {known?.stale ? " recently" : ""}. Checking asks {platformLabel(platform)} directly
+            — it puts nothing on a campaign and spends no budget.
           </p>
         ) : resolution.isPending ? (
           <div className="space-y-2">
@@ -131,6 +146,32 @@ export function ChannelCard({
           <div className="space-y-2">
             <p className="text-sm">{data.message}</p>
             <GapList gaps={data.gaps} platform={platform} />
+            {/* ★AND NOT EVERY REFUSAL IS ABOUT THE AUDIENCE. "Connect LinkedIn
+                Ads to see what this looks like there" is a refusal about the
+                CONNECTION, and rendering it as a bare sentence leaves a
+                first-run business — nothing connected, which is the default
+                state of this page — with no way forward from the screen that
+                told them. */}
+            {CONNECTION_CODES.has(data.code) && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                <Button asChild size="sm" variant="outline">
+                  <Link href="/dashboard/integrations">Go to integrations</Link>
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => void resolution.refetch()}>
+                  I&apos;ve done that — check again
+                </Button>
+              </div>
+            )}
+            {RETRYABLE_CODES.has(data.code) && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="mt-1"
+                onClick={() => void resolution.refetch()}
+              >
+                Try again
+              </Button>
+            )}
           </div>
         ) : (
           <div className="space-y-3">
@@ -170,24 +211,66 @@ export function ChannelCard({
 
             <GapList gaps={data.gaps} platform={platform} />
 
-            {/* ★"WE COULDN'T RE-ASK" IS NOT "THIS IS CURRENT". Without saying
-                so, a failed refresh is indistinguishable from a cache hit —
-                which is why the api reports it separately from `stale`. */}
+            {/* ★TWO STATEMENTS, AND A FIRST CUT SHOWED ONLY ONE OF THEM AT A
+                TIME. `stale` is about the ENTRY — it cannot be shown to be
+                current — and `refreshFailed` is about the CALL. On the
+                combination that matters most (a stale entry we then failed to
+                refresh) suppressing the first told the customer the refresh
+                failed and left them believing what they were reading was
+                current. The api reports them separately for exactly this. */}
+            {data.stale && data.rematerialisable && (
+              <p className="text-xs text-muted-foreground">
+                This was worked out by an older version of us, so we can&apos;t promise it&apos;s
+                today&apos;s answer — ask again for a fresh one.
+              </p>
+            )}
             {data.refreshFailed && (
               <p className="text-xs text-muted-foreground">
                 We couldn&apos;t ask {platformLabel(platform)} again just now, so this is what we
                 had. {data.refreshFailed.message}
               </p>
             )}
-            {data.stale && !data.refreshFailed && data.rematerialisable && (
-              <p className="text-xs text-muted-foreground">
-                This was worked out by an older version of us — ask again for today&apos;s answer.
-              </p>
-            )}
           </div>
         )}
       </CardContent>
     </Card>
+  );
+}
+
+/** Refusals whose fix is a connection the customer owns. */
+const CONNECTION_CODES = new Set(["NOT_CONNECTED", "NEEDS_REAUTH"]);
+/** Refusals that are ours or the platform's, and may simply work next time. */
+const RETRYABLE_CODES = new Set(["PROVIDER_FAILED", "TIMED_OUT", "TOKEN_FAILED"]);
+
+/**
+ * The refresh control, or the sentence saying why there isn't one.
+ *
+ * ★A CHANNEL SHAPE NOBODY DERIVED CANNOT BE RE-DERIVED, and the two ways that
+ * happens need different sentences: a human built this one, or it was read off
+ * a campaign as it ran. Offering the button on either would be a dead control
+ * — the api refuses both, `force` included.
+ */
+function RefreshControl({
+  data,
+  platform,
+  onRefresh,
+  busy,
+}: {
+  data: AudienceResolutionResponse | undefined;
+  platform: string;
+  onRefresh: () => Promise<void>;
+  busy: boolean;
+}) {
+  if (!data?.available) return null;
+  const { canRefresh, reason } = refreshability(data.resolution, {
+    rematerialisable: data.rematerialisable,
+  });
+  if (!canRefresh) return <span className="text-xs text-muted-foreground">{reason}</span>;
+  return (
+    <Button size="sm" variant="ghost" onClick={() => void onRefresh()} disabled={busy}>
+      <RefreshCw className={`mr-1.5 size-3.5 ${busy ? "animate-spin" : ""}`} aria-hidden="true" />
+      {busy ? `Asking ${platformLabel(platform)}…` : "Ask again"}
+    </Button>
   );
 }
 

--- a/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
@@ -41,15 +41,18 @@ import { ChannelCard } from "./_components/channel-card";
 function detailErrorState(error: unknown): {
   title: string;
   description: string;
-  action: { label: string; href: string };
+  action?: { label: string; href: string };
 } {
   const back = { label: "Back to your audiences", href: "/dashboard/growth/audiences" };
   const code = error instanceof ApiError ? error.code : undefined;
   if (code === "FORBIDDEN") {
+    // ★NO ACTION, WHICH IS THE LIST'S RULE AND NOT A DIFFERENCE OF TASTE. The
+    // list answers this same 403 with the same sentence and deliberately
+    // offers no button; sending the customer "back to your audiences" walks
+    // them from "Pick a business first" to "Pick a business first".
     return {
       title: "Pick a business first",
       description: "Audiences belong to one business at a time — choose one and this will load.",
-      action: back,
     };
   }
   if (code === "VALIDATION_ERROR") {

--- a/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { ApiError } from "@/lib/api";
+import { audienceLibraryApi } from "@/lib/api/audiences";
+import { useAuth } from "@/providers/auth-provider";
+import {
+  audienceShape,
+  historyLine,
+  LIBRARY_CHANNELS,
+  originIsOurs,
+  originLabel,
+  outcomeLine,
+} from "@/lib/audience-library-rules";
+import { ChannelCard } from "./_components/channel-card";
+
+/**
+ * One audience, and what it looks like on each channel (G3).
+ *
+ * ★THIS IS WHERE THE SEAM STOPS BEING A CLAIM IN A DOCUMENT. The library row
+ * can say "1 thing X can't express"; this page has to say WHICH thing and WHY,
+ * because that is the difference between a customer who knows their audience is
+ * narrower on X and one who finds out by spending against it.
+ *
+ * ★AND THE HYPOTHESIS IS THE AUDIENCE. What is shown at the top is the
+ * business-language description — no URNs, no platform enums — and each channel
+ * card below it is that description RESOLVED, which is a cache of it rather
+ * than the thing itself. A channel resolving badly does not make the audience
+ * worse; it makes that channel a worse fit, and the page is arranged to say so.
+ */
+export default function AudienceDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { business } = useAuth();
+
+  const set = useQuery({
+    queryKey: ["audience-set", business?._id ?? "none", id],
+    queryFn: () => audienceLibraryApi.getSet(id),
+    retry: false,
+  });
+
+  const row = set.data?.set;
+
+  return (
+    <div className="space-y-6">
+      <Button asChild variant="ghost" size="sm" className="-ml-2">
+        <Link href="/dashboard/growth/audiences">
+          <ArrowLeft className="mr-1.5 size-3.5" aria-hidden="true" />
+          All audiences
+        </Link>
+      </Button>
+
+      {set.isPending ? (
+        <div className="space-y-3">
+          <Skeleton className="h-8 w-72" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : set.isError || !row ? (
+        <EmptyState
+          icon={Users}
+          title={
+            set.error instanceof ApiError && set.error.status === 404
+              ? "We couldn't find that audience"
+              : "We couldn't load that audience"
+          }
+          description={
+            set.error instanceof ApiError && set.error.status === 404
+              ? "It may belong to another business, or have been removed."
+              : "That's on us. Nothing has been changed."
+          }
+          action={{ label: "Back to your audiences", href: "/dashboard/growth/audiences" }}
+        />
+      ) : (
+        <>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <h2 className="text-2xl font-bold tracking-tight">{row.name}</h2>
+              <Badge variant={originIsOurs(row.source) ? "outline" : "secondary"}>
+                {originLabel(row.source)}
+              </Badge>
+            </div>
+            {row.description && <p className="text-muted-foreground">{row.description}</p>}
+            {(() => {
+              const history = historyLine(row);
+              const outcome = outcomeLine(row.outcome);
+              if (!history && !outcome) return null;
+              return (
+                <p className="text-sm text-muted-foreground">
+                  {[history, outcome].filter(Boolean).join(" · ")}
+                </p>
+              );
+            })()}
+          </div>
+
+          <Card>
+            <CardContent className="space-y-2 p-4">
+              <h3 className="text-sm font-medium">Who this audience is</h3>
+              {(() => {
+                const shape = audienceShape(row);
+                if (shape.length === 0) {
+                  // ★AN IMPORTED SET HAS NO HYPOTHESIS, AND SAYING SO IS THE
+                  // POINT. Its targeting is the platform's own, read off a
+                  // campaign that ran — there is no business-language
+                  // description, and inventing one out of URNs would be a
+                  // sentence we made up. The channel it came from still shows
+                  // exactly what it targets, below.
+                  return (
+                    <p className="text-sm text-muted-foreground">
+                      This one was read off a campaign as it ran, so we don&apos;t have a
+                      plain-language description of who it targets — only the channel&apos;s own
+                      targeting, below.
+                    </p>
+                  );
+                }
+                return (
+                  <ul className="space-y-1">
+                    {shape.map((r) => (
+                      <li key={r.attribute} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                        <span className="text-xs text-muted-foreground">{r.label}</span>
+                        {r.values.map((v, i) => (
+                          <Badge
+                            key={`${r.attribute}:${i}:${v}`}
+                            variant="outline"
+                            className="font-normal whitespace-normal"
+                          >
+                            {v}
+                          </Badge>
+                        ))}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              })()}
+              {row.hypothesis?.rationale && (
+                <p className="pt-1 text-sm text-muted-foreground">{row.hypothesis.rationale}</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-3">
+            <div>
+              <h3 className="text-lg font-semibold">On each channel</h3>
+              <p className="text-sm text-muted-foreground">
+                The same audience, expressed in each channel&apos;s own terms — including
+                what a channel can&apos;t say.
+              </p>
+            </div>
+            {LIBRARY_CHANNELS.map((platform) => (
+              <ChannelCard key={platform} set={row} platform={platform} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
@@ -14,8 +14,8 @@ import { audienceLibraryApi } from "@/lib/api/audiences";
 import { useAuth } from "@/providers/auth-provider";
 import {
   audienceShape,
+  detailChannels,
   historyLine,
-  LIBRARY_CHANNELS,
   originIsOurs,
   originLabel,
   outcomeLine,
@@ -36,6 +36,43 @@ import { ChannelCard } from "./_components/channel-card";
  * than the thing itself. A channel resolving badly does not make the audience
  * worse; it makes that channel a worse fit, and the page is arranged to say so.
  */
+/** What to say when one audience will not load. Mirrors the list's own
+ *  branching: the conditions are the route's, not this page's. */
+function detailErrorState(error: unknown): {
+  title: string;
+  description: string;
+  action: { label: string; href: string };
+} {
+  const back = { label: "Back to your audiences", href: "/dashboard/growth/audiences" };
+  const code = error instanceof ApiError ? error.code : undefined;
+  if (code === "FORBIDDEN") {
+    return {
+      title: "Pick a business first",
+      description: "Audiences belong to one business at a time — choose one and this will load.",
+      action: back,
+    };
+  }
+  if (code === "VALIDATION_ERROR") {
+    return {
+      title: "That isn't an audience link",
+      description: "The address is missing part of an audience id.",
+      action: back,
+    };
+  }
+  if (error instanceof ApiError && error.status === 404) {
+    return {
+      title: "We couldn't find that audience",
+      description: "It may belong to another business, or have been removed.",
+      action: back,
+    };
+  }
+  return {
+    title: "We couldn't load that audience",
+    description: "That's on us. Nothing has been changed.",
+    action: back,
+  };
+}
+
 export default function AudienceDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { business } = useAuth();
@@ -63,20 +100,12 @@ export default function AudienceDetailPage({ params }: { params: Promise<{ id: s
           <Skeleton className="h-32 w-full" />
         </div>
       ) : set.isError || !row ? (
-        <EmptyState
-          icon={Users}
-          title={
-            set.error instanceof ApiError && set.error.status === 404
-              ? "We couldn't find that audience"
-              : "We couldn't load that audience"
-          }
-          description={
-            set.error instanceof ApiError && set.error.status === 404
-              ? "It may belong to another business, or have been removed."
-              : "That's on us. Nothing has been changed."
-          }
-          action={{ label: "Back to your audiences", href: "/dashboard/growth/audiences" }}
-        />
+        // ★THE SAME VOCABULARY AS THE LIST, because they answer to the same
+        // conditions. A customer with no active business got "Pick a business
+        // first" one click away and "That's on us" here — two answers to one
+        // condition inside one feature — and a pasted bad id got an apology for
+        // something that is not our fault.
+        <EmptyState icon={Users} {...detailErrorState(set.error)} />
       ) : (
         <>
           <div className="space-y-2">
@@ -152,7 +181,12 @@ export default function AudienceDetailPage({ params }: { params: Promise<{ id: s
                 what a channel can&apos;t say.
               </p>
             </div>
-            {LIBRARY_CHANNELS.map((platform) => (
+            {/* ★THE UNION OF WHAT WE KNOW AND WHAT COULD BE ASKED. Rendering
+                the hardcoded list alone dropped any channel a set carries that
+                the constant does not name — a legacy row born on a third
+                platform showed a reach line on the library ROW and then
+                vanished from the page whose premise is that it knows more. */}
+            {detailChannels(row).map((platform) => (
               <ChannelCard key={platform} set={row} platform={platform} />
             ))}
           </div>

--- a/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Sparkles, History, PencilLine } from "lucide-react";
+import Link from "next/link";
+import { Sparkles, History, PencilLine, ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type { AudienceSet } from "@/lib/api/audiences";
@@ -57,7 +58,18 @@ export function AudienceSetCard({ set }: { set: AudienceSet }) {
       <CardContent className="space-y-3 p-4">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0">
-            <h3 className="font-semibold break-words">{set.name}</h3>
+            {/* ★THE ROW IS THE WAY IN. G3's per-channel view is where "1 thing
+                X can't express" becomes WHICH thing and WHY, and a detail page
+                nothing links to is the same as no detail page. */}
+            <h3 className="font-semibold break-words">
+              <Link
+                href={`/dashboard/growth/audiences/${set.id}`}
+                className="hover:underline focus-visible:underline"
+              >
+                {set.name}
+                <ChevronRight className="ml-0.5 inline size-3.5 align-baseline" aria-hidden="true" />
+              </Link>
+            </h3>
             {set.description && (
               <p className="mt-0.5 text-sm text-muted-foreground break-words">{set.description}</p>
             )}

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -309,6 +309,77 @@ export interface AudienceSetsResponse {
   offset: number;
 }
 
+/**
+ * One thing this audience asks for that a channel could not express.
+ *
+ * ★PER ATTRIBUTE AND BY NAME, NEVER A COUNT. "Two things couldn't be expressed"
+ * is not information a customer can act on; "X can't target seniority, and it
+ * matched 3 of your 5 job titles" is. `unsupported` separates the two kinds:
+ * the channel has no way to say this AT ALL, versus it tried and some values
+ * did not bind.
+ */
+export interface AudienceChannelGap {
+  attribute: string;
+  variant: string;
+  unsupported: boolean;
+  /** Why, when `unsupported`. In the customer's terms, naming the channel. */
+  reason?: string;
+  /** Values the channel's own search could not bind, each with its own reason.
+   *  Empty when `unsupported` — nothing was asked. */
+  values: Array<{ value: string; reason: string }>;
+}
+
+/** One channel's stored shape of an audience. The criteria themselves are the
+ *  platform's own and deliberately not rendered — `basis` is the readable half. */
+export interface AudienceResolution {
+  basis?: Array<{ attribute: string; values: string[] }>;
+  geoCodes?: string[];
+  unresolved?: Array<{ attribute: string; value: string; reason: string }>;
+  droppedAttributes?: string[];
+  reach?: { supported: boolean; value?: number; belowFloor?: boolean; fetchedAt?: string };
+  adapterVersion?: string;
+  resolvedAt: string;
+  /** A HUMAN built this channel shape. It is not a cache and nothing may
+   *  re-resolve it — there is nothing it could be out of date WITH. */
+  authored?: boolean;
+}
+
+/**
+ * What an audience looks like on one channel.
+ *
+ * ★A REFUSAL IS A 200 WITH A REASON, NOT AN ERROR. "This audience doesn't work
+ * on X, and here is which part X couldn't express" is the ANSWER to the
+ * question asked — a client that rendered it as a failed request would turn an
+ * honest, useful result into a broken screen.
+ */
+export type AudienceResolutionResponse =
+  | {
+      platform: string;
+      available: true;
+      /** `cache` — returned as stored. `resolved` — freshly asked. */
+      from: "cache" | "resolved";
+      /** The entry is real but cannot be shown to be current. */
+      stale: boolean;
+      rematerialisable: boolean;
+      /** Present when we TRIED to re-ask the channel and could not, and are
+       *  showing what we had instead. Without it a failed refresh is
+       *  indistinguishable from a cache hit. */
+      refreshFailed?: { code: string; message: string };
+      resolution: AudienceResolution;
+      gaps: AudienceChannelGap[];
+    }
+  | {
+      platform: string;
+      available: false;
+      code: string;
+      message: string;
+      gaps: AudienceChannelGap[];
+    };
+
+export interface AudienceSetResponse {
+  set: AudienceSet;
+}
+
 export const audienceLibraryApi = {
   /**
    * The library. Filters are SERVER-SIDE and the enums are the server's: a
@@ -323,4 +394,26 @@ export const audienceLibraryApi = {
     const qs = params.toString();
     return api.get<AudienceSetsResponse>(`/v1/audiences/sets${qs ? `?${qs}` : ""}`);
   },
+
+  /** One audience, with the channels it is already known to work on. */
+  getSet: (id: string) => api.get<AudienceSetResponse>(`/v1/audiences/sets/${id}`),
+
+  /**
+   * What this audience looks like on ONE channel.
+   *
+   * ★IT WRITES ON A GET, DELIBERATELY, AND THE API SAYS SO. The typeahead round
+   * and the reach call have already been paid by the time there is anything to
+   * return, so the answer is cached into the set — but that also means this is
+   * an ACTION rather than something to fire on mount for every channel. The
+   * list view renders what is already stored; this asks.
+   *
+   * `refresh` re-asks a channel we have already asked. It cannot touch an
+   * AUTHORED entry: a channel shape a human built has no producer to be out of
+   * date with, and "refreshing" it would replace their own entity ids with
+   * whatever our search ranks first today.
+   */
+  getResolution: (id: string, platform: string, opts: { refresh?: boolean } = {}) =>
+    api.get<AudienceResolutionResponse>(
+      `/v1/audiences/sets/${id}/resolutions/${platform}${opts.refresh ? "?refresh=true" : ""}`,
+    ),
 };

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -478,9 +478,16 @@ describe("detailChannels", () => {
     // premise is that it knows more than the row know less.
     expect(detailChannels({ channels: [channel({ platform: "meta" })] })).toEqual([
       "linkedin",
-      "meta",
       "x",
+      "meta",
     ]);
+  });
+
+  it("★leads with the channels a customer can act on, not with alphabet", () => {
+    // A plain `.sort()` put `google_ads` — the kind of row this union exists
+    // for, and one no adapter can answer for — at the TOP of the page, above
+    // the two channels that work.
+    expect(detailChannels({ channels: [channel({ platform: "google_ads" })] })[0]).toBe("linkedin");
   });
 
   it("offers the unasked ones too, without duplicating the asked", () => {

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { AudienceChannel, AudienceSet, AudienceSource, AudienceSetStatus } from "@/lib/api/audiences";
+import type {
+  AudienceChannel,
+  AudienceResolution,
+  AudienceSet,
+  AudienceSource,
+  AudienceSetStatus,
+} from "@/lib/api/audiences";
 
 /**
  * The api's own enums, derived so that a change on EITHER side breaks.
@@ -29,11 +35,14 @@ import { SOURCES, STATUSES, SEARCH_MAX } from "@/app/(site)/dashboard/growth/aud
 import {
   audienceShape,
   channelNotes,
+  gapSentence,
   historyLine,
   originIsOurs,
   originLabel,
   outcomeLine,
   reachReading,
+  refreshability,
+  resolutionReach,
   unaskedChannels,
 } from "./audience-library-rules";
 
@@ -307,5 +316,121 @@ describe("outcomeLine", () => {
     // `Math.round(-0.4)` is JavaScript's `-0`, which renders as "-0". A number
     // we cannot explain is one we do not show.
     expect(outcomeLine(outcome({ spend: -1, currency: "USD" }))).not.toContain("spent");
+  });
+});
+
+describe("resolutionReach — the per-channel view knows one thing the list does not", () => {
+  const resolution = (over: Partial<AudienceResolution> = {}): AudienceResolution => ({
+    resolvedAt: "2026-08-01T00:00:00Z",
+    ...over,
+  });
+
+  it("★tells 'nobody asked' from 'the channel has no count'", () => {
+    // The list gets a stored entry and cannot separate these — the api reports
+    // "the platform publishes none" and "our call failed" identically, on
+    // purpose. Here we also know whether anybody asked at all, and that is a
+    // third fact.
+    expect(resolutionReach(resolution(), "x")).toEqual({
+      text: "We haven't asked X for a size.",
+      sourced: false,
+    });
+    expect(resolutionReach(resolution({ reach: { supported: false } }), "x")).toEqual({
+      text: "X doesn't give us a size for this audience.",
+      sourced: false,
+    });
+  });
+
+  it("gives the number, and marks it as one we sourced", () => {
+    expect(
+      resolutionReach(resolution({ reach: { supported: true, value: 2_400_000 } }), "linkedin"),
+    ).toEqual({ text: "About 2,400,000 people on LinkedIn", sourced: true });
+  });
+
+  it("★never prints a zero, and says what a floor MEANS", () => {
+    // LinkedIn's masked `total: 0` means "fewer than 300" — so the useful
+    // sentence is not the number, it is that the campaign will not deliver.
+    for (const reach of [
+      { supported: true, belowFloor: true },
+      { supported: true, value: 0 },
+    ]) {
+      const out = resolutionReach(resolution({ reach }), "linkedin");
+      expect(out.sourced).toBe(false);
+      expect(out.text).toContain("wouldn't deliver");
+      expect(out.text).not.toMatch(/\b0\b/);
+    }
+  });
+
+  it("refuses a supported reach with no number rather than rendering undefined", () => {
+    expect(resolutionReach(resolution({ reach: { supported: true } }), "x").sourced).toBe(false);
+  });
+});
+
+describe("gapSentence — two kinds of gap, two different complaints", () => {
+  it("uses the channel's OWN reason when it cannot express the attribute at all", () => {
+    expect(
+      gapSentence(
+        {
+          attribute: "seniority",
+          variant: "any",
+          unsupported: true,
+          reason: "X has no way to target seniority.",
+          values: [],
+        },
+        "x",
+      ),
+    ).toBe("X has no way to target seniority.");
+  });
+
+  it("falls back to a sentence rather than rendering nothing", () => {
+    // ★A GAP WITH NO PROSE IS STILL A GAP. The stored shape records no reason —
+    // only `attribute|variant` — so a reader that showed nothing would report a
+    // clean audience over one that lost an attribute.
+    expect(
+      gapSentence({ attribute: "job_title", variant: "current", unsupported: true, values: [] }, "x"),
+    ).toBe("X can't target job title.");
+  });
+
+  it("★counts the VALUES separately, because that is a different fact", () => {
+    // "X can't target job title" is about the channel. "X couldn't match 2 of
+    // your job titles" is about those two values, and a customer can act on it.
+    expect(
+      gapSentence(
+        {
+          attribute: "job_title",
+          variant: "current",
+          unsupported: false,
+          values: [
+            { value: "Head of Corporate Travel", reason: "no match" },
+            { value: "Travel Ops Lead", reason: "no match" },
+          ],
+        },
+        "x",
+      ),
+    ).toBe("X couldn't match 2 job title values.");
+  });
+});
+
+describe("refreshability — three questions, and none of them is the other two", () => {
+  it("★never re-asks a channel shape a HUMAN built", () => {
+    // There is no producer for it to be out of date with, and re-resolving
+    // would run the platform's typeahead on the customer's own chip text and
+    // replace their entity ids with whatever ranks first today. The api refuses
+    // it too, `force` included; offering the button would be a dead control.
+    const out = refreshability({ authored: true }, { rematerialisable: true });
+    expect(out.canRefresh).toBe(false);
+    expect(out.reason).toContain("by hand");
+  });
+
+  it("★never re-asks an IMPORTED set either, and for a different reason", () => {
+    // Its criteria are a record of what somebody actually ran. Nothing to
+    // re-derive — and the sentence has to say that rather than "you built this",
+    // which would be false.
+    const out = refreshability({}, { rematerialisable: false });
+    expect(out.canRefresh).toBe(false);
+    expect(out.reason).toContain("read off a campaign");
+  });
+
+  it("offers the refresh on an ordinary derived shape", () => {
+    expect(refreshability({}, { rematerialisable: true })).toEqual({ canRefresh: true });
   });
 });

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -35,6 +35,7 @@ import { SOURCES, STATUSES, SEARCH_MAX } from "@/app/(site)/dashboard/growth/aud
 import {
   audienceShape,
   channelNotes,
+  detailChannels,
   gapSentence,
   historyLine,
   originIsOurs,
@@ -43,6 +44,7 @@ import {
   reachReading,
   refreshability,
   resolutionReach,
+  shouldAskOnMount,
   unaskedChannels,
 } from "./audience-library-rules";
 
@@ -430,7 +432,62 @@ describe("refreshability — three questions, and none of them is the other two"
     expect(out.reason).toContain("read off a campaign");
   });
 
+  it("★says 'you built this' about a set that is BOTH authored and importless", () => {
+    // A captured set carries a human-built channel shape AND a hypothesis. Both
+    // reasons are true of the row; only one of them is true of the SHAPE, and
+    // "read off a campaign as it ran" would be a false sentence about it.
+    expect(refreshability({ authored: true }, { rematerialisable: false }).reason).toContain(
+      "by hand",
+    );
+  });
+
   it("offers the refresh on an ordinary derived shape", () => {
     expect(refreshability({}, { rematerialisable: true })).toEqual({ canRefresh: true });
+  });
+});
+
+describe("shouldAskOnMount — a cache read is free and a stale entry is not", () => {
+  it("★never fires a metered resolution just because a page opened", () => {
+    // The route is a cache read only when the stored entry is CURRENT. On a
+    // stale, re-expressible one it takes an ORG-WIDE rate-limit token and runs
+    // a full typeahead round, a reach call and a write — and the pre-E1
+    // `resolved` block is stale BY CONSTRUCTION, so opening a detail page used
+    // to spend several of those before the customer touched anything.
+    expect(shouldAskOnMount(channel({ stale: true, rematerialisable: true }))).toBe(false);
+  });
+
+  it("asks for a fresh entry, which costs nothing", () => {
+    expect(shouldAskOnMount(channel({ stale: false }))).toBe(true);
+  });
+
+  it("asks for a stale IMPORTED entry, which the api cannot re-resolve anyway", () => {
+    // No hypothesis to re-express, so the api returns the cached entry after
+    // one findOne. Withholding it would hide what we already have for nothing.
+    expect(shouldAskOnMount(channel({ stale: true, rematerialisable: false }))).toBe(true);
+  });
+
+  it("asks nothing about a channel we have never resolved", () => {
+    expect(shouldAskOnMount(undefined)).toBe(false);
+  });
+});
+
+describe("detailChannels", () => {
+  it("★shows every channel the SET carries, not only the ones we hardcode", () => {
+    // A set resolved against a platform this client does not list still shows a
+    // reach line on the library ROW; dropping it here would make the page whose
+    // premise is that it knows more than the row know less.
+    expect(detailChannels({ channels: [channel({ platform: "meta" })] })).toEqual([
+      "linkedin",
+      "meta",
+      "x",
+    ]);
+  });
+
+  it("offers the unasked ones too, without duplicating the asked", () => {
+    expect(detailChannels({ channels: [channel({ platform: "linkedin" })] })).toEqual([
+      "linkedin",
+      "x",
+    ]);
+    expect(detailChannels({ channels: [] })).toEqual(["linkedin", "x"]);
   });
 });

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -339,21 +339,45 @@ export function outcomeLine(outcome: AudienceSet["outcome"]): string | null {
 }
 
 /**
- * One channel's answer, in the sentences a person reads (G3).
+ * Should this channel be asked the moment the page opens?
  *
- * ★THE THREE ABSENCES ARE THREE DIFFERENT ANSWERS AND THIS IS WHERE THEY STOP
- * BEING A COUNT. The list view can say "1 thing X can't express"; this view has
- * to say WHICH thing and WHY, because that is the difference between a customer
- * who knows their audience is narrower on X and one who finds out by spending.
+ * ★"IT ASKS ONLY WHEN ASKED" WAS FALSE FOR EVERY STALE CHANNEL, and this
+ * function is the fix. `GET /sets/:id/resolutions/:platform` is only a cache
+ * read when the stored entry is CURRENT; on a stale one the api takes a
+ * rate-limit token and runs a full typeahead round, a reach call and a write.
+ * The pre-E1 `resolved` block is stale BY CONSTRUCTION — it records no adapter
+ * build — and every derived set in a business goes stale at once the day an
+ * adapter version moves. So opening a detail page could spend several metered
+ * resolutions before the customer touched anything, and two page opens could
+ * exhaust an ORG-WIDE bucket.
+ *
+ * A stale entry is still shown, from what the list already carries; asking for
+ * a fresh one is a button.
  */
-export interface ChannelVerdict {
-  /** `available` — the channel can run this audience. `refused` — it cannot,
-   *  and the reason is the answer rather than an error. `unasked` — nobody has
-   *  asked, which is neither. */
-  kind: "available" | "refused" | "unasked";
-  headline: string;
-  /** Present on `refused`: the channel's own reason, in the customer's terms. */
-  detail?: string;
+export function shouldAskOnMount(
+  channel: Pick<AudienceChannel, "stale" | "rematerialisable"> | undefined,
+): boolean {
+  if (!channel) return false;
+  // A stale entry the api CANNOT re-resolve (an imported set) is returned
+  // straight from cache, so asking costs nothing and shows more.
+  return !channel.stale || !channel.rematerialisable;
+}
+
+/**
+ * Every channel worth a card on the detail page: the ones we know about, plus
+ * the ones a customer could ask about.
+ *
+ * ★A UNION, NOT A HARDCODED LIST. The page rendered `LIBRARY_CHANNELS` alone,
+ * so a set carrying a resolution for anything else — a legacy row born on a
+ * third platform, or the next adapter before this constant is edited — showed a
+ * reach line on the library ROW and then vanished from the page whose whole
+ * premise is that it knows more than the row.
+ */
+export function detailChannels(
+  set: Pick<AudienceSet, "channels">,
+  known: readonly string[] = LIBRARY_CHANNELS,
+): string[] {
+  return [...new Set([...set.channels.map((c) => c.platform), ...known])].sort();
 }
 
 /**
@@ -436,6 +460,10 @@ export function refreshability(
   entry: { authored?: boolean },
   opts: { rematerialisable: boolean },
 ): { canRefresh: boolean; reason?: string } {
+  // ★`authored` OUTRANKS `rematerialisable`, and the order is the point. A
+  // captured set is BOTH — a human built the channel shape and it carries a
+  // hypothesis — and "you built this one by hand" is the true sentence;
+  // "read off a campaign as it ran" would be false about the same row.
   if (entry.authored) {
     return {
       canRefresh: false,

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -377,7 +377,15 @@ export function detailChannels(
   set: Pick<AudienceSet, "channels">,
   known: readonly string[] = LIBRARY_CHANNELS,
 ): string[] {
-  return [...new Set([...set.channels.map((c) => c.platform), ...known])].sort();
+  // ★THE KNOWN CHANNELS LEAD, IN THEIR OWN ORDER. A plain `.sort()` put
+  // `google_ads` — the kind of row this union exists for, and one no adapter
+  // can answer for — at the TOP of the page, above the two channels a customer
+  // can actually act on.
+  const extras = set.channels
+    .map((c) => c.platform)
+    .filter((p) => !known.includes(p))
+    .sort();
+  return [...known, ...new Set(extras)];
 }
 
 /**

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -1,5 +1,7 @@
 import type {
   AudienceChannel,
+  AudienceChannelGap,
+  AudienceResolution,
   AudienceHypothesisAttribute,
   AudienceSet,
   AudienceSource,
@@ -334,4 +336,117 @@ export function outcomeLine(outcome: AudienceSet["outcome"]): string | null {
     }
   }
   return parts.join(" · ");
+}
+
+/**
+ * One channel's answer, in the sentences a person reads (G3).
+ *
+ * ★THE THREE ABSENCES ARE THREE DIFFERENT ANSWERS AND THIS IS WHERE THEY STOP
+ * BEING A COUNT. The list view can say "1 thing X can't express"; this view has
+ * to say WHICH thing and WHY, because that is the difference between a customer
+ * who knows their audience is narrower on X and one who finds out by spending.
+ */
+export interface ChannelVerdict {
+  /** `available` — the channel can run this audience. `refused` — it cannot,
+   *  and the reason is the answer rather than an error. `unasked` — nobody has
+   *  asked, which is neither. */
+  kind: "available" | "refused" | "unasked";
+  headline: string;
+  /** Present on `refused`: the channel's own reason, in the customer's terms. */
+  detail?: string;
+}
+
+/**
+ * What a gap MEANS, as a sentence.
+ *
+ * ★TWO KINDS, AND THEY ARE NOT THE SAME COMPLAINT. `unsupported` is the channel
+ * having no way to express the attribute at all — a fact about the channel.
+ * Values that did not bind are the channel trying and failing on specific ones
+ * — a fact about those values. Collapsing them tells a customer their channel
+ * cannot do something it does perfectly well, or the reverse.
+ */
+export function gapSentence(gap: AudienceChannelGap, platform: string): string {
+  if (gap.unsupported) {
+    return gap.reason ?? `${platformLabel(platform)} can't target ${attributeLabel(gap.attribute).toLowerCase()}.`;
+  }
+  const n = gap.values.length;
+  return (
+    `${platformLabel(platform)} couldn't match ${n} ${attributeLabel(gap.attribute).toLowerCase()} ` +
+    `value${n === 1 ? "" : "s"}.`
+  );
+}
+
+/**
+ * The reach line for a per-channel view, where we know whether the channel was
+ * ASKED.
+ *
+ * ★THIS IS THE ONE PLACE THE THREE READINGS ARE ALL DISTINGUISHABLE. The list
+ * gets a stored entry and cannot tell "the platform publishes no count" from
+ * "our call for it failed" — the api reports both as `supported: false` on
+ * purpose. Here we also know whether anybody asked at all, and "nobody has
+ * asked" is a different sentence from either.
+ */
+export function resolutionReach(
+  resolution: AudienceResolution,
+  platform: string,
+): { text: string; sourced: boolean } {
+  const reach = resolution.reach;
+  if (!reach) {
+    return { text: `We haven't asked ${platformLabel(platform)} for a size.`, sourced: false };
+  }
+  if (!reach.supported) {
+    return {
+      text: `${platformLabel(platform)} doesn't give us a size for this audience.`,
+      sourced: false,
+    };
+  }
+  if (reach.belowFloor || reach.value === 0) {
+    // ★A LITERAL ZERO IS THE FLOOR, NOT A COUNT — LinkedIn's masked `total: 0`
+    // means "fewer than 300", and the api maps it to `belowFloor` with no
+    // number. "0 people" is the sentence this whole file refuses.
+    return {
+      text: `Too small for ${platformLabel(platform)} to count — a campaign on it wouldn't deliver.`,
+      sourced: false,
+    };
+  }
+  if (typeof reach.value !== "number") {
+    return {
+      text: `${platformLabel(platform)} doesn't give us a size for this audience.`,
+      sourced: false,
+    };
+  }
+  return {
+    text: `About ${REACH_FORMAT.format(reach.value)} people on ${platformLabel(platform)}`,
+    sourced: true,
+  };
+}
+
+/**
+ * Whether a channel's stored shape may be refreshed, and what to say if not.
+ *
+ * ★THREE DIFFERENT QUESTIONS, AND COLLAPSING ANY TWO BREAKS SOMETHING REAL.
+ * `authored` — a human built this shape; there is no producer to be out of date
+ * with and re-resolving would overwrite their own choices with a search result.
+ * `rematerialisable` — there is a business-language hypothesis to re-express;
+ * false for an imported set, whose criteria are a record of what was RUN.
+ * `stale` — the entry cannot be shown to be current. Only the third is a reason
+ * to refresh, and only when the first two allow it.
+ */
+export function refreshability(
+  entry: { authored?: boolean },
+  opts: { rematerialisable: boolean },
+): { canRefresh: boolean; reason?: string } {
+  if (entry.authored) {
+    return {
+      canRefresh: false,
+      reason: "You built this one by hand, so there's nothing for us to re-work out.",
+    };
+  }
+  if (!opts.rematerialisable) {
+    return {
+      canRefresh: false,
+      reason: "This was read off a campaign as it ran, so there's no description to rebuild from.",
+    };
+  }
+  return { canRefresh: true };
 }


### PR DESCRIPTION
> "On LinkedIn: 2.4M people. On X: we can't get a count, and these two things can't be expressed there."

That sentence is what the whole channel-neutral track was for, and this is the first place a customer can read it. New detail page at `/dashboard/growth/audiences/[id]`, one card per channel, calling F2's `GET /sets/:id/resolutions/:platform`.

**The seam stops being a claim in a document.** The library row can say "1 thing X can't express"; this page says *which* thing and *why* — the difference between a customer who knows their audience is narrower on X and one who finds out by spending. Two kinds of gap, kept apart because they are different complaints: "X has no way to target seniority" is about the channel; "X couldn't match 2 of your job titles" is about those two values, and it names them.

**A refusal is rendered as the answer, not as a broken screen.** The api returns 200 with a reason precisely so "this audience is a geography and nothing else, so there's nothing to translate for X" is what the customer asked to know.

**Three flags, three questions, and the page refuses to collapse any of them** — each with a test: `authored` (a human built it; no producer to be out of date with, and re-resolving would overwrite their own entity ids), `rematerialisable` (false for an imported set, whose criteria record what was *run* — a different sentence, because "you built this" would be false), `stale` (the only one that is a reason to ask again).

## What review changed

- **opening the page was spending a rate-limit token per stale channel.** The card asked on mount for anything already in the set's list, under a comment claiming that "costs nothing". It is free only when the entry is *current* — and the pre-E1 `resolved` block is stale by construction, so two page opens could exhaust an org-wide bucket before the customer touched anything.
- **the refresh threw away the only response that carries `refreshFailed`** — it awaited the forced call, discarded it, and issued a second unforced GET. So the paragraph whose comment says "without saying so, a failed refresh is indistinguishable from a cache hit" was unreachable on the one path that produces it. It also had no `catch`: a 429 stopped the spinner over identical data and said nothing.
- **a connection refusal was a dead end** — which on a first-run business is the *default* state of this page.
- `stale` was suppressed whenever `refreshFailed` was present, which is exactly the combination the ledger's §2.3 exists to keep apart.
- the page rendered a hardcoded channel list, dropping any channel the set actually carries.
- 403 and 400 both read "That's on us", one click from the list's correct answer for the same condition.

Every fix mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)