### PR TITLE
feat(ads): a campaign that should have stopped and has not (P2 b2c)

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -44,6 +44,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { AdvertisingDeclarationCard } from "@/components/ads/advertising-declaration-card";
+import { formatDeclaredAt } from "@/lib/ads-copy";
 import { EmptyState } from "@/components/molecules/empty-state";
 import {
   AlertTriangle,
@@ -134,6 +135,7 @@ export function LinkedInAdsPanel() {
           gate below renders an EmptyState — which used to hide this warning in
           the one case it matters most. */}
       <SpendAlarmBanner />
+      <FlightEndBanner />
       {/* Above the gate for the same reason, plus one of its own: the
           declaration governs every campaign create including the autonomous
           ones, and a business can make it before it connects. Not on
@@ -193,10 +195,13 @@ export function LinkedInAdsPanel() {
  * Campaigns still SERVING past the budget cap the user set.
  *
  * The api derives `spendAlarm` (at/over cap AND still active), which covers
- * both an auto-pause that failed and one that never ran — including the case
- * that makes this the ONLY protection there is: campaigns created through the
- * Ads Manager get no monitor at all, because the monitoring workflow starts
- * only from the WhatsApp BOOST command.
+ * both an auto-pause that failed and one that never ran.
+ *
+ * (That last case used to be the common one: campaigns created through the Ads
+ * Manager got no monitor at all, because the monitoring workflow started only
+ * from the WhatsApp BOOST command. Closed by the hourly sweep — P1, api#1030 —
+ * so this banner is now the escalation of a failure rather than the only
+ * protection there is.)
  *
  * Own component, mounted above the connection gate, sharing CampaignsPanel's
  * queryKey (react-query dedupes, so no extra request).
@@ -243,6 +248,90 @@ function SpendAlarmBanner() {
                   {r.spendAlarm?.reason ? `. ${r.spendAlarm.reason}.` : "."}
                 </li>
               ))}
+            </ul>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Campaigns that should have STOPPED and have not.
+ *
+ * ★THE STATE THIS RENDERS ONLY EXISTS BECAUSE THE MONITOR NOW REFUSES TO LIE.
+ * LinkedIn carries no `end` on a campaign's `runSchedule` — the flight window
+ * lives only on our row — and the monitor used to write `status: "completed"`
+ * locally with no platform call at all, so a campaign that had not also
+ * tripped its budget cap carried on serving indefinitely while this screen
+ * reported it finished. It now stops the campaign on LinkedIn first, and
+ * leaves the row `active` when it cannot.
+ *
+ * ★AND A SEPARATE BANNER FROM SpendAlarmBanner, DELIBERATELY. "You are over
+ * the cap you set" and "this should have stopped four days ago" are different
+ * asks with different remedies, and the population here is exactly the
+ * campaigns that UNDER-spend — so folding it into the spend banner would make
+ * it unreadable in the case where it matters most. A campaign in both states
+ * appears in both, which is the truth.
+ *
+ * ★AND THE CTA IS CAMPAIGN MANAGER, FOR THE REASON THE SPEND BANNER GIVES:
+ * Peakhour's own Pause uses the connection whose failure is why this is here.
+ * Hedged the same way, because for a rate limit or an undelivered request it
+ * very likely succeeds on retry.
+ */
+function FlightEndBanner() {
+  const campaigns = useQuery({
+    queryKey: ["linkedin-managed-campaigns"],
+    queryFn: () => linkedInAdsApi.managedCampaigns(),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+  const pastEnd = (campaigns.data?.campaigns ?? []).filter((r) => r.flightEndAlarm?.pastEnd);
+  if (pastEnd.length === 0) return null;
+
+  return (
+    <Card role="alert" className="border-destructive/40 bg-destructive/5">
+      <CardContent className="space-y-2 p-4 text-sm">
+        <div className="flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
+          <div className="space-y-1">
+            <p className="font-medium text-destructive">
+              {pastEnd.length === 1
+                ? "A campaign has passed its end date and is still running"
+                : `${pastEnd.length} campaigns have passed their end date and are still running`}
+            </p>
+            <p className="text-muted-foreground">
+              We could not stop {pastEnd.length === 1 ? "it" : "them"} on LinkedIn, so{" "}
+              {pastEnd.length === 1 ? "it may still be" : "they may still be"} spending.{" "}
+              <strong className="font-medium text-foreground">
+                Stop {pastEnd.length === 1 ? "it" : "them"} in LinkedIn Campaign Manager
+              </strong>{" "}
+              — the controls here use the same connection, so if that is what
+              failed they will fail again.
+            </p>
+            <ul className="space-y-1 pt-1">
+              {pastEnd.map((r) => {
+                // ★REUSED, NOT REWRITTEN. `formatDeclaredAt` already renders a
+                // UTC instant as "30 Jul 2026" and already returns "" rather
+                // than the words "Invalid Date" — which inside an alert about
+                // somebody's money reads as a bug in the alarm and costs it the
+                // credibility it needs at the moment it is being read. A second
+                // near-identical formatter is how the two drift.
+                const ended = formatDeclaredAt(r.flightEndAlarm?.endsAt ?? "");
+                return (
+                  <li key={r._id} className="text-muted-foreground">
+                    <span className="font-medium text-foreground">{r.name}</span>
+                    {ended ? ` — ended ${ended}` : " — past its end date"}
+                    {/* ★NO INVENTED CAUSE. An absent reason means no tick has yet
+                        recorded why this campaign is still here — which is what a
+                        monitor that has not run since it expired looks like. "We
+                        cannot tell" must never render as an explanation. */}
+                    {r.flightEndAlarm?.reason
+                      ? `. ${r.flightEndAlarm.reason}.`
+                      : ". We have not yet recorded why it could not be stopped."}
+                  </li>
+                );
+              })}
             </ul>
           </div>
         </div>

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/ui/table";
 import { AdvertisingDeclarationCard } from "@/components/ads/advertising-declaration-card";
 import { formatDeclaredAt } from "@/lib/ads-copy";
+import { flightEndBanner, flightEndDetail } from "@/lib/flight-end-copy";
 import { EmptyState } from "@/components/molecules/empty-state";
 import {
   AlertTriangle,
@@ -286,52 +287,42 @@ function FlightEndBanner() {
     staleTime: 30_000,
     refetchOnWindowFocus: false,
   });
-  const pastEnd = (campaigns.data?.campaigns ?? []).filter((r) => r.flightEndAlarm?.pastEnd);
-  if (pastEnd.length === 0) return null;
+  const rows = campaigns.data?.campaigns ?? [];
+  const copy = flightEndBanner(rows);
+  if (!copy) return null;
+  const pastEnd = rows.filter((r) => r.flightEndAlarm?.pastEnd);
 
   return (
-    <Card role="alert" className="border-destructive/40 bg-destructive/5">
+    // ★role="status", NOT role="alert", AND THAT IS DELIBERATE. SpendAlarmBanner
+    // is assertive because money is going out past a cap the user set. This one
+    // is usually "our record disagrees with LinkedIn" — worth seeing, not worth
+    // interrupting a screen-reader user mid-sentence for — and two simultaneous
+    // assertive regions announce the same campaign name twice, in full, on every
+    // Pause/Archive/Sync invalidation. `aria-label` distinguishes them.
+    <Card
+      role="status"
+      aria-label="Campaigns past their end date"
+      className="border-destructive/40 bg-destructive/5"
+    >
       <CardContent className="space-y-2 p-4 text-sm">
         <div className="flex items-start gap-2">
           <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
           <div className="space-y-1">
-            <p className="font-medium text-destructive">
-              {pastEnd.length === 1
-                ? "A campaign has passed its end date and is still running"
-                : `${pastEnd.length} campaigns have passed their end date and are still running`}
-            </p>
-            <p className="text-muted-foreground">
-              We could not stop {pastEnd.length === 1 ? "it" : "them"} on LinkedIn, so{" "}
-              {pastEnd.length === 1 ? "it may still be" : "they may still be"} spending.{" "}
-              <strong className="font-medium text-foreground">
-                Stop {pastEnd.length === 1 ? "it" : "them"} in LinkedIn Campaign Manager
-              </strong>{" "}
-              — the controls here use the same connection, so if that is what
-              failed they will fail again.
-            </p>
+            <p className="font-medium text-destructive">{copy.headline}</p>
+            <p className="text-muted-foreground">{copy.body}</p>
             <ul className="space-y-1 pt-1">
-              {pastEnd.map((r) => {
-                // ★REUSED, NOT REWRITTEN. `formatDeclaredAt` already renders a
-                // UTC instant as "30 Jul 2026" and already returns "" rather
-                // than the words "Invalid Date" — which inside an alert about
-                // somebody's money reads as a bug in the alarm and costs it the
-                // credibility it needs at the moment it is being read. A second
-                // near-identical formatter is how the two drift.
-                const ended = formatDeclaredAt(r.flightEndAlarm?.endsAt ?? "");
-                return (
-                  <li key={r._id} className="text-muted-foreground">
-                    <span className="font-medium text-foreground">{r.name}</span>
-                    {ended ? ` — ended ${ended}` : " — past its end date"}
-                    {/* ★NO INVENTED CAUSE. An absent reason means no tick has yet
-                        recorded why this campaign is still here — which is what a
-                        monitor that has not run since it expired looks like. "We
-                        cannot tell" must never render as an explanation. */}
-                    {r.flightEndAlarm?.reason
-                      ? `. ${r.flightEndAlarm.reason}.`
-                      : ". We have not yet recorded why it could not be stopped."}
-                  </li>
-                );
-              })}
+              {pastEnd.map((r) => (
+                <li key={r._id} className="text-muted-foreground">
+                  <span className="font-medium text-foreground">{r.name}</span>
+                  {" — "}
+                  {/* ★REUSED, NOT REWRITTEN. `formatDeclaredAt` already renders
+                      a UTC instant as "30 Jul 2026" and already returns "" rather
+                      than the words "Invalid Date" — which inside an alert about
+                      somebody's money reads as a bug in the alarm. A second
+                      near-identical formatter is how the two drift. */}
+                  {flightEndDetail(r.flightEndAlarm!, formatDeclaredAt(r.flightEndAlarm!.endsAt))}
+                </li>
+              ))}
             </ul>
           </div>
         </div>
@@ -458,10 +449,12 @@ function CampaignsPanel() {
         <p className="mt-3 border-t pt-2 text-[11px] text-muted-foreground">
           Campaigns are created in LinkedIn as drafts under a draft group —
           they cannot spend until you activate them. Set the audience with the
-          Audience button before activating. Campaigns are watched against
-          their total budget and flagged above if spend passes it — automatic
-          pausing currently runs only for campaigns started from WhatsApp, so
-          treat the flag as your signal to pause in LinkedIn Campaign Manager.
+          Audience button before activating. Every campaign is then checked
+          hourly and paused automatically when spend reaches the total budget
+          you set, or when it passes its end date — LinkedIn is not given an end
+          date of its own, so that stop is ours to make. If either one fails you
+          are told above; that is your signal to stop it in LinkedIn Campaign
+          Manager.
         </p>
       </CardContent>
     </Card>

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -136,7 +136,7 @@ export function LinkedInAdsPanel() {
           gate below renders an EmptyState — which used to hide this warning in
           the one case it matters most. */}
       <SpendAlarmBanner />
-      <FlightEndBanner />
+      <FlightEndBanner canUseRowControls={isConnected} />
       {/* Above the gate for the same reason, plus one of its own: the
           declaration governs every campaign create including the autonomous
           ones, and a business can make it before it connects. Not on
@@ -280,54 +280,61 @@ function SpendAlarmBanner() {
  * Hedged the same way, because for a rate limit or an undelivered request it
  * very likely succeeds on retry.
  */
-function FlightEndBanner() {
+function FlightEndBanner({ canUseRowControls }: { canUseRowControls: boolean }) {
   const campaigns = useQuery({
     queryKey: ["linkedin-managed-campaigns"],
     queryFn: () => linkedInAdsApi.managedCampaigns(),
     staleTime: 30_000,
     refetchOnWindowFocus: false,
   });
+  // ★MOUNTED WHETHER OR NOT THERE IS ANYTHING TO SAY, AND THAT IS THE POINT OF
+  // THE WRAPPER. A `role="status"` region that is inserted together with its
+  // content is announced by nobody: screen readers announce a polite live
+  // region when its CONTENTS change, not when the region itself appears. The
+  // fix for the double-announcement had removed the announcement.
   const rows = campaigns.data?.campaigns ?? [];
-  const copy = flightEndBanner(rows);
-  if (!copy) return null;
-  const pastEnd = rows.filter((r) => r.flightEndAlarm?.pastEnd);
+  // The banner cannot point at a row that is not on screen: it is mounted above
+  // the connection gate, and a revoked connection is the state most likely to
+  // produce these rows in the first place.
+  const copy = flightEndBanner(rows, canUseRowControls);
 
   return (
-    // ★role="status", NOT role="alert", AND THAT IS DELIBERATE. SpendAlarmBanner
-    // is assertive because money is going out past a cap the user set. This one
-    // is usually "our record disagrees with LinkedIn" — worth seeing, not worth
-    // interrupting a screen-reader user mid-sentence for — and two simultaneous
-    // assertive regions announce the same campaign name twice, in full, on every
-    // Pause/Archive/Sync invalidation. `aria-label` distinguishes them.
-    <Card
-      role="status"
-      aria-label="Campaigns past their end date"
-      className="border-destructive/40 bg-destructive/5"
-    >
-      <CardContent className="space-y-2 p-4 text-sm">
-        <div className="flex items-start gap-2">
-          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
-          <div className="space-y-1">
-            <p className="font-medium text-destructive">{copy.headline}</p>
-            <p className="text-muted-foreground">{copy.body}</p>
-            <ul className="space-y-1 pt-1">
-              {pastEnd.map((r) => (
-                <li key={r._id} className="text-muted-foreground">
-                  <span className="font-medium text-foreground">{r.name}</span>
-                  {" — "}
-                  {/* ★REUSED, NOT REWRITTEN. `formatDeclaredAt` already renders
-                      a UTC instant as "30 Jul 2026" and already returns "" rather
-                      than the words "Invalid Date" — which inside an alert about
-                      somebody's money reads as a bug in the alarm. A second
-                      near-identical formatter is how the two drift. */}
-                  {flightEndDetail(r.flightEndAlarm!, formatDeclaredAt(r.flightEndAlarm!.endsAt))}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <div role="status" aria-label="Campaigns past their end date">
+      {copy && (
+        <Card className="border-destructive/40 bg-destructive/5">
+          <CardContent className="space-y-2 p-4 text-sm">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
+              <div className="space-y-1">
+                {/* "Warning:" carries the severity that colour alone conveys —
+                    the icon is aria-hidden and this region is polite. */}
+                <p className="font-medium text-destructive">
+                  <span className="sr-only">Warning: </span>
+                  {copy.headline}
+                </p>
+                <p className="text-muted-foreground">{copy.body}</p>
+                <ul className="space-y-1 pt-1">
+                  {copy.rows.map((r) => (
+                    <li key={r._id} className="text-muted-foreground">
+                      <span className="font-medium text-foreground">{r.name}</span>
+                      {" — "}
+                      {/* ★REUSED, NOT REWRITTEN. `formatDeclaredAt` already
+                          returns "" rather than the words "Invalid Date", which
+                          inside an alert about somebody's money reads as a bug
+                          in the alarm. A second formatter is how the two drift. */}
+                      {flightEndDetail(
+                        r.flightEndAlarm!,
+                        formatDeclaredAt(r.flightEndAlarm!.endsAt),
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
   );
 }
 

--- a/src/app/(site)/dashboard/ads/ads-channels.ts
+++ b/src/app/(site)/dashboard/ads/ads-channels.ts
@@ -52,7 +52,7 @@ export const ADS_CHANNELS = [
     providerKey: "linkedin_ads",
     description:
       "Boost your proven LinkedIn posts into campaigns — created as non-spending drafts you activate when ready.",
-    crons: ["performance-sync", "growth-optimizer"],
+    crons: ["ad-campaign-monitor", "performance-sync", "growth-optimizer"],
     invalidateQueryKeys: [["linkedin-managed-campaigns"], ["content-hub-integrations"]],
     ownedParams: [],
   },

--- a/src/components/dev/cron-metadata.test.ts
+++ b/src/components/dev/cron-metadata.test.ts
@@ -165,8 +165,12 @@ describe("ad-campaign-monitor summary", () => {
 
   it("★leads with campaigns it could not stop, not with the count", () => {
     const s = summarize({ ticked: 40, refreshed: 40, flightEndBlocked: 2, unmonitorable: 1 });
-    expect(s).toMatchObject({ level: "warning" });
-    expect((s as { message: string }).message).toMatch(/could NOT be stopped/);
+    // ★THE FULL STRING. Asserting only /could NOT be stopped/ let the count be
+    // interpolated from the WRONG counter, and let the plural invert, unseen.
+    expect(s).toEqual({
+      message: "2 campaigns passed the end date and could NOT be stopped — check Campaign Manager.",
+      level: "warning",
+    });
   });
 
   it("★surfaces campaigns it could not check at all, on its own", () => {
@@ -174,17 +178,46 @@ describe("ad-campaign-monitor summary", () => {
     // higher-priority branch answers, and deleting this one entirely would
     // still pass. That is how a counter stops being surfaced silently.
     const s = summarize({ ticked: 40, refreshed: 40, unmonitorable: 3 });
-    expect(s).toMatchObject({ level: "warning" });
-    expect((s as { message: string }).message).toMatch(/could not be checked at all/);
+    expect(s).toEqual({ message: "3 campaigns could not be checked at all.", level: "warning" });
   });
 
-  it("★warns on a tick that visited campaigns but refreshed none", () => {
-    // `ticked` counts rows visited; a tick that returned early on a draft or a
-    // dead connection evaluated no budget at all. "40 checked" beside 0
-    // refreshed is the reassuring silence the cron exists to end.
-    const s = summarize({ ticked: 40, refreshed: 0 });
+  it("★does NOT warn just because nothing refreshed — that is the normal first state", () => {
+    // A first cut warned on `refreshed === 0`, framing it as a dead connection.
+    // It is equally the newly-onboarded happy path: `/boost` creates campaigns
+    // as drafts, a draft has nothing to refresh, and the sweep visits it anyway.
+    // Warning there trains the user to ignore the warning. The genuine faults
+    // are all counted separately and all outrank this line.
+    expect(summarize({ ticked: 40, refreshed: 0 })).toBe("0 campaigns checked.");
+  });
+
+  it("★surfaces a tick where every row THREW, which read as a green success", () => {
+    // The handler increments neither `ticked` nor `unmonitorable` in its per-row
+    // catch, so forty errored rows returned `{ticked: 0, failed: 40}` and the
+    // first cut rendered "0 campaigns checked." as a success toast.
+    const s = summarize({ ticked: 0, refreshed: 0, failed: 40 });
     expect(s).toMatchObject({ level: "warning" });
-    expect((s as { message: string }).message).toMatch(/none had live figures/);
+    expect((s as { message: string }).message).toMatch(/40 campaigns could not be checked/);
+  });
+
+  it("★surfaces the opposite failure: stopped on the platform, not recorded here", () => {
+    const s = summarize({ ticked: 3, refreshed: 3, rowNotUpdated: 2 });
+    expect(s).toMatchObject({ level: "warning" });
+    expect((s as { message: string }).message).toMatch(/could not be updated here/);
+  });
+
+  it("★surfaces campaigns in a status nothing sweeps, and rows that could not be read", () => {
+    expect(summarize({ ticked: 5, refreshed: 5, unswept: 2 })).toMatchObject({ level: "warning" });
+    expect(summarize({ ticked: 5, refreshed: 5, notFound: 1, skippedUnreadable: 2 })).toMatchObject({
+      level: "warning",
+    });
+    expect(
+      (summarize({ ticked: 5, refreshed: 5, notFound: 1, skippedUnreadable: 2 }) as { message: string })
+        .message,
+    ).toMatch(/3 campaign rows could not be read/);
+  });
+
+  it("distinguishes an empty batch from a batch that did nothing", () => {
+    expect(summarize({ ticked: 0, refreshed: 0 })).toBe("No campaigns needed checking.");
   });
 
   it("reports a healthy tick with the number that means something", () => {
@@ -194,13 +227,23 @@ describe("ad-campaign-monitor summary", () => {
   });
 
   it("says a capped tick is not finished", () => {
-    expect(summarize({ ticked: 40, refreshed: 40, truncated: true })).toMatchObject({
+    expect(summarize({ ticked: 40, refreshed: 40, truncated: true })).toEqual({
+      message: "40 campaigns checked. More remain — run again.",
       level: "warning",
     });
   });
 
-  it("singularises, and defers to the generic toast on a shape it does not recognise", () => {
+  it("singularises everywhere, including the plural that read `3 paused at its budget cap`", () => {
     expect(summarize({ ticked: 1, refreshed: 1 })).toBe("1 campaign checked.");
+    expect(summarize({ ticked: 3, refreshed: 3, autoPaused: 3 })).toBe(
+      "3 campaigns checked, 3 paused at their budget caps.",
+    );
+    expect(summarize({ ticked: 1, refreshed: 1, autoPaused: 1 })).toBe(
+      "1 campaign checked, 1 paused at its budget cap.",
+    );
+    expect(summarize({ ticked: 1, refreshed: 1, flightEndBlocked: 1 })).toMatchObject({
+      message: "1 campaign passed the end date and could NOT be stopped — check Campaign Manager.",
+    });
     expect(summarize({})).toBeNull();
     expect(summarize(null)).toBeNull();
     expect(summarize("nonsense")).toBeNull();

--- a/src/components/dev/cron-metadata.test.ts
+++ b/src/components/dev/cron-metadata.test.ts
@@ -162,62 +162,78 @@ describe("summarizeCronBody", () => {
  */
 describe("ad-campaign-monitor summary", () => {
   const summarize = CRON_METADATA["ad-campaign-monitor"].summarize!;
+  const msg = (d: unknown) => {
+    const r = summarize(d);
+    return typeof r === "string" ? r : r?.message;
+  };
 
-  it("★leads with campaigns it could not stop, not with the count", () => {
-    const s = summarize({ ticked: 40, refreshed: 40, flightEndBlocked: 2, unmonitorable: 1 });
-    // ★THE FULL STRING. Asserting only /could NOT be stopped/ let the count be
-    // interpolated from the WRONG counter, and let the plural invert, unseen.
-    expect(s).toEqual({
-      message: "2 campaigns passed the end date and could NOT be stopped — check Campaign Manager.",
+  it("\u2605says EVERY problem, not just the worst one", () => {
+    // A first cut returned on the first branch that matched, so thirty-five
+    // errored rows went unmentioned beside one blocked flight end. Ordered
+    // worst-first; all of them said.
+    expect(summarize({ ticked: 5, refreshed: 5, failed: 35, flightEndBlocked: 1 })).toEqual({
+      message:
+        "1 passed the end date and could NOT be stopped \u2014 check Campaign Manager; 35 errored.",
       level: "warning",
     });
   });
 
-  it("★surfaces campaigns it could not check at all, on its own", () => {
-    // Asserted WITHOUT flightEndBlocked beside it: with both set the
-    // higher-priority branch answers, and deleting this one entirely would
-    // still pass. That is how a counter stops being surfaced silently.
-    const s = summarize({ ticked: 40, refreshed: 40, unmonitorable: 3 });
-    expect(s).toEqual({ message: "3 campaigns could not be checked at all.", level: "warning" });
+  it("\u2605leads with campaigns it could not stop", () => {
+    expect(summarize({ ticked: 40, refreshed: 40, flightEndBlocked: 2, unmonitorable: 1 })).toEqual({
+      message:
+        "2 passed the end date and could NOT be stopped \u2014 check Campaign Manager; 1 could not be checked at all.",
+      level: "warning",
+    });
   });
 
-  it("★does NOT warn just because nothing refreshed — that is the normal first state", () => {
-    // A first cut warned on `refreshed === 0`, framing it as a dead connection.
-    // It is equally the newly-onboarded happy path: `/boost` creates campaigns
-    // as drafts, a draft has nothing to refresh, and the sweep visits it anyway.
-    // Warning there trains the user to ignore the warning. The genuine faults
-    // are all counted separately and all outrank this line.
+  it("\u2605surfaces a tick where every row THREW, which read as a green success", () => {
+    // The handler increments neither `ticked` nor `unmonitorable` in its per-row
+    // catch, so forty errored rows returned {ticked: 0, failed: 40} and the
+    // first cut rendered "0 campaigns checked." as a success toast.
+    expect(summarize({ ticked: 0, refreshed: 0, failed: 40 })).toEqual({
+      message: "40 errored.",
+      level: "warning",
+    });
+  });
+
+  it("\u2605surfaces each remaining counter on its own, so none can be dropped unseen", () => {
+    // Asserted one at a time: with two set, the higher-priority branch answers
+    // and deleting the lower one entirely would still pass.
+    expect(msg({ ticked: 40, refreshed: 40, unmonitorable: 3 })).toBe("3 could not be checked at all.");
+    expect(msg({ ticked: 3, refreshed: 3, rowNotUpdated: 2 })).toBe(
+      "2 stopped on the platform but not updated here.",
+    );
+    expect(msg({ ticked: 5, refreshed: 5, unswept: 2 })).toBe("2 in a status nothing monitors.");
+    expect(msg({ ticked: 5, refreshed: 5, notFound: 1 })).toBe("1 could not be read.");
+    expect(msg({ ticked: 5, refreshed: 5, skippedUnreadable: 2 })).toBe("2 could not be read.");
+    expect(msg({ ticked: 5, refreshed: 5, notFound: 1, skippedUnreadable: 2 })).toBe(
+      "3 could not be read.",
+    );
+  });
+
+  it("\u2605keeps `More remain` on a capped tick that ALSO had problems", () => {
+    // `truncated` used to be reachable only when no warning fired, so a capped
+    // tick with blocked flight ends lost "run again" entirely — and the tail of
+    // that queue is exactly what was not enforced.
+    expect(msg({ ticked: 40, refreshed: 40, flightEndBlocked: 1, truncated: true })).toContain(
+      "More remain \u2014 run again.",
+    );
+  });
+
+  it("\u2605does NOT warn just because nothing refreshed — that is the normal first state", () => {
+    // `/boost` creates campaigns as drafts, a draft has nothing to refresh, and
+    // the sweep visits it anyway. Warning there trains the user to ignore the
+    // warning.
     expect(summarize({ ticked: 40, refreshed: 0 })).toBe("0 campaigns checked.");
   });
 
-  it("★surfaces a tick where every row THREW, which read as a green success", () => {
-    // The handler increments neither `ticked` nor `unmonitorable` in its per-row
-    // catch, so forty errored rows returned `{ticked: 0, failed: 40}` and the
-    // first cut rendered "0 campaigns checked." as a success toast.
-    const s = summarize({ ticked: 0, refreshed: 0, failed: 40 });
-    expect(s).toMatchObject({ level: "warning" });
-    expect((s as { message: string }).message).toMatch(/40 campaigns could not be checked/);
-  });
-
-  it("★surfaces the opposite failure: stopped on the platform, not recorded here", () => {
-    const s = summarize({ ticked: 3, refreshed: 3, rowNotUpdated: 2 });
-    expect(s).toMatchObject({ level: "warning" });
-    expect((s as { message: string }).message).toMatch(/could not be updated here/);
-  });
-
-  it("★surfaces campaigns in a status nothing sweeps, and rows that could not be read", () => {
-    expect(summarize({ ticked: 5, refreshed: 5, unswept: 2 })).toMatchObject({ level: "warning" });
-    expect(summarize({ ticked: 5, refreshed: 5, notFound: 1, skippedUnreadable: 2 })).toMatchObject({
-      level: "warning",
-    });
-    expect(
-      (summarize({ ticked: 5, refreshed: 5, notFound: 1, skippedUnreadable: 2 }) as { message: string })
-        .message,
-    ).toMatch(/3 campaign rows could not be read/);
-  });
-
-  it("distinguishes an empty batch from a batch that did nothing", () => {
-    expect(summarize({ ticked: 0, refreshed: 0 })).toBe("No campaigns needed checking.");
+  it("\u2605never says `0 campaigns checked, 12 finished` — a sentence that contradicts itself", () => {
+    // Reachable: a row the platform has never heard of ends WITHOUT ever
+    // refreshing (the monitor returns `ended` with no `refreshed`).
+    expect(summarize({ ticked: 12, refreshed: 0, ended: 12 })).toBe("12 finished.");
+    expect(summarize({ ticked: 12, refreshed: 0, autoPaused: 2, ended: 10 })).toBe(
+      "2 paused at their budget caps, 10 finished.",
+    );
   });
 
   it("reports a healthy tick with the number that means something", () => {
@@ -228,9 +244,24 @@ describe("ad-campaign-monitor summary", () => {
 
   it("says a capped tick is not finished", () => {
     expect(summarize({ ticked: 40, refreshed: 40, truncated: true })).toEqual({
-      message: "40 campaigns checked. More remain — run again.",
+      message: "40 campaigns checked. More remain \u2014 run again.",
       level: "warning",
     });
+  });
+
+  it("\u2605counts an all-X batch as work, not as an empty one", () => {
+    // `skippedOtherWriter` is one of the six mutually-exclusive per-row
+    // outcomes. Omitting it from the batch total made a tick of forty X
+    // campaigns report "No campaigns needed checking." — and swallowed
+    // `truncated` with it, because the empty answer returns first.
+    expect(summarize({ ticked: 0, refreshed: 0, skippedOtherWriter: 40, truncated: true })).toEqual({
+      message: "0 campaigns checked. More remain \u2014 run again.",
+      level: "warning",
+    });
+  });
+
+  it("distinguishes an empty batch from a batch that did nothing", () => {
+    expect(summarize({ ticked: 0, refreshed: 0 })).toBe("No campaigns needed checking.");
   });
 
   it("singularises everywhere, including the plural that read `3 paused at its budget cap`", () => {
@@ -241,9 +272,9 @@ describe("ad-campaign-monitor summary", () => {
     expect(summarize({ ticked: 1, refreshed: 1, autoPaused: 1 })).toBe(
       "1 campaign checked, 1 paused at its budget cap.",
     );
-    expect(summarize({ ticked: 1, refreshed: 1, flightEndBlocked: 1 })).toMatchObject({
-      message: "1 campaign passed the end date and could NOT be stopped — check Campaign Manager.",
-    });
+  });
+
+  it("defers to the generic toast on a shape it does not recognise", () => {
     expect(summarize({})).toBeNull();
     expect(summarize(null)).toBeNull();
     expect(summarize("nonsense")).toBeNull();

--- a/src/components/dev/cron-metadata.test.ts
+++ b/src/components/dev/cron-metadata.test.ts
@@ -149,3 +149,60 @@ describe("summarizeCronBody", () => {
     expect(summarizeCronBody(withoutSummarizer!, JSON.stringify({ ok: true }))).toBeNull();
   });
 });
+
+/**
+ * ★THE AD MONITOR'S SUMMARY IS THE ONE THAT CAN SAY SOMETHING FALSE ABOUT
+ * SOMEBODY'S MONEY.
+ *
+ * Its payload carries two counters whose whole purpose is that a broken tick
+ * must not read like a healthy one — `flightEndBlocked` (campaigns past their
+ * end date that could not be stopped, and LinkedIn carries no `runSchedule.end`
+ * so nothing else will stop them) and `unmonitorable`. Both otherwise hide
+ * inside a green "40 campaigns checked."
+ */
+describe("ad-campaign-monitor summary", () => {
+  const summarize = CRON_METADATA["ad-campaign-monitor"].summarize!;
+
+  it("★leads with campaigns it could not stop, not with the count", () => {
+    const s = summarize({ ticked: 40, refreshed: 40, flightEndBlocked: 2, unmonitorable: 1 });
+    expect(s).toMatchObject({ level: "warning" });
+    expect((s as { message: string }).message).toMatch(/could NOT be stopped/);
+  });
+
+  it("★surfaces campaigns it could not check at all, on its own", () => {
+    // Asserted WITHOUT flightEndBlocked beside it: with both set the
+    // higher-priority branch answers, and deleting this one entirely would
+    // still pass. That is how a counter stops being surfaced silently.
+    const s = summarize({ ticked: 40, refreshed: 40, unmonitorable: 3 });
+    expect(s).toMatchObject({ level: "warning" });
+    expect((s as { message: string }).message).toMatch(/could not be checked at all/);
+  });
+
+  it("★warns on a tick that visited campaigns but refreshed none", () => {
+    // `ticked` counts rows visited; a tick that returned early on a draft or a
+    // dead connection evaluated no budget at all. "40 checked" beside 0
+    // refreshed is the reassuring silence the cron exists to end.
+    const s = summarize({ ticked: 40, refreshed: 0 });
+    expect(s).toMatchObject({ level: "warning" });
+    expect((s as { message: string }).message).toMatch(/none had live figures/);
+  });
+
+  it("reports a healthy tick with the number that means something", () => {
+    expect(summarize({ ticked: 12, refreshed: 9, autoPaused: 1, ended: 2 })).toBe(
+      "9 campaigns checked, 1 paused at its budget cap, 2 finished.",
+    );
+  });
+
+  it("says a capped tick is not finished", () => {
+    expect(summarize({ ticked: 40, refreshed: 40, truncated: true })).toMatchObject({
+      level: "warning",
+    });
+  });
+
+  it("singularises, and defers to the generic toast on a shape it does not recognise", () => {
+    expect(summarize({ ticked: 1, refreshed: 1 })).toBe("1 campaign checked.");
+    expect(summarize({})).toBeNull();
+    expect(summarize(null)).toBeNull();
+    expect(summarize("nonsense")).toBeNull();
+  });
+});

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -47,6 +47,62 @@ export interface CronMetadata {
 }
 
 export const CRON_METADATA: Record<string, CronMetadata> = {
+  "ad-campaign-monitor": {
+    label: "Check ad campaigns",
+    frequency: "Runs every hour",
+    description:
+      "Refreshes each live ad campaign's spend from the platform, pauses one that has reached the total budget you set, and stops one that has passed its end date.",
+    summarize: (data) => {
+      const d = data as
+        | {
+            ticked?: number;
+            refreshed?: number;
+            autoPaused?: number;
+            ended?: number;
+            unmonitorable?: number;
+            flightEndBlocked?: number;
+            truncated?: boolean;
+          }
+        | null;
+      if (typeof d?.ticked !== "number") return null;
+
+      // ★THE TWO BAD OUTCOMES OUTRANK THE COUNT, because both mean a campaign
+      // may still be spending with nothing able to stop it — and both otherwise
+      // hide inside a green "40 campaigns checked."
+      if (typeof d.flightEndBlocked === "number" && d.flightEndBlocked > 0) {
+        return {
+          message: `${d.flightEndBlocked} campaign${d.flightEndBlocked === 1 ? "" : "s"} passed the end date and could NOT be stopped — check Campaign Manager.`,
+          level: "warning",
+        };
+      }
+      if (typeof d.unmonitorable === "number" && d.unmonitorable > 0) {
+        return {
+          message: `${d.unmonitorable} campaign${d.unmonitorable === 1 ? "" : "s"} could not be checked at all.`,
+          level: "warning",
+        };
+      }
+
+      // ★`refreshed`, NOT `ticked`, IS THE NUMBER THAT MEANS ANYTHING. A tick
+      // that returned early on a draft or a dead connection evaluated no
+      // budget at all, so "40 checked" beside 0 refreshed is the reassuring
+      // silence this cron exists to end.
+      const refreshed = typeof d.refreshed === "number" ? d.refreshed : 0;
+      if (d.ticked > 0 && refreshed === 0) {
+        return {
+          message: `${d.ticked} campaign${d.ticked === 1 ? "" : "s"} visited, but none had live figures to check.`,
+          level: "warning",
+        };
+      }
+      const parts = [`${refreshed} campaign${refreshed === 1 ? "" : "s"} checked`];
+      if (d.autoPaused) parts.push(`${d.autoPaused} paused at its budget cap`);
+      if (d.ended) parts.push(`${d.ended} finished`);
+      const message = `${parts.join(", ")}.`;
+      // A capped tick is not hourly enforcement for the tail of the queue.
+      return d.truncated
+        ? { message: `${message} More remain — run again.`, level: "warning" }
+        : message;
+    },
+  },
   "media-cleanup-suggestions": {
     label: "Find cleanup suggestions",
     frequency: "Runs weekly (Sun 4:00 AM UTC)",

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -49,9 +49,9 @@ export interface CronMetadata {
 export const CRON_METADATA: Record<string, CronMetadata> = {
   "ad-campaign-monitor": {
     label: "Check ad campaigns",
-    frequency: "Runs every hour",
+    frequency: "Runs hourly (at :15 past)",
     description:
-      "Refreshes each live ad campaign's spend from the platform, pauses one that has reached the total budget you set, and stops one that has passed its end date.",
+      "Refreshes ad campaigns' spend from the platform, pauses one that has reached the total budget you set, and stops one that has passed its end date. Up to 40 campaigns per run; X campaigns are handled by their own sync.",
     summarize: (data) => {
       const d = data as
         | {
@@ -61,46 +61,71 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
             ended?: number;
             unmonitorable?: number;
             flightEndBlocked?: number;
+            rowNotUpdated?: number;
+            failed?: number;
+            notFound?: number;
+            unswept?: number;
+            skippedUnreadable?: number;
             truncated?: boolean;
           }
         | null;
+      const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
       if (typeof d?.ticked !== "number") return null;
 
-      // ★THE TWO BAD OUTCOMES OUTRANK THE COUNT, because both mean a campaign
-      // may still be spending with nothing able to stop it — and both otherwise
-      // hide inside a green "40 campaigns checked."
-      if (typeof d.flightEndBlocked === "number" && d.flightEndBlocked > 0) {
-        return {
-          message: `${d.flightEndBlocked} campaign${d.flightEndBlocked === 1 ? "" : "s"} passed the end date and could NOT be stopped — check Campaign Manager.`,
-          level: "warning",
-        };
+      const batch =
+        num(d.ticked) +
+        num(d.unmonitorable) +
+        num(d.failed) +
+        num(d.notFound) +
+        num(d.skippedUnreadable);
+      if (batch === 0) return "No campaigns needed checking.";
+
+      // ★EVERY OUTCOME THAT MEANS "NOBODY IS WATCHING THIS CAMPAIGN" OUTRANKS
+      // THE COUNT, because each of them otherwise hides inside a green
+      // "40 campaigns checked." A first cut read only two of the six, so a tick
+      // where every single row threw reported `{ticked: 0, failed: 40}` as
+      // "0 campaigns checked." — a success toast over forty logged errors.
+      const warn = (message: string) => ({ message, level: "warning" as const });
+      const plural = (n: number) => (n === 1 ? "" : "s");
+      if (num(d.flightEndBlocked) > 0) {
+        return warn(
+          `${d.flightEndBlocked} campaign${plural(num(d.flightEndBlocked))} passed the end date and could NOT be stopped — check Campaign Manager.`,
+        );
       }
-      if (typeof d.unmonitorable === "number" && d.unmonitorable > 0) {
-        return {
-          message: `${d.unmonitorable} campaign${d.unmonitorable === 1 ? "" : "s"} could not be checked at all.`,
-          level: "warning",
-        };
+      if (num(d.failed) > 0) {
+        return warn(`${d.failed} campaign${plural(num(d.failed))} could not be checked — the run errored on ${num(d.failed) === 1 ? "it" : "them"}.`);
+      }
+      if (num(d.unmonitorable) > 0) {
+        return warn(`${d.unmonitorable} campaign${plural(num(d.unmonitorable))} could not be checked at all.`);
+      }
+      if (num(d.rowNotUpdated) > 0) {
+        // The OPPOSITE failure: spend has stopped, our record has not caught up.
+        return warn(
+          `${d.rowNotUpdated} campaign${plural(num(d.rowNotUpdated))} stopped on the platform but could not be updated here.`,
+        );
+      }
+      if (num(d.unswept) > 0) {
+        return warn(`${d.unswept} campaign${plural(num(d.unswept))} in a status nothing is monitoring.`);
+      }
+      if (num(d.notFound) > 0 || num(d.skippedUnreadable) > 0) {
+        const n = num(d.notFound) + num(d.skippedUnreadable);
+        return warn(`${n} campaign row${plural(n)} could not be read.`);
       }
 
-      // ★`refreshed`, NOT `ticked`, IS THE NUMBER THAT MEANS ANYTHING. A tick
-      // that returned early on a draft or a dead connection evaluated no
-      // budget at all, so "40 checked" beside 0 refreshed is the reassuring
-      // silence this cron exists to end.
-      const refreshed = typeof d.refreshed === "number" ? d.refreshed : 0;
-      if (d.ticked > 0 && refreshed === 0) {
-        return {
-          message: `${d.ticked} campaign${d.ticked === 1 ? "" : "s"} visited, but none had live figures to check.`,
-          level: "warning",
-        };
+      // ★`refreshed`, NOT `ticked`, IS THE NUMBER THAT MEANS ANYTHING: a tick
+      // that returned early evaluated no budget at all. But zero refreshed is
+      // NOT a fault on its own — a business whose campaigns are all drafts is
+      // the normal newly-onboarded state, and `/boost` creates drafts. The
+      // fault cases are all handled above, so this reports rather than warns.
+      const refreshed = num(d.refreshed);
+      const parts = [`${refreshed} campaign${plural(refreshed)} checked`];
+      if (num(d.autoPaused) > 0) {
+        parts.push(`${d.autoPaused} paused at ${num(d.autoPaused) === 1 ? "its budget cap" : "their budget caps"}`);
       }
-      const parts = [`${refreshed} campaign${refreshed === 1 ? "" : "s"} checked`];
-      if (d.autoPaused) parts.push(`${d.autoPaused} paused at its budget cap`);
-      if (d.ended) parts.push(`${d.ended} finished`);
+      if (num(d.ended) > 0) parts.push(`${d.ended} finished`);
       const message = `${parts.join(", ")}.`;
       // A capped tick is not hourly enforcement for the tail of the queue.
-      return d.truncated
-        ? { message: `${message} More remain — run again.`, level: "warning" }
-        : message;
+      return d.truncated ? warn(`${message} More remain — run again.`) : message;
     },
   },
   "media-cleanup-suggestions": {

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -66,66 +66,82 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
             notFound?: number;
             unswept?: number;
             skippedUnreadable?: number;
+            skippedOtherWriter?: number;
             truncated?: boolean;
           }
         | null;
       const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
       if (typeof d?.ticked !== "number") return null;
 
+      // ★ALL SIX MUTUALLY-EXCLUSIVE PER-ROW OUTCOMES. Reading the sweep's loop:
+      // exactly one of {skippedUnreadable, skippedOtherWriter}, one of
+      // {notFound, unmonitorable, ticked}, or `failed` increments per row. A
+      // first cut summed five and omitted `skippedOtherWriter`, so a batch of
+      // forty X campaigns reported "No campaigns needed checking." — and
+      // swallowed `truncated` with it, because the empty-batch answer returns
+      // before the truncation check.
       const batch =
         num(d.ticked) +
         num(d.unmonitorable) +
         num(d.failed) +
         num(d.notFound) +
-        num(d.skippedUnreadable);
+        num(d.skippedUnreadable) +
+        num(d.skippedOtherWriter);
       if (batch === 0) return "No campaigns needed checking.";
 
-      // ★EVERY OUTCOME THAT MEANS "NOBODY IS WATCHING THIS CAMPAIGN" OUTRANKS
-      // THE COUNT, because each of them otherwise hides inside a green
-      // "40 campaigns checked." A first cut read only two of the six, so a tick
-      // where every single row threw reported `{ticked: 0, failed: 40}` as
-      // "0 campaigns checked." — a success toast over forty logged errors.
-      const warn = (message: string) => ({ message, level: "warning" as const });
       const plural = (n: number) => (n === 1 ? "" : "s");
+
+      // ★EVERY OUTCOME THAT MEANS "NOBODY IS WATCHING THIS CAMPAIGN" IS
+      // COLLECTED, NOT JUST THE WORST ONE. Each of them otherwise hides inside a
+      // green "40 campaigns checked." A first cut read two of the seven, so a
+      // tick where every single row threw reported {ticked: 0, failed: 40} as
+      // "0 campaigns checked." — a success toast over forty logged errors. A
+      // later cut read all of them but returned on the FIRST, so thirty-five
+      // errored rows went unmentioned beside one blocked flight end. Ordered
+      // worst-first; all of them said.
+      const problems: string[] = [];
       if (num(d.flightEndBlocked) > 0) {
-        return warn(
-          `${d.flightEndBlocked} campaign${plural(num(d.flightEndBlocked))} passed the end date and could NOT be stopped — check Campaign Manager.`,
+        problems.push(
+          `${d.flightEndBlocked} passed the end date and could NOT be stopped — check Campaign Manager`,
         );
       }
-      if (num(d.failed) > 0) {
-        return warn(`${d.failed} campaign${plural(num(d.failed))} could not be checked — the run errored on ${num(d.failed) === 1 ? "it" : "them"}.`);
-      }
-      if (num(d.unmonitorable) > 0) {
-        return warn(`${d.unmonitorable} campaign${plural(num(d.unmonitorable))} could not be checked at all.`);
-      }
+      if (num(d.failed) > 0) problems.push(`${d.failed} errored`);
+      if (num(d.unmonitorable) > 0) problems.push(`${d.unmonitorable} could not be checked at all`);
       if (num(d.rowNotUpdated) > 0) {
         // The OPPOSITE failure: spend has stopped, our record has not caught up.
-        return warn(
-          `${d.rowNotUpdated} campaign${plural(num(d.rowNotUpdated))} stopped on the platform but could not be updated here.`,
-        );
+        problems.push(`${d.rowNotUpdated} stopped on the platform but not updated here`);
       }
-      if (num(d.unswept) > 0) {
-        return warn(`${d.unswept} campaign${plural(num(d.unswept))} in a status nothing is monitoring.`);
-      }
-      if (num(d.notFound) > 0 || num(d.skippedUnreadable) > 0) {
-        const n = num(d.notFound) + num(d.skippedUnreadable);
-        return warn(`${n} campaign row${plural(n)} could not be read.`);
-      }
+      if (num(d.unswept) > 0) problems.push(`${d.unswept} in a status nothing monitors`);
+      const unreadable = num(d.notFound) + num(d.skippedUnreadable);
+      if (unreadable > 0) problems.push(`${unreadable} could not be read`);
 
       // ★`refreshed`, NOT `ticked`, IS THE NUMBER THAT MEANS ANYTHING: a tick
       // that returned early evaluated no budget at all. But zero refreshed is
       // NOT a fault on its own — a business whose campaigns are all drafts is
-      // the normal newly-onboarded state, and `/boost` creates drafts. The
-      // fault cases are all handled above, so this reports rather than warns.
+      // the normal newly-onboarded state, and `/boost` creates drafts. So it
+      // reports rather than warns, and it does not lead when there is nothing
+      // to report: "0 campaigns checked, 12 finished." is a sentence that
+      // contradicts itself, and it is reachable — the rows the platform has
+      // never heard of end without ever refreshing.
       const refreshed = num(d.refreshed);
-      const parts = [`${refreshed} campaign${plural(refreshed)} checked`];
-      if (num(d.autoPaused) > 0) {
-        parts.push(`${d.autoPaused} paused at ${num(d.autoPaused) === 1 ? "its budget cap" : "their budget caps"}`);
+      const done: string[] = [];
+      if (refreshed > 0 || (num(d.ended) === 0 && num(d.autoPaused) === 0)) {
+        done.push(`${refreshed} campaign${plural(refreshed)} checked`);
       }
-      if (num(d.ended) > 0) parts.push(`${d.ended} finished`);
-      const message = `${parts.join(", ")}.`;
+      if (num(d.autoPaused) > 0) {
+        done.push(
+          `${d.autoPaused} paused at ${num(d.autoPaused) === 1 ? "its budget cap" : "their budget caps"}`,
+        );
+      }
+      if (num(d.ended) > 0) done.push(`${d.ended} finished`);
+
+      const tail = d.truncated ? " More remain — run again." : "";
+      if (problems.length > 0) {
+        return { message: `${problems.join("; ")}.${tail}`, level: "warning" as const };
+      }
+      const message = `${done.join(", ")}.${tail}`;
       // A capped tick is not hourly enforcement for the tail of the queue.
-      return d.truncated ? warn(`${message} More remain — run again.`) : message;
+      return d.truncated ? { message, level: "warning" as const } : message;
     },
   },
   "media-cleanup-suggestions": {

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -159,6 +159,23 @@ export interface ManagedCampaign {
    * number under the cap next to an alarm saying it was over.
    */
   spendAlarm?: { overCap: true; spend: number; cap: number; reason?: string };
+  /**
+   * Past the end date its owner set, and still `active`.
+   *
+   * ★A DIFFERENT ABSENCE FROM `spendAlarm`, WHICH IS WHY IT IS A DIFFERENT
+   * FIELD. LinkedIn never carries an `end` on the campaign's `runSchedule` —
+   * the flight cap lives only on our row — so the monitor has to stop the
+   * campaign on the platform itself, and it leaves the row `active` when it
+   * cannot. `spendAlarm` does not cover that: it requires the campaign to be
+   * over its budget cap, and this population is exactly the campaigns that
+   * UNDER-spend. A campaign can be in one, the other, or both.
+   *
+   * `reason` absent is meaningful and must not be filled in here — it means no
+   * tick has yet recorded WHY the campaign is still running, which is what a
+   * monitor that has not run since it expired looks like. "We cannot tell" is
+   * its own answer.
+   */
+  flightEndAlarm?: { pastEnd: true; endsAt: string; reason?: string };
   createdAt: string;
   updatedAt?: string;
   /** Audit ids (hex) — present on rows created via the routes. */

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -175,7 +175,25 @@ export interface ManagedCampaign {
    * monitor that has not run since it expired looks like. "We cannot tell" is
    * its own answer.
    */
-  flightEndAlarm?: { pastEnd: true; endsAt: string; reason?: string };
+  flightEndAlarm?: {
+    pastEnd: true;
+    endsAt: string;
+    /**
+     * Has any monitor tick looked at this row since it expired? False means
+     * nobody has asked yet — the ordinary gap before the hourly sweep reaches
+     * it, and permanent on dev where crons do not run. A surface that reads
+     * that as "we tried and failed" is inventing a failure.
+     */
+    checkedSinceEnd: boolean;
+    /**
+     * Present ONLY when a stop was attempted and failed. This is the only
+     * evidence that "we could not stop it" is a true sentence. Its absence
+     * covers three different situations — not looked at yet, looked at and
+     * fine, and the one where the platform stop SUCCEEDED and only our local
+     * write failed — and none of them is a failure to stop.
+     */
+    reason?: string;
+  };
   createdAt: string;
   updatedAt?: string;
   /** Audit ids (hex) — present on rows created via the routes. */

--- a/src/lib/flight-end-copy.test.ts
+++ b/src/lib/flight-end-copy.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  flightEndBanner,
+  flightEndDetail,
+  flightEndState,
+  elapsedSince,
+  type FlightEndRow,
+} from "./flight-end-copy";
+
+/**
+ * ★THE BANNER'S FIRST CUT ASSERTED A CAUSE THE API NEVER ESTABLISHED.
+ *
+ * It said, above every row, "We could not stop them on LinkedIn, so they may
+ * still be spending." `flightEndAlarm` is derived from two facts — `active`
+ * and past `endsAt` — which is also what a campaign looks like when the sweep
+ * has not reached it (forever, on dev, where crons do not run), and when the
+ * platform stop SUCCEEDED and only our local write failed. In that last case
+ * every clause was false and the customer was sent to Campaign Manager to stop
+ * an already-stopped campaign.
+ */
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-08-07T12:00:00Z");
+const endedIso = new Date(NOW - 4 * DAY).toISOString();
+
+function row(over: Partial<FlightEndRow["flightEndAlarm"]> = {}, id = "1"): FlightEndRow {
+  return {
+    _id: id,
+    name: "Q3 demand gen",
+    flightEndAlarm: { pastEnd: true, endsAt: endedIso, checkedSinceEnd: true, ...over },
+  };
+}
+
+describe("flightEndState — the three absences stay distinct", () => {
+  it("a recorded reason is the ONLY evidence that a stop failed", () => {
+    expect(flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: true, reason: "x" }))
+      .toBe("stop_failed");
+  });
+
+  it("nobody has asked yet is its own state, not a quiet failure", () => {
+    expect(flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: false })).toBe(
+      "not_checked",
+    );
+  });
+
+  it("asked, and nothing recorded, is a third thing again", () => {
+    expect(flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: true })).toBe(
+      "no_failure_recorded",
+    );
+  });
+
+  it("a reason wins over checkedSinceEnd — the evidence outranks the timestamp", () => {
+    expect(
+      flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: false, reason: "x" }),
+    ).toBe("stop_failed");
+  });
+});
+
+describe("flightEndDetail — one row's sentence", () => {
+  it("★only claims a failure when one was recorded", () => {
+    const failed = flightEndDetail(row({ reason: "the connection needs a reconnect" }).flightEndAlarm!, "3 Aug 2026", NOW);
+    expect(failed).toContain("We could not stop it");
+    expect(failed).toContain("the connection needs a reconnect");
+
+    const unchecked = flightEndDetail(row({ checkedSinceEnd: false }).flightEndAlarm!, "3 Aug 2026", NOW);
+    expect(unchecked).not.toContain("could not stop");
+    expect(unchecked).toContain("cannot tell whether it is still running");
+
+    const quiet = flightEndDetail(row().flightEndAlarm!, "3 Aug 2026", NOW);
+    expect(quiet).not.toContain("could not stop");
+    expect(quiet).toContain("may already be stopped");
+  });
+
+  it("★never doubles the full stop on an api-authored sentence", () => {
+    const withStop = flightEndDetail(row({ reason: "LinkedIn refused the ad account." }).flightEndAlarm!, "3 Aug 2026", NOW);
+    expect(withStop).not.toContain("..");
+    const without = flightEndDetail(row({ reason: "LinkedIn refused the ad account" }).flightEndAlarm!, "3 Aug 2026", NOW);
+    expect(without.endsWith(".")).toBe(true);
+  });
+
+  it("carries how long ago, which is the number that conveys urgency", () => {
+    expect(flightEndDetail(row().flightEndAlarm!, "3 Aug 2026", NOW)).toContain("(4 days ago)");
+  });
+
+  it("survives an empty formatted date rather than rendering an empty clause", () => {
+    const s = flightEndDetail(row().flightEndAlarm!, "", NOW);
+    expect(s).toContain("past its end date");
+    expect(s).not.toContain("ended .");
+  });
+});
+
+describe("elapsedSince", () => {
+  it("reads in hours below two days and days above", () => {
+    expect(elapsedSince(new Date(NOW - 5 * 3_600_000).toISOString(), NOW)).toBe("5 hours");
+    expect(elapsedSince(new Date(NOW - 1 * 3_600_000).toISOString(), NOW)).toBe("1 hour");
+    expect(elapsedSince(new Date(NOW - 3 * DAY).toISOString(), NOW)).toBe("3 days");
+    expect(elapsedSince(new Date(NOW - 1 * DAY).toISOString(), NOW)).toBe("24 hours");
+  });
+
+  it("says nothing rather than something wrong", () => {
+    expect(elapsedSince(undefined, NOW)).toBeNull();
+    expect(elapsedSince("not-a-date", NOW)).toBeNull();
+    // A future end date is not "0 hours ago" — it is not past at all.
+    expect(elapsedSince(new Date(NOW + DAY).toISOString(), NOW)).toBeNull();
+    expect(elapsedSince(new Date(NOW - 60_000).toISOString(), NOW)).toBeNull();
+  });
+});
+
+describe("flightEndBanner — the headline makes the weakest claim that covers every row", () => {
+  it("returns nothing when no campaign is past its end date", () => {
+    expect(flightEndBanner([])).toBeNull();
+    expect(flightEndBanner([{ _id: "1", name: "x" }])).toBeNull();
+  });
+
+  it("★says `we could not stop them` ONLY when every row recorded a failure", () => {
+    const all = flightEndBanner([row({ reason: "a" }, "1"), row({ reason: "b" }, "2")], NOW)!;
+    expect(all.headline).toContain("we could not stop them");
+    expect(all.hedgeApplies).toBe(true);
+
+    // One row without a recorded failure and the strong claim is gone.
+    const mixed = flightEndBanner([row({ reason: "a" }, "1"), row({}, "2")], NOW)!;
+    expect(mixed.headline).not.toContain("could not stop");
+    expect(mixed.headline).toContain("our records still show them running");
+    expect(mixed.hedgeApplies).toBe(false);
+  });
+
+  it("★drops the `it will fail again` hedge when nothing failed — it steers users off the fix", () => {
+    // That hedge is earned on the spend banner, where the alarm implies a stop
+    // was attempted. Here it usually was not, and the row's own Pause works.
+    const quiet = flightEndBanner([row({}, "1")], NOW)!;
+    expect(quiet.body).not.toContain("fail again");
+    expect(quiet.body).toContain("Pause on the row below");
+
+    const failed = flightEndBanner([row({ reason: "a" }, "1")], NOW)!;
+    expect(failed.body).toContain("fail again");
+  });
+
+  it("counts and singularises correctly", () => {
+    const one = flightEndBanner([row({}, "1")], NOW)!;
+    expect(one.count).toBe(1);
+    expect(one.headline).toBe("A campaign passed its end date and our record still shows it running");
+
+    const three = flightEndBanner([row({}, "1"), row({}, "2"), row({}, "3")], NOW)!;
+    expect(three.count).toBe(3);
+    expect(three.headline).toBe(
+      "3 campaigns passed their end date and our records still show them running",
+    );
+    expect(flightEndBanner([row({ reason: "a" }, "1"), row({ reason: "b" }, "2")], NOW)!.headline).toBe(
+      "2 campaigns passed their end date and we could not stop them",
+    );
+  });
+
+  it("ignores rows without the flag when counting", () => {
+    const b = flightEndBanner([row({}, "1"), { _id: "2", name: "healthy" }], NOW)!;
+    expect(b.count).toBe(1);
+  });
+
+  it("★always explains that LinkedIn has no end date of its own", () => {
+    // The single fact that makes this banner's existence make sense: the flight
+    // cap is ours alone, so our stop is the only one there is.
+    for (const b of [flightEndBanner([row({}, "1")], NOW)!, flightEndBanner([row({ reason: "a" }, "1")], NOW)!]) {
+      expect(b.body).toMatch(/never given an end date|was not given an end date/);
+    }
+  });
+});

--- a/src/lib/flight-end-copy.test.ts
+++ b/src/lib/flight-end-copy.test.ts
@@ -8,20 +8,37 @@ import {
 } from "./flight-end-copy";
 
 /**
- * ★THE BANNER'S FIRST CUT ASSERTED A CAUSE THE API NEVER ESTABLISHED.
+ * ★THE BANNER'S FIRST CUT ASSERTED A CAUSE THE API NEVER ESTABLISHED, AND THE
+ * FIX FOR IT ASSERTED THE CAUSE TWICE.
  *
- * It said, above every row, "We could not stop them on LinkedIn, so they may
- * still be spending." `flightEndAlarm` is derived from two facts — `active`
- * and past `endsAt` — which is also what a campaign looks like when the sweep
- * has not reached it (forever, on dev, where crons do not run), and when the
- * platform stop SUCCEEDED and only our local write failed. In that last case
- * every clause was false and the customer was sent to Campaign Manager to stop
- * an already-stopped campaign.
+ * Round 1: it said, above every row, "We could not stop them on LinkedIn, so
+ * they may still be spending." `flightEndAlarm` is derived from two facts —
+ * `active` and past `endsAt` — which is also what a campaign looks like when
+ * the sweep has not reached it, and when the platform stop SUCCEEDED and only
+ * our local write failed. In that last case every clause was false.
+ *
+ * Round 2: the fix prefixed the api's own sentence with "We could not stop it:"
+ * — and the api composes that string as "the platform stop failed: <cause>", so
+ * every row rendered two colons and said the same thing twice.
+ *
+ * ★WHICH IS WHY THE `stop_failed` FIXTURES BELOW ARE SAMPLED FROM THE WRITER.
+ * The round-1 fixtures were invented ("the connection needs a reconnect"), and
+ * no invented string has the shape the api can actually emit — which is exactly
+ * why the double-prefix shipped green.
  */
 
 const DAY = 24 * 60 * 60 * 1000;
 const NOW = Date.parse("2026-08-07T12:00:00Z");
 const endedIso = new Date(NOW - 4 * DAY).toISOString();
+
+/**
+ * Verbatim from `peakhour-api/src/v1/services/ads/campaign-monitor.ts`:
+ * `recordUnstoppableExpiry` composes `the platform stop failed: ${info.reason}`,
+ * and `info.reason` for the commonest case is the no-connection string from
+ * `monitorOneCampaign`. If the api's composition changes, this fixture is what
+ * should be updated — and the assertions below are what will notice.
+ */
+const API_REASON = "the platform stop failed: there is no active LinkedIn Ads connection to stop it with";
 
 function row(over: Partial<FlightEndRow["flightEndAlarm"]> = {}, id = "1"): FlightEndRow {
   return {
@@ -33,7 +50,7 @@ function row(over: Partial<FlightEndRow["flightEndAlarm"]> = {}, id = "1"): Flig
 
 describe("flightEndState — the three absences stay distinct", () => {
   it("a recorded reason is the ONLY evidence that a stop failed", () => {
-    expect(flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: true, reason: "x" }))
+    expect(flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: true, reason: API_REASON }))
       .toBe("stop_failed");
   });
 
@@ -51,56 +68,87 @@ describe("flightEndState — the three absences stay distinct", () => {
 
   it("a reason wins over checkedSinceEnd — the evidence outranks the timestamp", () => {
     expect(
-      flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: false, reason: "x" }),
+      flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: false, reason: API_REASON }),
     ).toBe("stop_failed");
+  });
+
+  it("★a whitespace-only reason is NOT evidence — the predicate trims too", () => {
+    // The render trimmed and the predicate did not, so "   " counted as a
+    // failure and then printed an empty clause: the exact hole the trim was
+    // added to close, left open on the other side of it.
+    expect(flightEndState({ pastEnd: true, endsAt: endedIso, checkedSinceEnd: true, reason: "   " }))
+      .toBe("no_failure_recorded");
   });
 });
 
 describe("flightEndDetail — one row's sentence", () => {
-  it("★only claims a failure when one was recorded", () => {
-    const failed = flightEndDetail(row({ reason: "the connection needs a reconnect" }).flightEndAlarm!, "3 Aug 2026", NOW);
-    expect(failed).toContain("We could not stop it");
-    expect(failed).toContain("the connection needs a reconnect");
+  const detail = (over: Parameters<typeof row>[0] = {}) =>
+    flightEndDetail(row(over).flightEndAlarm!, "3 Aug 2026", NOW);
 
-    const unchecked = flightEndDetail(row({ checkedSinceEnd: false }).flightEndAlarm!, "3 Aug 2026", NOW);
-    expect(unchecked).not.toContain("could not stop");
-    expect(unchecked).toContain("cannot tell whether it is still running");
+  it("★does not prefix a sentence the api has already written", () => {
+    const s = detail({ reason: API_REASON });
+    expect(s).toBe(
+      "ended 3 Aug 2026 (4 days ago). The platform stop failed: there is no active LinkedIn Ads connection to stop it with.",
+    );
+    // One colon, not two, and "the flight window ended" is not restated.
+    expect(s.match(/:/g)).toHaveLength(1);
+  });
 
-    const quiet = flightEndDetail(row().flightEndAlarm!, "3 Aug 2026", NOW);
-    expect(quiet).not.toContain("could not stop");
-    expect(quiet).toContain("may already be stopped");
+  it("★only claims a failure when one was recorded — full strings, not substrings", () => {
+    expect(detail({ checkedSinceEnd: false })).toBe(
+      "ended 3 Aug 2026 (4 days ago). We have not checked it since, so we cannot tell whether it is still running.",
+    );
+    expect(detail()).toBe(
+      "ended 3 Aug 2026 (4 days ago). We have no record of stopping it, and none of failing to — check Campaign Manager.",
+    );
+  });
+
+  it("★never reassures that a campaign is probably fine", () => {
+    // `recordUnstoppableExpiry`'s own write has a catch, and a legacy row that
+    // fails the validator produces a campaign that could NOT be stopped and has
+    // no entry saying so. "It may already be stopped on LinkedIn" is round 1's
+    // defect inverted: a claim stronger than the evidence, pointing the other
+    // way.
+    expect(detail()).not.toMatch(/may already be stopped/);
   });
 
   it("★never doubles the full stop on an api-authored sentence", () => {
-    const withStop = flightEndDetail(row({ reason: "LinkedIn refused the ad account." }).flightEndAlarm!, "3 Aug 2026", NOW);
-    expect(withStop).not.toContain("..");
-    const without = flightEndDetail(row({ reason: "LinkedIn refused the ad account" }).flightEndAlarm!, "3 Aug 2026", NOW);
-    expect(without.endsWith(".")).toBe(true);
+    expect(detail({ reason: "the platform stop failed: LinkedIn refused the ad account." })).not.toContain("..");
+    expect(detail({ reason: API_REASON }).endsWith(".")).toBe(true);
   });
 
   it("carries how long ago, which is the number that conveys urgency", () => {
-    expect(flightEndDetail(row().flightEndAlarm!, "3 Aug 2026", NOW)).toContain("(4 days ago)");
+    expect(detail()).toContain("(4 days ago)");
   });
 
   it("survives an empty formatted date rather than rendering an empty clause", () => {
     const s = flightEndDetail(row().flightEndAlarm!, "", NOW);
-    expect(s).toContain("past its end date");
-    expect(s).not.toContain("ended .");
+    expect(s).toBe(
+      "past its end date. We have no record of stopping it, and none of failing to — check Campaign Manager.",
+    );
   });
 });
 
 describe("elapsedSince", () => {
-  it("reads in hours below two days and days above", () => {
+  it("reads in hours below two days", () => {
     expect(elapsedSince(new Date(NOW - 5 * 3_600_000).toISOString(), NOW)).toBe("5 hours");
     expect(elapsedSince(new Date(NOW - 1 * 3_600_000).toISOString(), NOW)).toBe("1 hour");
-    expect(elapsedSince(new Date(NOW - 3 * DAY).toISOString(), NOW)).toBe("3 days");
     expect(elapsedSince(new Date(NOW - 1 * DAY).toISOString(), NOW)).toBe("24 hours");
+  });
+
+  it("★agrees with the calendar date printed beside it", () => {
+    // Flooring elapsed HOURS while the date is a calendar DAY makes the two
+    // contradict each other: 49 hours is "2 days", but 4 Aug read on 7 Aug is
+    // three calendar days. Two numbers about one fact, disagreeing, in an alert.
+    const ended = Date.parse("2026-08-04T23:00:00Z");
+    const read = Date.parse("2026-08-07T00:30:00Z");
+    expect(elapsedSince(new Date(ended).toISOString(), read)).toBe("3 days");
+    expect(elapsedSince(new Date(NOW - 3 * DAY).toISOString(), NOW)).toBe("3 days");
   });
 
   it("says nothing rather than something wrong", () => {
     expect(elapsedSince(undefined, NOW)).toBeNull();
     expect(elapsedSince("not-a-date", NOW)).toBeNull();
-    // A future end date is not "0 hours ago" — it is not past at all.
     expect(elapsedSince(new Date(NOW + DAY).toISOString(), NOW)).toBeNull();
     expect(elapsedSince(new Date(NOW - 60_000).toISOString(), NOW)).toBeNull();
   });
@@ -109,57 +157,88 @@ describe("elapsedSince", () => {
 describe("flightEndBanner — the headline makes the weakest claim that covers every row", () => {
   it("returns nothing when no campaign is past its end date", () => {
     expect(flightEndBanner([])).toBeNull();
-    expect(flightEndBanner([{ _id: "1", name: "x" }])).toBeNull();
+    // ★A row WITH an alarm object whose `pastEnd` is not true — the round-1
+    // fixture omitted the whole object, so the `.pastEnd` check itself was
+    // untested and could be reduced to a truthiness check on the object.
+    expect(
+      flightEndBanner([
+        { _id: "1", name: "x", flightEndAlarm: { endsAt: endedIso, checkedSinceEnd: true } as never },
+      ]),
+    ).toBeNull();
   });
 
   it("★says `we could not stop them` ONLY when every row recorded a failure", () => {
-    const all = flightEndBanner([row({ reason: "a" }, "1"), row({ reason: "b" }, "2")], NOW)!;
-    expect(all.headline).toContain("we could not stop them");
-    expect(all.hedgeApplies).toBe(true);
+    const all = flightEndBanner([row({ reason: API_REASON }, "1"), row({ reason: API_REASON }, "2")], true)!;
+    expect(all.headline).toBe("2 campaigns passed their end date and we could not stop them");
 
-    // One row without a recorded failure and the strong claim is gone.
-    const mixed = flightEndBanner([row({ reason: "a" }, "1"), row({}, "2")], NOW)!;
-    expect(mixed.headline).not.toContain("could not stop");
-    expect(mixed.headline).toContain("our records still show them running");
-    expect(mixed.hedgeApplies).toBe(false);
+    const mixed = flightEndBanner([row({ reason: API_REASON }, "1"), row({}, "2")], true)!;
+    expect(mixed.headline).toBe(
+      "2 campaigns passed their end date and our records still show them running",
+    );
   });
 
-  it("★drops the `it will fail again` hedge when nothing failed — it steers users off the fix", () => {
-    // That hedge is earned on the spend banner, where the alarm implies a stop
-    // was attempted. Here it usually was not, and the row's own Pause works.
-    const quiet = flightEndBanner([row({}, "1")], NOW)!;
-    expect(quiet.body).not.toContain("fail again");
-    expect(quiet.body).toContain("Pause on the row below");
-
-    const failed = flightEndBanner([row({ reason: "a" }, "1")], NOW)!;
-    expect(failed.body).toContain("fail again");
+  it("★a MIXED set still points at Campaign Manager — Pause would fail on the failed rows", () => {
+    // Round 1 applied the hedge to all rows; its fix dropped it unless ALL rows
+    // failed, which sent a reader with nine connection-refused campaigns and one
+    // merely-unchecked campaign to a Pause button guaranteed to fail on nine.
+    // Anything failed => the advice that is safe for every row in the list.
+    const mixed = flightEndBanner([row({ reason: API_REASON }, "1"), row({}, "2")], true)!;
+    expect(mixed.body).toContain("Campaign Manager");
+    expect(mixed.body).toContain("fail again");
+    expect(mixed.body).not.toContain("Pause on the row below");
   });
 
-  it("counts and singularises correctly", () => {
-    const one = flightEndBanner([row({}, "1")], NOW)!;
-    expect(one.count).toBe(1);
+  it("★offers the row's own Pause only when nothing failed AND the row is on screen", () => {
+    const connected = flightEndBanner([row({}, "1")], true)!;
+    expect(connected.body).toContain("Use Pause on the row below");
+    expect(connected.body).not.toContain("fail again");
+
+    // ★Above the connection gate there IS no row below — and a revoked
+    // connection is the state most likely to produce these rows, so the
+    // disconnected reader is the likeliest one to be sent to a button that is
+    // not on their screen.
+    const disconnected = flightEndBanner([row({}, "1")], false)!;
+    expect(disconnected.body).not.toContain("row below");
+    expect(disconnected.body).toContain("Stop it in LinkedIn Campaign Manager.");
+  });
+
+  it("counts and singularises off the rows it actually returns", () => {
+    const one = flightEndBanner([row({}, "1")], true)!;
+    expect(one.rows).toHaveLength(1);
     expect(one.headline).toBe("A campaign passed its end date and our record still shows it running");
+    expect(one.body).toContain("Use Pause on the row below, or stop it in");
 
-    const three = flightEndBanner([row({}, "1"), row({}, "2"), row({}, "3")], NOW)!;
-    expect(three.count).toBe(3);
+    const three = flightEndBanner([row({}, "1"), row({}, "2"), row({}, "3")], true)!;
+    expect(three.rows).toHaveLength(3);
     expect(three.headline).toBe(
       "3 campaigns passed their end date and our records still show them running",
     );
-    expect(flightEndBanner([row({ reason: "a" }, "1"), row({ reason: "b" }, "2")], NOW)!.headline).toBe(
-      "2 campaigns passed their end date and we could not stop them",
+    expect(flightEndBanner([row({ reason: API_REASON }, "1")], true)!.headline).toBe(
+      "A campaign passed its end date and we could not stop it",
     );
   });
 
-  it("ignores rows without the flag when counting", () => {
-    const b = flightEndBanner([row({}, "1"), { _id: "2", name: "healthy" }], NOW)!;
-    expect(b.count).toBe(1);
+  it("★the headline count is the LISTED rows, not the rows it was handed", () => {
+    // Two independent filters that must agree by convention is how a count and
+    // a list drift apart, so the banner returns the rows it counted.
+    const b = flightEndBanner(
+      [row({}, "1"), { _id: "2", name: "healthy" }, { _id: "3", name: "also healthy" }],
+      true,
+    )!;
+    expect(b.rows).toHaveLength(1);
+    expect(b.headline).toMatch(/^A campaign /);
   });
 
   it("★always explains that LinkedIn has no end date of its own", () => {
     // The single fact that makes this banner's existence make sense: the flight
     // cap is ours alone, so our stop is the only one there is.
-    for (const b of [flightEndBanner([row({}, "1")], NOW)!, flightEndBanner([row({ reason: "a" }, "1")], NOW)!]) {
-      expect(b.body).toMatch(/never given an end date|was not given an end date/);
+    const expected = "LinkedIn is never given an end date for these campaigns, so our own stop is the only one there is.";
+    for (const b of [
+      flightEndBanner([row({}, "1")], true)!,
+      flightEndBanner([row({}, "1")], false)!,
+      flightEndBanner([row({ reason: API_REASON }, "1")], true)!,
+    ]) {
+      expect(b.body.startsWith(expected)).toBe(true);
     }
   });
 });

--- a/src/lib/flight-end-copy.ts
+++ b/src/lib/flight-end-copy.ts
@@ -48,7 +48,12 @@ export interface FlightEndRow {
 export type FlightEndState = "stop_failed" | "not_checked" | "no_failure_recorded";
 
 export function flightEndState(alarm: FlightEndRow["flightEndAlarm"]): FlightEndState {
-  if (alarm?.reason) return "stop_failed";
+  // ★TRIMMED IN THE PREDICATE, NOT ONLY IN THE RENDER. A first cut trimmed
+  // where the string is printed and tested raw truthiness here, so a
+  // whitespace-only reason counted as evidence of a failure and then rendered
+  // as an empty clause — the exact hole the trim was added to close, left open
+  // on the other side of it.
+  if (alarm?.reason?.trim()) return "stop_failed";
   return alarm?.checkedSinceEnd ? "no_failure_recorded" : "not_checked";
 }
 
@@ -63,7 +68,13 @@ export function elapsedSince(iso: string | undefined, now = Date.now()): string 
   const hours = Math.floor((now - t) / 3_600_000);
   if (hours < 1) return null;
   if (hours < 48) return `${hours} hour${hours === 1 ? "" : "s"}`;
-  const days = Math.floor(hours / 24);
+  // ★CALENDAR DAYS IN UTC, MATCHING THE DATE PRINTED BESIDE IT. Flooring
+  // elapsed hours while the date is a calendar day makes the two disagree:
+  // ended 2026-08-04T23:00Z read at 2026-08-07T00:30Z is 49 hours — "2 days" —
+  // next to "4 Aug 2026", which is three calendar days ago. Two numbers about
+  // one fact, contradicting each other, in an alert.
+  const utcDay = (ms: number) => Math.floor(ms / 86_400_000);
+  const days = utcDay(now) - utcDay(t);
   return `${days} day${days === 1 ? "" : "s"}`;
 }
 
@@ -85,8 +96,13 @@ export function flightEndDetail(
     : "past its end date";
   switch (flightEndState(alarm)) {
     case "stop_failed": {
+      // ★NO LEAD-IN OF OUR OWN. The api composes this string as "the platform
+      // stop failed: <cause>", so prefixing it with "We could not stop it:"
+      // produced two colons and said the same thing twice. The api owns the
+      // sentence; this side owns the date.
       const reason = alarm.reason!.trim();
-      return `${ended}. We could not stop it: ${reason}${reason.endsWith(".") ? "" : "."}`;
+      const cap = reason.charAt(0).toUpperCase() + reason.slice(1);
+      return `${ended}. ${cap}${cap.endsWith(".") ? "" : "."}`;
     }
     case "not_checked":
       // ★NO CLAIM ABOUT WHETHER IT IS SPENDING. Nothing has looked at it since
@@ -95,7 +111,13 @@ export function flightEndDetail(
       // saying we failed.
       return `${ended}. We have not checked it since, so we cannot tell whether it is still running.`;
     case "no_failure_recorded":
-      return `${ended}. We have not recorded stopping it, and no failure either — it may already be stopped on LinkedIn.`;
+      // ★AND NO REASSURANCE EITHER. "It may already be stopped" is reachable
+      // when it is false: `recordUnstoppableExpiry`'s own write has a catch, and
+      // a legacy row that fails the collection's validator produces a campaign
+      // that could NOT be stopped and has no entry saying so. Telling that
+      // customer it is probably fine is round 1's defect inverted — a claim
+      // stronger than the evidence, pointing the other way.
+      return `${ended}. We have no record of stopping it, and none of failing to — check Campaign Manager.`;
   }
 }
 
@@ -110,12 +132,26 @@ export function flightEndDetail(
  */
 export function flightEndBanner(
   rows: FlightEndRow[],
-  now = Date.now(),
-): { headline: string; body: string; hedgeApplies: boolean; count: number } | null {
-  const pastEnd = rows.filter((r) => r.flightEndAlarm?.pastEnd);
+  /**
+   * Can the reader actually use the per-row Pause button? False above the
+   * connection gate, where the banner is mounted and the campaigns table is
+   * not — and a revoked connection is the state most likely to PRODUCE these
+   * rows, so the disconnected reader is the likeliest one to be told to press
+   * a button that is not on their screen.
+   */
+  canUseRowControls = true,
+): {
+  headline: string;
+  body: string;
+  rows: FlightEndRow[];
+} | null {
+  const pastEnd = rows.filter((r) => r.flightEndAlarm?.pastEnd === true);
   if (pastEnd.length === 0) return null;
   const one = pastEnd.length === 1;
-  const allFailed = pastEnd.every((r) => flightEndState(r.flightEndAlarm) === "stop_failed");
+  const it = one ? "it" : "them";
+  const states = pastEnd.map((r) => flightEndState(r.flightEndAlarm));
+  const allFailed = states.every((st) => st === "stop_failed");
+  const anyFailed = states.some((st) => st === "stop_failed");
 
   const headline = allFailed
     ? one
@@ -125,19 +161,32 @@ export function flightEndBanner(
       ? "A campaign passed its end date and our record still shows it running"
       : `${pastEnd.length} campaigns passed their end date and our records still show them running`;
 
-  // ★THE HEDGE IS EARNED, NOT INHERITED. The spend banner says "the controls
-  // here use the same connection, so if that is what failed they will fail
-  // again" — which is true there, because that alarm implies a stop was
-  // attempted and failed. Here it usually was not, and in that case the row's
-  // own Pause button works in one click. Telling the customer it will not is
-  // steering them away from the fix.
-  const body = allFailed
-    ? `LinkedIn was not given an end date, so nothing else will stop ${one ? "it" : "them"}. ` +
-      `Stop ${one ? "it" : "them"} in LinkedIn Campaign Manager — the controls here use the same ` +
-      `connection, so if that is what failed they will fail again.`
-    : `LinkedIn is never given an end date for these campaigns, so our own stop is the only one ` +
-      `there is. Use Pause on the row below, or stop ${one ? "it" : "them"} in LinkedIn Campaign ` +
-      `Manager.`;
+  // ★THE REMEDY IS SCOPED TO WHAT IS TRUE OF EVERY ROW LISTED, WHICH IS WHY
+  // "any" AND "all" ARE BOTH NEEDED.
+  //
+  // The hedge — "the controls here use the same connection, so if that is what
+  // failed they will fail again" — is earned only where a stop actually failed.
+  // A first cut applied it to all rows (round 1); its fix dropped it unless ALL
+  // rows failed, which sent a reader with nine connection-refused campaigns and
+  // one merely unchecked campaign to a Pause button guaranteed to fail on nine
+  // of them. Anything failed => Campaign Manager, because that is the advice
+  // that is safe for every row in the list.
+  const noEnd =
+    `LinkedIn is never given an end date for these campaigns, so our own stop is the only one ` +
+    `there is.`;
+  let body: string;
+  if (anyFailed) {
+    body =
+      `${noEnd} Stop ${it} in LinkedIn Campaign Manager — the controls here use the same ` +
+      `connection, so if that is what failed they will fail again.`;
+  } else if (canUseRowControls) {
+    body = `${noEnd} Use Pause on the row below, or stop ${it} in LinkedIn Campaign Manager.`;
+  } else {
+    body = `${noEnd} Stop ${it} in LinkedIn Campaign Manager.`;
+  }
 
-  return { headline, body, hedgeApplies: allFailed, count: pastEnd.length };
+  // The rows come back rather than being re-filtered by the caller: two
+  // independent filters that must agree by convention is how a count and a list
+  // drift apart.
+  return { headline, body, rows: pastEnd };
 }

--- a/src/lib/flight-end-copy.ts
+++ b/src/lib/flight-end-copy.ts
@@ -1,0 +1,143 @@
+/**
+ * What the "should have stopped, and has not" banner is allowed to say.
+ *
+ * WHY THIS FILE EXISTS: the first cut of that banner put ONE sentence above the
+ * list — "We could not stop them on LinkedIn, so they may still be spending" —
+ * and the api's flag does not support it. `flightEndAlarm` is derived from two
+ * facts, `status === "active"` and `endsAt` in the past. That is ALSO what a
+ * campaign looks like when:
+ *
+ *   - the hourly sweep simply has not reached it yet (its grace period covers
+ *     the ordinary gap, but a truncated sweep runs behind it), and forever on
+ *     dev, where crons do not run at all;
+ *   - the platform stop SUCCEEDED and only our local row write failed. The api
+ *     logs that case verbatim as "Spend has stopped; our record of it has not."
+ *     Telling that customer their campaign is still spending, and sending them
+ *     to Campaign Manager to stop an already-stopped campaign, is a false
+ *     statement about money on the surface built to stop us making them.
+ *
+ * ★SO THE HEADLINE MAKES THE WEAKEST CLAIM THAT COVERS EVERY ROW IN IT, and the
+ * per-row detail carries the specific one. The only sentence permitted to say
+ * "we could not stop it" is one about a campaign where a stop was attempted and
+ * failed — which is exactly when the api sends `reason`.
+ *
+ * Pure so it can be tested without rendering, which is this repo's convention
+ * for anything whose wording matters (see `ads-copy.ts`).
+ */
+
+/** The shape this module needs off a campaign row. */
+export interface FlightEndRow {
+  _id: string;
+  name?: string;
+  flightEndAlarm?: {
+    pastEnd: true;
+    endsAt: string;
+    checkedSinceEnd: boolean;
+    reason?: string;
+  };
+}
+
+/**
+ * Which of the three states a row is in.
+ *
+ * ★THE THREE STAY DISTINCT. "We asked and could not stop it", "nobody has
+ * asked yet" and "we asked and found nothing wrong" are three different things
+ * with three different remedies, and collapsing any two of them is how a
+ * customer is told to go and fix something that is not broken.
+ */
+export type FlightEndState = "stop_failed" | "not_checked" | "no_failure_recorded";
+
+export function flightEndState(alarm: FlightEndRow["flightEndAlarm"]): FlightEndState {
+  if (alarm?.reason) return "stop_failed";
+  return alarm?.checkedSinceEnd ? "no_failure_recorded" : "not_checked";
+}
+
+/** "4 days", "6 hours", or null when it is neither yet or unreadable. */
+export function elapsedSince(iso: string | undefined, now = Date.now()): string | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  // A future end date floors to a negative hour count, so the `< 1` guard below
+  // already covers it — no separate sign check, which would be a line no test
+  // could ever fail.
+  const hours = Math.floor((now - t) / 3_600_000);
+  if (hours < 1) return null;
+  if (hours < 48) return `${hours} hour${hours === 1 ? "" : "s"}`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+/**
+ * One row's sentence.
+ *
+ * `reason` is an api-authored sentence and may already end in a full stop, so
+ * it is joined without adding a second one — ".." in an alert reads as a bug in
+ * the alert.
+ */
+export function flightEndDetail(
+  alarm: NonNullable<FlightEndRow["flightEndAlarm"]>,
+  formattedDate: string,
+  now = Date.now(),
+): string {
+  const ago = elapsedSince(alarm.endsAt, now);
+  const ended = formattedDate
+    ? `ended ${formattedDate}${ago ? ` (${ago} ago)` : ""}`
+    : "past its end date";
+  switch (flightEndState(alarm)) {
+    case "stop_failed": {
+      const reason = alarm.reason!.trim();
+      return `${ended}. We could not stop it: ${reason}${reason.endsWith(".") ? "" : "."}`;
+    }
+    case "not_checked":
+      // ★NO CLAIM ABOUT WHETHER IT IS SPENDING. Nothing has looked at it since
+      // it ended, so whether LinkedIn is still serving it is exactly what we do
+      // not know — and "we cannot tell" is its own answer, not a softer way of
+      // saying we failed.
+      return `${ended}. We have not checked it since, so we cannot tell whether it is still running.`;
+    case "no_failure_recorded":
+      return `${ended}. We have not recorded stopping it, and no failure either — it may already be stopped on LinkedIn.`;
+  }
+}
+
+/**
+ * The banner as a whole, or null when there is nothing to say.
+ *
+ * The headline is chosen by what is true of EVERY row listed: only when every
+ * one of them carries a recorded stop failure may it say we could not stop
+ * them. Otherwise it says what all of them have in common — past their end
+ * date, and our record still shows them running — and lets the rows explain
+ * themselves.
+ */
+export function flightEndBanner(
+  rows: FlightEndRow[],
+  now = Date.now(),
+): { headline: string; body: string; hedgeApplies: boolean; count: number } | null {
+  const pastEnd = rows.filter((r) => r.flightEndAlarm?.pastEnd);
+  if (pastEnd.length === 0) return null;
+  const one = pastEnd.length === 1;
+  const allFailed = pastEnd.every((r) => flightEndState(r.flightEndAlarm) === "stop_failed");
+
+  const headline = allFailed
+    ? one
+      ? "A campaign passed its end date and we could not stop it"
+      : `${pastEnd.length} campaigns passed their end date and we could not stop them`
+    : one
+      ? "A campaign passed its end date and our record still shows it running"
+      : `${pastEnd.length} campaigns passed their end date and our records still show them running`;
+
+  // ★THE HEDGE IS EARNED, NOT INHERITED. The spend banner says "the controls
+  // here use the same connection, so if that is what failed they will fail
+  // again" — which is true there, because that alarm implies a stop was
+  // attempted and failed. Here it usually was not, and in that case the row's
+  // own Pause button works in one click. Telling the customer it will not is
+  // steering them away from the fix.
+  const body = allFailed
+    ? `LinkedIn was not given an end date, so nothing else will stop ${one ? "it" : "them"}. ` +
+      `Stop ${one ? "it" : "them"} in LinkedIn Campaign Manager — the controls here use the same ` +
+      `connection, so if that is what failed they will fail again.`
+    : `LinkedIn is never given an end date for these campaigns, so our own stop is the only one ` +
+      `there is. Use Pause on the row below, or stop ${one ? "it" : "them"} in LinkedIn Campaign ` +
+      `Manager.`;
+
+  return { headline, body, hedgeApplies: allFailed, count: pastEnd.length };
+}


### PR DESCRIPTION
Pairs with [peakhour-api#1033](https://github.com/travelxp/peakhour-api/pull/1033).

The api half stops an expired campaign on LinkedIn before the row goes terminal,
and leaves the row `active` when it cannot — which is the honest state, and was
invisible. `spendAlarm` does not cover it: that flag requires the campaign to be
over its budget cap, and this population is exactly the campaigns that
UNDER-spend.

## The banner, and what it is allowed to say

`flightEndAlarm` is derived from two facts: `status: "active"` and `endsAt` in
the past. It does **not** mean a stop was attempted. Round 1 caught the first cut
asserting otherwise, in two ways that were both false statements about money:

- A campaign that ended at 14:00 with the sweep due at 15:15 got a red alert
  saying Peakhour had tried and failed to stop it. (Forever, on dev, where crons
  do not run.)
- On `flight_end_stopped_row_not_updated` — platform stop succeeds, local write
  fails — all three sentences were false, and the customer was sent to Campaign
  Manager to stop an already-stopped campaign.

So the headline makes the weakest claim true of every row listed, and the
per-row detail carries the specific one. **Three states, kept distinct:** we
asked and could not / nobody has asked yet / we asked and found nothing. Only
the first is allowed the sentence "we could not stop it", and only it gets the
"same connection, so it will fail again" hedge — in the other two the row's own
Pause button works in one click.

The copy is a pure module with tests (`src/lib/flight-end-copy.ts`), matching
`ads-copy.ts`. The banner had no tests before and its two false sentences
shipped green.

## Also

- **`cron-metadata.test.ts` has been failing on master** since api#1030 shipped
  `ad-campaign-monitor` with no b2c entry. Added — and its summarizer reads all
  six failure counters, not two: a tick where *every* row threw returns
  `{ticked: 0, failed: 40}` and previously rendered "0 campaigns checked." as a
  green success toast over forty logged errors.
- `ad-campaign-monitor` added to the LinkedIn channel's `crons`, so the toolbar
  on the page this banner lives on can run it.
- The customer-facing paragraph still said automatic pausing runs only for
  WhatsApp campaigns. P1 closed that.
- `role="status"` + `aria-label` rather than a second `role="alert"`.

12 mutations, 12 kills. 317 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)