### PR TITLE
feat(audience): use an audience you already have, and keep the one you built (G4)

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/audience-card.tsx
+++ b/src/app/(site)/dashboard/ads/_components/audience-card.tsx
@@ -13,7 +13,9 @@ import { audienceClaim, reachLine } from "@/lib/audience-card-rules";
 import { attributeLabel } from "@/lib/audience-library-rules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Check, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { BookmarkPlus, Check, Sparkles } from "lucide-react";
+import { SaveAudienceDialog } from "@/components/audience/save-audience-dialog";
 
 /**
  * The audience a campaign actually has, said out loud.
@@ -42,6 +44,7 @@ import { Check, Sparkles } from "lucide-react";
 
 export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
   const queryClient = useQueryClient();
+  const [saveOpen, setSaveOpen] = useState(false);
   const prov = campaign.targetingProvenance;
   const origin = campaign.audienceOrigin;
 
@@ -147,6 +150,39 @@ export function AudienceCard({ campaign }: { campaign: ManagedCampaign }) {
           </Button>
         </div>
       )}
+
+      {/* ★KEEP THE ONE THEY BUILT (G4). "Learned from the user through their
+          MANUAL campaigns" was half-built for a year: a hand-edit was captured
+          as a diff on the campaign and on the set, and never became a library
+          entry — so the single audience a customer authored was the one they
+          could not reuse. Offered rather than automatic: a library that fills
+          up with every one-off experiment is a library nobody opens.
+
+          ★AND NOT ON AN UNVERIFIED RECORD. When the provenance no longer
+          matches the campaign's targeting we cannot say what this audience IS,
+          so "save this" would save a description of something else. */}
+      {!unverified && (
+        <div className="mt-2">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-xs"
+            onClick={() => setSaveOpen(true)}
+          >
+            <BookmarkPlus className="mr-1 size-3" aria-hidden="true" />
+            Save as an audience
+          </Button>
+        </div>
+      )}
+
+      {saveOpen ? (
+        <SaveAudienceDialog
+          open={saveOpen}
+          onOpenChange={setSaveOpen}
+          campaignId={campaign._id}
+          campaignName={campaign.name}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -45,9 +45,20 @@ import {
 } from "@/components/ui/table";
 import { AdvertisingDeclarationCard } from "@/components/ads/advertising-declaration-card";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { AlertTriangle, Archive, Megaphone, Pause, Play, RefreshCw, Rocket, Target } from "lucide-react";
+import {
+  AlertTriangle,
+  Archive,
+  Library,
+  Megaphone,
+  Pause,
+  Play,
+  RefreshCw,
+  Rocket,
+  Target,
+} from "lucide-react";
 import { AudienceCard } from "./audience-card";
 import { TargetingDialog, editorTargeting } from "./targeting-dialog";
+import { UseSavedAudienceDialog } from "@/components/audience/use-saved-audience-dialog";
 
 /**
  * LinkedIn Ads panel (G1 MVP) — the Growth pillar's first live surface,
@@ -378,6 +389,7 @@ function CampaignRow({
   const [confirmActivate, setConfirmActivate] = useState(false);
   const [confirmArchive, setConfirmArchive] = useState(false);
   const [targetingOpen, setTargetingOpen] = useState(false);
+  const [libraryOpen, setLibraryOpen] = useState(false);
 
   const status = useMutation({
     mutationFn: (next: "active" | "paused" | "archived") =>
@@ -565,6 +577,25 @@ function CampaignRow({
               {hasAudience ? "Audience" : "Set audience"}
             </Button>
           ) : null}
+          {/* ★AND THE OTHER WAY TO GET AN AUDIENCE, WHICH THE LIBRARY EXISTS
+              FOR (G4). Every boosted campaign has taken whatever the engine
+              proposed at the moment it was created; the rows a customer had
+              already built, imported or corrected could not be put on anything.
+              Applying spends nothing — a draft stays a draft. */}
+          {canTarget ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              disabled={busy}
+              title="Use an audience you already have"
+              onClick={() => setLibraryOpen(true)}
+            >
+              <Library className="mr-1 size-3" />
+              Saved
+            </Button>
+          ) : null}
           {canActivate ? (
             <Button
               type="button"
@@ -613,6 +644,16 @@ function CampaignRow({
             open={targetingOpen}
             onOpenChange={setTargetingOpen}
             campaign={campaign}
+          />
+        ) : null}
+
+        {libraryOpen ? (
+          <UseSavedAudienceDialog
+            open={libraryOpen}
+            onOpenChange={setLibraryOpen}
+            campaignId={campaign._id}
+            campaignName={campaign.name}
+            platform="linkedin"
           />
         ) : null}
 

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -653,7 +653,10 @@ function CampaignRow({
             onOpenChange={setLibraryOpen}
             campaignId={campaign._id}
             campaignName={campaign.name}
-            platform="linkedin"
+            // The campaign's OWN channel, which is what the api materialises
+            // the set for. Hardcoding this panel's would list the wrong
+            // channel's audiences and then take a 409 from the api.
+            platform={campaign.platform ?? "linkedin"}
           />
         ) : null}
 

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -654,9 +654,11 @@ function CampaignRow({
             campaignId={campaign._id}
             campaignName={campaign.name}
             // The campaign's OWN channel, which is what the api materialises
-            // the set for. Hardcoding this panel's would list the wrong
-            // channel's audiences and then take a 409 from the api.
-            platform={campaign.platform ?? "linkedin"}
+            // the set for. Every row in THIS panel is linkedin — the route
+            // filters on it server-side and `platform` is required on the type,
+            // so this changes nothing today; it is what stops the picker being
+            // wrong the day a campaign list carries a second channel.
+            platform={campaign.platform}
           />
         ) : null}
 

--- a/src/components/audience/save-audience-dialog.tsx
+++ b/src/components/audience/save-audience-dialog.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { BookmarkPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ApiError } from "@/lib/api";
+import { audienceLibraryApi } from "@/lib/api/audiences";
+
+/**
+ * Keep the audience you just built by hand (G4, calling F3).
+ *
+ * ★THE MISSING THIRD WAY AN AUDIENCE GETS INTO THE LIBRARY. Peakhour's own
+ * suggestions land there; a business's historical campaigns land there; the one
+ * audience the customer actually AUTHORED — by opening the targeting editor and
+ * disagreeing with us — was captured as a diff on the campaign and then had
+ * nowhere to live. The one they wrote themselves was the one they could not
+ * reuse.
+ *
+ * ★OFFERED, NEVER AUTOMATIC. A library that fills up with every one-off
+ * experiment is a library nobody opens, which is why the targeting editor goes
+ * on saving nothing and this button exists instead.
+ */
+export function SaveAudienceDialog({
+  open,
+  onOpenChange,
+  campaignId,
+  campaignName,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  campaignId: string;
+  campaignName: string;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+
+  const save = useMutation({
+    mutationFn: () =>
+      audienceLibraryApi.saveFromCampaign({
+        campaignId,
+        ...(name.trim() ? { name: name.trim() } : {}),
+      }),
+    onSuccess: (res) => {
+      void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
+      onOpenChange(false);
+      setName("");
+      // ★"YOU ALREADY SAVED THIS" IS A DIFFERENT SENTENCE FROM "SAVED". The api
+      // returns the existing row rather than a duplicate — a person can press a
+      // button twice — and claiming to have created something we did not is a
+      // small lie about their own library.
+      toast.success(res.alreadySaved ? "You'd already saved this one." : "Saved to your audiences.", {
+        description:
+          // ★AND WHAT DID NOT SURVIVE IS SAID, BECAUSE THE DIRECTION IS
+          // BROADER. A facet we could not put into business language drops a
+          // whole AND-block, so the saved audience reaches MORE people than the
+          // campaign does — the one thing a customer must not discover by
+          // spending.
+          res.lost.length > 0
+            ? `${res.lost.length} part${res.lost.length === 1 ? "" : "s"} of the targeting couldn't be described in plain language, so the saved audience is BROADER than this campaign: ${res.lost
+                .map((l) => l.reason)
+                .join("; ")}.`
+            : undefined,
+        duration: res.lost.length > 0 ? 12_000 : undefined,
+        action: {
+          label: "Open",
+          onClick: () => {
+            window.location.href = `/dashboard/growth/audiences/${res.set.id}`;
+          },
+        },
+      });
+    },
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "NO_TARGETING") {
+        toast.error("This campaign has no targeting to save yet — set its audience first.");
+        return;
+      }
+      if (code === "LIBRARY_FULL") {
+        toast.error(err instanceof ApiError ? err.message : "Your library is full.");
+        return;
+      }
+      toast.error("We couldn't save that audience. Nothing was changed.");
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && save.isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <BookmarkPlus className="size-4" aria-hidden="true" />
+            Save this as an audience
+          </DialogTitle>
+          <DialogDescription>
+            Keep this campaign&apos;s targeting in your{" "}
+            <Link href="/dashboard/growth/audiences" className="underline">
+              audience library
+            </Link>{" "}
+            so you can put it on another campaign — or on another channel — later. It
+            changes nothing about this campaign.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="save-audience-name">Name (optional)</Label>
+          <Input
+            id="save-audience-name"
+            value={name}
+            onChange={(e) => setName(e.target.value.slice(0, 120))}
+            maxLength={120}
+            placeholder={`Audience from “${campaignName}”`}
+          />
+          <p className="text-xs text-muted-foreground">
+            We&apos;ll name it after the campaign if you leave this empty.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={save.isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => save.mutate()} disabled={save.isPending}>
+            {save.isPending ? "Saving…" : "Save audience"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/audience/save-audience-dialog.tsx
+++ b/src/components/audience/save-audience-dialog.tsx
@@ -16,7 +16,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useRouter } from "next/navigation";
 import { ApiError } from "@/lib/api";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+import { classifyApplyError } from "@/lib/audience-apply-errors";
 import { audienceLibraryApi } from "@/lib/api/audiences";
 
 /**
@@ -45,6 +48,7 @@ export function SaveAudienceDialog({
   campaignName: string;
 }) {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const [name, setName] = useState("");
 
   const save = useMutation({
@@ -76,23 +80,27 @@ export function SaveAudienceDialog({
         duration: res.lost.length > 0 ? 12_000 : undefined,
         action: {
           label: "Open",
-          onClick: () => {
-            window.location.href = `/dashboard/growth/audiences/${res.set.id}`;
-          },
+          // `router.push`, not `window.location` — this is an in-app route, and
+          // a full document reload of the SPA to reach it throws away every
+          // cache the customer just filled.
+          onClick: () => router.push(`/dashboard/growth/audiences/${res.set.id}`),
         },
       });
     },
     onError: (err) => {
-      const code = err instanceof ApiError ? err.code : undefined;
-      if (code === "NO_TARGETING") {
-        toast.error("This campaign has no targeting to save yet — set its audience first.");
+      // ★THE SAME CLASSIFIER AS THE APPLY PATH. A first cut named two codes and
+      // flattened the rest — including `NO_HYPOTHESIS`, whose message names the
+      // exact facets that could not be described and explains that saving would
+      // produce an audience usable on one campaign only. That sentence is the
+      // whole answer.
+      if (classifyApplyError(err instanceof ApiError ? err.code : undefined) === "audience") {
+        toast.error(
+          (err instanceof ApiError && err.message) ||
+            "We couldn't save that audience. Nothing was changed.",
+        );
         return;
       }
-      if (code === "LIBRARY_FULL") {
-        toast.error(err instanceof ApiError ? err.message : "Your library is full.");
-        return;
-      }
-      toast.error("We couldn't save that audience. Nothing was changed.");
+      toastUnhandledApiError(err, "save that audience");
     },
   });
 

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -135,17 +135,37 @@ export function UseSavedAudienceDialog({
           // to a customer whose next act is to activate it.
           void queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
           void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
+          // The set really did move to `applied` — the claim is not released on
+          // this path — so a detail page open elsewhere is now wrong too.
+          void queryClient.invalidateQueries({ queryKey: ["audience-set"] });
           onOpenChange(false);
           setChosen(null);
+          // Same as the success path: this IS a success on the platform, and a
+          // caller advancing a flow on it would otherwise stall silently.
+          onApplied?.();
           toast.warning(
             message ||
               `The audience was applied on ${platformLabel(platform)} but we couldn't save it here — apply again to refresh.`,
+            // ★AND IT DOES NOT AUTO-DISMISS. This is the money-critical
+            // message on this surface — the campaign's targeting has moved and
+            // our copy has not — and a four-second toast is how a customer
+            // activates against an audience they never saw.
+            { duration: Number.POSITIVE_INFINITY },
           );
           return;
         case "ad_account_not_authorized":
           // Not a reconnect, and the shared helper is the one place that says
           // so properly — this is the 403 that is live on the boost path.
-          toastAdAccountNotAuthorized(err, "Putting an audience on this campaign");
+          // ★THE CHANNEL, NAMED. The helper defaults its third argument to
+          // "LinkedIn", and this is the one component in the codebase that
+          // takes `platform` as a prop precisely so it can be channel-neutral
+          // — the same storage-key-in-a-headline defect api#1026 fixed on the
+          // server, reintroduced one layer up by omitting an argument.
+          toastAdAccountNotAuthorized(
+            err,
+            "Putting an audience on this campaign",
+            platformLabel(platform),
+          );
           return;
         case "ad_account_forbidden":
           toastAdAccountForbidden(err, `${platformLabel(platform)} refused this ad account.`);
@@ -169,6 +189,14 @@ export function UseSavedAudienceDialog({
 
   const rows = sets.data?.sets ?? [];
   const total = sets.data?.total ?? 0;
+  /**
+   * ★A SELECTION THE CUSTOMER CAN NO LONGER SEE MAY NOT BE APPLIED. Pick an
+   * audience, then type a search that excludes it: the row disappears, nothing
+   * on screen is selected, and "Use this audience" stayed enabled — applying
+   * the invisible one. Derived rather than cleared in an effect, so it cannot
+   * be out of step with the rows for a render.
+   */
+  const selected = chosen && rows.some((r) => r.id === chosen.id) ? chosen : null;
 
   return (
     <Dialog
@@ -279,8 +307,8 @@ export function UseSavedAudienceDialog({
           </Button>
           <Button
             type="button"
-            disabled={!chosen || apply.isPending}
-            onClick={() => chosen && apply.mutate(chosen.id)}
+            disabled={!selected || apply.isPending}
+            onClick={() => selected && apply.mutate(selected.id)}
           >
             {apply.isPending ? "Applying…" : "Use this audience"}
           </Button>

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Check, Library } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ApiError } from "@/lib/api";
+import { audienceLibraryApi, type AudienceSet } from "@/lib/api/audiences";
+import { useAudienceSets } from "@/hooks/use-audience-library";
+import {
+  audienceShape,
+  channelNotes,
+  originLabel,
+  platformLabel,
+  reachReading,
+} from "@/lib/audience-library-rules";
+
+/**
+ * Put an audience you already have on this campaign (G4).
+ *
+ * ★THE LIBRARY'S WHOLE POINT, AND UNTIL NOW IT HAD NO WAY IN. `biz_audience_sets`
+ * exists so an audience built once can be reused on a campaign created months
+ * later — but every boosted campaign got whatever the engine proposed at the
+ * moment it was created, and the rows nobody could reach might as well not have
+ * been there.
+ *
+ * ★IT SPENDS NOTHING. A draft stays a draft; an active campaign re-enters the
+ * platform's review with a new audience, exactly as the manual targeting editor
+ * already does.
+ *
+ * ★AND IT ASKS FOR AUDIENCES THAT WORK ON THIS CAMPAIGN'S CHANNEL, which is
+ * "carries a shape for it", not "was born on it" — an idea planned on LinkedIn
+ * and since resolved for X belongs in both lists. That is the channel-neutral
+ * library's entire claim, and this is the first place a customer feels it.
+ */
+export function UseSavedAudienceDialog({
+  open,
+  onOpenChange,
+  campaignId,
+  campaignName,
+  platform,
+  onApplied,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  campaignId: string;
+  campaignName: string;
+  platform: string;
+  onApplied?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [q, setQ] = useState("");
+  const [chosen, setChosen] = useState<AudienceSet | null>(null);
+
+  // ★DISCARDED AUDIENCES ARE NOT OFFERED. A discard is a decision the customer
+  // made, and re-offering it as a suggestion is the surface arguing with them.
+  // The api would refuse it anyway (409 SET_DISCARDED), so offering it would be
+  // a dead control as well as a rude one.
+  const sets = useAudienceSets({
+    platform,
+    status: "proposed",
+    ...(q.trim() ? { q: q.trim() } : {}),
+    limit: 20,
+  });
+
+  const apply = useMutation({
+    mutationFn: (setId: string) => audienceLibraryApi.applySet(setId, campaignId),
+    onSuccess: (res) => {
+      toast.success("That audience is on the campaign now.", {
+        description:
+          res.supersededSetIds.length > 0
+            ? "The one it replaced is marked as superseded — nothing was deleted."
+            : "Nothing has started spending — activate the campaign when you're ready.",
+      });
+      // The campaign's targeting and provenance both moved, and so did the
+      // library's own bookkeeping (this set is applied; another may have been
+      // superseded).
+      void queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+      void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
+      void queryClient.invalidateQueries({ queryKey: ["audience-set"] });
+      onOpenChange(false);
+      setChosen(null);
+      onApplied?.();
+    },
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      const message = err instanceof ApiError ? err.message : "";
+      // ★THE API'S REFUSALS ARE ANSWERS AND ARE SHOWN AS THEY ARE WRITTEN. Every
+      // one of these is a sentence about THIS audience on THIS channel —
+      // "we won't spend against a version we can't confirm", "X can't express
+      // anything that makes this audience specific" — and replacing them with
+      // "something went wrong" would throw away the only useful part.
+      if (
+        code &&
+        [
+          "SET_STALE",
+          "SET_NOT_SERVABLE",
+          "SET_DISCARDED",
+          "PLATFORM_MISMATCH",
+          "FACET_NOT_APPLIABLE",
+          "NO_HYPOTHESIS",
+          "INVALID_TRANSITION",
+        ].includes(code)
+      ) {
+        toast.error(message || "We couldn't put that audience on this campaign.");
+        return;
+      }
+      if (code === "NEEDS_REAUTH" || code === "NOT_CONNECTED") {
+        toast.error(`${platformLabel(platform)} Ads needs reconnecting before we can do that.`);
+        return;
+      }
+      toast.error("We couldn't put that audience on this campaign. Nothing was changed.");
+    },
+  });
+
+  const rows = sets.data?.sets ?? [];
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && apply.isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Library className="size-4" aria-hidden="true" />
+            Use a saved audience
+          </DialogTitle>
+          <DialogDescription>
+            Put one of your existing audiences on &ldquo;{campaignName}&rdquo;. This replaces
+            the campaign&apos;s whole audience and starts no spending — activate it when
+            you&apos;re ready.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          value={q}
+          onChange={(e) => setQ(e.target.value.slice(0, 80))}
+          maxLength={80}
+          placeholder="Search your audiences…"
+          aria-label="Search your audiences"
+        />
+
+        <div className="max-h-[45vh] space-y-2 overflow-y-auto pr-1">
+          {sets.isPending ? (
+            <>
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+            </>
+          ) : sets.isError ? (
+            <p className="text-sm text-muted-foreground">
+              We couldn&apos;t load your audiences just now.
+            </p>
+          ) : rows.length === 0 ? (
+            // ★TWO EMPTIES AGAIN, AND THEY ARE NOT THE SAME SENTENCE. "Nothing
+            // matches that search" is not "you have no audiences that work
+            // here", and the second is not "you have no audiences".
+            <p className="text-sm text-muted-foreground">
+              {q.trim()
+                ? "Nothing in your library matches that."
+                : `None of your saved audiences has been worked out for ${platformLabel(platform)} yet — open one from Audiences and check this channel first.`}
+            </p>
+          ) : (
+            rows.map((set) => {
+              const channel = set.channels.find((c) => c.platform === platform);
+              const shape = audienceShape(set);
+              const picked = chosen?.id === set.id;
+              return (
+                <button
+                  key={set.id}
+                  type="button"
+                  onClick={() => setChosen(set)}
+                  className={`w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/50 ${
+                    picked ? "border-primary bg-muted/40" : ""
+                  }`}
+                  aria-pressed={picked}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-sm font-medium">{set.name}</span>
+                    <span className="flex items-center gap-1.5">
+                      {picked && <Check className="size-3.5 text-primary" aria-hidden="true" />}
+                      <Badge variant="outline" className="text-[10px] font-normal">
+                        {originLabel(set.source)}
+                      </Badge>
+                    </span>
+                  </div>
+                  {shape.length > 0 && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {shape.map((r) => `${r.label}: ${r.values.join(", ")}`).join(" · ")}
+                    </p>
+                  )}
+                  {/* The reach on THIS channel, and what it could not express —
+                      both of which are what the customer is choosing between. */}
+                  {channel && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {[reachReading(channel).text, ...channelNotes(channel)].join(" · ")}
+                    </p>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={apply.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!chosen || apply.isPending}
+            onClick={() => chosen && apply.mutate(chosen.id)}
+          >
+            {apply.isPending ? "Applying…" : "Use this audience"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Check, Library } from "lucide-react";
@@ -17,6 +17,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError } from "@/lib/api";
+import {
+  toastAdAccountForbidden,
+  toastAdAccountNotAuthorized,
+  toastUnhandledApiError,
+} from "@/lib/toast-errors";
+import { classifyApplyError } from "@/lib/audience-apply-errors";
+import { SEARCH_MAX } from "@/app/(site)/dashboard/growth/audiences/filters";
 import { audienceLibraryApi, type AudienceSet } from "@/lib/api/audiences";
 import { useAudienceSets } from "@/hooks/use-audience-library";
 import {
@@ -45,6 +52,22 @@ import {
  * and since resolved for X belongs in both lists. That is the channel-neutral
  * library's entire claim, and this is the first place a customer feels it.
  */
+
+/** How many to show. Searching is the way through a bigger library — a picker
+ *  with pagination is a page. */
+const PAGE = 20;
+
+/** Debounce a value. Same shape as the library page's and the targeting
+ *  dialog's; kept local rather than shared until a fourth caller wants it. */
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
 export function UseSavedAudienceDialog({
   open,
   onOpenChange,
@@ -63,16 +86,24 @@ export function UseSavedAudienceDialog({
   const queryClient = useQueryClient();
   const [q, setQ] = useState("");
   const [chosen, setChosen] = useState<AudienceSet | null>(null);
+  // ★DEBOUNCED, LIKE THE LIBRARY PAGE. `GET /sets` runs a regex `find` AND a
+  // `countDocuments` per request, over a query the api itself documents as a
+  // blocking-sort collection scan — so an undebounced picker double-scans a
+  // customer's library on every keystroke.
+  const search = useDebounced(q.trim(), 350);
 
-  // ★DISCARDED AUDIENCES ARE NOT OFFERED. A discard is a decision the customer
-  // made, and re-offering it as a suggestion is the surface arguing with them.
-  // The api would refuse it anyway (409 SET_DISCARDED), so offering it would be
-  // a dead control as well as a rude one.
+  // ★NOT-DISCARDED, NOT "PROPOSED". A discard is a decision the customer made,
+  // and re-offering it is the surface arguing with them (the api 409s it
+  // anyway) — but a first cut asked for `proposed` because that was the only
+  // filter the api had, and apply sets `applied`. So every audience they had
+  // ever used disappeared from this list: the SECOND campaign could not reuse
+  // the audience, which is the whole of what a library is for. `excludeStatus`
+  // exists for this.
   const sets = useAudienceSets({
     platform,
-    status: "proposed",
-    ...(q.trim() ? { q: q.trim() } : {}),
-    limit: 20,
+    excludeStatus: "discarded",
+    ...(search ? { q: search } : {}),
+    limit: PAGE,
   });
 
   const apply = useMutation({
@@ -95,37 +126,49 @@ export function UseSavedAudienceDialog({
       onApplied?.();
     },
     onError: (err) => {
-      const code = err instanceof ApiError ? err.code : undefined;
       const message = err instanceof ApiError ? err.message : "";
-      // ★THE API'S REFUSALS ARE ANSWERS AND ARE SHOWN AS THEY ARE WRITTEN. Every
-      // one of these is a sentence about THIS audience on THIS channel —
-      // "we won't spend against a version we can't confirm", "X can't express
-      // anything that makes this audience specific" — and replacing them with
-      // "something went wrong" would throw away the only useful part.
-      if (
-        code &&
-        [
-          "SET_STALE",
-          "SET_NOT_SERVABLE",
-          "SET_DISCARDED",
-          "PLATFORM_MISMATCH",
-          "FACET_NOT_APPLIABLE",
-          "NO_HYPOTHESIS",
-          "INVALID_TRANSITION",
-        ].includes(code)
-      ) {
-        toast.error(message || "We couldn't put that audience on this campaign.");
-        return;
+      switch (classifyApplyError(err instanceof ApiError ? err.code : undefined)) {
+        case "persisted_on_platform":
+          // ★A QUALIFIED SUCCESS, NOT A FAILURE. The platform HAS the new
+          // audience; only our mirror did not save. A first cut said "nothing
+          // was changed" — about a campaign whose targeting had already moved,
+          // to a customer whose next act is to activate it.
+          void queryClient.invalidateQueries({ queryKey: ["linkedin-managed-campaigns"] });
+          void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
+          onOpenChange(false);
+          setChosen(null);
+          toast.warning(
+            message ||
+              `The audience was applied on ${platformLabel(platform)} but we couldn't save it here — apply again to refresh.`,
+          );
+          return;
+        case "ad_account_not_authorized":
+          // Not a reconnect, and the shared helper is the one place that says
+          // so properly — this is the 403 that is live on the boost path.
+          toastAdAccountNotAuthorized(err, "Putting an audience on this campaign");
+          return;
+        case "ad_account_forbidden":
+          toastAdAccountForbidden(err, `${platformLabel(platform)} refused this ad account.`);
+          return;
+        case "audience":
+          // ★THE API'S SENTENCE, AS WRITTEN. Each is about THIS audience on
+          // THIS channel — "we won't spend against a version we can't
+          // confirm", "add a location to it first" — and it is the only useful
+          // part of the answer.
+          toast.error(message || "We couldn't put that audience on this campaign.");
+          return;
+        default:
+          // ★AND EVERYTHING ELSE TO THE SHARED HANDLER, which owns the
+          // retry-versus-permanent split, the support reference, and the
+          // NOT_FOUND deploy-order hazard. A bare `toast.error` here is the
+          // pattern `toast-errors.ts` was written to end.
+          toastUnhandledApiError(err, "put that audience on the campaign", platformLabel(platform));
       }
-      if (code === "NEEDS_REAUTH" || code === "NOT_CONNECTED") {
-        toast.error(`${platformLabel(platform)} Ads needs reconnecting before we can do that.`);
-        return;
-      }
-      toast.error("We couldn't put that audience on this campaign. Nothing was changed.");
     },
   });
 
   const rows = sets.data?.sets ?? [];
+  const total = sets.data?.total ?? 0;
 
   return (
     <Dialog
@@ -150,12 +193,20 @@ export function UseSavedAudienceDialog({
 
         <Input
           value={q}
-          onChange={(e) => setQ(e.target.value.slice(0, 80))}
-          maxLength={80}
+          onChange={(e) => setQ(e.target.value.slice(0, SEARCH_MAX))}
+          maxLength={SEARCH_MAX}
           placeholder="Search your audiences…"
           aria-label="Search your audiences"
         />
 
+        {total > PAGE && (
+          // ★SAID, BECAUSE A LIST THAT STOPS AT TWENTY WITH NOTHING SAYING SO
+          // IS A LIBRARY THAT LOOKS SMALLER THAN IT IS. Searching is the way
+          // through; paginating a picker is not worth the surface.
+          <p className="text-xs text-muted-foreground">
+            Showing {rows.length} of {total} — search to narrow it down.
+          </p>
+        )}
         <div className="max-h-[45vh] space-y-2 overflow-y-auto pr-1">
           {sets.isPending ? (
             <>
@@ -171,7 +222,7 @@ export function UseSavedAudienceDialog({
             // matches that search" is not "you have no audiences that work
             // here", and the second is not "you have no audiences".
             <p className="text-sm text-muted-foreground">
-              {q.trim()
+              {search
                 ? "Nothing in your library matches that."
                 : `None of your saved audiences has been worked out for ${platformLabel(platform)} yet — open one from Audiences and check this channel first.`}
             </p>

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -399,6 +399,58 @@ export const audienceLibraryApi = {
   getSet: (id: string) => api.get<AudienceSetResponse>(`/v1/audiences/sets/${id}`),
 
   /**
+   * Put a library audience on a campaign (G4).
+   *
+   * ★IT SPENDS NOTHING AND ACTIVATES NOTHING. A draft campaign stays a draft;
+   * an active one re-enters the platform's review with a new audience, exactly
+   * as the manual targeting editor already does. Generating an audience is not
+   * authority to spend it, and neither is putting it on a campaign.
+   *
+   * ★AND IT ASKS FOR THE CAMPAIGN'S OWN CHANNEL. The api materialises the set
+   * for whatever platform the campaign runs on and REFUSES to spend against a
+   * resolution it cannot confirm — so a 409 here is the engine declining to
+   * guess, not a broken request.
+   */
+  applySet: (setId: string, campaignId: string) =>
+    api.post<{
+      setId: string;
+      campaignId: string;
+      appliedAt: string;
+      /** Sets this replaced, counting only those now running nowhere else.
+       *  Empty is the common answer and is not an error. */
+      supersededSetIds: string[];
+    }>(`/v1/audiences/sets/${setId}/apply`, { campaignId }),
+
+  /**
+   * Keep the audience someone built by hand (F3/G4).
+   *
+   * ★OFFERED, NEVER AUTOMATIC. A library that fills up with every one-off
+   * experiment is a library nobody opens — so the api creates the set when
+   * asked, and the targeting editor goes on doing nothing of the sort. This is
+   * where the ask comes from.
+   *
+   * It lands at evidence tier `stated`: they chose it, usually against a
+   * proposal we had just shown them, which the design calls the best signal
+   * this engine gets.
+   */
+  saveFromCampaign: (body: { campaignId: string; name?: string; description?: string }) =>
+    api.post<{
+      set: AudienceSet;
+      /**
+       * What did not survive the trip into business language, each with its
+       * reason — a facet we have no name for, one whose entities the campaign
+       * never named, one only partly named, or an attribute past the cap.
+       *
+       * ★AND THE DIRECTION IS BROADER, NOT NARROWER: a lost include removes a
+       * whole AND-block, so the saved audience reaches MORE people than the
+       * campaign did. Silence here would be the dangerous half.
+       */
+      lost: Array<{ facet: string; reason: string }>;
+      /** So a client can say "you already saved this" rather than "saved!". */
+      alreadySaved: boolean;
+    }>("/v1/audiences/sets/from-campaign", body),
+
+  /**
    * What this audience looks like on ONE channel.
    *
    * ★IT WRITES ON A GET, DELIBERATELY, AND THE API SAYS SO. The typeahead round

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -291,24 +291,24 @@ export interface AudienceSet {
   createdAt: string;
 }
 
-export interface AudienceSetsQuery {
+/**
+ * ★`status` AND `excludeStatus` ARE MUTUALLY EXCLUSIVE, AND THE TYPE SAYS SO.
+ * They filter the same field, so the api answers 400 when both arrive — a rule
+ * it spent a `refine()` on. As two independent optionals, the obvious next
+ * change ("hide discarded" added to the library page's existing status
+ * dropdown) would send both and 400 the whole library.
+ */
+type StatusFilter =
+  | { status?: AudienceSetStatus; excludeStatus?: never }
+  | { status?: never; excludeStatus?: AudienceSetStatus };
+
+export type AudienceSetsQuery = StatusFilter & {
   platform?: string;
-  status?: AudienceSetStatus;
-  /**
-   * Everything EXCEPT one status, which `status` cannot express.
-   *
-   * ★"NOT DISCARDED" IS THE QUESTION A PICKER ASKS. A discarded audience must
-   * not be offered — the customer decided, and apply 409s it — but `status`
-   * takes one value, so the only available proxy was `proposed`, and apply
-   * sets `applied`: every audience they had ever used vanished from the
-   * picker, and the second campaign could not reuse the audience.
-   */
-  excludeStatus?: AudienceSetStatus;
   source?: AudienceSource;
   q?: string;
   limit?: number;
   offset?: number;
-}
+};
 
 export interface AudienceSetsResponse {
   sets: AudienceSet[];

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -294,6 +294,16 @@ export interface AudienceSet {
 export interface AudienceSetsQuery {
   platform?: string;
   status?: AudienceSetStatus;
+  /**
+   * Everything EXCEPT one status, which `status` cannot express.
+   *
+   * ★"NOT DISCARDED" IS THE QUESTION A PICKER ASKS. A discarded audience must
+   * not be offered — the customer decided, and apply 409s it — but `status`
+   * takes one value, so the only available proxy was `proposed`, and apply
+   * sets `applied`: every audience they had ever used vanished from the
+   * picker, and the second campaign could not reuse the audience.
+   */
+  excludeStatus?: AudienceSetStatus;
   source?: AudienceSource;
   q?: string;
   limit?: number;

--- a/src/lib/audience-apply-errors.test.ts
+++ b/src/lib/audience-apply-errors.test.ts
@@ -26,6 +26,11 @@ const API_CODES: Array<[code: string, kind: ReturnType<typeof classifyApplyError
   // about a campaign they are about to activate.
   ["APPLY_PERSIST_FAILED", "persisted_on_platform"],
   ["AD_ACCOUNT_NOT_AUTHORIZED", "ad_account_not_authorized"],
+  // ★THE SPELLING THAT IS STILL DEPLOYED. api#1026 renamed it; until that api
+  // is in production this is the code on the wire, and a table asserting only
+  // the new name is green while the live path tells the customer to open a
+  // ticket.
+  ["APP_NOT_AUTHORIZED", "ad_account_not_authorized"],
   ["AD_ACCOUNT_FORBIDDEN", "ad_account_forbidden"],
   // Shared copy lives in toast-errors.ts; a second sentence here would drift.
   ["NOT_CONNECTED", "unhandled"],
@@ -35,10 +40,12 @@ const API_CODES: Array<[code: string, kind: ReturnType<typeof classifyApplyError
   ["INVALID_TRANSITION", "unhandled"],
   ["NOT_FOUND", "unhandled"],
   ["FORBIDDEN", "unhandled"],
-  ["NO_PLATFORM_ID", "unhandled"],
+  ["NO_PLATFORM_ID", "audience"],
   ["APPLY_FAILED", "unhandled"],
   ["TOKEN_FAILED", "unhandled"],
-  ["PLATFORM_UNSUPPORTED", "unhandled"],
+  // ★A PRODUCT GAP, NOT A TICKET. Both routes author a sentence for it, and
+  // `unhandled` makes a 4xx `permanent` — a non-dismissable "contact support".
+  ["PLATFORM_UNSUPPORTED", "audience"],
   // ── passed through from materialiseForPlatform ─────────────────────────
   // ★THE TWO THE FIRST CUT MISSED. Their messages are the ones the feature's
   // own commit message quoted as the reason not to flatten anything.
@@ -52,6 +59,13 @@ const API_CODES: Array<[code: string, kind: ReturnType<typeof classifyApplyError
   ["TIMED_OUT", "unhandled"],
   // ── the from-campaign route ────────────────────────────────────────────
   ["NO_TARGETING", "audience"],
+  // Its insert catch-all. `unhandled` is a DECISION here, not where an
+  // unlisted code lands: a 502 has no sentence worth quoting and the shared
+  // handler's "try again in a moment" is right.
+  ["SAVE_FAILED", "unhandled"],
+  // Both routes. Practically unreachable from these dialogs — both clamp to the
+  // server's own limits — but it is a code they can return.
+  ["VALIDATION_ERROR", "unhandled"],
   ["LIBRARY_FULL", "audience"],
   ["NO_HYPOTHESIS", "audience"],
 ];

--- a/src/lib/audience-apply-errors.test.ts
+++ b/src/lib/audience-apply-errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { classifyApplyError } from "./audience-apply-errors";
+
+/**
+ * ★A TABLE AGAINST THE API'S OWN CODE LIST, because the defect this file was
+ * written for was a hand-maintained allowlist that missed two codes and
+ * misspelled a third. The list below is every code
+ * `POST /v1/audiences/sets/:id/apply` and `POST /v1/audiences/sets/from-campaign`
+ * can return, mirrored from the routes — including the ones the materialiser
+ * emits and the route passes through verbatim.
+ *
+ * Nothing may classify as `unhandled` by accident: `unhandled` is a decision to
+ * let the shared `toastUnhandledApiError` own the copy, and it is stated here
+ * per code rather than being where unlisted codes fall.
+ */
+const API_CODES: Array<[code: string, kind: ReturnType<typeof classifyApplyError>]> = [
+  // ── the apply route ────────────────────────────────────────────────────
+  ["SET_DISCARDED", "audience"],
+  ["SET_STALE", "audience"],
+  ["SET_NOT_SERVABLE", "audience"],
+  ["PLATFORM_MISMATCH", "audience"],
+  ["FACET_NOT_APPLIABLE", "audience"],
+  ["APPLY_REJECTED", "audience"],
+  // ★THE PLATFORM HAS THE AUDIENCE AND WE DO NOT. Anything that renders this
+  // as "nothing was changed" is telling the customer the opposite of the truth
+  // about a campaign they are about to activate.
+  ["APPLY_PERSIST_FAILED", "persisted_on_platform"],
+  ["AD_ACCOUNT_NOT_AUTHORIZED", "ad_account_not_authorized"],
+  ["AD_ACCOUNT_FORBIDDEN", "ad_account_forbidden"],
+  // Shared copy lives in toast-errors.ts; a second sentence here would drift.
+  ["NOT_CONNECTED", "unhandled"],
+  ["NEEDS_REAUTH", "unhandled"],
+  ["NO_AD_ACCOUNT", "unhandled"],
+  ["RATE_LIMITED", "unhandled"],
+  ["INVALID_TRANSITION", "unhandled"],
+  ["NOT_FOUND", "unhandled"],
+  ["FORBIDDEN", "unhandled"],
+  ["NO_PLATFORM_ID", "unhandled"],
+  ["APPLY_FAILED", "unhandled"],
+  ["TOKEN_FAILED", "unhandled"],
+  ["PLATFORM_UNSUPPORTED", "unhandled"],
+  // ── passed through from materialiseForPlatform ─────────────────────────
+  // ★THE TWO THE FIRST CUT MISSED. Their messages are the ones the feature's
+  // own commit message quoted as the reason not to flatten anything.
+  ["NOTHING_RESOLVED", "audience"],
+  ["NO_GEOGRAPHY", "audience"],
+  // ★AND THE ONE IT MISSPELLED: the route lists SET_NOT_SERVABLE, the
+  // materialiser emits NOT_SERVABLE, and only the first was handled.
+  ["NOT_SERVABLE", "audience"],
+  ["NO_CAPABILITIES", "audience"],
+  ["PROVIDER_FAILED", "unhandled"],
+  ["TIMED_OUT", "unhandled"],
+  // ── the from-campaign route ────────────────────────────────────────────
+  ["NO_TARGETING", "audience"],
+  ["LIBRARY_FULL", "audience"],
+  ["NO_HYPOTHESIS", "audience"],
+];
+
+describe("classifyApplyError", () => {
+  it.each(API_CODES)("classifies %s as %s", (code, kind) => {
+    expect(classifyApplyError(code)).toBe(kind);
+  });
+
+  it("hands an unknown code to the shared handler rather than guessing", () => {
+    // A code we have never seen has no sentence we can vouch for, and
+    // `toastUnhandledApiError` is where the retry/permanent split and the
+    // support reference live.
+    expect(classifyApplyError("SOMETHING_NEW")).toBe("unhandled");
+    expect(classifyApplyError(undefined)).toBe("unhandled");
+  });
+});

--- a/src/lib/audience-apply-errors.ts
+++ b/src/lib/audience-apply-errors.ts
@@ -47,6 +47,17 @@ export type ApplyErrorKind =
  * `MaterialiseResult` codes, which the route passes through verbatim.
  */
 const AUDIENCE_REFUSALS = new Set([
+  // ★A PRODUCT GAP IS NOT A SUPPORT TICKET. Both routes author a specific
+  // sentence for this ("we don't have X's targeting vocabulary yet"), and
+  // sending it to the shared handler made it a 4xx with no disposition —
+  // therefore `permanent`, therefore a NON-DISMISSABLE "contact support and
+  // quote this reference" toast, for something no support agent can clear. It
+  // is reachable today: the capability registry is empty for a platform until
+  // its migration runs, and the registry crons do not run in dev.
+  "PLATFORM_UNSUPPORTED",
+  // Same shape: "this campaign has no identity on the platform to target",
+  // which is a sentence about this campaign and not a ticket.
+  "NO_PLATFORM_ID",
   // the route's own
   "SET_DISCARDED",
   "SET_STALE",
@@ -68,7 +79,15 @@ const AUDIENCE_REFUSALS = new Set([
 export function classifyApplyError(code: string | undefined): ApplyErrorKind {
   if (!code) return "unhandled";
   if (code === "APPLY_PERSIST_FAILED") return "persisted_on_platform";
-  if (code === "AD_ACCOUNT_NOT_AUTHORIZED") return "ad_account_not_authorized";
+  // ★BOTH SPELLINGS, BECAUSE ONLY ONE OF THEM IS DEPLOYED. api#1026 renamed
+  // `APP_NOT_AUTHORIZED` to the platform-wide `AD_ACCOUNT_NOT_AUTHORIZED`, and
+  // until that api is in production the LIVE code is the old one — so a
+  // classifier that knew only the new name would have left the very 403 this
+  // was written for falling through to "contact support", with a green test
+  // asserting the name that is not yet on the wire.
+  if (code === "AD_ACCOUNT_NOT_AUTHORIZED" || code === "APP_NOT_AUTHORIZED") {
+    return "ad_account_not_authorized";
+  }
   if (code === "AD_ACCOUNT_FORBIDDEN") return "ad_account_forbidden";
   if (AUDIENCE_REFUSALS.has(code)) return "audience";
   // ★EVERYTHING ELSE GOES TO THE SHARED HANDLER, INCLUDING THE ONES THAT LOOK

--- a/src/lib/audience-apply-errors.ts
+++ b/src/lib/audience-apply-errors.ts
@@ -1,0 +1,79 @@
+/**
+ * What the api's refusals MEAN when you put an audience on a campaign, or save
+ * one off it (G4).
+ *
+ * ★MOST OF THESE ARE ANSWERS, NOT ERRORS, AND THEY ARE WRITTEN FOR THE
+ * CUSTOMER. "We won't spend against a version of this audience we can't
+ * confirm", "X can't express anything that makes this audience specific", "add
+ * a location to it first" — every one is a sentence about THIS audience on THIS
+ * channel, and replacing it with "something went wrong" throws away the only
+ * useful part.
+ *
+ * ★BUT NOT ALL OF THEM ARE. A first cut hand-listed the ones to pass through
+ * and missed `NOTHING_RESOLVED` and `NO_GEOGRAPHY` — the two whose sentences
+ * the commit message was quoting — and listed `SET_NOT_SERVABLE` while the
+ * materialiser emits `NOT_SERVABLE`, a one-word slip that neutered the branch.
+ * Hence a classifier with a test against the api's own list rather than an
+ * allowlist nobody can check.
+ */
+
+/**
+ * How a caller should treat an apply failure.
+ *
+ * `audience` — the api authored a sentence about this audience and this
+ *   channel. Show it as written.
+ * `ad_account_not_authorized` / `ad_account_forbidden` — a 403 about the ad
+ *   ACCOUNT. Both have platform-wide copy and neither is fixed by a reconnect,
+ *   which is why they are not lumped in with the rest.
+ * `persisted_on_platform` — ★THE PLATFORM HAS THE NEW AUDIENCE AND WE DO NOT.
+ *   Treating this as a plain failure tells the customer "nothing was changed"
+ *   about a campaign whose targeting has already moved — and the next thing
+ *   they do is activate it.
+ * `unhandled` — hand to `toastUnhandledApiError`, which owns the
+ *   retry/permanent split, the support reference, and the NOT_FOUND
+ *   deploy-order hazard.
+ */
+export type ApplyErrorKind =
+  | "audience"
+  | "ad_account_not_authorized"
+  | "ad_account_forbidden"
+  | "persisted_on_platform"
+  | "unhandled";
+
+/**
+ * Refusals whose message is ABOUT THE AUDIENCE and is written for a customer.
+ *
+ * Sourced from the apply route and from `materialiseForPlatform`'s own
+ * `MaterialiseResult` codes, which the route passes through verbatim.
+ */
+const AUDIENCE_REFUSALS = new Set([
+  // the route's own
+  "SET_DISCARDED",
+  "SET_STALE",
+  "SET_NOT_SERVABLE",
+  "PLATFORM_MISMATCH",
+  "FACET_NOT_APPLIABLE",
+  "APPLY_REJECTED",
+  // the materialiser's, passed through
+  "NOT_SERVABLE",
+  "NOTHING_RESOLVED",
+  "NO_GEOGRAPHY",
+  "NO_CAPABILITIES",
+  // the save route's
+  "NO_TARGETING",
+  "LIBRARY_FULL",
+  "NO_HYPOTHESIS",
+]);
+
+export function classifyApplyError(code: string | undefined): ApplyErrorKind {
+  if (!code) return "unhandled";
+  if (code === "APPLY_PERSIST_FAILED") return "persisted_on_platform";
+  if (code === "AD_ACCOUNT_NOT_AUTHORIZED") return "ad_account_not_authorized";
+  if (code === "AD_ACCOUNT_FORBIDDEN") return "ad_account_forbidden";
+  if (AUDIENCE_REFUSALS.has(code)) return "audience";
+  // ★EVERYTHING ELSE GOES TO THE SHARED HANDLER, INCLUDING THE ONES THAT LOOK
+  // OBVIOUS. `NOT_CONNECTED`, `NEEDS_REAUTH` and `RATE_LIMITED` all have
+  // platform-wide copy there, and a second hand-written sentence here is a
+  // second place for it to drift.
+  return "unhandled";
+}


### PR DESCRIPTION
The two actions that make the library a library rather than a list. Needs peakhour-api#1026 (`excludeStatus` + the 403 rename).

## Use a saved audience

`POST /sets/:id/apply` has existed since B2 and had **no caller** — so every boosted campaign took whatever the engine proposed at the moment it was created, and the audiences a customer had planned, imported or corrected could not be put on anything.

The picker asks for the ones that **work on this campaign's channel**, which is "carries a shape for it" rather than "was born on it": an idea planned on LinkedIn and since resolved for X belongs in both lists. That is the channel-neutral library's whole claim, made tangible.

It spends nothing. A draft stays a draft; an active campaign re-enters review with a new audience, exactly as the manual editor already does.

## Save the one you built

"Learned from the user through their MANUAL campaigns" was half-built for a year: a hand-edit was captured as a structured diff on the campaign and on the set, and never became a library entry — so the single audience a customer actually authored was the one they could not reuse. F3 built the route; this is where the ask comes from. Offered, never automatic.

## What review changed

- **`APPLY_PERSIST_FAILED` was rendered as "nothing was changed".** It is the opposite: the platform has the new audience and only our mirror failed. The row then refetches showing the OLD audience, and the customer's next act is to activate a campaign they believe targets it.
- **the 403 live on the boost path today was unhandled** — `AD_ACCOUNT_NOT_AUTHORIZED` / `AD_ACCOUNT_FORBIDDEN` reached the customer as "Nothing was changed", naming neither cause nor fix.
- **the codes carrying the sentences the commit quoted were the ones missing from its allowlist** — `NOTHING_RESOLVED`, `NO_GEOGRAPHY`, and `SET_NOT_SERVABLE` where the materialiser emits `NOT_SERVABLE`. Replaced with a classifier and a table test over every code the two routes can return.
- everything the classifier does not claim now goes to `toastUnhandledApiError`, which exists because these surfaces ended their onError chains with a bare `toast.error` and a 100%-reproducible contract bug went unnoticed for months.
- **the picker asked for `status: "proposed"`**, so every audience the customer had ever applied vanished from it — the second campaign could not reuse the audience.
- the search was undebounced against a query the api documents as a collection scan plus a `countDocuments`; a list that stops at twenty now says so; the campaign's own platform is passed rather than a hardcoded one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)