### PR TITLE
feat(signals): the Insight Tag gets a screen, and it shows evidence not a tick

### DIFF
--- a/src/app/(site)/dashboard/growth/signals/page.tsx
+++ b/src/app/(site)/dashboard/growth/signals/page.tsx
@@ -5,7 +5,7 @@ import { Check, Minus, Radar, X } from "lucide-react";
 import { ApiError } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ConfirmDialog } from "@/components/molecules/confirm-dialog";
 import { EmptyState } from "@/components/molecules/empty-state";
 import {
   useCreateSignal,
@@ -60,7 +61,13 @@ import {
  * next to real ones. "Last seen" is a fact; "1,284 hits" would not be.
  */
 export default function SignalsPage() {
-  const { data, isPending, isError, refetch, isFetching } = useSignals();
+  const { data, isPending, error, refetch, isFetching } = useSignals();
+  // ★A REMOVAL MESSAGE THAT OUTLIVES THE CARD IT CAME FROM. Removing invalidates
+  // the list, the signal disappears, and the card unmounts — so a notice
+  // rendered inside it flashed for a few hundred milliseconds and vanished.
+  // The one thing worth saying about removing ("your page is still loading the
+  // tag") is exactly the thing that must survive.
+  const [removed, setRemoved] = useState<string | null>(null);
 
   return (
     <div className="space-y-6">
@@ -73,17 +80,25 @@ export default function SignalsPage() {
         </p>
       </div>
 
+      {removed && (
+        <p className="rounded-md border bg-muted/40 p-3 text-sm">
+          {providerLabel(removed as SignalProvider)} removed from Peakhour. If the snippet
+          is on your site it is still there and still loading — take it out of your pages
+          to actually stop it. Setting it up again issues a NEW site key, so you will need
+          to replace the snippet everywhere it appears.
+        </p>
+      )}
+
       {isPending ? (
         <div className="space-y-4">
           <Skeleton className="h-56 w-full" />
         </div>
-      ) : isError ? (
-        <EmptyState
-          icon={Radar}
-          title="We couldn&apos;t load your signals"
-          description="That&apos;s on us — nothing has been changed. Try again in a moment."
-          action={{ label: "Try again", onClick: () => void refetch() }}
-        />
+      ) : !data ? (
+        // ★`!data`, NOT `isError`. A failed BACKGROUND refetch — a tab-away and
+        // back on a flaky connection — sets `isError` while the loaded data is
+        // still there, and branching on it would throw the whole screen away
+        // over a transient blip.
+        <EmptyState {...listErrorState(error, () => void refetch())} icon={Radar} />
       ) : (
         <div className="space-y-4">
           {data.availableProviders.map((provider) => {
@@ -95,6 +110,7 @@ export default function SignalsPage() {
                 rails={data.availableRails}
                 onRecheck={() => void refetch()}
                 rechecking={isFetching}
+                onRemoved={() => setRemoved(provider)}
               />
             ) : (
               <SetUpCard key={provider} provider={provider} rails={data.availableRails} />
@@ -104,6 +120,65 @@ export default function SignalsPage() {
       )}
     </div>
   );
+}
+
+/**
+ * What to say when the list will not load, and whether a retry can help.
+ *
+ * ★"THAT'S ON US, TRY AGAIN" IS THE WRONG ANSWER TO TWO OF THESE. A caller with
+ * no active business gets a 403 that no amount of retrying will change, and the
+ * fix — pick a business — is one the customer can carry out. A remedy that
+ * cannot resolve the failure is worse than none.
+ */
+function listErrorState(error: unknown, onRetry: () => void) {
+  const code = error instanceof ApiError ? error.code : undefined;
+  if (code === "NO_ACTIVE_BUSINESS") {
+    return {
+      title: "Pick a business first",
+      description:
+        "Signals belong to one business at a time — choose one and they'll load.",
+    };
+  }
+  if (code === "FORBIDDEN") {
+    return {
+      title: "You don't have access to this",
+      description: "Ask an owner or admin on this business to open it for you.",
+    };
+  }
+  return {
+    title: "We couldn't load your signals",
+    description: "That's on us — nothing has been changed. Try again in a moment.",
+    action: { label: "Try again", onClick: onRetry },
+  };
+}
+
+/**
+ * The message for a failed write.
+ *
+ * ★EVERY CODE THE API CAN RETURN, AND NO `FORBIDDEN` ENDS IN "TRY AGAIN". These
+ * routes are `requireRole("admin")`, so an editor hits 403 on every write —
+ * being told to retry would be advice that can never come good. And
+ * `NOTHING_TO_UPDATE` is its own code precisely so that pressing Save with
+ * nothing changed does not produce a lecture about Partner ID characters.
+ */
+function writeErrorMessage(error: unknown): string {
+  const code = error instanceof ApiError ? error.code : undefined;
+  switch (code) {
+    case "SIGNAL_EXISTS":
+      return "This business already has one of these — reload the page to see it.";
+    case "FORBIDDEN":
+      return "You need an admin or owner role on this business to change a signal.";
+    case "NO_ACTIVE_BUSINESS":
+      return "Pick a business first — signals belong to one business at a time.";
+    case "NOTHING_TO_UPDATE":
+      return "Nothing was changed.";
+    case "VALIDATION_ERROR":
+      return "A Partner ID can only contain letters, numbers, hyphens and underscores.";
+    case "NOT_FOUND":
+      return "That signal isn't there any more — reload the page.";
+    default:
+      return "We couldn't save that. Nothing has been changed — try again in a moment.";
+  }
 }
 
 /** The three levels, drawn so that "not applicable" cannot read as "not done". */
@@ -155,11 +230,13 @@ function SignalCard({
   rails,
   onRecheck,
   rechecking,
+  onRemoved,
 }: {
   signal: Signal;
   rails: SignalRail[];
   onRecheck: () => void;
   rechecking: boolean;
+  onRemoved: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [partnerId, setPartnerId] = useState(signal.partnerId);
@@ -170,22 +247,44 @@ function SignalCard({
   const state = stateCopy(signal);
 
   const partnerIdChanged = partnerId.trim() !== signal.partnerId;
+  const railChanged = rail !== signal.delivery.rail;
+  const hasChanges = partnerIdChanged || railChanged;
+
+  /** Reset the form to whatever the server now says, and open or close it.
+   *  ★WITHOUT THIS, `useState(signal.partnerId)` keeps the value it was
+   *  initialised with: after a save the card re-renders with fresh props and
+   *  the form still shows what was typed, so cancelling and re-opening shows a
+   *  stale draft as if it were stored. */
+  const toggleEditing = (open: boolean) => {
+    if (open) {
+      setPartnerId(signal.partnerId);
+      setRail(signal.delivery.rail);
+      update.reset();
+    }
+    setEditing(open);
+  };
 
   return (
     <Card>
-      <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+      <CardHeader>
         <div>
           <CardTitle className="text-base">{providerLabel(signal.provider)}</CardTitle>
           <p className="text-sm text-muted-foreground">
             Partner ID {signal.partnerId} · {railLabel(signal.delivery.rail)}
           </p>
         </div>
-        <Badge
-          variant={state.tone === "ok" ? "default" : "secondary"}
-          className={state.tone === "attention" ? "border-amber-500/40 text-amber-700" : undefined}
-        >
-          {state.title}
-        </Badge>
+        {/* ★CardAction, NOT A flex-row OVERRIDE. CardHeader is a GRID, and
+            tailwind-merge keeps both `grid` and `flex-row` because they are in
+            different groups — so the override did nothing and the badge stacked
+            underneath the title instead of sitting top-right. */}
+        <CardAction>
+          <Badge
+            variant={state.tone === "ok" ? "default" : "secondary"}
+            className={state.tone === "attention" ? "border-amber-500/40 text-amber-700" : undefined}
+          >
+            {state.title}
+          </Badge>
+        </CardAction>
       </CardHeader>
       <CardContent className="space-y-5">
         <p className="text-sm">{state.body}</p>
@@ -202,27 +301,43 @@ function SignalCard({
           <Button variant="outline" size="sm" onClick={() => setShowSnippet((v) => !v)}>
             {showSnippet ? "Hide snippet" : "Show snippet"}
           </Button>
-          <Button variant="outline" size="sm" onClick={() => setEditing((v) => !v)}>
+          <Button variant="outline" size="sm" onClick={() => toggleEditing(!editing)}>
             {editing ? "Cancel" : "Edit"}
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive"
-            disabled={remove.isPending}
-            onClick={() => remove.mutate(signal.provider)}
-          >
-            Remove
-          </Button>
+          {/* ★CONFIRMED, BECAUSE IT IS NOT REVERSIBLE. Setting the signal up
+              again mints a NEW site key, so every page already carrying the old
+              snippet beacons to a key that no longer exists — silently, forever
+              — and the customer has to re-paste everywhere. That is the whole
+              reason this is a dialog and not a click. */}
+          <ConfirmDialog
+            trigger={
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive"
+                disabled={remove.isPending}
+              >
+                Remove
+              </Button>
+            }
+            title={`Remove your ${providerLabel(signal.provider)}?`}
+            description={
+              "This removes our record and our proof that it works — not the code on your site. " +
+              "Setting it up again issues a NEW site key, so you would have to replace the snippet " +
+              "on every page that carries it."
+            }
+            variant="destructive"
+            confirmLabel="Remove"
+            onConfirm={() =>
+              remove.mutate(signal.provider, { onSuccess: () => onRemoved() })
+            }
+          />
         </div>
 
-        {/* ★REMOVING OUR RECORD IS NOT REMOVING THEIR TAG, and saying so
-            afterwards would be too late to be useful. */}
-        {remove.isSuccess && (
-          <p className="text-sm text-muted-foreground">
-            Removed from Peakhour. If you pasted the snippet into your site yourself, it
-            is still there and still loading — take it out of your pages to stop it.
-          </p>
+        {/* A failed remove used to produce nothing at all: the button re-enabled
+            and the card stayed, which reads as "it didn't register the click". */}
+        {remove.isError && (
+          <p className="text-sm text-destructive">{writeErrorMessage(remove.error)}</p>
         )}
 
         {showSnippet && <SnippetBlock provider={signal.provider} />}
@@ -230,9 +345,9 @@ function SignalCard({
         {editing && (
           <div className="space-y-3 rounded-md border p-4">
             <div className="space-y-1.5">
-              <Label htmlFor="partnerId">Partner ID</Label>
+              <Label htmlFor={`edit-partner-${signal.provider}`}>Partner ID</Label>
               <Input
-                id="partnerId"
+                id={`edit-partner-${signal.provider}`}
                 value={partnerId}
                 onChange={(e) => setPartnerId(e.target.value)}
                 placeholder="1234567"
@@ -249,22 +364,22 @@ function SignalCard({
               <p className="text-sm text-amber-700">{PARTNER_ID_CHANGE_WARNING}</p>
             )}
             {update.isError && (
-              <p className="text-sm text-destructive">
-                {update.error instanceof ApiError && update.error.code === "VALIDATION_ERROR"
-                  ? "A Partner ID can only contain letters, numbers, hyphens and underscores."
-                  : "We couldn't save that. Nothing has been changed — try again in a moment."}
-              </p>
+              <p className="text-sm text-destructive">{writeErrorMessage(update.error)}</p>
             )}
+            {/* ★DISABLED WHEN NOTHING CHANGED, rather than sending an empty
+                patch. The api answers a `{}` body with a 400, and mapping that
+                to a message means telling somebody who pressed Save without
+                editing anything that their Partner ID is malformed. */}
             <Button
               size="sm"
-              disabled={update.isPending}
+              disabled={update.isPending || !hasChanges}
               onClick={() =>
                 update.mutate(
                   {
                     provider: signal.provider,
                     patch: {
                       ...(partnerIdChanged ? { partnerId: partnerId.trim() } : {}),
-                      ...(rail !== signal.delivery.rail ? { rail } : {}),
+                      ...(railChanged ? { rail } : {}),
                     },
                   },
                   { onSuccess: () => setEditing(false) },
@@ -282,7 +397,12 @@ function SignalCard({
 
 function SnippetBlock({ provider }: { provider: SignalProvider }) {
   const { data, isPending, isError } = useSignalSnippet(provider);
-  const [copied, setCopied] = useState(false);
+  // ★KEYED ON THE SNIPPET ITSELF, NOT A BOOLEAN. A boolean never reset, so a
+  // customer who copied, changed their Partner ID and saved would be looking at
+  // a NEW snippet under a button still reading "Copied" — which is the precise
+  // failure the change warning exists to prevent, one component further down.
+  const [copiedText, setCopiedText] = useState<string | null>(null);
+  const [copyFailed, setCopyFailed] = useState(false);
 
   if (isPending) return <Skeleton className="h-40 w-full" />;
   if (isError || !data) {
@@ -308,11 +428,31 @@ function SnippetBlock({ provider }: { provider: SignalProvider }) {
         variant="outline"
         size="sm"
         onClick={() => {
-          void navigator.clipboard?.writeText(data.snippet).then(() => setCopied(true));
+          // ★A FAILURE HERE MUST NOT BE SILENT. On an insecure origin
+          // `navigator.clipboard` is undefined and the optional chain made the
+          // click a no-op — no copy, no error, button unchanged — so the
+          // customer walks away believing they have the snippet. A rejected
+          // `writeText` (permission denied, document not focused) did the same.
+          setCopyFailed(false);
+          const clipboard = navigator.clipboard;
+          if (!clipboard) {
+            setCopyFailed(true);
+            return;
+          }
+          clipboard.writeText(data.snippet).then(
+            () => setCopiedText(data.snippet),
+            () => setCopyFailed(true),
+          );
         }}
       >
-        {copied ? "Copied" : "Copy snippet"}
+        {copiedText === data.snippet ? "Copied" : "Copy snippet"}
       </Button>
+      {copyFailed && (
+        <p className="text-sm text-destructive">
+          Your browser wouldn&apos;t let us copy that. Select the snippet above and copy it
+          by hand.
+        </p>
+      )}
     </div>
   );
 }
@@ -377,15 +517,7 @@ function SetUpCard({ provider, rails }: { provider: SignalProvider; rails: Signa
           <RailSelect value={rail} rails={rails} onChange={setRail} />
         </div>
         {create.isError && (
-          <p className="text-sm text-destructive">
-            {create.error instanceof ApiError && create.error.code === "SIGNAL_EXISTS"
-              ? "This business already has one of these — reload the page to see it."
-              : create.error instanceof ApiError && create.error.code === "FORBIDDEN"
-                ? "You need an admin or owner role on this business to set up a signal."
-                : create.error instanceof ApiError && create.error.code === "VALIDATION_ERROR"
-                  ? "A Partner ID can only contain letters, numbers, hyphens and underscores."
-                  : "We couldn't save that. Nothing has been changed — try again in a moment."}
-          </p>
+          <p className="text-sm text-destructive">{writeErrorMessage(create.error)}</p>
         )}
         <Button
           size="sm"

--- a/src/app/(site)/dashboard/growth/signals/page.tsx
+++ b/src/app/(site)/dashboard/growth/signals/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useAuth } from "@/providers/auth-provider";
 import { Check, Minus, Radar, X } from "lucide-react";
 import { ApiError } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
@@ -61,6 +62,7 @@ import {
  * next to real ones. "Last seen" is a fact; "1,284 hits" would not be.
  */
 export default function SignalsPage() {
+  const { business } = useAuth();
   const { data, isPending, error, refetch, isFetching } = useSignals();
   // ★A REMOVAL MESSAGE THAT OUTLIVES THE CARD IT CAME FROM. Removing invalidates
   // the list, the signal disappears, and the card unmounts — so a notice
@@ -68,6 +70,13 @@ export default function SignalsPage() {
   // The one thing worth saying about removing ("your page is still loading the
   // tag") is exactly the thing that must survive.
   const [removed, setRemoved] = useState<string | null>(null);
+  // ★AND IT STOPS THE MOMENT THAT PROVIDER IS CONFIGURED AGAIN. Nothing cleared
+  // it, so after removing and re-adding, a present-tense "removed from
+  // Peakhour … you will need to replace the snippet" sat above a working card,
+  // advising something the customer had already done. DERIVED rather than
+  // reset: a second piece of state that has to be cleared correctly is how the
+  // first one got it wrong.
+  const showRemoved = removed && !data?.signals.some((s) => s.provider === removed) ? removed : null;
 
   return (
     <div className="space-y-6">
@@ -80,16 +89,30 @@ export default function SignalsPage() {
         </p>
       </div>
 
-      {removed && (
+      {showRemoved && (
         <p className="rounded-md border bg-muted/40 p-3 text-sm">
-          {providerLabel(removed as SignalProvider)} removed from Peakhour. If the snippet
+          {providerLabel(showRemoved as SignalProvider)} removed from Peakhour. If the snippet
           is on your site it is still there and still loading — take it out of your pages
           to actually stop it. Setting it up again issues a NEW site key, so you will need
           to replace the snippet everywhere it appears.
         </p>
       )}
 
-      {isPending ? (
+      {/* ★NO BUSINESS IS ITS OWN STATE, NOT A LOADING ONE — and round 1 made
+          this worse rather than better. Adding `enabled: !!business` to the
+          hook stopped the query firing, and a disabled TanStack query with no
+          cached data reports `isPending` FOREVER: the fix replaced a correct
+          "Pick a business first" message with a permanent skeleton, and made
+          its own `NO_ACTIVE_BUSINESS` branch unreachable in the same commit.
+          The pattern the rest of this app uses (`dashboard/pages`) checks the
+          business before the query state, which is what this does now. */}
+      {!business ? (
+        <EmptyState
+          icon={Radar}
+          title="Pick a business first"
+          description="Signals belong to one business at a time — choose one and they'll load."
+        />
+      ) : isPending ? (
         <div className="space-y-4">
           <Skeleton className="h-56 w-full" />
         </div>
@@ -139,10 +162,24 @@ function listErrorState(error: unknown, onRetry: () => void) {
         "Signals belong to one business at a time — choose one and they'll load.",
     };
   }
-  if (code === "FORBIDDEN") {
+  // ★THE TWO CODES THAT ACTUALLY REACH A CUSTOMER HERE, and neither was mapped.
+  // A first cut listed `FORBIDDEN` — which this route does not emit, since it
+  // carries no `requireRole` — while `NO_ORG` (from `requireOrg`) and
+  // `UNAUTHORIZED` (an expired session whose refresh failed) both fell through
+  // to "that's on us, try again", with a retry button that can never resolve
+  // either. Mapping codes the route cannot produce and missing the ones it can
+  // is worse than mapping none: it reads as coverage.
+  if (code === "NO_ORG") {
     return {
-      title: "You don't have access to this",
-      description: "Ask an owner or admin on this business to open it for you.",
+      title: "This account isn't set up yet",
+      description:
+        "Signals belong to an organisation, and yours isn't finished. Finish onboarding and they'll load.",
+    };
+  }
+  if (code === "UNAUTHORIZED") {
+    return {
+      title: "Your session has expired",
+      description: "Sign in again and this will come straight back.",
     };
   }
   return {
@@ -155,15 +192,26 @@ function listErrorState(error: unknown, onRetry: () => void) {
 /**
  * The message for a failed write.
  *
- * ★EVERY CODE THE API CAN RETURN, AND NO `FORBIDDEN` ENDS IN "TRY AGAIN". These
- * routes are `requireRole("admin")`, so an editor hits 403 on every write —
- * being told to retry would be advice that can never come good. And
- * `NOTHING_TO_UPDATE` is its own code precisely so that pressing Save with
- * nothing changed does not produce a lecture about Partner ID characters.
+ * ★NO `FORBIDDEN` ENDS IN "TRY AGAIN". These routes are `requireRole("admin")`,
+ * so an editor hits 403 on every write — being told to retry would be advice
+ * that can never come good. And `NOTHING_TO_UPDATE` is its own code precisely
+ * so that pressing Save with nothing changed does not produce a lecture about
+ * Partner ID characters.
+ *
+ * ★AN EARLIER DRAFT CLAIMED "EVERY CODE THE API CAN RETURN" AND MISSED TWO —
+ * `NO_ORG` and `UNAUTHORIZED`, both from middleware ABOVE the route, which is
+ * exactly where a list built by reading one handler stops looking. The claim is
+ * dropped rather than re-made: the default branch is the honest one, and every
+ * code below is there because it was traced to a `fail(...)` that can reach a
+ * customer.
  */
 function writeErrorMessage(error: unknown): string {
   const code = error instanceof ApiError ? error.code : undefined;
   switch (code) {
+    case "NO_ORG":
+      return "This account isn't finished being set up — finish onboarding and try again.";
+    case "UNAUTHORIZED":
+      return "Your session has expired. Sign in again and nothing will be lost.";
     case "SIGNAL_EXISTS":
       return "This business already has one of these — reload the page to see it.";
     case "FORBIDDEN":
@@ -402,7 +450,10 @@ function SnippetBlock({ provider }: { provider: SignalProvider }) {
   // a NEW snippet under a button still reading "Copied" — which is the precise
   // failure the change warning exists to prevent, one component further down.
   const [copiedText, setCopiedText] = useState<string | null>(null);
-  const [copyFailed, setCopyFailed] = useState(false);
+  // ★KEYED ON THE SNIPPET TOO, for the reason  is. A boolean stayed
+  // true across a refetch, so a stale "we could not copy that" sat under a NEW
+  // snippet — the same bug as the stale "Copied", one state variable along.
+  const [copyFailedFor, setCopyFailedFor] = useState<string | null>(null);
 
   if (isPending) return <Skeleton className="h-40 w-full" />;
   if (isError || !data) {
@@ -433,21 +484,21 @@ function SnippetBlock({ provider }: { provider: SignalProvider }) {
           // click a no-op — no copy, no error, button unchanged — so the
           // customer walks away believing they have the snippet. A rejected
           // `writeText` (permission denied, document not focused) did the same.
-          setCopyFailed(false);
+          setCopyFailedFor(null);
           const clipboard = navigator.clipboard;
           if (!clipboard) {
-            setCopyFailed(true);
+            setCopyFailedFor(data.snippet);
             return;
           }
           clipboard.writeText(data.snippet).then(
             () => setCopiedText(data.snippet),
-            () => setCopyFailed(true),
+            () => setCopyFailedFor(data.snippet),
           );
         }}
       >
         {copiedText === data.snippet ? "Copied" : "Copy snippet"}
       </Button>
-      {copyFailed && (
+      {copyFailedFor === data.snippet && (
         <p className="text-sm text-destructive">
           Your browser wouldn&apos;t let us copy that. Select the snippet above and copy it
           by hand.
@@ -466,6 +517,33 @@ function RailSelect({
   rails: SignalRail[];
   onChange: (r: SignalRail) => void;
 }) {
+  // ★A STORED RAIL THE SERVER NO LONGER OFFERS RENDERS AS TEXT, NOT AS A BLANK
+  // SELECT. Radix suppresses the placeholder when `value` is set and portals
+  // nothing when no item matches — so a `wordpress` row (which this PR
+  // deliberately keeps alive) opened an edit form with an empty control under
+  // the label "How it reaches your site", and Save disabled because nothing had
+  // changed. The field looked broken on exactly the row the feature spends its
+  // largest fix defending.
+  if (!rails.includes(value)) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {railLabel(value)} — this option isn&apos;t available any more.{" "}
+        {rails.length === 1
+          ? `Saving will move it to “${railLabel(rails[0])}”.`
+          : "Pick another below."}
+        {rails.length === 1 && (
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto p-0 pl-1"
+            onClick={() => onChange(rails[0])}
+          >
+            Switch now
+          </Button>
+        )}
+      </p>
+    );
+  }
   return (
     <Select value={value} onValueChange={(v) => onChange(v as SignalRail)}>
       <SelectTrigger>

--- a/src/app/(site)/dashboard/growth/signals/page.tsx
+++ b/src/app/(site)/dashboard/growth/signals/page.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Minus, Radar, X } from "lucide-react";
+import { ApiError } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EmptyState } from "@/components/molecules/empty-state";
+import {
+  useCreateSignal,
+  useRemoveSignal,
+  useSignalSnippet,
+  useSignals,
+  useUpdateSignal,
+} from "@/hooks/use-signals";
+import type { Signal, SignalProvider, SignalRail } from "@/lib/api/signals";
+import {
+  PARTNER_ID_CHANGE_WARNING,
+  evidenceChain,
+  providerLabel,
+  railLabel,
+  stateCopy,
+} from "@/lib/signal-copy";
+
+/**
+ * Signals — the tracking tags on the customer's own website, and the evidence
+ * they fire.
+ *
+ * `peakhour-mongodb/docs/idea/linkedin-ads-engine-v2.md` §5 item 1.
+ *
+ * ── ★WHY THIS SCREEN LOOKS LIKE A CHAIN AND NOT A TOGGLE ──────────────────
+ *
+ * §6 asks how "installed" is VERIFIED rather than asserted — "a fired event,
+ * not a saved setting". The obvious UI for a tracking tag is a switch and a
+ * green tick, and it would be a lie: a switch records that somebody CHOSE
+ * something, which is the weakest of the three things we know and the one most
+ * easily mistaken for installation.
+ *
+ * So the card renders the chain instead — set up → sent to your site → seen
+ * working — with the middle step showing NOT APPLICABLE rather than "not done"
+ * when the customer pastes the snippet themselves, because there is no step of
+ * ours in that path to observe.
+ *
+ * ── ★AND THERE ARE NO NUMBERS ON IT ──────────────────────────────────────
+ *
+ * Not an omission. The collection stores no fire count on purpose — the beacon
+ * is coalesced, so a counter would count observation windows rather than visits
+ * — and a figure that is neither is a confident number nobody sourced sitting
+ * next to real ones. "Last seen" is a fact; "1,284 hits" would not be.
+ */
+export default function SignalsPage() {
+  const { data, isPending, isError, refetch, isFetching } = useSignals();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold tracking-tight">Signals</h2>
+        <p className="text-muted-foreground">
+          A small piece of code on your website that lets LinkedIn recognise the people
+          who visit it. It&apos;s what makes retargeting — advertising to people who
+          already came to your site — possible at all.
+        </p>
+      </div>
+
+      {isPending ? (
+        <div className="space-y-4">
+          <Skeleton className="h-56 w-full" />
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon={Radar}
+          title="We couldn&apos;t load your signals"
+          description="That&apos;s on us — nothing has been changed. Try again in a moment."
+          action={{ label: "Try again", onClick: () => void refetch() }}
+        />
+      ) : (
+        <div className="space-y-4">
+          {data.availableProviders.map((provider) => {
+            const signal = data.signals.find((s) => s.provider === provider);
+            return signal ? (
+              <SignalCard
+                key={provider}
+                signal={signal}
+                rails={data.availableRails}
+                onRecheck={() => void refetch()}
+                rechecking={isFetching}
+              />
+            ) : (
+              <SetUpCard key={provider} provider={provider} rails={data.availableRails} />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The three levels, drawn so that "not applicable" cannot read as "not done". */
+function EvidenceChain({ signal }: { signal: Signal }) {
+  return (
+    <ol className="space-y-3">
+      {evidenceChain(signal).map((step) => (
+        <li key={step.label} className="flex gap-3">
+          <span
+            aria-hidden
+            className={
+              step.reached === true
+                ? "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600"
+                : step.reached === false
+                  ? "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-dashed text-muted-foreground"
+                  : "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"
+            }
+          >
+            {step.reached === true ? (
+              <Check className="size-3" />
+            ) : step.reached === null ? (
+              <Minus className="size-3" />
+            ) : (
+              <X className="size-3 opacity-40" />
+            )}
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-medium">
+              {step.label}
+              {/* ★SAID IN WORDS, NOT ONLY IN AN ICON. A dash and a cross are two
+                  greys apart; "doesn't apply" is the whole difference between a
+                  rail that cannot report and a rail that has not. */}
+              {step.reached === null && (
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  doesn&apos;t apply here
+                </span>
+              )}
+            </p>
+            <p className="text-sm text-muted-foreground">{step.detail}</p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function SignalCard({
+  signal,
+  rails,
+  onRecheck,
+  rechecking,
+}: {
+  signal: Signal;
+  rails: SignalRail[];
+  onRecheck: () => void;
+  rechecking: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [partnerId, setPartnerId] = useState(signal.partnerId);
+  const [rail, setRail] = useState<SignalRail>(signal.delivery.rail);
+  const [showSnippet, setShowSnippet] = useState(false);
+  const update = useUpdateSignal();
+  const remove = useRemoveSignal();
+  const state = stateCopy(signal);
+
+  const partnerIdChanged = partnerId.trim() !== signal.partnerId;
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+        <div>
+          <CardTitle className="text-base">{providerLabel(signal.provider)}</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Partner ID {signal.partnerId} · {railLabel(signal.delivery.rail)}
+          </p>
+        </div>
+        <Badge
+          variant={state.tone === "ok" ? "default" : "secondary"}
+          className={state.tone === "attention" ? "border-amber-500/40 text-amber-700" : undefined}
+        >
+          {state.title}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-sm">{state.body}</p>
+
+        <EvidenceChain signal={signal} />
+
+        <div className="flex flex-wrap gap-2">
+          {/* ★"CHECK AGAIN", NOT A LIVE POLL. We are not watching the customer's
+              site; we look when asked. A spinner that implied otherwise would be
+              a claim about our own behaviour that is not true. */}
+          <Button variant="outline" size="sm" onClick={onRecheck} disabled={rechecking}>
+            {rechecking ? "Checking…" : "Check again"}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setShowSnippet((v) => !v)}>
+            {showSnippet ? "Hide snippet" : "Show snippet"}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setEditing((v) => !v)}>
+            {editing ? "Cancel" : "Edit"}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive"
+            disabled={remove.isPending}
+            onClick={() => remove.mutate(signal.provider)}
+          >
+            Remove
+          </Button>
+        </div>
+
+        {/* ★REMOVING OUR RECORD IS NOT REMOVING THEIR TAG, and saying so
+            afterwards would be too late to be useful. */}
+        {remove.isSuccess && (
+          <p className="text-sm text-muted-foreground">
+            Removed from Peakhour. If you pasted the snippet into your site yourself, it
+            is still there and still loading — take it out of your pages to stop it.
+          </p>
+        )}
+
+        {showSnippet && <SnippetBlock provider={signal.provider} />}
+
+        {editing && (
+          <div className="space-y-3 rounded-md border p-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="partnerId">Partner ID</Label>
+              <Input
+                id="partnerId"
+                value={partnerId}
+                onChange={(e) => setPartnerId(e.target.value)}
+                placeholder="1234567"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>How it reaches your site</Label>
+              <RailSelect value={rail} rails={rails} onChange={setRail} />
+            </div>
+            {/* ★THE COST OF THE CHANGE, BEFORE THE CLICK. Changing the Partner ID
+                clears the verification, so the card drops back to "Not seen yet"
+                — which reads as a regression to anybody who was not told why. */}
+            {partnerIdChanged && (
+              <p className="text-sm text-amber-700">{PARTNER_ID_CHANGE_WARNING}</p>
+            )}
+            {update.isError && (
+              <p className="text-sm text-destructive">
+                {update.error instanceof ApiError && update.error.code === "VALIDATION_ERROR"
+                  ? "A Partner ID can only contain letters, numbers, hyphens and underscores."
+                  : "We couldn't save that. Nothing has been changed — try again in a moment."}
+              </p>
+            )}
+            <Button
+              size="sm"
+              disabled={update.isPending}
+              onClick={() =>
+                update.mutate(
+                  {
+                    provider: signal.provider,
+                    patch: {
+                      ...(partnerIdChanged ? { partnerId: partnerId.trim() } : {}),
+                      ...(rail !== signal.delivery.rail ? { rail } : {}),
+                    },
+                  },
+                  { onSuccess: () => setEditing(false) },
+                )
+              }
+            >
+              Save
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SnippetBlock({ provider }: { provider: SignalProvider }) {
+  const { data, isPending, isError } = useSignalSnippet(provider);
+  const [copied, setCopied] = useState(false);
+
+  if (isPending) return <Skeleton className="h-40 w-full" />;
+  if (isError || !data) {
+    // ★THE ONE ERROR WORTH ITS OWN SENTENCE. The api REFUSES to build a snippet
+    // it cannot address correctly, rather than emitting one pointing at the
+    // wrong deployment — which would be pasted somewhere permanent and could
+    // never verify.
+    return (
+      <p className="text-sm text-destructive">
+        We couldn&apos;t build your snippet just now. Don&apos;t paste an older copy —
+        try again in a moment and use the fresh one.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-muted-foreground">{data.placement}</p>
+      <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs">
+        <code>{data.snippet}</code>
+      </pre>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          void navigator.clipboard?.writeText(data.snippet).then(() => setCopied(true));
+        }}
+      >
+        {copied ? "Copied" : "Copy snippet"}
+      </Button>
+    </div>
+  );
+}
+
+function RailSelect({
+  value,
+  rails,
+  onChange,
+}: {
+  value: SignalRail;
+  rails: SignalRail[];
+  onChange: (r: SignalRail) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as SignalRail)}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {/* ★THE RAILS ARE THE SERVER'S. There is no Shopify option because there
+            is no Shopify rail — nothing in the product can inject a script into
+            a Shopify theme, and an option that recorded an intention we cannot
+            act on would read as installed while installing nothing. A Shopify
+            merchant pastes the snippet, which is `manual` and is a first-class
+            choice here rather than a fallback. */}
+        {rails.map((r) => (
+          <SelectItem key={r} value={r}>
+            {railLabel(r)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function SetUpCard({ provider, rails }: { provider: SignalProvider; rails: SignalRail[] }) {
+  const [partnerId, setPartnerId] = useState("");
+  const [rail, setRail] = useState<SignalRail>(rails[0] ?? "manual");
+  const create = useCreateSignal();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{providerLabel(provider)}</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Not set up yet. You&apos;ll find your Partner ID in LinkedIn Campaign Manager
+          under Account Assets → Insight Tag.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-1.5">
+          <Label htmlFor={`partner-${provider}`}>Partner ID</Label>
+          <Input
+            id={`partner-${provider}`}
+            value={partnerId}
+            onChange={(e) => setPartnerId(e.target.value)}
+            placeholder="1234567"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label>How it should reach your site</Label>
+          <RailSelect value={rail} rails={rails} onChange={setRail} />
+        </div>
+        {create.isError && (
+          <p className="text-sm text-destructive">
+            {create.error instanceof ApiError && create.error.code === "SIGNAL_EXISTS"
+              ? "This business already has one of these — reload the page to see it."
+              : create.error instanceof ApiError && create.error.code === "FORBIDDEN"
+                ? "You need an admin or owner role on this business to set up a signal."
+                : create.error instanceof ApiError && create.error.code === "VALIDATION_ERROR"
+                  ? "A Partner ID can only contain letters, numbers, hyphens and underscores."
+                  : "We couldn't save that. Nothing has been changed — try again in a moment."}
+          </p>
+        )}
+        <Button
+          size="sm"
+          disabled={create.isPending || partnerId.trim().length === 0}
+          onClick={() => create.mutate({ provider, partnerId: partnerId.trim(), rail })}
+        >
+          Set up
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(site)/dashboard/layout.tsx
+++ b/src/app/(site)/dashboard/layout.tsx
@@ -154,6 +154,14 @@ const NAV_GROUPS: NavGroup[] = [
           // what it goes on.
           { href: "/dashboard/growth/business", label: "Your Business" },
           { href: "/dashboard/growth/audiences", label: "Audiences" },
+          // ★SIGNALS SITS UNDER AUDIENCES BECAUSE IT IS WHAT MAKES ONE OF THEM
+          // POSSIBLE. A retargeting audience IS website visitors, and without a
+          // tag on the site there is nobody to retarget — so this is a
+          // prerequisite of the list above it, not a settings page. It is under
+          // Growth rather than Integrations deliberately: Integrations is where
+          // a CONNECTION to somebody else's account lives, and this is code on
+          // the customer's own site.
+          { href: "/dashboard/growth/signals", label: "Signals" },
           { href: "/dashboard/ads", label: "Ads" },
           { href: "/dashboard/outcomes", label: "Outcomes" },
           { href: "/dashboard/optimizer", label: "Optimizer" },

--- a/src/hooks/use-signals.ts
+++ b/src/hooks/use-signals.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/providers/auth-provider";
+import {
+  signalsApi,
+  type Signal,
+  type SignalProvider,
+  type SignalRail,
+  type SignalsResponse,
+  type SnippetResponse,
+} from "@/lib/api/signals";
+
+/**
+ * Website signals — the tracking tags a business has on its own site.
+ *
+ * ★THE BUSINESS IS IN EVERY KEY. A signal is per-business (its partner id, its
+ * public site key, its verification), and a cache key that did not say which
+ * business is one `clear()` away from showing another one's site key — which
+ * is the value the customer is about to paste into a page.
+ */
+
+const key = (businessId: string | undefined) => ["signals", businessId ?? "none"] as const;
+
+export function useSignals() {
+  const { business } = useAuth();
+  return useQuery<SignalsResponse>({
+    queryKey: key(business?._id),
+    queryFn: () => signalsApi.list(),
+    // ★NO `refetchInterval`. A signal that has never fired is waiting on a
+    // human — installing a snippet, or a visitor arriving — and polling every
+    // few seconds would spend the customer's battery to re-render an unchanged
+    // "not yet". The page offers an explicit re-check instead, which is also
+    // the honest shape: we are not watching, we are looking when asked.
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * The snippet, fetched only when a surface actually asks for it.
+ *
+ * Separate from the list because it is per-provider and because the api
+ * REFUSES rather than guessing its own origin — a snippet carrying the wrong
+ * beacon address would be pasted somewhere permanent and could never verify.
+ * That refusal has to be able to surface on its own.
+ */
+export function useSignalSnippet(provider: SignalProvider | null) {
+  const { business } = useAuth();
+  return useQuery<SnippetResponse>({
+    queryKey: [...key(business?._id), "snippet", provider],
+    queryFn: () => signalsApi.snippet(provider as SignalProvider),
+    enabled: !!provider,
+  });
+}
+
+export function useCreateSignal() {
+  const qc = useQueryClient();
+  const { business } = useAuth();
+  return useMutation<Signal, unknown, { provider: SignalProvider; partnerId: string; rail: SignalRail }>({
+    mutationFn: (body) => signalsApi.create(body),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: key(business?._id) }),
+  });
+}
+
+export function useUpdateSignal() {
+  const qc = useQueryClient();
+  const { business } = useAuth();
+  return useMutation<
+    Signal,
+    unknown,
+    { provider: SignalProvider; patch: { partnerId?: string; rail?: SignalRail } }
+  >({
+    mutationFn: ({ provider, patch }) => signalsApi.update(provider, patch),
+    // ★THE SNIPPET IS INVALIDATED TOO, and it is the one that matters: changing
+    // the partner id changes the snippet the customer has to republish, and a
+    // cached copy of the old one is the exact thing they must not paste.
+    onSuccess: () => void qc.invalidateQueries({ queryKey: key(business?._id) }),
+  });
+}
+
+export function useRemoveSignal() {
+  const qc = useQueryClient();
+  const { business } = useAuth();
+  return useMutation({
+    mutationFn: (provider: SignalProvider) => signalsApi.remove(provider),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: key(business?._id) }),
+  });
+}

--- a/src/hooks/use-signals.ts
+++ b/src/hooks/use-signals.ts
@@ -27,6 +27,14 @@ export function useSignals() {
   return useQuery<SignalsResponse>({
     queryKey: key(business?._id),
     queryFn: () => signalsApi.list(),
+    // ★GATED, LIKE EVERY OTHER BUSINESS-SCOPED HOOK HERE. Without it the query
+    // fires once under the `"none"` key before auth resolves and again under
+    // the real one — and for a multi-business org with nothing pinned
+    // (`auth-provider` only auto-resolves when there is exactly one) the first
+    // call 403s and there IS no second, so the page sits on an error state
+    // forever. A key that says which business is undermined by a bucket that
+    // says "none".
+    enabled: !!business?._id,
     // ★NO `refetchInterval`. A signal that has never fired is waiting on a
     // human — installing a snippet, or a visitor arriving — and polling every
     // few seconds would spend the customer's battery to re-render an unchanged
@@ -49,7 +57,7 @@ export function useSignalSnippet(provider: SignalProvider | null) {
   return useQuery<SnippetResponse>({
     queryKey: [...key(business?._id), "snippet", provider],
     queryFn: () => signalsApi.snippet(provider as SignalProvider),
-    enabled: !!provider,
+    enabled: !!provider && !!business?._id,
   });
 }
 

--- a/src/lib/api/signals.ts
+++ b/src/lib/api/signals.ts
@@ -1,0 +1,127 @@
+import { api } from "@/lib/api";
+
+/**
+ * Website signals — the tracking tags a business has on its OWN site, and the
+ * evidence they fire.
+ *
+ * `peakhour-mongodb/docs/idea/linkedin-ads-engine-v2.md` §5 item 1. This is the
+ * first item in that sequence because two of the three default audience sets
+ * depend on it: a retargeting audience IS website visitors.
+ *
+ * ── ★THE ONE THING THIS CLIENT MUST NOT DO ────────────────────────────────
+ *
+ * §6 asks how "installed" is VERIFIED rather than asserted. The api answers by
+ * keeping THREE LEVELS OF EVIDENCE apart, and every one of them arrives here
+ * separately so the UI cannot quietly promote one into another:
+ *
+ *   declared — somebody chose a rail and a partner id. A saved setting.
+ *   served   — a rail we control fetched the snippet. Only `wordpress` can
+ *              reach this; on `manual` there is no server of ours in the path,
+ *              so `lastServedAt: null` there is a FACT ABOUT THE RAIL and must
+ *              never be rendered as a problem.
+ *   fired    — a browser loaded the provider's script and called our beacon.
+ *              The only level that is evidence.
+ *
+ * `evidence` and `state` are different questions — "has this ever been
+ * proven?" and "is it proven today?" — and a tag that fired last year is
+ * `fired` + `not_seen_recently`. Rendering one and dropping the other loses a
+ * fact whichever way it goes.
+ */
+
+export type SignalProvider = "linkedin_insight";
+export type SignalRail = "wordpress" | "manual";
+
+/** The highest level of evidence ever reached. Not a status. */
+export type SignalEvidence = "declared" | "served" | "fired";
+
+/**
+ * Where a signal stands right now.
+ *
+ * ★`not_seen_recently` IS NOT "BROKEN", and copy must never say it is. Nobody
+ * can distinguish a tag that was removed from a website nobody visited, so the
+ * surface shows `lastFiredAt` — a fact — and lets the customer judge. "We
+ * cannot tell" is its own answer and must not render as a diagnosis.
+ */
+export type SignalState = "never_fired" | "firing" | "not_seen_recently";
+
+export interface Signal {
+  provider: SignalProvider;
+  partnerId: string;
+  /** The public key in the snippet. Not a secret — it is in the page source of
+   *  every page carrying the tag — and the surface cannot render the snippet
+   *  without it. */
+  siteKey: string;
+  delivery: {
+    rail: SignalRail;
+    chosenAt: string;
+    /** Level 2. `null` on the `manual` rail BY DEFINITION — see the header. */
+    lastServedAt: string | null;
+  };
+  /** Level 3, and `null` means NEVER FIRED — the ordinary first state of a
+   *  signal configured a minute ago, and the alarming state of one configured a
+   *  month ago. The difference is `delivery.chosenAt`, not a flag. */
+  verification: {
+    firstFiredAt: string;
+    lastFiredAt: string;
+    /** `null` when the beacon's origin could not be read. Distinct from
+     *  `verification` itself being null. */
+    lastFiredHost: string | null;
+    /** `firstFiredAt === lastFiredAt` — one observation window has ever
+     *  reported. The collection stores no fire count on purpose (a coalesced
+     *  beacon counts windows, not visits), so this is the only thing near a
+     *  count that exists, and it is a boolean rather than a number for exactly
+     *  that reason. ★NOTHING HERE MAY BE RENDERED AS TRAFFIC. */
+    seenOnceOnly: boolean;
+  } | null;
+  evidence: SignalEvidence;
+  state: SignalState;
+  /** How long `firing` lasts without a new beacon. Read from the api rather
+   *  than hardcoded, so the copy cannot drift from the rule. */
+  freshWindowDays: number;
+}
+
+export interface SignalsResponse {
+  signals: Signal[];
+  availableProviders: SignalProvider[];
+  availableRails: SignalRail[];
+}
+
+export interface SnippetResponse {
+  provider: SignalProvider;
+  siteKey: string;
+  rail: SignalRail;
+  snippet: string;
+  placement: string;
+}
+
+export const signalsApi = {
+  list: () => api.get<SignalsResponse>("/v1/signals"),
+
+  /** Configure a signal. 409 SIGNAL_EXISTS when one already exists for the
+   *  provider — the unique index winning a double-click, which the api turns
+   *  into the same answer the sequential path gives. */
+  create: (body: { provider: SignalProvider; partnerId: string; rail: SignalRail }) =>
+    api.post<Signal>("/v1/signals", body),
+
+  /**
+   * ★CHANGING THE PARTNER ID CLEARS THE VERIFICATION, and the UI has to say so
+   * BEFORE the click. The beacon is keyed by `siteKey`, not by the partner id,
+   * so a published page would keep reporting "firing" for a tag pointing at an
+   * account the customer no longer uses. The response comes back
+   * `never_fired`, which is the truth and looks like a regression if nobody
+   * was warned.
+   */
+  update: (provider: SignalProvider, patch: { partnerId?: string; rail?: SignalRail }) =>
+    api.patch<Signal>(`/v1/signals/${provider}`, patch),
+
+  /** Removes OUR record, not their page: on the `manual` rail the tag keeps
+   *  loading and its beacons become no-ops, which is what
+   *  `snippetMayRemainOnSite` is for. */
+  remove: (provider: SignalProvider) =>
+    api.delete<{ deleted: true; provider: SignalProvider; snippetMayRemainOnSite: boolean }>(
+      `/v1/signals/${provider}`,
+    ),
+
+  snippet: (provider: SignalProvider) =>
+    api.get<SnippetResponse>(`/v1/signals/${provider}/snippet`),
+};

--- a/src/lib/signal-copy.test.ts
+++ b/src/lib/signal-copy.test.ts
@@ -118,18 +118,43 @@ describe("state copy never says more than the data supports", () => {
     // 15 minutes, so "just visit your site" produces no change on this screen
     // for a customer who already has it open — after being told that is the
     // quickest way to find out.
-    for (const state of ["never_fired", "not_seen_recently"] as const) {
-      const body = stateCopy(base({ state })).body;
-      expect(body, state).toMatch(/private window|new window/i);
-      expect(body, state).toMatch(/once per browser session/i);
+    //
+    // ★AND ON THE `wordpress` BRANCH TOO. A first cut looped over `base({state})`
+    // only, and `base()` hardcodes `rail: "manual"` — so the branch round 1
+    // rewrote was uncovered by the test that names its rule, and restoring
+    // "then visit your site to confirm it" there left 11/11 green.
+    const cases: Array<[string, Signal]> = [
+      ["manual/never_fired", base({ state: "never_fired" })],
+      ["manual/not_seen_recently", base({ state: "not_seen_recently" })],
+      ["wordpress/never_fired", withRail("wordpress", { state: "never_fired" })],
+      ["wordpress/not_seen_recently", withRail("wordpress", { state: "not_seen_recently" })],
+    ];
+    for (const [name, signal] of cases) {
+      const body = stateCopy(signal).body;
+      expect(body, name).toMatch(/private window|new window/i);
+      expect(body, name).toMatch(/once per browser session/i);
     }
   });
 
-  it("carries no number that could be read as traffic", () => {
-    for (const state of ["firing", "never_fired", "not_seen_recently"] as const) {
-      const body = stateCopy(state === "firing" ? fired() : base({ state })).body;
-      // The freshness window is the only figure allowed, and it is the api's.
-      expect(body.replace(/\b7 days\b/g, ""), state).not.toMatch(/\d+[\d,]*\s*(visits?|hits?|views?|people)/i);
+  it("★carries no number that could be read as traffic — on EVERY branch", () => {
+    // ★THE FIRST CUT LOOPED OVER `fired()`, WHOSE FIXTURE HARDCODES
+    // `seenOnceOnly: true` — so the ONE string in the file that interpolates a
+    // figure was never rendered by any test, and injecting "1,284 real visits"
+    // left 11/11 green. The rule this file names first, guarded by a loop that
+    // could not reach it.
+    const bodies = [
+      stateCopy(fired()).body,
+      stateCopy(fired({ seenOnceOnly: false })).body,
+      stateCopy(base({ state: "never_fired" })).body,
+      stateCopy(withRail("wordpress", { state: "never_fired" })).body,
+      stateCopy(base({ state: "not_seen_recently" })).body,
+    ];
+    for (const body of bodies) {
+      // ★NO DIGIT AT ALL once the api's own freshness window is removed, rather
+      // than a list of unit words. A blocklist only catches the phrasings
+      // whoever wrote it imagined; "1,284 loads", "seen 12×" and "3 sessions"
+      // all slip past one.
+      expect(body.replace(/\b7 days\b/g, ""), body).not.toMatch(/\d/);
     }
   });
 });

--- a/src/lib/signal-copy.test.ts
+++ b/src/lib/signal-copy.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { evidenceChain, stateCopy, formatWhen, railLabel } from "@/lib/signal-copy";
+import type { Signal, SignalRail } from "@/lib/api/signals";
+
+/**
+ * ★EVERY FAILURE THIS FILE GUARDS AGAINST LOOKS THE SAME FROM THE OUTSIDE: a
+ * confident sentence about the customer's website that we have no evidence for.
+ * None of them throw, none of them fail a typecheck, and none of them are
+ * visible without reading the copy against what the data actually means.
+ */
+
+const base = (over: Partial<Signal> = {}): Signal => ({
+  provider: "linkedin_insight",
+  partnerId: "1234567",
+  siteKey: "0123456789abcdef0123456789abcdef",
+  delivery: { rail: "manual", chosenAt: "2026-08-01T00:00:00.000Z", lastServedAt: null },
+  verification: null,
+  evidence: "declared",
+  state: "never_fired",
+  freshWindowDays: 7,
+  ...over,
+});
+
+const withRail = (rail: SignalRail, over: Partial<Signal> = {}) =>
+  base({ delivery: { rail, chosenAt: "2026-08-01T00:00:00.000Z", lastServedAt: null }, ...over });
+
+describe("the evidence chain keeps three levels apart", () => {
+  it("★a `manual` rail's middle step is NOT APPLICABLE, never a failure", () => {
+    // The step that cannot exist on this rail: there is no server of ours in the
+    // path, so nothing could observe a serve. Rendering it unchecked would tell
+    // every copy-paste customer something is wrong with an installation that is
+    // fine.
+    const [, sent] = evidenceChain(withRail("manual"));
+    expect(sent.reached).toBeNull();
+    expect(sent.detail).not.toMatch(/hasn't|not yet|can't deliver/i);
+  });
+
+  it("★a `wordpress` rail with no serve does NOT promise a sync that does not exist", () => {
+    // THE ASSERTION THAT WOULD HAVE MADE THE ORIGINAL BUG UNSHIPPABLE. Nothing
+    // writes `lastServedAt` — there is no plugin-facing snippet endpoint — so
+    // copy saying "it asks for this when it next syncs" told the customer to
+    // wait for something that can never happen. Writing this test forces the
+    // question "what sets lastServedAt?", which is how the defect surfaces.
+    const [, sent] = evidenceChain(withRail("wordpress"));
+    expect(sent.reached).toBe(false);
+    expect(sent.detail).not.toMatch(/sync/i);
+    expect(sent.detail).toMatch(/by hand/i);
+
+    // And the state copy must not tell them to wait either.
+    const body = stateCopy(withRail("wordpress")).body;
+    expect(body).not.toMatch(/that's normal until|wait/i);
+  });
+
+  it("a served wordpress signal reports the serve as a fact with a time", () => {
+    const [, sent] = evidenceChain(
+      withRail("wordpress", {
+        delivery: {
+          rail: "wordpress",
+          chosenAt: "2026-08-01T00:00:00.000Z",
+          lastServedAt: new Date(Date.now() - 3_600_000).toISOString(),
+        },
+      }),
+    );
+    expect(sent.reached).toBe(true);
+    expect(sent.detail).toMatch(/picked it up/i);
+  });
+});
+
+describe("state copy never says more than the data supports", () => {
+  const fired = (over: Partial<Signal["verification"]> = {}) =>
+    base({
+      state: "firing",
+      evidence: "fired",
+      verification: {
+        firstFiredAt: new Date().toISOString(),
+        lastFiredAt: new Date().toISOString(),
+        lastFiredHost: "www.example.com",
+        seenOnceOnly: true,
+        ...over,
+      } as Signal["verification"],
+    });
+
+  it("★a single fire does NOT claim the tag is installed on their site", () => {
+    // A beacon proves a browser SOMEWHERE ran the snippet — the site key is in
+    // the page source of every page carrying it — and one fire is most often the
+    // customer testing on staging or localhost. The host is what makes the claim
+    // checkable, so it has to appear in the sentence that makes it.
+    const body = stateCopy(fired()).body;
+    expect(body).not.toMatch(/enough to know it's installed/i);
+    expect(body).toContain("www.example.com");
+  });
+
+  it("an unreadable host leaves no empty phrase behind", () => {
+    const body = stateCopy(fired({ lastFiredHost: null })).body;
+    expect(body).not.toMatch(/ on \.|on $|on ,/);
+    expect(body).toMatch(/load(ed)? once/i);
+  });
+
+  it("★`not_seen_recently` never says broken, and never guesses which it is", () => {
+    const body = stateCopy(
+      base({
+        state: "not_seen_recently",
+        evidence: "fired",
+        verification: {
+          firstFiredAt: "2026-01-01T00:00:00.000Z",
+          lastFiredAt: "2026-06-01T00:00:00.000Z",
+          lastFiredHost: null,
+          seenOnceOnly: false,
+        },
+      }),
+    ).body;
+    expect(body).not.toMatch(/broken|not working|failed/i);
+    expect(body).toMatch(/can't tell/i);
+  });
+
+  it("★telling them to check says HOW, because the obvious way silently does nothing", () => {
+    // The snippet beacons once per browser SESSION and the server coalesces for
+    // 15 minutes, so "just visit your site" produces no change on this screen
+    // for a customer who already has it open — after being told that is the
+    // quickest way to find out.
+    for (const state of ["never_fired", "not_seen_recently"] as const) {
+      const body = stateCopy(base({ state })).body;
+      expect(body, state).toMatch(/private window|new window/i);
+      expect(body, state).toMatch(/once per browser session/i);
+    }
+  });
+
+  it("carries no number that could be read as traffic", () => {
+    for (const state of ["firing", "never_fired", "not_seen_recently"] as const) {
+      const body = stateCopy(state === "firing" ? fired() : base({ state })).body;
+      // The freshness window is the only figure allowed, and it is the api's.
+      expect(body.replace(/\b7 days\b/g, ""), state).not.toMatch(/\d+[\d,]*\s*(visits?|hits?|views?|people)/i);
+    }
+  });
+});
+
+describe("railLabel", () => {
+  it("describes what the rail DOES, so a card can name it without a legend", () => {
+    expect(railLabel("manual")).toMatch(/paste/i);
+    expect(railLabel("wordpress")).toMatch(/wordpress/i);
+  });
+});
+
+describe("formatWhen", () => {
+  it("never renders a negative age when a clock is skewed", () => {
+    expect(formatWhen(new Date(Date.now() + 60_000).toISOString())).toBe("just now");
+  });
+
+  it("says so rather than inventing a time", () => {
+    expect(formatWhen(undefined)).toBe("at an unknown time");
+    expect(formatWhen("not a date")).toBe("at an unknown time");
+  });
+});

--- a/src/lib/signal-copy.ts
+++ b/src/lib/signal-copy.ts
@@ -1,0 +1,154 @@
+import type { Signal, SignalProvider, SignalRail } from "@/lib/api/signals";
+
+/**
+ * The words this surface is allowed to use about a signal.
+ *
+ * ★COPY IS THE PRODUCT HERE, AND MOST OF THE WAYS TO GET IT WRONG PRODUCE THE
+ * SAME SYMPTOM: a confident sentence about the customer's website that we have
+ * no evidence for. The rules, from
+ * `peakhour-mongodb/docs/idea/linkedin-ads-engine-v2.md` §4.3:
+ *
+ *   - **The three absences stay distinct.** "Nobody set this up", "set up and
+ *     never seen", and "seen before, not lately" are three different situations
+ *     with three different next actions, and must never share a sentence.
+ *   - **"We cannot tell" is its own answer**, and must never render as "we
+ *     chose this". We cannot distinguish a tag that was REMOVED from a website
+ *     nobody VISITED, so `not_seen_recently` never says "broken".
+ *   - **Never a confident number we did not source.** There are no numbers on
+ *     this surface at all: the collection stores no fire count on purpose,
+ *     because a coalesced beacon counts observation windows rather than visits.
+ *   - **★Copy written for one channel is not copy for another.** The `manual`
+ *     rail has no plugin to blame and no serve to observe; the `wordpress` rail
+ *     does. A single sentence covering both is wrong for one of them, which is
+ *     why every function here takes the rail.
+ */
+
+export function providerLabel(provider: SignalProvider): string {
+  switch (provider) {
+    case "linkedin_insight":
+      return "LinkedIn Insight Tag";
+    default:
+      return provider;
+  }
+}
+
+export function railLabel(rail: SignalRail): string {
+  return rail === "wordpress" ? "Through the WordPress plugin" : "Pasted into your site";
+}
+
+export type EvidenceStep = {
+  label: string;
+  /** `true` reached, `false` not reached, `null` NOT APPLICABLE on this rail —
+   *  which is a third state on purpose. Rendering "not applicable" as "not
+   *  reached" would show every `manual` signal permanently missing a step it
+   *  can never have. */
+  reached: boolean | null;
+  detail: string;
+};
+
+/**
+ * The three levels of evidence, as a chain the customer can read.
+ *
+ * ★THE MIDDLE ONE IS `null` ON THE `manual` RAIL. There is no server of ours in
+ * that path, so nothing could ever observe a serve — its absence is a fact
+ * about the rail, not a failure, and a tick-list that showed it unchecked would
+ * be telling every copy-paste customer that something is wrong.
+ */
+export function evidenceChain(signal: Signal): EvidenceStep[] {
+  const served = signal.delivery.lastServedAt;
+  return [
+    {
+      label: "Set up",
+      reached: true,
+      detail: `${railLabel(signal.delivery.rail)}, ${formatWhen(signal.delivery.chosenAt)}.`,
+    },
+    {
+      label: "Sent to your site",
+      reached: signal.delivery.rail === "wordpress" ? !!served : null,
+      detail:
+        signal.delivery.rail !== "wordpress"
+          ? "Not something we can see when you paste the snippet yourself — there's no step of ours in between."
+          : served
+            ? `Your WordPress plugin last picked it up ${formatWhen(served)}.`
+            : "Your WordPress plugin hasn't picked it up yet. It asks for this when it next syncs.",
+    },
+    {
+      label: "Seen working",
+      reached: !!signal.verification,
+      detail: signal.verification
+        ? `A browser loaded LinkedIn's tag ${formatWhen(signal.verification.lastFiredAt)}${
+            signal.verification.lastFiredHost ? ` on ${signal.verification.lastFiredHost}` : ""
+          }.`
+        : "No browser has loaded LinkedIn's tag yet.",
+    },
+  ];
+}
+
+/**
+ * The headline for a signal's current state, and the next thing to do about it.
+ *
+ * ★NOTHING HERE SAYS "BROKEN", AND `not_seen_recently` IS WHY. A quiet tag and
+ * a removed tag look identical from where we stand, so the copy states the fact
+ * (when we last saw it) and offers the check, rather than a diagnosis we cannot
+ * support.
+ */
+export function stateCopy(signal: Signal): { title: string; body: string; tone: "ok" | "waiting" | "attention" } {
+  const provider = providerLabel(signal.provider);
+  switch (signal.state) {
+    case "firing":
+      return {
+        title: "Working",
+        body: signal.verification?.seenOnceOnly
+          ? `We've seen your ${provider} load once. That's enough to know it's installed — it'll keep confirming itself as people visit.`
+          : `We've seen your ${provider} load on a real visit in the last ${signal.freshWindowDays} days.`,
+        tone: "ok",
+      };
+    case "never_fired":
+      return {
+        title: "Not seen yet",
+        body:
+          signal.delivery.rail === "wordpress"
+            ? `Set up, but no browser has loaded it yet. That's normal until your plugin syncs and someone visits your site.`
+            : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then visit a page yourself to confirm it.`,
+        tone: "waiting",
+      };
+    case "not_seen_recently":
+      return {
+        title: "Quiet",
+        body:
+          `We last saw your ${provider} load ${formatWhen(signal.verification?.lastFiredAt)}, and nothing since. ` +
+          `That can mean the tag was removed, or simply that nobody has visited — we can't tell which from here. ` +
+          `Opening your site in a browser is the quickest way to find out.`,
+        tone: "attention",
+      };
+    default:
+      return { title: "Unknown", body: "", tone: "waiting" };
+  }
+}
+
+/**
+ * ★WHAT CHANGING THE PARTNER ID COSTS, SAID BEFORE THE CLICK.
+ *
+ * The api clears `verification` when the partner id changes, because the beacon
+ * is keyed by the site key rather than by the partner id — so a page still
+ * carrying the old snippet would go on reporting "working" for a tag pointing
+ * at an account the customer no longer uses. The result is a signal that reads
+ * "Not seen yet" immediately afterwards, which looks like a regression to
+ * anybody who was not told.
+ */
+export const PARTNER_ID_CHANGE_WARNING =
+  "Changing the Partner ID means the snippet on your site is out of date, so we stop counting it as verified until we see the new one load. You'll need to republish the snippet.";
+
+export function formatWhen(iso: string | undefined): string {
+  if (!iso) return "at an unknown time";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "at an unknown time";
+  const mins = Math.round((Date.now() - then) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins} minute${mins === 1 ? "" : "s"} ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days} day${days === 1 ? "" : "s"} ago`;
+  return new Date(then).toLocaleDateString();
+}

--- a/src/lib/signal-copy.ts
+++ b/src/lib/signal-copy.ts
@@ -38,11 +38,12 @@ const CONFIRM_HINT =
   "open your site in a NEW private window (the snippet only reports once per browser session) " +
   "and press Check again a minute later.";
 
-/** " on www.example.com", or nothing when the beacon's origin was unreadable —
- *  which is a real state and must not become an empty pair of quotes. */
+/** " from www.example.com", or nothing when the beacon's origin was unreadable
+ *  — a real state (the api UNSETS the host rather than leaving a stale one), and
+ *  one that must never leave a dangling preposition behind. */
 function hostClause(signal: Signal): string {
   const host = signal.verification?.lastFiredHost;
-  return host ? ` on ${host}` : "";
+  return host ? ` from ${host}` : "";
 }
 
 export function providerLabel(provider: SignalProvider): string {
@@ -135,9 +136,17 @@ export function stateCopy(signal: Signal): { title: string; body: string; tone: 
         // where "that's enough to know it's installed" would be wrong. The host
         // we heard from is named, so the customer can judge it, and is the
         // reason the api stores it at all.
+        // ★NO "THE ADDRESS ABOVE". An earlier draft said so, and there is no
+        // address above: the host appears in this same sentence when we have
+        // one, in the evidence step BELOW when we do, and NOWHERE when the
+        // beacon's origin was unreadable — which is a real state the api
+        // deliberately produces by unsetting the host. A sentence that points
+        // at something that is not on the screen is worse than a vaguer one.
         body: signal.verification?.seenOnceOnly
-          ? `We've seen your ${provider} load once${hostClause(signal)}. That's one browser, in one session — worth checking the address above is the site you meant.`
-          : `We've seen your ${provider} load on a real visit${hostClause(signal)} in the last ${signal.freshWindowDays} days.`,
+          ? hostClause(signal)
+            ? `We've seen your ${provider} load once, from ${signal.verification.lastFiredHost}. That's one browser in one session — check that address is the site you meant.`
+            : `We've seen your ${provider} load once, though we couldn't tell which site from. That's one browser in one session.`
+          : `We've seen your ${provider} load on a real visit${hostClause(signal)} within the last ${signal.freshWindowDays} days.`,
         tone: "ok",
       };
     case "never_fired":

--- a/src/lib/signal-copy.ts
+++ b/src/lib/signal-copy.ts
@@ -23,6 +23,28 @@ import type { Signal, SignalProvider, SignalRail } from "@/lib/api/signals";
  *     why every function here takes the rail.
  */
 
+/**
+ * ★HOW TO CONFIRM IT, SAID ACCURATELY — because the obvious instruction does
+ * not work.
+ *
+ * The snippet marks `sessionStorage` and beacons ONCE PER BROWSER SESSION, and
+ * the server then coalesces to one write per signal per 15 minutes. So a
+ * customer who already has the site open in that tab, or who re-checks within
+ * the window, produces no new beacon and no change on this screen — after being
+ * told that visiting the site is "the quickest way to find out". Two true
+ * sentences that combine into a false one.
+ */
+const CONFIRM_HINT =
+  "open your site in a NEW private window (the snippet only reports once per browser session) " +
+  "and press Check again a minute later.";
+
+/** " on www.example.com", or nothing when the beacon's origin was unreadable —
+ *  which is a real state and must not become an empty pair of quotes. */
+function hostClause(signal: Signal): string {
+  const host = signal.verification?.lastFiredHost;
+  return host ? ` on ${host}` : "";
+}
+
 export function providerLabel(provider: SignalProvider): string {
   switch (provider) {
     case "linkedin_insight":
@@ -70,7 +92,15 @@ export function evidenceChain(signal: Signal): EvidenceStep[] {
           ? "Not something we can see when you paste the snippet yourself — there's no step of ours in between."
           : served
             ? `Your WordPress plugin last picked it up ${formatWhen(served)}.`
-            : "Your WordPress plugin hasn't picked it up yet. It asks for this when it next syncs.",
+            : // ★NO PROMISE OF A SYNC, BECAUSE THERE ISN'T ONE. An earlier draft
+              // said "it asks for this when it next syncs" — telling the customer
+              // to wait for something that does not exist. Nothing writes
+              // `lastServedAt` today: there is no plugin-facing snippet endpoint
+              // and the plugin has no signals code, which is why `wordpress` is
+              // not offered as a choice. A stored row can still carry it (an
+              // older row, or a later api enabling the rail), so this branch
+              // stays — saying what is true.
+              "The plugin can't deliver this yet. Add the snippet to your site by hand for now.",
     },
     {
       label: "Seen working",
@@ -98,9 +128,16 @@ export function stateCopy(signal: Signal): { title: string; body: string; tone: 
     case "firing":
       return {
         title: "Working",
+        // ★"WE'VE SEEN IT LOAD ON <HOST>", NOT "IT'S INSTALLED". A beacon proves
+        // a browser SOMEWHERE ran the snippet — the site key is in the page
+        // source of every page carrying it — and the single-fire case is most
+        // often the customer testing on staging or localhost, which is exactly
+        // where "that's enough to know it's installed" would be wrong. The host
+        // we heard from is named, so the customer can judge it, and is the
+        // reason the api stores it at all.
         body: signal.verification?.seenOnceOnly
-          ? `We've seen your ${provider} load once. That's enough to know it's installed — it'll keep confirming itself as people visit.`
-          : `We've seen your ${provider} load on a real visit in the last ${signal.freshWindowDays} days.`,
+          ? `We've seen your ${provider} load once${hostClause(signal)}. That's one browser, in one session — worth checking the address above is the site you meant.`
+          : `We've seen your ${provider} load on a real visit${hostClause(signal)} in the last ${signal.freshWindowDays} days.`,
         tone: "ok",
       };
     case "never_fired":
@@ -108,8 +145,10 @@ export function stateCopy(signal: Signal): { title: string; body: string; tone: 
         title: "Not seen yet",
         body:
           signal.delivery.rail === "wordpress"
-            ? `Set up, but no browser has loaded it yet. That's normal until your plugin syncs and someone visits your site.`
-            : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then visit a page yourself to confirm it.`,
+            ? // No promise of a sync — see `evidenceChain`. Nothing delivers this
+              // rail yet, so "wait" would be advice that can never come good.
+              `Set up, but nothing has put it on your site yet. Add the snippet by hand for now, then ${CONFIRM_HINT}`
+            : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then ${CONFIRM_HINT}`,
         tone: "waiting",
       };
     case "not_seen_recently":
@@ -118,7 +157,7 @@ export function stateCopy(signal: Signal): { title: string; body: string; tone: 
         body:
           `We last saw your ${provider} load ${formatWhen(signal.verification?.lastFiredAt)}, and nothing since. ` +
           `That can mean the tag was removed, or simply that nobody has visited — we can't tell which from here. ` +
-          `Opening your site in a browser is the quickest way to find out.`,
+          `To check: ${CONFIRM_HINT}`,
         tone: "attention",
       };
     default:


### PR DESCRIPTION
`peakhour-mongodb/docs/idea/linkedin-ads-engine-v2.md` §5 item 1 — the b2c half,
over `/v1/signals` (api#1037) and `biz_signals` (mongodb#472, merged).

`/dashboard/growth/signals`, under Audiences in the nav, because a retargeting
audience IS website visitors and without a tag there is nobody to retarget. Under
Growth rather than Integrations deliberately: Integrations is where a CONNECTION
to somebody else's account lives, and this is code on the customer's own site.

## ★Why it is a chain and not a toggle

§6 asks how "installed" is VERIFIED rather than asserted. The obvious UI for a
tracking tag is a switch and a green tick, and it would be a lie: a switch
records that somebody CHOSE something, which is the weakest of the three things
we know and the one most easily mistaken for installation.

```
Set up            — a rail and a partner id were chosen. A saved setting.
Sent to your site — a rail we control fetched the snippet.
Seen working      — a browser loaded LinkedIn's tag and called our beacon.
```

★The middle step renders **NOT APPLICABLE** — a dash *and the words "doesn't
apply here"* — on the paste rail, because there is no step of ours in that path
to observe. A tick-list showing it unchecked would tell every copy-paste
customer something is wrong.

## What the copy may not say

- **`not_seen_recently` never says "broken".** A removed tag and a website
  nobody visited look identical from here.
- **No numbers at all.** The collection stores no fire count on purpose, so
  there is nothing that could be rendered as traffic.
- **"Check again", not a live poll.** We are not watching their site.
- Changing the Partner ID is warned about *before* the click, because it clears
  the verification and the card drops to "Not seen yet".

## ★What review changed

Round 1 found 13. The first is the one the standing rule exists for:

★**The `wordpress` rail was the pre-selected default and is not implemented
anywhere.** Nothing writes `delivery.lastServedAt` — no plugin-facing endpoint
exists and the plugin has no signals code — so the default choice gave a
permanent cross on "Sent to your site", copy telling the customer to wait for a
sync that cannot happen, and a tag that never fires because nothing put it on a
page, with the state copy calling that *normal*. The api now serves only
`manual`; the WordPress rail is the next PR.

★**"We've seen it load once — that's enough to know it's installed"** claimed
what the api's own comment says a beacon cannot support. It names the host now.

★**"Visit your site to confirm it" silently does nothing** for anyone who
already has the site open — the snippet beacons once per browser session and the
server coalesces for 15 minutes. Two true sentences that combined into a false
one.

Also: Remove was unconfirmed, irreversible (a new site key orphans every
published snippet), its explanation unreachable, and its failure silent; a no-op
Save produced a lecture about Partner ID characters; `FORBIDDEN` fell through to
"try again in a moment" on two surfaces; `useSignals` had no business gate;
`CardHeader` is a grid so the `flex-row` override was inert; `copied` never
reset; a clipboard failure was silent; and a failed background refetch destroyed
the loaded page.

11 new tests — the three the review named as highest-value, plus the copy rules
— and both false sentences are mutation-checked. 336 green, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
