### PR TITLE
feat(audience): the loop, made visible (H1 b2c)

### DIFF
--- a/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
   originLabel,
   outcomeLine,
 } from "@/lib/audience-library-rules";
+import { editLines } from "@/lib/audience-learning-rules";
 import { ChannelCard } from "./_components/channel-card";
 
 /**
@@ -175,6 +176,37 @@ export default function AudienceDetailPage({ params }: { params: Promise<{ id: s
               )}
             </CardContent>
           </Card>
+
+          {/* ★WHAT WE PROPOSED, WHAT YOU CHANGED, WHAT HAPPENED (H1). The
+              corrections have been recorded on this row since B5 and shown to
+              nobody — and a proposal-then-correction pair is what the design
+              calls the single best signal this engine gets. A customer who
+              cannot see that we kept theirs has no reason to make another. */}
+          {(() => {
+            const edits = editLines(row);
+            if (edits.length === 0) return null;
+            return (
+              <Card>
+                <CardContent className="space-y-2 p-4">
+                  <h3 className="text-sm font-medium">What you changed</h3>
+                  <ul className="space-y-1">
+                    {edits.map((edit, i) => (
+                      <li key={`${edit.attribute}:${i}`} className="text-sm text-muted-foreground">
+                        {edit.text}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="text-xs text-muted-foreground">
+                    We use these to change what we suggest next — see{" "}
+                    <Link href="/dashboard/growth/business" className="underline">
+                      what we&apos;ve learned
+                    </Link>
+                    .
+                  </p>
+                </CardContent>
+              </Card>
+            );
+          })()}
 
           <div className="space-y-3">
             <div>

--- a/src/app/(site)/dashboard/growth/business/page.tsx
+++ b/src/app/(site)/dashboard/growth/business/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AudienceProfilePanel } from "@/components/audience/audience-profile-panel";
+import { WhatWeveLearned } from "@/components/audience/what-weve-learned";
 
 /**
  * Your Business (G2) — what the platform understands about the customer.
@@ -36,6 +37,12 @@ export default function YourBusinessPage() {
           collapsing the only content behind a click is how a surface stays
           unread. */}
       <AudienceProfilePanel defaultOpen />
+
+      {/* ★AND WHAT THE CORRECTIONS ABOVE HAVE ACTUALLY TAUGHT US (H1). A
+          customer asked to correct our understanding, whose corrections
+          visibly go nowhere, stops correcting — and the loop has been running
+          for months with nothing rendering a single thing it learned. */}
+      <WhatWeveLearned />
     </div>
   );
 }

--- a/src/components/audience/what-weve-learned.tsx
+++ b/src/components/audience/what-weve-learned.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { GraduationCap } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { audienceLibraryApi, type AudienceSkillLearning } from "@/lib/api/audiences";
+import { useAuth } from "@/providers/auth-provider";
+import { learningState } from "@/lib/audience-learning-rules";
+
+/**
+ * What the engine has learned about this business's audiences (H1).
+ *
+ * ★THE LOOP HAS BEEN RUNNING AND NOBODY COULD SEE IT. The weekly tuning cron
+ * has distilled `whatWorks`/`whatDoesntWork` from corrections and outcomes
+ * since D3, `userEdits` has recorded every hand-correction since B5, and
+ * `outcome` has carried what the campaigns did — none of it rendered anywhere.
+ * A customer being asked to correct our understanding, whose corrections
+ * visibly go nowhere, stops correcting.
+ *
+ * ★AND "NOTHING YET" IS THREE DIFFERENT SENTENCES. Never set up; set up and
+ * still watching; and watching with too few decided observations to say
+ * anything — the extractor refuses below the api's own floor, because a pattern
+ * from four edits is a hunch. Collapsing them into one empty card would tell a
+ * customer the engine has learned nothing about a business it has never been
+ * asked about.
+ */
+export function WhatWeveLearned() {
+  const { business } = useAuth();
+  const learning = useQuery({
+    queryKey: ["audience-learning", business?._id ?? "none"],
+    queryFn: () => audienceLibraryApi.getLearning(),
+    retry: false,
+  });
+
+  const skills = learning.data?.skills ?? [];
+  const minimum = learning.data?.minimumObservations ?? 0;
+  const withLearnings = skills.filter((s) => s.learnings);
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-center gap-2">
+          <GraduationCap className="size-4 text-muted-foreground" aria-hidden="true" />
+          <h3 className="text-sm font-medium">What we&apos;ve learned about your audiences</h3>
+        </div>
+
+        {learning.isPending ? (
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-full max-w-md" />
+            <Skeleton className="h-3 w-full max-w-sm" />
+          </div>
+        ) : learning.isError ? (
+          <p className="text-sm text-muted-foreground">
+            We couldn&apos;t load this just now.
+          </p>
+        ) : withLearnings.length === 0 ? (
+          // ★THE HONEST EMPTY, AND IT SAYS WHICH EMPTY IT IS. Every skill's own
+          // state is on the row below; this is the summary of them.
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Nothing yet. We learn from two things: the corrections you make to what we
+              suggest, and what the campaigns running an audience actually do.
+            </p>
+            <ul className="space-y-1">
+              {skills.map((skill) => (
+                <li key={skill.skillId} className="text-xs text-muted-foreground">
+                  <span className="font-medium">{skill.label}</span> —{" "}
+                  {learningState(skill, minimum).text}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {skills.map((skill) => (
+              <SkillLearning key={skill.skillId} skill={skill} minimum={minimum} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SkillLearning({
+  skill,
+  minimum,
+}: {
+  skill: AudienceSkillLearning;
+  minimum: number;
+}) {
+  const state = learningState(skill, minimum);
+  return (
+    <div className="space-y-1">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <span className="text-sm font-medium">{skill.label}</span>
+        {/* ★THE SAMPLE TRAVELS WITH THE FINDING. A pattern from 4 observations
+            and one from 400 read differently, and the number is the only thing
+            that says which this is. */}
+        <span className="text-xs text-muted-foreground">{state.text}</span>
+      </div>
+      {skill.learnings && (
+        <ul className="space-y-0.5">
+          {skill.learnings.whatWorks.map((line) => (
+            <li key={`w:${line}`} className="text-xs text-muted-foreground">
+              <span className="text-foreground">Works:</span> {line}
+            </li>
+          ))}
+          {skill.learnings.whatDoesntWork.map((line) => (
+            <li key={`d:${line}`} className="text-xs text-muted-foreground">
+              <span className="text-foreground">Doesn&apos;t:</span> {line}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -390,6 +390,49 @@ export interface AudienceSetResponse {
   set: AudienceSet;
 }
 
+/**
+ * What the engine has learned about this business's audiences (H1).
+ *
+ * ★EVERY FIELD HERE HAD A WRITER AND NO READER. The weekly tuning cron has been
+ * distilling `whatWorks`/`whatDoesntWork` from corrections and outcomes since
+ * D3, and nothing has ever shown a customer one of them.
+ */
+export interface AudienceSkillLearning {
+  skillId: string;
+  /** What this skill does, in the customer's terms. */
+  label: string;
+  /** ★FALSE MEANS NEVER SET UP FOR THIS BUSINESS, which is not "learned
+   *  nothing" — a business whose skills have never been cloned has not
+   *  disappointed anybody. */
+  configured: boolean;
+  status?: string;
+  /** Absent — not empty — when the extractor has never had enough to distil.
+   *  It refuses below `minimumObservations` on purpose. */
+  learnings?: {
+    whatWorks: string[];
+    whatDoesntWork: string[];
+    /** ★HOW MANY OBSERVATIONS THESE CAME FROM. A pattern from 4 and one from
+     *  400 read differently, and this is the only thing that says which. */
+    sampleSize?: number;
+    updatedAt?: string;
+  };
+  /** ★NEVER A SCORE WITHOUT ITS COUNTS. The api sends both or neither. */
+  effectiveness?: {
+    score?: number;
+    totalUses: number;
+    accepted: number;
+    edited: number;
+    rejected: number;
+  };
+}
+
+export interface AudienceLearningResponse {
+  /** How many decided observations the extractor needs before it publishes
+   *  anything. Sent by the api so "not yet" can say how far off it is. */
+  minimumObservations: number;
+  skills: AudienceSkillLearning[];
+}
+
 export const audienceLibraryApi = {
   /**
    * The library. Filters are SERVER-SIDE and the enums are the server's: a
@@ -407,6 +450,9 @@ export const audienceLibraryApi = {
 
   /** One audience, with the channels it is already known to work on. */
   getSet: (id: string) => api.get<AudienceSetResponse>(`/v1/audiences/sets/${id}`),
+
+  /** What the engine has learned about this business's audiences (H1). */
+  getLearning: () => api.get<AudienceLearningResponse>("/v1/audiences/learning"),
 
   /**
    * Put a library audience on a campaign (G4).

--- a/src/lib/audience-learning-rules.test.ts
+++ b/src/lib/audience-learning-rules.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import type { AudienceSkillLearning } from "@/lib/api/audiences";
+import { editLines, learningState } from "./audience-learning-rules";
+
+/**
+ * H1's judgement, which is — again — almost entirely about which KIND of
+ * nothing. "We have learned nothing" is four different sentences depending on
+ * why, and only one of them is about the engine failing.
+ */
+
+const skill = (over: Partial<AudienceSkillLearning> = {}): AudienceSkillLearning => ({
+  skillId: "generate_audience_hypotheses",
+  label: "Suggesting audiences",
+  configured: true,
+  ...over,
+});
+
+describe("learningState", () => {
+  it("★never says 'learned nothing' about a skill nobody has set up", () => {
+    // A business whose skills have never been cloned has not disappointed
+    // anybody, and saying otherwise is an accusation aimed the wrong way.
+    const out = learningState(skill({ configured: false }), 8);
+    expect(out.kind).toBe("not_set_up");
+    expect(out.text).toContain("not set up");
+  });
+
+  it("★counts toward the floor rather than promising 'soon'", () => {
+    // The extractor refuses below the api's floor on purpose — a pattern from
+    // four edits is a hunch — so a young business is EARLY, not failing. "1 of
+    // 8" is something a customer can act on; "soon" is a promise nobody made.
+    const out = learningState(
+      skill({ effectiveness: { totalUses: 9, accepted: 1, edited: 0, rejected: 0 } }),
+      8,
+    );
+    expect(out.kind).toBe("too_few");
+    expect(out.text).toBe("watching — 1 of 8 so far");
+  });
+
+  it("★counts DECISIONS, not runs", () => {
+    // `totalUses` counts every invocation; only accepted / edited / rejected
+    // are decisions, and those are what the extractor waits for. Counting runs
+    // would tell a customer they were nearly there when nobody had judged
+    // anything.
+    const out = learningState(
+      skill({ effectiveness: { totalUses: 40, accepted: 2, edited: 1, rejected: 1 } }),
+      8,
+    );
+    expect(out.text).toBe("watching — 4 of 8 so far");
+  });
+
+  it("carries the sample a finding came from", () => {
+    // A pattern from 4 observations and one from 400 read differently, and this
+    // is the only thing that says which.
+    const out = learningState(
+      skill({ learnings: { whatWorks: ["x"], whatDoesntWork: [], sampleSize: 24 } }),
+      8,
+    );
+    expect(out.kind).toBe("learned");
+    expect(out.text).toBe("from 24 times you told us");
+  });
+
+  it("does not invent a sample it was not given", () => {
+    const out = learningState(skill({ learnings: { whatWorks: ["x"], whatDoesntWork: [] } }), 8);
+    expect(out.kind).toBe("learned");
+    expect(out.text).not.toMatch(/\d/);
+  });
+});
+
+describe("editLines", () => {
+  it("★reads an absent `to` as a REMOVAL, not as an empty choice", () => {
+    // The api omits `to` when the attribute was removed outright — "changed to
+    // nothing in particular" is what an empty list would read as, and the
+    // removal is the lesson.
+    const [line] = editLines({
+      userEdits: [{ at: "x", attribute: "seniority", from: ["Director", "VP"] }],
+    });
+    expect(line!.text).toBe("You removed seniority (Director, VP)");
+  });
+
+  it("★reads an absent `from` as an ADDITION, which is the other direction", () => {
+    // They chose something we never suggested — the strongest correction there
+    // is, and indistinguishable from a change if both halves are flattened.
+    const [line] = editLines({
+      userEdits: [{ at: "x", attribute: "job_title", to: ["Head of Corporate Travel"] }],
+    });
+    expect(line!.text).toBe("You added job title: Head of Corporate Travel");
+  });
+
+  it("names both halves of a change", () => {
+    const [line] = editLines({
+      userEdits: [{ at: "x", attribute: "geo", from: ["India"], to: ["India", "UAE"] }],
+    });
+    expect(line!.text).toBe("You changed location from India to India, UAE");
+  });
+
+  it("falls back to a word rather than rendering a blank for an unattributed edit", () => {
+    // `attribute` is optional on the row. An edit with no attribute is still an
+    // edit, and dropping it would make a corrected audience look untouched.
+    const [line] = editLines({ userEdits: [{ at: "x", to: ["something"] }] });
+    expect(line!.text).toContain("targeting");
+  });
+
+  it("says nothing about an audience nobody corrected", () => {
+    expect(editLines({})).toEqual([]);
+  });
+});

--- a/src/lib/audience-learning-rules.ts
+++ b/src/lib/audience-learning-rules.ts
@@ -1,0 +1,94 @@
+import type { AudienceSet, AudienceSkillLearning } from "@/lib/api/audiences";
+import { attributeLabel } from "@/lib/audience-library-rules";
+
+/**
+ * The decisions the learning surfaces make (H1), extracted so they can be
+ * tested — this repo is vitest node-only by design.
+ *
+ * ★AND WHAT THEY DECIDE IS, AGAIN, WHICH KIND OF NOTHING. "We have learned
+ * nothing" is four different sentences depending on why, and only one of them
+ * is about the engine failing.
+ */
+
+export interface LearningState {
+  kind: "learned" | "watching" | "too_few" | "not_set_up";
+  text: string;
+}
+
+/**
+ * What to say about one skill's learnings.
+ *
+ * ★"NEVER SET UP" IS NOT "LEARNED NOTHING". A business whose skills have never
+ * been cloned has not disappointed anybody, and telling them the engine has
+ * learned nothing about them would be an accusation aimed the wrong way.
+ *
+ * ★AND "TOO FEW OBSERVATIONS" IS NOT "NOTHING TO SAY". The extractor refuses to
+ * publish below the api's floor on purpose — a pattern from four edits is a
+ * hunch — so a young business is early, not disappointing. The floor comes from
+ * the api precisely so this sentence can say how far off it is.
+ */
+export function learningState(skill: AudienceSkillLearning, minimum: number): LearningState {
+  if (skill.learnings) {
+    const n = skill.learnings.sampleSize;
+    return {
+      kind: "learned",
+      text:
+        typeof n === "number"
+          ? `from ${n} time${n === 1 ? "" : "s"} you told us`
+          : "from your corrections",
+    };
+  }
+  if (!skill.configured) return { kind: "not_set_up", text: "not set up for you yet" };
+  const decided = decidedCount(skill);
+  if (minimum > 0 && decided < minimum) {
+    // ★A COUNT, NOT "SOON". "1 of 8" is something a customer can act on —
+    // correct one more audience — and "soon" is a promise nobody made.
+    return { kind: "too_few", text: `watching — ${decided} of ${minimum} so far` };
+  }
+  return { kind: "watching", text: "watching, nothing to report yet" };
+}
+
+/** How many decided observations this skill has. `totalUses` counts every run;
+ *  only accepted / edited / rejected are DECISIONS, which is what the extractor
+ *  counts. */
+function decidedCount(skill: AudienceSkillLearning): number {
+  const e = skill.effectiveness;
+  if (!e) return 0;
+  return (e.accepted ?? 0) + (e.edited ?? 0) + (e.rejected ?? 0);
+}
+
+/** One hand-correction, as a sentence a person reads. */
+export interface EditLine {
+  attribute: string;
+  /** What we proposed. Empty when we proposed nothing for this attribute — the
+   *  customer ADDED it, which is the more interesting direction. */
+  from: string[];
+  /** What they chose instead. Empty when they removed the attribute outright,
+   *  which is itself the lesson. */
+  to: string[];
+  text: string;
+}
+
+/**
+ * What we proposed and what the customer changed it to.
+ *
+ * ★AN ABSENT `to` IS NOT AN EMPTY CHOICE. The api omits it when the attribute
+ * was removed outright — "changed to nothing in particular" is what an empty
+ * list would read as, and the removal is the lesson. An absent `from` is the
+ * mirror: they added something we never suggested.
+ */
+export function editLines(set: Pick<AudienceSet, "userEdits">): EditLine[] {
+  return (set.userEdits ?? []).map((edit) => {
+    const attribute = edit.attribute ?? "targeting";
+    const label = attributeLabel(attribute);
+    const from = edit.from ?? [];
+    const to = edit.to ?? [];
+    const text =
+      to.length === 0
+        ? `You removed ${label.toLowerCase()}${from.length > 0 ? ` (${from.join(", ")})` : ""}`
+        : from.length === 0
+          ? `You added ${label.toLowerCase()}: ${to.join(", ")}`
+          : `You changed ${label.toLowerCase()} from ${from.join(", ")} to ${to.join(", ")}`;
+    return { attribute, from, to, text };
+  });
+}


### PR DESCRIPTION
A customer asked to correct our understanding, whose corrections visibly go nowhere, stops correcting. Three fields have recorded exactly that and shown it to nobody. Needs peakhour-api#1027 for `GET /learning`.

**On a set: what you changed.** `userEdits` has captured every hand-correction since B5, and the design calls the proposal-then-correction pair the single best signal this engine gets.

**On Your Business: what we've learned.** `biz_skills.learnings` has been distilled weekly from those corrections and from what the campaigns running an audience actually did — and read by nothing.

## "We have learned nothing" is four different sentences

Each with a test:

- **never set up for this business** — not a disappointment, and saying otherwise is an accusation aimed the wrong way;
- **watching, not enough decided observations yet** — counted against the api's own floor, so "1 of 8" is something a customer can act on rather than a "soon" nobody promised;
- **watching with enough, nothing to report**;
- **a finding**, carrying the sample it came from — a pattern from 4 observations and one from 400 read differently.

**`totalUses` is not the count.** Every run is a use; only accepted / edited / rejected are *decisions*, and those are what the extractor waits for. Counting runs would tell a customer they were nearly there when nobody had judged anything.

**An absent `to` is a removal, not an empty choice.** The api omits it when the attribute was taken out — "changed to nothing in particular" is what an empty list reads as, and the removal is the lesson. An absent `from` is the mirror: they added something we never suggested, which is the strongest correction there is.

All four of those are mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)