### PR TITLE
fix(signals): copy for a WordPress rail that now works — and stop telling people to paste

### DIFF
--- a/src/app/(site)/dashboard/growth/signals/page.tsx
+++ b/src/app/(site)/dashboard/growth/signals/page.tsx
@@ -224,6 +224,13 @@ export function writeErrorMessage(error: unknown): string {
       return "A Partner ID can only contain letters, numbers, hyphens and underscores.";
     case "NOT_FOUND":
       return "That signal isn't there any more — reload the page.";
+    // ★FROM , MOUNTED APP-LEVEL ABOVE EVERY ROUTE — the layer a list
+    // built by reading handlers AND their routers still stops one short of. The
+    // client retries once, so these only surface when the retry fails too, and
+    // the remedy is a reload rather than a wait.
+    case "CSRF_MISSING":
+    case "CSRF_INVALID":
+      return "Your session got out of step — reload the page and try that again.";
     // ★NOT "TRY AGAIN IN A MOMENT". The rail is offered only to a business whose
     // WordPress site has checked in recently, and a site that has gone quiet
     // will not come back because the customer pressed Save again. Reachable
@@ -237,10 +244,10 @@ export function writeErrorMessage(error: unknown): string {
 }
 
 /** The three levels, drawn so that "not applicable" cannot read as "not done". */
-function EvidenceChain({ signal }: { signal: Signal }) {
+function EvidenceChain({ signal, railOffered }: { signal: Signal; railOffered: boolean }) {
   return (
     <ol className="space-y-3">
-      {evidenceChain(signal).map((step) => (
+      {evidenceChain(signal, railOffered).map((step) => (
         <li key={step.label} className="flex gap-3">
           <span
             aria-hidden
@@ -299,7 +306,12 @@ function SignalCard({
   const [showSnippet, setShowSnippet] = useState(false);
   const update = useUpdateSignal();
   const remove = useRemoveSignal();
-  const state = stateCopy(signal);
+  // ★THE COPY NEEDS TO KNOW WHETHER THE API STILL OFFERS THIS RAIL. It is the
+  // only evidence that the plugin is alive — the api withdraws the rail when a
+  // site stops checking in — and without it the card promises a delivery the
+  // api has already given up on.
+  const railOffered = rails.includes(signal.delivery.rail);
+  const state = stateCopy(signal, railOffered);
 
   const partnerIdChanged = partnerId.trim() !== signal.partnerId;
   const railChanged = rail !== signal.delivery.rail;
@@ -344,7 +356,7 @@ function SignalCard({
       <CardContent className="space-y-5">
         <p className="text-sm">{state.body}</p>
 
-        <EvidenceChain signal={signal} />
+        <EvidenceChain signal={signal} railOffered={railOffered} />
 
         <div className="flex flex-wrap gap-2">
           {/* ★"CHECK AGAIN", NOT A LIVE POLL. We are not watching the customer's
@@ -536,7 +548,7 @@ function RailSelect({
       <p className="text-sm text-muted-foreground">
         {railLabel(value)} — this option isn&apos;t available any more.{" "}
         {rails.length === 1
-          ? `Saving will move it to “${railLabel(rails[0])}”.`
+          ? `Switch now to move it to “${railLabel(rails[0])}”.`
           : "Pick another below."}
         {rails.length === 1 && (
           <Button

--- a/src/app/(site)/dashboard/growth/signals/page.tsx
+++ b/src/app/(site)/dashboard/growth/signals/page.tsx
@@ -153,7 +153,7 @@ export default function SignalsPage() {
  * fix — pick a business — is one the customer can carry out. A remedy that
  * cannot resolve the failure is worse than none.
  */
-function listErrorState(error: unknown, onRetry: () => void) {
+export function listErrorState(error: unknown, onRetry: () => void) {
   const code = error instanceof ApiError ? error.code : undefined;
   if (code === "NO_ACTIVE_BUSINESS") {
     return {
@@ -205,7 +205,7 @@ function listErrorState(error: unknown, onRetry: () => void) {
  * code below is there because it was traced to a `fail(...)` that can reach a
  * customer.
  */
-function writeErrorMessage(error: unknown): string {
+export function writeErrorMessage(error: unknown): string {
   const code = error instanceof ApiError ? error.code : undefined;
   switch (code) {
     case "NO_ORG":
@@ -224,6 +224,13 @@ function writeErrorMessage(error: unknown): string {
       return "A Partner ID can only contain letters, numbers, hyphens and underscores.";
     case "NOT_FOUND":
       return "That signal isn't there any more — reload the page.";
+    // ★NOT "TRY AGAIN IN A MOMENT". The rail is offered only to a business whose
+    // WordPress site has checked in recently, and a site that has gone quiet
+    // will not come back because the customer pressed Save again. Reachable
+    // from the edit form, which deliberately keeps an unavailable stored rail
+    // on screen, and from a second tab.
+    case "RAIL_UNAVAILABLE":
+      return "We haven't heard from a WordPress site on this business recently. If you've just updated the plugin it checks in within the hour — or choose to paste the snippet in yourself.";
     default:
       return "We couldn't save that. Nothing has been changed — try again in a moment.";
   }

--- a/src/app/(site)/dashboard/growth/signals/page.tsx
+++ b/src/app/(site)/dashboard/growth/signals/page.tsx
@@ -224,20 +224,20 @@ export function writeErrorMessage(error: unknown): string {
       return "A Partner ID can only contain letters, numbers, hyphens and underscores.";
     case "NOT_FOUND":
       return "That signal isn't there any more — reload the page.";
-    // ★FROM , MOUNTED APP-LEVEL ABOVE EVERY ROUTE — the layer a list
+    // ★FROM `csrfGuard`, MOUNTED APP-LEVEL ABOVE EVERY ROUTE — the layer a list
     // built by reading handlers AND their routers still stops one short of. The
     // client retries once, so these only surface when the retry fails too, and
     // the remedy is a reload rather than a wait.
     case "CSRF_MISSING":
     case "CSRF_INVALID":
-      return "Your session got out of step — reload the page and try that again.";
+      return "Your sign-in got out of step. Sign in again and nothing will be lost.";
     // ★NOT "TRY AGAIN IN A MOMENT". The rail is offered only to a business whose
     // WordPress site has checked in recently, and a site that has gone quiet
     // will not come back because the customer pressed Save again. Reachable
     // from the edit form, which deliberately keeps an unavailable stored rail
     // on screen, and from a second tab.
     case "RAIL_UNAVAILABLE":
-      return "We haven't heard from a WordPress site on this business recently. If you've just updated the plugin it checks in within the hour — or choose to paste the snippet in yourself.";
+      return "We haven't heard from a WordPress site on this business recently. If you've just updated the plugin it usually checks in within an hour of your site being visited — or choose to paste the snippet in yourself.";
     default:
       return "We couldn't save that. Nothing has been changed — try again in a moment.";
   }
@@ -548,7 +548,7 @@ function RailSelect({
       <p className="text-sm text-muted-foreground">
         {railLabel(value)} — this option isn&apos;t available any more.{" "}
         {rails.length === 1
-          ? `Switch now to move it to “${railLabel(rails[0])}”.`
+          ? `Switch now, then Save, to move it to “${railLabel(rails[0])}”.`
           : "Pick another below."}
         {rails.length === 1 && (
           <Button

--- a/src/lib/signal-copy.test.ts
+++ b/src/lib/signal-copy.test.ts
@@ -30,7 +30,7 @@ describe("the evidence chain keeps three levels apart", () => {
     // path, so nothing could observe a serve. Rendering it unchecked would tell
     // every copy-paste customer something is wrong with an installation that is
     // fine.
-    const [, sent] = evidenceChain(withRail("manual"));
+    const [, sent] = evidenceChain(withRail("manual"), true);
     expect(sent.reached).toBeNull();
     expect(sent.detail).not.toMatch(/hasn't|not yet|can't deliver/i);
   });
@@ -86,9 +86,9 @@ describe("the evidence chain keeps three levels apart", () => {
 
     // And it still must not promise a sync in words that read as a deadline, or
     // tell them to wait for something that has already happened.
-    const unserved = evidenceChain(withRail("wordpress"))[1];
+    const unserved = evidenceChain(withRail("wordpress"), true)[1];
     expect(unserved.reached).toBe(false);
-    expect(unserved.detail).toMatch(/hourly/i);
+    expect(unserved.detail).toMatch(/about once an hour/i);
   });
 
   it("a served wordpress signal reports the serve as a fact with a time", () => {
@@ -100,9 +100,15 @@ describe("the evidence chain keeps three levels apart", () => {
           lastServedAt: new Date(Date.now() - 3_600_000).toISOString(),
         },
       }),
+      true,
     );
     expect(sent.reached).toBe(true);
-    expect(sent.detail).toMatch(/picked it up/i);
+    // ★"FETCHED", NEVER "PUT IT ON YOUR SITE". `lastServedAt` records that the
+    // plugin ASKED US for the snippet; it is not evidence that any page printed
+    // it. The plugin's own header states the rule — printing is not evidence —
+    // and a first cut of this copy asserted delivery from this field.
+    expect(sent.detail).toMatch(/fetched it/i);
+    expect(sent.detail).not.toMatch(/putting it on your site|is being delivered/i);
   });
 });
 
@@ -125,13 +131,13 @@ describe("state copy never says more than the data supports", () => {
     // the page source of every page carrying it — and one fire is most often the
     // customer testing on staging or localhost. The host is what makes the claim
     // checkable, so it has to appear in the sentence that makes it.
-    const body = stateCopy(fired()).body;
+    const body = stateCopy(fired(), true).body;
     expect(body).not.toMatch(/enough to know it's installed/i);
     expect(body).toContain("www.example.com");
   });
 
   it("an unreadable host leaves no empty phrase behind", () => {
-    const body = stateCopy(fired({ lastFiredHost: null })).body;
+    const body = stateCopy(fired({ lastFiredHost: null }), true).body;
     expect(body).not.toMatch(/ on \.|on $|on ,/);
     expect(body).toMatch(/load(ed)? once/i);
   });
@@ -148,6 +154,7 @@ describe("state copy never says more than the data supports", () => {
           seenOnceOnly: false,
         },
       }),
+      true,
     ).body;
     expect(body).not.toMatch(/broken|not working|failed/i);
     expect(body).toMatch(/can't tell/i);
@@ -188,7 +195,7 @@ describe("state copy never says more than the data supports", () => {
       ["wordpress/served/not_seen_recently", served({ state: "not_seen_recently" })],
     ];
     for (const [name, signal] of cases) {
-      const body = stateCopy(signal).body;
+      const body = stateCopy(signal, true).body;
       expect(body, name).toMatch(/private window|new window/i);
       expect(body, name).toMatch(/once per browser session/i);
     }
@@ -201,11 +208,11 @@ describe("state copy never says more than the data supports", () => {
     // left 11/11 green. The rule this file names first, guarded by a loop that
     // could not reach it.
     const bodies = [
-      stateCopy(fired()).body,
-      stateCopy(fired({ seenOnceOnly: false })).body,
-      stateCopy(base({ state: "never_fired" })).body,
-      stateCopy(withRail("wordpress", { state: "never_fired" })).body,
-      stateCopy(base({ state: "not_seen_recently" })).body,
+      stateCopy(fired(), true).body,
+      stateCopy(fired({ seenOnceOnly: false }), true).body,
+      stateCopy(base({ state: "never_fired" }), true).body,
+      stateCopy(withRail("wordpress", { state: "never_fired" }), true).body,
+      stateCopy(base({ state: "not_seen_recently" }), true).body,
     ];
     for (const body of bodies) {
       // ★NO DIGIT AT ALL once the api's own freshness window is removed, rather
@@ -232,5 +239,129 @@ describe("formatWhen", () => {
   it("says so rather than inventing a time", () => {
     expect(formatWhen(undefined)).toBe("at an unknown time");
     expect(formatWhen("not a date")).toBe("at an unknown time");
+  });
+});
+
+describe("★the railOffered mechanism itself — asserted positively, not by absence", () => {
+  // ★ROUND 1 ADDED `railOffered` AND NOTHING CHECKED IT. Neutering it entirely —
+  // treating every wordpress signal as offered — left the whole suite green,
+  // because every assertion around it was a NEGATIVE ("does not say paste",
+  // "does not say private window") that holds identically either way. A
+  // mechanism guarded only by negatives is a mechanism that can be deleted.
+  const wp = (over: Partial<Signal> = {}) =>
+    withRail("wordpress", {
+      delivery: { rail: "wordpress", chosenAt: "2026-08-01T00:00:00.000Z", lastServedAt: null },
+      ...over,
+    });
+
+  it("★a withdrawn rail says we have LOST TRACK — never that nothing is delivering", () => {
+    // The plugin CACHES the snippet and prints from cache; its own docblock is
+    // "a failed fetch keeps the previous answer". So a site that stopped
+    // checking in may well still be printing the tag, and a first cut said
+    // "nothing is putting the tag on your site" — directly above a green
+    // "last fetched it" tick.
+    for (const state of ["never_fired", "not_seen_recently"] as const) {
+      const signal = wp({
+        state,
+        delivery: {
+          rail: "wordpress",
+          chosenAt: "2026-08-01T00:00:00.000Z",
+          lastServedAt: "2026-08-07T00:00:00.000Z",
+        },
+        verification:
+          state === "never_fired"
+            ? null
+            : {
+                firstFiredAt: "2026-06-01T00:00:00.000Z",
+                lastFiredAt: "2026-06-01T00:00:00.000Z",
+                lastFiredHost: null,
+                seenOnceOnly: true,
+              },
+      });
+      const body = stateCopy(signal, false).body;
+      expect(body, state).toMatch(/lost track/i);
+      expect(body, state).not.toMatch(/nothing is putting|stopped putting/i);
+      // And it differs from the offered wording, which is what a neutered
+      // `railOffered` would collapse.
+      expect(body, state).not.toBe(stateCopy(signal, true).body);
+      expect(evidenceChain(signal, false)[1].detail).not.toBe(
+        evidenceChain(signal, true)[1].detail,
+      );
+    }
+  });
+
+  it("★a withdrawn rail names all three causes, not just a dead plugin", () => {
+    // The api withdraws it when the connection is inactive, when the site is
+    // bound to another business, OR when it has not asked in 14 days.
+    // "Reactivate the plugin" is the wrong instruction for the first two.
+    const body = stateCopy(wp({ state: "never_fired" }), false).body;
+    expect(body).toMatch(/connected/i);
+    expect(body).toMatch(/integrations/i);
+    expect(body).toMatch(/past(e|ing)/i);
+  });
+
+  it("★★'nothing to do' expires on its own, because railOffered does not bound it", () => {
+    // The api stamps the ask BEFORE its own early returns — including the one
+    // its comment calls "the state a customer cannot get out of by themselves"
+    // — so a signal can sit offered-and-unfetched forever. After a day, an
+    // unfetched signal is evidence AGAINST the promise.
+    const fresh = wp({
+      state: "never_fired",
+      delivery: {
+        rail: "wordpress",
+        chosenAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+        lastServedAt: null,
+      },
+    });
+    const old = wp({
+      state: "never_fired",
+      delivery: {
+        rail: "wordpress",
+        chosenAt: new Date(Date.now() - 72 * 3_600_000).toISOString(),
+        lastServedAt: null,
+      },
+    });
+    expect(stateCopy(fresh, true).body).toMatch(/nothing to do/i);
+    expect(stateCopy(old, true).body).not.toMatch(/nothing to do/i);
+    expect(stateCopy(old, true).body).toMatch(/something is in the way/i);
+  });
+
+  it("★a fetch is never reported as a delivery", () => {
+    // `lastServedAt` records that the plugin ASKED US. It is not evidence that
+    // any page printed anything — deactivate the plugin and printing stops while
+    // the fetch stamp stays fresh for a fortnight.
+    const served = wp({
+      state: "not_seen_recently",
+      delivery: {
+        rail: "wordpress",
+        chosenAt: "2026-08-01T00:00:00.000Z",
+        lastServedAt: "2026-08-08T10:00:00.000Z",
+      },
+      verification: {
+        firstFiredAt: "2026-06-01T00:00:00.000Z",
+        lastFiredAt: "2026-06-01T00:00:00.000Z",
+        lastFiredHost: null,
+        seenOnceOnly: true,
+      },
+    });
+    const body = stateCopy(served, true).body;
+    expect(body).not.toMatch(/is being delivered|putting it on your site/i);
+    // ★AND IT KEEPS "WE CAN'T TELL", which a first cut deleted here — the
+    // narrower unknown is still an unknown.
+    expect(body).toMatch(/can't tell/i);
+  });
+
+  it("★no branch claims a cadence the plugin cannot keep", () => {
+    // WP-Cron is traffic-driven: "checks in hourly" is not sourceable on a site
+    // nobody is visiting, which is exactly the site that has never fired.
+    const all = [
+      stateCopy(wp({ state: "never_fired" }), true).body,
+      stateCopy(wp({ state: "never_fired" }), false).body,
+      evidenceChain(wp({ state: "never_fired" }), true)[1].detail,
+      evidenceChain(wp({ state: "never_fired" }), false)[1].detail,
+    ];
+    for (const body of all) {
+      expect(body).not.toMatch(/checks in hourly|every hour\b|within the hour\b/i);
+    }
   });
 });

--- a/src/lib/signal-copy.test.ts
+++ b/src/lib/signal-copy.test.ts
@@ -47,6 +47,8 @@ describe("the evidence chain keeps three levels apart", () => {
     const states = ["never_fired", "not_seen_recently", "firing"] as const;
     for (const state of states) {
       for (const served of [null, "2026-08-08T10:00:00.000Z"]) {
+       for (const onceOnly of [true, false]) {
+        for (const railOffered of [true, false]) {
         const signal = withRail("wordpress", {
           state,
           delivery: { rail: "wordpress", chosenAt: "2026-08-01T00:00:00.000Z", lastServedAt: served },
@@ -54,16 +56,31 @@ describe("the evidence chain keeps three levels apart", () => {
             state === "never_fired"
               ? null
               : {
+                  // ★`seenOnceOnly` IS DERIVED FROM THE TWO TIMESTAMPS BEING
+                  // EQUAL (the api derives it exactly so), and a first cut set
+                  // equal timestamps with `seenOnceOnly: false` — a combination
+                  // the api cannot produce, which quietly meant the loop never
+                  // rendered the single-fire branch at all.
                   firstFiredAt: "2026-08-01T00:00:00.000Z",
-                  lastFiredAt: "2026-08-01T00:00:00.000Z",
+                  lastFiredAt: onceOnly ? "2026-08-01T00:00:00.000Z" : "2026-08-02T00:00:00.000Z",
                   lastFiredHost: "www.example.com",
-                  seenOnceOnly: false,
+                  seenOnceOnly: onceOnly,
                 },
         });
-        const where = `${state}/${served ? "served" : "unserved"}`;
-        const [, sent] = evidenceChain(signal);
-        expect(sent.detail, where).not.toMatch(/by hand|paste/i);
-        expect(stateCopy(signal).body, where).not.toMatch(/by hand|paste/i);
+        const where = `${state}/${served ? "served" : "unserved"}/once=${onceOnly}/offered=${railOffered}`;
+        const [, sent] = evidenceChain(signal, railOffered);
+        const body = stateCopy(signal, railOffered).body;
+        // ★NEVER "add it by hand" — that is the double-install. "switch … to
+        // pasting" IS allowed and is the honest remedy when the rail is gone,
+        // because switching REPLACES the delivery rather than adding to it.
+        expect(sent.detail, where).not.toMatch(/by hand|paste the snippet in|add the snippet/i);
+        expect(body, where).not.toMatch(/by hand|add the snippet/i);
+        // ★AND THE CHECK HINT ONLY WHERE A CHECK CAN CHANGE ANYTHING — i.e. once
+        // the plugin has actually fetched. A first cut applied this to
+        // `never_fired` and not `not_seen_recently`, and the mutation survived.
+        if (!served) expect(body, where).not.toMatch(/private window/i);
+       }
+      }
       }
     }
 
@@ -165,7 +182,10 @@ describe("state copy never says more than the data supports", () => {
       ["manual/never_fired", base({ state: "never_fired" })],
       ["manual/not_seen_recently", base({ state: "not_seen_recently" })],
       ["wordpress/served/never_fired", served({ state: "never_fired" })],
-      ["wordpress/not_seen_recently", withRail("wordpress", { state: "not_seen_recently" })],
+      // ★SERVED, because on this rail the hint is only shown once the plugin
+      // HAS the snippet — before that, opening a private window cannot change
+      // anything, and the companion test above asserts the hint is absent there.
+      ["wordpress/served/not_seen_recently", served({ state: "not_seen_recently" })],
     ];
     for (const [name, signal] of cases) {
       const body = stateCopy(signal).body;

--- a/src/lib/signal-copy.test.ts
+++ b/src/lib/signal-copy.test.ts
@@ -35,20 +35,43 @@ describe("the evidence chain keeps three levels apart", () => {
     expect(sent.detail).not.toMatch(/hasn't|not yet|can't deliver/i);
   });
 
-  it("★a `wordpress` rail with no serve does NOT promise a sync that does not exist", () => {
-    // THE ASSERTION THAT WOULD HAVE MADE THE ORIGINAL BUG UNSHIPPABLE. Nothing
-    // writes `lastServedAt` — there is no plugin-facing snippet endpoint — so
-    // copy saying "it asks for this when it next syncs" told the customer to
-    // wait for something that can never happen. Writing this test forces the
-    // question "what sets lastServedAt?", which is how the defect surfaces.
-    const [, sent] = evidenceChain(withRail("wordpress"));
-    expect(sent.reached).toBe(false);
-    expect(sent.detail).not.toMatch(/sync/i);
-    expect(sent.detail).toMatch(/by hand/i);
+  it("★★a `wordpress` rail NEVER tells the customer to paste the snippet", () => {
+    // ★THE RULE CHANGED WITH THE FEATURE, AND THIS IS THE STRONGER VERSION.
+    // While no rail could deliver, the honest copy was "add it by hand"; now
+    // that the plugin prints the tag, that same sentence installs it TWICE —
+    // two Insight Tags, two beacons. The api refuses to serve a `manual` row
+    // over this rail for exactly that reason, and copy is the other half of it.
+    //
+    // Asserted across every state a wordpress-rail signal can be in, because
+    // the instruction is wrong in all of them and the previous test covered one.
+    const states = ["never_fired", "not_seen_recently", "firing"] as const;
+    for (const state of states) {
+      for (const served of [null, "2026-08-08T10:00:00.000Z"]) {
+        const signal = withRail("wordpress", {
+          state,
+          delivery: { rail: "wordpress", chosenAt: "2026-08-01T00:00:00.000Z", lastServedAt: served },
+          verification:
+            state === "never_fired"
+              ? null
+              : {
+                  firstFiredAt: "2026-08-01T00:00:00.000Z",
+                  lastFiredAt: "2026-08-01T00:00:00.000Z",
+                  lastFiredHost: "www.example.com",
+                  seenOnceOnly: false,
+                },
+        });
+        const where = `${state}/${served ? "served" : "unserved"}`;
+        const [, sent] = evidenceChain(signal);
+        expect(sent.detail, where).not.toMatch(/by hand|paste/i);
+        expect(stateCopy(signal).body, where).not.toMatch(/by hand|paste/i);
+      }
+    }
 
-    // And the state copy must not tell them to wait either.
-    const body = stateCopy(withRail("wordpress")).body;
-    expect(body).not.toMatch(/that's normal until|wait/i);
+    // And it still must not promise a sync in words that read as a deadline, or
+    // tell them to wait for something that has already happened.
+    const unserved = evidenceChain(withRail("wordpress"))[1];
+    expect(unserved.reached).toBe(false);
+    expect(unserved.detail).toMatch(/hourly/i);
   });
 
   it("a served wordpress signal reports the serve as a fact with a time", () => {
@@ -123,10 +146,25 @@ describe("state copy never says more than the data supports", () => {
     // only, and `base()` hardcodes `rail: "manual"` — so the branch round 1
     // rewrote was uncovered by the test that names its rule, and restoring
     // "then visit your site to confirm it" there left 11/11 green.
+    // ★THE HINT BELONGS WHERE A CHECK IS ACTIONABLE, AND NOWHERE ELSE. A
+    // wordpress-rail signal the plugin has not fetched yet is waiting on US,
+    // not on the customer — telling them to open a private window there is
+    // busywork that cannot change the state, which is its own kind of false
+    // advice. So the served/unserved distinction is part of the rule, not an
+    // exception to it.
+    const served = (over: Partial<Signal> = {}) =>
+      withRail("wordpress", {
+        delivery: {
+          rail: "wordpress",
+          chosenAt: "2026-08-01T00:00:00.000Z",
+          lastServedAt: "2026-08-08T10:00:00.000Z",
+        },
+        ...over,
+      });
     const cases: Array<[string, Signal]> = [
       ["manual/never_fired", base({ state: "never_fired" })],
       ["manual/not_seen_recently", base({ state: "not_seen_recently" })],
-      ["wordpress/never_fired", withRail("wordpress", { state: "never_fired" })],
+      ["wordpress/served/never_fired", served({ state: "never_fired" })],
       ["wordpress/not_seen_recently", withRail("wordpress", { state: "not_seen_recently" })],
     ];
     for (const [name, signal] of cases) {

--- a/src/lib/signal-copy.ts
+++ b/src/lib/signal-copy.ts
@@ -77,7 +77,7 @@ export type EvidenceStep = {
  * about the rail, not a failure, and a tick-list that showed it unchecked would
  * be telling every copy-paste customer that something is wrong.
  */
-export function evidenceChain(signal: Signal): EvidenceStep[] {
+export function evidenceChain(signal: Signal, railOffered = true): EvidenceStep[] {
   const served = signal.delivery.lastServedAt;
   return [
     {
@@ -93,15 +93,17 @@ export function evidenceChain(signal: Signal): EvidenceStep[] {
           ? "Not something we can see when you paste the snippet yourself — there's no step of ours in between."
           : served
             ? `Your WordPress plugin last picked it up ${formatWhen(served)}.`
-            : // ★A WAIT WITH AN END, AND NO INSTRUCTION TO PASTE ANYTHING. The
-              // plugin fetches hourly, so this state is normal and temporary —
-              // and the previous copy ("add the snippet by hand for now") was
-              // written when nothing could deliver this rail. Once the plugin
-              // CAN, following that instruction leaves the customer with the
-              // plugin-printed tag AND a pasted one: two Insight Tags, two
-              // beacons. The api refuses to serve a `manual` row over this rail
-              // for exactly that reason; the copy must not undo it.
-              "Your WordPress plugin checks in hourly and hasn't picked this up yet. Nothing to do — it will.",
+            : // ★NO PROMISE IN THIS STEP — the step states a FACT, and the promise
+              // lives in `stateCopy`, where it can be made conditional. A first
+              // cut ended this line "Nothing to do — it will", which contradicted
+              // step 3 on a signal that has already fired (delivery unobserved,
+              // fire observed) and, worse, never expired: the api WITHDRAWS this
+              // rail once the site stops checking in, and the card went on
+              // promising a delivery the api had formally given up on, with the
+              // paste escape hatch removed.
+              railOffered
+              ? "Your WordPress plugin hasn't picked this up yet — it checks in hourly."
+              : "We haven't heard from your WordPress plugin recently.",
     },
     {
       label: "Seen working",
@@ -123,8 +125,25 @@ export function evidenceChain(signal: Signal): EvidenceStep[] {
  * (when we last saw it) and offers the check, rather than a diagnosis we cannot
  * support.
  */
-export function stateCopy(signal: Signal): { title: string; body: string; tone: "ok" | "waiting" | "attention" } {
+export function stateCopy(
+  signal: Signal,
+  railOffered = true,
+): { title: string; body: string; tone: "ok" | "waiting" | "attention" } {
   const provider = providerLabel(signal.provider);
+  // ★"NOTHING TO DO — IT WILL" IS ONLY SAYABLE WHILE THE API STILL OFFERS THIS
+  // RAIL, and that is what makes it a sourced claim rather than a hope. The api
+  // withdraws `wordpress` from `availableRails` once the site stops checking in,
+  // so `railOffered` IS the evidence that the plugin is alive and will fetch.
+  // Without it the promise never expired: a site whose plugin was deactivated
+  // got "nothing to do" forever, with the paste escape hatch removed, while the
+  // api had already concluded the delivery would never happen.
+  const wpDelivering = signal.delivery.rail === "wordpress" && railOffered;
+  const wpAbandoned = signal.delivery.rail === "wordpress" && !railOffered;
+  // The one remedy that is always available and never double-installs: switch
+  // the rail. Never "paste it as well" — that is the double-install this whole
+  // change exists to prevent.
+  const SWITCH_HINT =
+    "Reactivate or update the plugin, or switch this signal to pasting the snippet in yourself.";
   switch (signal.state) {
     case "firing":
       return {
@@ -150,30 +169,62 @@ export function stateCopy(signal: Signal): { title: string; body: string; tone: 
         tone: "ok",
       };
     case "never_fired":
+      // ★NO PASTE INSTRUCTION ON THIS RAIL, IN ANY BRANCH. The plugin is putting
+      // the tag on the page; telling the customer to add it by hand as well
+      // installs it twice — two Insight Tags, two beacons. The api refuses to
+      // serve a `manual` row over this rail for the same reason.
+      if (wpAbandoned) {
+        return {
+          title: "Not seen yet",
+          body: `Set up, but we haven't heard from your WordPress plugin recently, so nothing is putting the tag on your site. ${SWITCH_HINT}`,
+          tone: "attention",
+        };
+      }
       return {
         title: "Not seen yet",
-        body:
-          signal.delivery.rail === "wordpress"
-            ? // ★NO PASTE INSTRUCTION ON THIS RAIL. The plugin is putting the tag
-              // on the page; telling the customer to add it by hand as well would
-              // install it twice. Which of the two waits they are in — the plugin
-              // fetching, or a visitor arriving — is exactly what the evidence
-              // chain above distinguishes, so this sentence does not guess.
-              signal.delivery.lastServedAt
-              ? `Your plugin has it, but no browser has loaded it yet. To check now, ${CONFIRM_HINT}`
-              : "Set up. Your WordPress plugin checks in hourly and will put it on your site — nothing to do."
-            : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then ${CONFIRM_HINT}`,
+        body: wpDelivering
+          ? // Which of the two waits they are in — the plugin fetching, or a
+            // visitor arriving — is what the evidence chain distinguishes, and
+            // the check hint belongs only in the second: before the plugin has
+            // it, opening a private window cannot change anything.
+            signal.delivery.lastServedAt
+            ? `Your plugin has it, but no browser has loaded it yet. To check now, ${CONFIRM_HINT}`
+            : "Set up. Your WordPress plugin checks in hourly and will put it on your site — nothing to do."
+          : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then ${CONFIRM_HINT}`,
         tone: "waiting",
       };
-    case "not_seen_recently":
+    case "not_seen_recently": {
+      const since = `We last saw your ${provider} load ${formatWhen(signal.verification?.lastFiredAt)}, and nothing since. `;
+      if (wpAbandoned) {
+        return {
+          title: "Quiet",
+          body: `${since}We haven't heard from your WordPress plugin recently either, so it may have stopped putting the tag on your site. ${SWITCH_HINT}`,
+          tone: "attention",
+        };
+      }
+      // ★THE SAME RULE AS `never_fired`, WHICH A FIRST CUT APPLIED TO ONE STATE
+      // AND NOT THE OTHER. On this rail we are not reduced to "we can't tell":
+      // when the plugin has fetched, we KNOW the tag is being delivered, so the
+      // unknown is narrower and the sentence should say the narrower thing. And
+      // when it has not fetched, the check hint is busywork that cannot change
+      // the state — exactly what the other branch was fixed for.
+      if (wpDelivering) {
+        return {
+          title: "Quiet",
+          body: signal.delivery.lastServedAt
+            ? `${since}Your plugin is still putting it on your site, so it is being delivered — we just haven't seen a browser load it. That can mean nobody has visited, or something on the page is blocking it. To check: ${CONFIRM_HINT}`
+            : `${since}Your plugin hasn't picked up the current snippet yet either — it checks in hourly.`,
+          tone: "attention",
+        };
+      }
       return {
         title: "Quiet",
         body:
-          `We last saw your ${provider} load ${formatWhen(signal.verification?.lastFiredAt)}, and nothing since. ` +
-          `That can mean the tag was removed, or simply that nobody has visited — we can't tell which from here. ` +
+          `${since}That can mean the tag was removed, or simply that nobody has visited — we can't tell which from here. ` +
           `To check: ${CONFIRM_HINT}`,
         tone: "attention",
       };
+    }
     default:
       return { title: "Unknown", body: "", tone: "waiting" };
   }

--- a/src/lib/signal-copy.ts
+++ b/src/lib/signal-copy.ts
@@ -38,6 +38,17 @@ const CONFIRM_HINT =
   "open your site in a NEW private window (the snippet only reports once per browser session) " +
   "and press Check again a minute later.";
 
+/** The only place this surface says "nothing to do", so the conditions under
+ *  which it is sayable are in one place. See `stateCopy`. */
+const NOTHING_TO_DO = "nothing to do.";
+
+/** Whole hours since an ISO timestamp; `Infinity` when it cannot be read, so an
+ *  unreadable date can never be what keeps a promise alive. */
+function hoursSince(iso: string | undefined): number {
+  const t = iso ? Date.parse(iso) : NaN;
+  return Number.isNaN(t) ? Infinity : (Date.now() - t) / 3_600_000;
+}
+
 /** " from www.example.com", or nothing when the beacon's origin was unreadable
  *  — a real state (the api UNSETS the host rather than leaving a stale one), and
  *  one that must never leave a dangling preposition behind. */
@@ -77,7 +88,7 @@ export type EvidenceStep = {
  * about the rail, not a failure, and a tick-list that showed it unchecked would
  * be telling every copy-paste customer that something is wrong.
  */
-export function evidenceChain(signal: Signal, railOffered = true): EvidenceStep[] {
+export function evidenceChain(signal: Signal, railOffered: boolean): EvidenceStep[] {
   const served = signal.delivery.lastServedAt;
   return [
     {
@@ -92,7 +103,13 @@ export function evidenceChain(signal: Signal, railOffered = true): EvidenceStep[
         signal.delivery.rail !== "wordpress"
           ? "Not something we can see when you paste the snippet yourself — there's no step of ours in between."
           : served
-            ? `Your WordPress plugin last picked it up ${formatWhen(served)}.`
+            ? railOffered
+              ? `Your WordPress plugin last fetched it ${formatWhen(served)}.`
+              : // ★THE SERVE IS STILL A FACT, AND SO IS HAVING LOST TRACK SINCE.
+                // Rendering only the first left a green tick reading "last
+                // fetched it 7 days ago" directly above a body saying we no
+                // longer know what that site is doing.
+                `Your WordPress plugin last fetched it ${formatWhen(served)}, and we have not heard from that site since.`
             : // ★NO PROMISE IN THIS STEP — the step states a FACT, and the promise
               // lives in `stateCopy`, where it can be made conditional. A first
               // cut ended this line "Nothing to do — it will", which contradicted
@@ -102,8 +119,8 @@ export function evidenceChain(signal: Signal, railOffered = true): EvidenceStep[
               // promising a delivery the api had formally given up on, with the
               // paste escape hatch removed.
               railOffered
-              ? "Your WordPress plugin hasn't picked this up yet — it checks in hourly."
-              : "We haven't heard from your WordPress plugin recently.",
+              ? "Your WordPress plugin hasn't fetched it yet — it asks about once an hour while your site is being visited."
+              : "We've lost track of the WordPress site meant to deliver this.",
     },
     {
       label: "Seen working",
@@ -127,23 +144,29 @@ export function evidenceChain(signal: Signal, railOffered = true): EvidenceStep[
  */
 export function stateCopy(
   signal: Signal,
-  railOffered = true,
+  railOffered: boolean,
 ): { title: string; body: string; tone: "ok" | "waiting" | "attention" } {
   const provider = providerLabel(signal.provider);
-  // ★"NOTHING TO DO — IT WILL" IS ONLY SAYABLE WHILE THE API STILL OFFERS THIS
-  // RAIL, and that is what makes it a sourced claim rather than a hope. The api
-  // withdraws `wordpress` from `availableRails` once the site stops checking in,
-  // so `railOffered` IS the evidence that the plugin is alive and will fetch.
-  // Without it the promise never expired: a site whose plugin was deactivated
-  // got "nothing to do" forever, with the paste escape hatch removed, while the
-  // api had already concluded the delivery would never happen.
-  const wpDelivering = signal.delivery.rail === "wordpress" && railOffered;
-  const wpAbandoned = signal.delivery.rail === "wordpress" && !railOffered;
-  // The one remedy that is always available and never double-installs: switch
-  // the rail. Never "paste it as well" — that is the double-install this whole
-  // change exists to prevent.
-  const SWITCH_HINT =
-    "Reactivate or update the plugin, or switch this signal to pasting the snippet in yourself.";
+  const wp = signal.delivery.rail === "wordpress";
+  // ★`railOffered` IS ONE OF THREE ANDed CONDITIONS, NOT "THE PLUGIN IS ALIVE".
+  // The api withdraws this rail when the connection is inactive, when the site
+  // is bound to another business, OR when it has not asked for 14 days — so
+  // "we haven't heard from your plugin recently" is wrong for the first two,
+  // and up to a fortnight late for the third. A first cut asserted it meant the
+  // first thing only, and paid for it twice below.
+  const wpHeardFrom = wp && railOffered;
+  const wpSilent = wp && !railOffered;
+  // ★AND THE PROMISE EXPIRES ON ITS OWN, because `railOffered` alone does not
+  // bound it. The api stamps the ask BEFORE its own early returns — including
+  // the one its comment calls "the state a customer cannot get out of by
+  // themselves" — so a signal can sit `railOffered` and unfetched forever. After
+  // a day, an unfetched signal is evidence AGAINST the promise, not for it.
+  const staleUnfetched =
+    !signal.delivery.lastServedAt && hoursSince(signal.delivery.chosenAt) > 24;
+  // ★THE REMEDY NAMES ALL THREE CAUSES, because "reactivate the plugin" is the
+  // wrong instruction for a site that was disconnected or re-bound.
+  const FIX_HINT =
+    "Check the plugin is active and this site is still connected under Integrations — or switch this signal to pasting the snippet in yourself.";
   switch (signal.state) {
     case "firing":
       return {
@@ -173,47 +196,62 @@ export function stateCopy(
       // the tag on the page; telling the customer to add it by hand as well
       // installs it twice — two Insight Tags, two beacons. The api refuses to
       // serve a `manual` row over this rail for the same reason.
-      if (wpAbandoned) {
+      if (wpSilent) {
+        // ★NOT "NOTHING IS PUTTING THE TAG ON YOUR SITE" — which was false. The
+        // plugin CACHES the snippet and prints from the cache; its own rule is
+        // that a failed fetch keeps the previous answer. A plugin that has
+        // stopped checking in may well still be printing the tag, and the card
+        // said otherwise directly above a green "last picked it up" tick.
         return {
           title: "Not seen yet",
-          body: `Set up, but we haven't heard from your WordPress plugin recently, so nothing is putting the tag on your site. ${SWITCH_HINT}`,
+          body: `Set up, but we've lost track of the WordPress site meant to deliver this, so we can't tell you whether it still is. ${FIX_HINT}`,
+          tone: "attention",
+        };
+      }
+      if (wpHeardFrom && staleUnfetched) {
+        return {
+          title: "Not seen yet",
+          body: `Set up, but your WordPress plugin still hasn't fetched it. That should happen within an hour of your site being visited, so something is in the way. ${FIX_HINT}`,
           tone: "attention",
         };
       }
       return {
         title: "Not seen yet",
-        body: wpDelivering
+        body: wpHeardFrom
           ? // Which of the two waits they are in — the plugin fetching, or a
             // visitor arriving — is what the evidence chain distinguishes, and
             // the check hint belongs only in the second: before the plugin has
             // it, opening a private window cannot change anything.
             signal.delivery.lastServedAt
-            ? `Your plugin has it, but no browser has loaded it yet. To check now, ${CONFIRM_HINT}`
-            : "Set up. Your WordPress plugin checks in hourly and will put it on your site — nothing to do."
+            ? `Your plugin has fetched it, but no browser has loaded it yet. To check now, ${CONFIRM_HINT}`
+            : `Set up. Your WordPress plugin fetches it about once an hour while your site is being visited — ${NOTHING_TO_DO}`
           : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then ${CONFIRM_HINT}`,
         tone: "waiting",
       };
     case "not_seen_recently": {
       const since = `We last saw your ${provider} load ${formatWhen(signal.verification?.lastFiredAt)}, and nothing since. `;
-      if (wpAbandoned) {
+      if (wpSilent) {
         return {
           title: "Quiet",
-          body: `${since}We haven't heard from your WordPress plugin recently either, so it may have stopped putting the tag on your site. ${SWITCH_HINT}`,
+          body: `${since}We've also lost track of the WordPress site meant to deliver it. ${FIX_HINT}`,
           tone: "attention",
         };
       }
       // ★THE SAME RULE AS `never_fired`, WHICH A FIRST CUT APPLIED TO ONE STATE
-      // AND NOT THE OTHER. On this rail we are not reduced to "we can't tell":
-      // when the plugin has fetched, we KNOW the tag is being delivered, so the
-      // unknown is narrower and the sentence should say the narrower thing. And
-      // when it has not fetched, the check hint is busywork that cannot change
-      // the state — exactly what the other branch was fixed for.
-      if (wpDelivering) {
+      // AND NOT THE OTHER: the check hint only where a check can change
+      // something. What that cut ALSO did was overclaim — "your plugin is still
+      // putting it on your site, so it is being delivered". `lastServedAt`
+      // records that the plugin FETCHED, never that it PRINTED, and the plugin's
+      // own header states the rule: printing is not evidence. Deactivate it, or
+      // use a theme without `wp_head`, and printing stops while the fetch stamp
+      // stays fresh for a fortnight — so that sentence asserted delivery for two
+      // weeks in the likeliest cause of this exact state.
+      if (wpHeardFrom) {
         return {
           title: "Quiet",
           body: signal.delivery.lastServedAt
-            ? `${since}Your plugin is still putting it on your site, so it is being delivered — we just haven't seen a browser load it. That can mean nobody has visited, or something on the page is blocking it. To check: ${CONFIRM_HINT}`
-            : `${since}Your plugin hasn't picked up the current snippet yet either — it checks in hourly.`,
+            ? `${since}Your plugin fetched it ${formatWhen(signal.delivery.lastServedAt)}, so it is still asking us for the tag — but we can't tell from here whether it is reaching your pages, or whether nobody has visited. To check: ${CONFIRM_HINT}`
+            : `${since}Your plugin hasn't fetched the current snippet either. ${FIX_HINT}`,
           tone: "attention",
         };
       }

--- a/src/lib/signal-copy.ts
+++ b/src/lib/signal-copy.ts
@@ -93,15 +93,15 @@ export function evidenceChain(signal: Signal): EvidenceStep[] {
           ? "Not something we can see when you paste the snippet yourself — there's no step of ours in between."
           : served
             ? `Your WordPress plugin last picked it up ${formatWhen(served)}.`
-            : // ★NO PROMISE OF A SYNC, BECAUSE THERE ISN'T ONE. An earlier draft
-              // said "it asks for this when it next syncs" — telling the customer
-              // to wait for something that does not exist. Nothing writes
-              // `lastServedAt` today: there is no plugin-facing snippet endpoint
-              // and the plugin has no signals code, which is why `wordpress` is
-              // not offered as a choice. A stored row can still carry it (an
-              // older row, or a later api enabling the rail), so this branch
-              // stays — saying what is true.
-              "The plugin can't deliver this yet. Add the snippet to your site by hand for now.",
+            : // ★A WAIT WITH AN END, AND NO INSTRUCTION TO PASTE ANYTHING. The
+              // plugin fetches hourly, so this state is normal and temporary —
+              // and the previous copy ("add the snippet by hand for now") was
+              // written when nothing could deliver this rail. Once the plugin
+              // CAN, following that instruction leaves the customer with the
+              // plugin-printed tag AND a pasted one: two Insight Tags, two
+              // beacons. The api refuses to serve a `manual` row over this rail
+              // for exactly that reason; the copy must not undo it.
+              "Your WordPress plugin checks in hourly and hasn't picked this up yet. Nothing to do — it will.",
     },
     {
       label: "Seen working",
@@ -154,9 +154,14 @@ export function stateCopy(signal: Signal): { title: string; body: string; tone: 
         title: "Not seen yet",
         body:
           signal.delivery.rail === "wordpress"
-            ? // No promise of a sync — see `evidenceChain`. Nothing delivers this
-              // rail yet, so "wait" would be advice that can never come good.
-              `Set up, but nothing has put it on your site yet. Add the snippet by hand for now, then ${CONFIRM_HINT}`
+            ? // ★NO PASTE INSTRUCTION ON THIS RAIL. The plugin is putting the tag
+              // on the page; telling the customer to add it by hand as well would
+              // install it twice. Which of the two waits they are in — the plugin
+              // fetching, or a visitor arriving — is exactly what the evidence
+              // chain above distinguishes, so this sentence does not guess.
+              signal.delivery.lastServedAt
+              ? `Your plugin has it, but no browser has loaded it yet. To check now, ${CONFIRM_HINT}`
+              : "Set up. Your WordPress plugin checks in hourly and will put it on your site — nothing to do."
             : `Set up, but no browser has loaded it yet. Add the snippet to your site if you haven't — then ${CONFIRM_HINT}`,
         tone: "waiting",
       };

--- a/src/lib/signal-errors.test.ts
+++ b/src/lib/signal-errors.test.ts
@@ -32,13 +32,32 @@ const WRITE_CODES = [
   "RAIL_UNAVAILABLE",
   "NO_ORG",
   "UNAUTHORIZED",
+  // ★AND THE APP-LEVEL GUARD, which is a THIRD layer: `csrfGuard` is mounted in
+  // `src/index.ts` above the v1 router, so a list traced from the handlers and
+  // their own middleware still stops one short. The commit that added this file
+  // claimed to have traced "the middleware above them" and had not.
+  "CSRF_MISSING",
+  "CSRF_INVALID",
 ];
 
 describe("signals error copy", () => {
   it("★maps every write code, and none of them is the generic fallback", () => {
+    // ★DISTINCT FROM THE FALLBACK *AND* FROM EACH OTHER. "≠ fallback" alone is
+    // satisfied by mapping every code to the same one-word string.
     const fallback = writeErrorMessage(err("SOMETHING_NOBODY_HAS_SEEN"));
+    const seen = new Map<string, string>();
     for (const code of WRITE_CODES) {
-      expect(writeErrorMessage(err(code)), code).not.toBe(fallback);
+      const msg = writeErrorMessage(err(code));
+      expect(msg, code).not.toBe(fallback);
+      // (No length floor. A first cut used one and failed on "Nothing was
+      // changed." — a correct message that is short because the situation is.
+      // Length is a proxy; distinctness is the property.)
+      const clash = seen.get(msg);
+      // Two codes MAY share a message when they are genuinely the same
+      // situation (the two CSRF ones are), so this records rather than forbids —
+      // what it refuses is a mapping that has collapsed wholesale.
+      if (clash) expect([clash, code].sort().join("|")).toBe("CSRF_INVALID|CSRF_MISSING");
+      seen.set(msg, code);
     }
   });
 
@@ -57,7 +76,10 @@ describe("signals error copy", () => {
       "NOTHING_TO_UPDATE",
       "RAIL_UNAVAILABLE",
     ]) {
-      expect(writeErrorMessage(err(code)), code).not.toMatch(/try again in a moment/i);
+      // Any bare retry, not one literal phrasing: "try again later" and
+      // "please retry" are the same actionless advice.
+      const msg = writeErrorMessage(err(code));
+      expect(msg, code).not.toMatch(/try again (in a moment|later|shortly)|please retry/i);
     }
   });
 

--- a/src/lib/signal-errors.test.ts
+++ b/src/lib/signal-errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "@/lib/api";
+import {
+  listErrorState,
+  writeErrorMessage,
+} from "@/app/(site)/dashboard/growth/signals/page";
+
+/**
+ * ★EVERY CODE THE SIGNALS ROUTES CAN RETURN, MAPPED TO A MESSAGE THAT IS NOT
+ * "TRY AGAIN IN A MOMENT" UNLESS TRYING AGAIN COULD ACTUALLY HELP.
+ *
+ * This surface has now shipped that mistake twice: `FORBIDDEN` and
+ * `NO_ACTIVE_BUSINESS` fell through to a retry button that could never resolve
+ * them, and `RAIL_UNAVAILABLE` was added api-side with no client case at all —
+ * caught only because a reviewer went looking. The list below is a decision
+ * about which codes exist, so adding one api-side and forgetting the client is
+ * a failing test rather than a customer being told to wait for nothing.
+ */
+const err = (code: string) => new ApiError(code, "server sentence", 400);
+
+/** Traced from `peakhour-api`: the route handlers plus the middleware ABOVE
+ *  them (`requireAuth` → UNAUTHORIZED, `requireOrg` → NO_ORG,
+ *  `requireRole` → FORBIDDEN). A list built by reading one handler stops
+ *  exactly where the middleware starts, which is how two of these were missed. */
+const WRITE_CODES = [
+  "SIGNAL_EXISTS",
+  "FORBIDDEN",
+  "NO_ACTIVE_BUSINESS",
+  "NOTHING_TO_UPDATE",
+  "VALIDATION_ERROR",
+  "NOT_FOUND",
+  "RAIL_UNAVAILABLE",
+  "NO_ORG",
+  "UNAUTHORIZED",
+];
+
+describe("signals error copy", () => {
+  it("★maps every write code, and none of them is the generic fallback", () => {
+    const fallback = writeErrorMessage(err("SOMETHING_NOBODY_HAS_SEEN"));
+    for (const code of WRITE_CODES) {
+      expect(writeErrorMessage(err(code)), code).not.toBe(fallback);
+    }
+  });
+
+  it("★no unretryable failure is answered with a BARE 'try again in a moment'", () => {
+    // ★THE RULE IS ABOUT AN ACTIONLESS RETRY, NOT THE WORDS "try again". A first
+    // cut forbade the phrase outright and failed on NO_ORG — whose message is
+    // "finish onboarding and try again", where the retry FOLLOWS a real action
+    // the customer can take. That is a good message. What is forbidden is
+    // offering a retry as the whole remedy for something waiting on nobody: a
+    // remedy that cannot resolve the failure is worse than none.
+    for (const code of [
+      "FORBIDDEN",
+      "NO_ACTIVE_BUSINESS",
+      "NO_ORG",
+      "UNAUTHORIZED",
+      "NOTHING_TO_UPDATE",
+      "RAIL_UNAVAILABLE",
+    ]) {
+      expect(writeErrorMessage(err(code)), code).not.toMatch(/try again in a moment/i);
+    }
+  });
+
+  it("★RAIL_UNAVAILABLE explains the wait and offers the other rail", () => {
+    const msg = writeErrorMessage(err("RAIL_UNAVAILABLE"));
+    expect(msg).toMatch(/wordpress/i);
+    expect(msg).toMatch(/hour/i);
+    expect(msg).toMatch(/paste/i);
+  });
+
+  it("the generic fallback is still there for a code nobody has seen", () => {
+    expect(writeErrorMessage(err("WAT"))).toMatch(/try again in a moment/i);
+    expect(writeErrorMessage(new Error("network"))).toMatch(/try again in a moment/i);
+  });
+
+  it("★the list surface offers a RETRY only where one could work", () => {
+    const retryable = listErrorState(new Error("network"), () => {});
+    expect(retryable.action).toBeDefined();
+    for (const code of ["NO_ACTIVE_BUSINESS", "NO_ORG", "UNAUTHORIZED"]) {
+      const state = listErrorState(err(code), () => {});
+      expect(state.action, code).toBeUndefined();
+      expect(state.description, code).not.toMatch(/try again/i);
+    }
+  });
+});


### PR DESCRIPTION
The api and plugin halves of the WordPress rail are in review
(peakhour-api#1038, peakhour-wordpress#96). **This has to merge before them.**

★**"Add the snippet by hand for now" now double-installs the tag.** That
sentence was honest when nothing could deliver the rail. With the plugin
printing it, a customer who follows the instruction ends up with the
plugin-printed tag *and* a pasted one — two Insight Tags, two beacons. The api
refuses to serve a `manual` row over this rail for exactly that reason; the copy
is the other half of that guard.

The wordpress-rail states now say what is true:

| state | copy |
|---|---|
| not yet fetched | "your plugin checks in hourly and hasn't picked this up yet. Nothing to do." |
| fetched, not yet fired | the check hint — now that a check is actually actionable |

★And the check hint is **not** shown before the plugin has it. That state is
waiting on us, not on the customer; telling them to open a private window there
is busywork that cannot change the state, which is its own kind of false advice.

★**`RAIL_UNAVAILABLE` fell through to "try again in a moment".** The api gates
the rail on a site having checked in recently, and a quiet site does not come
back because the customer pressed Save again.

## The new test, and what it taught me

`signal-errors.test.ts` covers the code→message mapping, because this surface
has shipped the same mistake twice: `FORBIDDEN`/`NO_ACTIVE_BUSINESS` fell
through once, and `RAIL_UNAVAILABLE` was added api-side with no client case at
all — caught only because a reviewer went looking. The code list is traced from
the handlers **and the middleware above them**, which is exactly where a list
built by reading one handler stops looking.

★Writing it corrected my own rule. The first version forbade the phrase "try
again" outright and failed on `NO_ORG` — whose message is "finish onboarding and
try again", where the retry *follows a real action*. That is a good message.
What is forbidden is the actionless "try again in a moment" as the whole remedy
for something waiting on nobody. The assertion is narrowed to that.

The wordpress-rail copy test is broadened from one state to every
state × served/unserved combination and asserts the invariant rather than the
old wording. Mutation-checked both ways.

341 green, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
