### PR TITLE
fix(pricing): the panel told four different stores the same reassuring thing

### DIFF
--- a/src/components/commerce/pricing.tsx
+++ b/src/components/commerce/pricing.tsx
@@ -21,6 +21,7 @@ import { FeatureGate } from "@/components/upgrade/feature-gate";
 import { useLocale } from "@/hooks/use-locale";
 import { minorToMajor } from "@/lib/money";
 import { PageShell } from "@/components/dashboard/page-shell";
+import { emptyPlanCopy, partialPlanCopy } from "@/lib/pricing-empty-copy";
 import {
   usePricer,
   usePricerBrief,
@@ -126,7 +127,7 @@ function PricingBody() {
 
       <PricingBrief hasProposals={data.proposals.length > 0} />
 
-      <PriceGrid proposals={data.proposals} plan={data} money={money} />
+      <PriceGrid plan={data} money={money} />
 
       <Promotions formatMajor={formatNumber} />
     </PageShell>
@@ -183,53 +184,19 @@ function PricingBrief({ hasProposals }: { hasProposals: boolean }) {
   );
 }
 
-/**
- * What to say when the markdown plan is empty.
- *
- * ★AN EMPTY PLAN HAS FIVE CAUSES AND ONLY ONE OF THEM IS GOOD NEWS. This panel
- * used to render the reassuring one — "nothing is sitting with tied-up capital"
- * — for all of them, keyed off `scanned` alone. So a store whose catalog scan
- * hit its cap, or whose slow stock was crowded out of the candidate set by
- * at-risk products, or that had switched markdowns off entirely, was told its
- * shelf was clear. The api now decides WHICH cause (`emptyReason`,
- * `services/commerce/pricer.ts`); this only chooses the words.
- *
- * ★AND IT FALLS BACK, because the SPA and the api deploy separately. Against an
- * api that predates the field the panel keeps its old two-state behaviour rather
- * than rendering nothing.
- */
-function emptyPlanCopy(plan: PricingPlan): string {
-  switch (plan.emptyReason) {
-    case "not_scanned":
-      return "No products have synced yet. Your markdown plan appears once your catalog and recent orders sync.";
-    case "markdowns_off":
-      // ★DOES NOT PROMISE CANDIDATES EXIST — the plan carries no slow count, so
-      // "raise it to see your candidates" would assert something unknowable.
-      return "Markdowns are switched off — your clearance ceiling is 0%, so nothing is being proposed. Raise it to see whether anything qualifies.";
-    case "candidates_truncated":
-      return "Peakhour checked the products needing the most urgent attention first and ran out of room before reaching your slow-moving stock — so this isn't a clean bill of health. Clearing your at-risk products will let a plan build.";
-    case "scan_truncated":
-      return "Nothing to mark down among the products Peakhour could scan — but your catalog is larger than one pass covers, so this isn't the whole shelf.";
-    case "clear":
-    case "none":
-      return "No slow stock to mark down right now — nothing is sitting with tied-up capital.";
-    default:
-      // An api that predates `emptyReason`. The old two-state behaviour.
-      return plan.scanned
-        ? "No slow stock to mark down right now — nothing is sitting with tied-up capital."
-        : "No products have synced yet. Your markdown plan appears once your catalog and recent orders sync.";
-  }
-}
-
+/** ★TAKES THE PLAN, NOT THE PLAN AND ITS OWN PROPOSALS. Passing both meant
+ *  emptiness was read from one prop and its explanation from another, which is
+ *  one refactor away from a grid that renders rows under an empty-state
+ *  sentence. */
 function PriceGrid({
-  proposals,
   plan,
   money,
 }: {
-  proposals: PricingProposal[];
   plan: PricingPlan;
   money: (minor: number | null, currency: string | null) => string;
 }) {
+  const proposals = plan.proposals;
+  const partial = partialPlanCopy(plan);
   const propose = useProposePricing();
   const [proposed, setProposed] = useState<Set<string>>(new Set());
 
@@ -260,19 +227,18 @@ function PriceGrid({
             {emptyPlanCopy(plan)}
           </p>
         ) : (
-          <div className="overflow-x-auto">
+          <>
             {/* ★A NON-EMPTY PLAN CAN BE PARTIAL TOO, and that is the quieter
-                failure: it looks complete. Either the catalog scan hit its cap
-                or slow stock was crowded out of the candidate set by at-risk
-                products, and neither is visible from a table that renders
-                whatever it was given. */}
-            {plan.truncated || plan.truncatedCandidates ? (
+                failure: it looks complete. ★OUTSIDE the horizontal scroller —
+                inside it, the caveat scrolled out of view exactly when the
+                merchant scrolled right to read the incomplete numbers it was
+                qualifying. */}
+            {partial ? (
               <p className="border-b bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
-                {plan.truncatedCandidates
-                  ? "Peakhour checks the most urgent products first and ran out of room, so there may be slow-moving stock this plan hasn't reached."
-                  : "Your catalog is larger than one pass covers, so this plan is built from the products that were scanned."}
+                {partial}
               </p>
             ) : null}
+            <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-left text-xs text-muted-foreground">
@@ -324,7 +290,8 @@ function PriceGrid({
                 })}
               </tbody>
             </table>
-          </div>
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/src/components/commerce/pricing.tsx
+++ b/src/components/commerce/pricing.tsx
@@ -25,6 +25,7 @@ import {
   usePricer,
   usePricerBrief,
   useProposePricing,
+  type PricingPlan,
   type PricingProposal,
 } from "@/hooks/use-commerce-pricer";
 import {
@@ -107,19 +108,25 @@ function PricingBody() {
           <ShieldCheck className="size-3.5" /> Guardrails:
         </span>
         <Badge variant="outline" className="font-normal">
-          Discount ceiling {guardrails.maxDiscountPct ?? "—"}%
+          Discount ceiling {guardrails.maxDiscountPct != null ? `${guardrails.maxDiscountPct}%` : "not set"}
         </Badge>
         <Badge variant="outline" className="font-normal">
           Margin floor {guardrails.marginFloorPct != null ? `${guardrails.marginFloorPct}%` : "not set"}
         </Badge>
-        <span className="text-muted-foreground">
-          Every markdown stays within these — the engine never proposes past them.
-        </span>
+        {/* ★THE CLAIM IS CONDITIONAL ON THERE BEING A CEILING TO STAY WITHIN.
+            "Every markdown stays within these" was unconditional, so it was
+            printed with no ceiling set (nothing to stay within) and with a
+            ceiling of 0 (no markdowns to stay within anything). */}
+        {guardrails.maxDiscountPct != null && guardrails.maxDiscountPct > 0 ? (
+          <span className="text-muted-foreground">
+            Every markdown stays within these — the engine never proposes past them.
+          </span>
+        ) : null}
       </div>
 
       <PricingBrief hasProposals={data.proposals.length > 0} />
 
-      <PriceGrid proposals={data.proposals} scanned={data.scanned} money={money} />
+      <PriceGrid proposals={data.proposals} plan={data} money={money} />
 
       <Promotions formatMajor={formatNumber} />
     </PageShell>
@@ -176,13 +183,51 @@ function PricingBrief({ hasProposals }: { hasProposals: boolean }) {
   );
 }
 
+/**
+ * What to say when the markdown plan is empty.
+ *
+ * ★AN EMPTY PLAN HAS FIVE CAUSES AND ONLY ONE OF THEM IS GOOD NEWS. This panel
+ * used to render the reassuring one — "nothing is sitting with tied-up capital"
+ * — for all of them, keyed off `scanned` alone. So a store whose catalog scan
+ * hit its cap, or whose slow stock was crowded out of the candidate set by
+ * at-risk products, or that had switched markdowns off entirely, was told its
+ * shelf was clear. The api now decides WHICH cause (`emptyReason`,
+ * `services/commerce/pricer.ts`); this only chooses the words.
+ *
+ * ★AND IT FALLS BACK, because the SPA and the api deploy separately. Against an
+ * api that predates the field the panel keeps its old two-state behaviour rather
+ * than rendering nothing.
+ */
+function emptyPlanCopy(plan: PricingPlan): string {
+  switch (plan.emptyReason) {
+    case "not_scanned":
+      return "No products have synced yet. Your markdown plan appears once your catalog and recent orders sync.";
+    case "markdowns_off":
+      // ★DOES NOT PROMISE CANDIDATES EXIST — the plan carries no slow count, so
+      // "raise it to see your candidates" would assert something unknowable.
+      return "Markdowns are switched off — your clearance ceiling is 0%, so nothing is being proposed. Raise it to see whether anything qualifies.";
+    case "candidates_truncated":
+      return "Peakhour checked the products needing the most urgent attention first and ran out of room before reaching your slow-moving stock — so this isn't a clean bill of health. Clearing your at-risk products will let a plan build.";
+    case "scan_truncated":
+      return "Nothing to mark down among the products Peakhour could scan — but your catalog is larger than one pass covers, so this isn't the whole shelf.";
+    case "clear":
+    case "none":
+      return "No slow stock to mark down right now — nothing is sitting with tied-up capital.";
+    default:
+      // An api that predates `emptyReason`. The old two-state behaviour.
+      return plan.scanned
+        ? "No slow stock to mark down right now — nothing is sitting with tied-up capital."
+        : "No products have synced yet. Your markdown plan appears once your catalog and recent orders sync.";
+  }
+}
+
 function PriceGrid({
   proposals,
-  scanned,
+  plan,
   money,
 }: {
   proposals: PricingProposal[];
-  scanned: boolean;
+  plan: PricingPlan;
   money: (minor: number | null, currency: string | null) => string;
 }) {
   const propose = useProposePricing();
@@ -212,12 +257,22 @@ function PriceGrid({
       <CardContent className="p-0">
         {proposals.length === 0 ? (
           <p className="px-4 py-10 text-center text-sm text-muted-foreground">
-            {scanned
-              ? "No slow stock to mark down right now — nothing is sitting with tied-up capital."
-              : "No products have synced yet. Your markdown plan appears once your catalog and recent orders sync."}
+            {emptyPlanCopy(plan)}
           </p>
         ) : (
           <div className="overflow-x-auto">
+            {/* ★A NON-EMPTY PLAN CAN BE PARTIAL TOO, and that is the quieter
+                failure: it looks complete. Either the catalog scan hit its cap
+                or slow stock was crowded out of the candidate set by at-risk
+                products, and neither is visible from a table that renders
+                whatever it was given. */}
+            {plan.truncated || plan.truncatedCandidates ? (
+              <p className="border-b bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+                {plan.truncatedCandidates
+                  ? "Peakhour checks the most urgent products first and ran out of room, so there may be slow-moving stock this plan hasn't reached."
+                  : "Your catalog is larger than one pass covers, so this plan is built from the products that were scanned."}
+              </p>
+            ) : null}
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-left text-xs text-muted-foreground">

--- a/src/hooks/use-commerce-pricer.ts
+++ b/src/hooks/use-commerce-pricer.ts
@@ -37,10 +37,37 @@ export interface PricingProposal {
   reason: string;
 }
 
+/**
+ * Why a markdown plan came back with no proposals — decided by the api
+ * (`services/commerce/pricer.ts`), rendered here.
+ *
+ * ★THE ORDERING IS NOT THIS PANEL'S TO REDERIVE, and re-deriving it is exactly
+ * how this panel came to tell merchants "nothing is sitting with tied-up
+ * capital" for four different situations, only one of which was good news. The
+ * api decides which cause the merchant can act on; each surface chooses its own
+ * words for it.
+ *
+ * ★OPTIONAL, because the SPA and the api deploy separately. An api that predates
+ * the field sends nothing, and the panel falls back to the `scanned` flag it has
+ * always had rather than rendering an empty string.
+ */
+export type PricingEmptyReason =
+  | "none"
+  | "not_scanned"
+  | "markdowns_off"
+  | "candidates_truncated"
+  | "scan_truncated"
+  | "clear";
+
 export interface PricingPlan {
   windowDays: number;
   scanned: boolean;
+  /** The catalog scan hit its cap — the plan covers part of the store. */
   truncated: boolean;
+  /** Slow stock may have been crowded out of the candidate set (the scan
+   *  returns at-risk products first and stops at 200). */
+  truncatedCandidates?: boolean;
+  emptyReason?: PricingEmptyReason;
   guardrails: PricerGuardrails;
   proposals: PricingProposal[];
   totalRecoveredCapitalMinor: number;

--- a/src/lib/pricing-empty-copy.test.ts
+++ b/src/lib/pricing-empty-copy.test.ts
@@ -42,6 +42,11 @@ describe("emptyPlanCopy", () => {
     const copy = emptyPlanCopy({ ...base, emptyReason: "candidates_truncated" });
     expect(copy).toContain("ran out of room");
     expect(copy).not.toContain(CLEAN_SHELF);
+    // ★AND DOES NOT PRESCRIBE CLEARING AT-RISK STOCK. The api computes this
+    // reason before the proposal loop, so a plan is also empty when slow items
+    // WERE examined and every one was filtered out (zero stock, unpriced,
+    // clamped). Advice about at-risk products would then not build a plan.
+    expect(copy).not.toContain("at-risk");
   });
 
   it("★never claims a clean shelf on a partial scan", () => {
@@ -53,8 +58,25 @@ describe("emptyPlanCopy", () => {
   it("★`none` is unreachable, so it must not map to the reassuring sentence", () => {
     // It means the plan is NOT empty. Reaching it here is a bug somewhere, and
     // the worst possible response to a bug is the most comforting sentence.
-    const copy = emptyPlanCopy({ ...base, emptyReason: "none", truncated: true });
-    expect(copy).toContain("isn't the whole shelf");
+    // ★Pinned with CLEAN flags too — with `truncated: true` the old code passed
+    // this by accident, via a fallback that happened to say something cautious.
+    for (const over of [{ truncated: true }, {}]) {
+      const copy = emptyPlanCopy({ ...base, emptyReason: "none", ...over });
+      expect(copy).not.toContain(CLEAN_SHELF);
+      expect(copy).toContain("doesn't recognise");
+    }
+  });
+
+  it("★an UNKNOWN reason is not a clean shelf — the api may ship a sixth", () => {
+    // The api omits a `default` so a new reason is a compile error there. This
+    // mirror cannot: a newer api can answer an SPA that has not redeployed, and
+    // routing that into the flag derivation would reinstate the false all-clear.
+    const copy = emptyPlanCopy({
+      ...base,
+      emptyReason: "some_future_reason" as PricingPlan["emptyReason"],
+    });
+    expect(copy).not.toContain(CLEAN_SHELF);
+    expect(copy).toContain("contact support");
   });
 });
 
@@ -101,7 +123,7 @@ describe("partialPlanCopy", () => {
     expect(partialPlanCopy(base)).toBeNull();
   });
 
-  it("★does NOT blame at-risk stock, unlike the empty case", () => {
+  it("★does NOT blame at-risk stock — neither caveat may", () => {
     // With proposals present, slow items DID make the set — so the cap was hit
     // partway through them, which happens with 300 slow products and no at-risk
     // ones at all. Advice about clearing at-risk stock would be about products

--- a/src/lib/pricing-empty-copy.test.ts
+++ b/src/lib/pricing-empty-copy.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { emptyPlanCopy, partialPlanCopy } from "./pricing-empty-copy";
+import type { PricingPlan } from "@/hooks/use-commerce-pricer";
+
+/**
+ * The Pricing panel told four different stores the same reassuring thing. These
+ * pin the five causes apart, and — the part that actually ships today — the
+ * legacy path used against an api that predates `emptyReason`.
+ */
+
+const base: PricingPlan = {
+  windowDays: 30,
+  scanned: true,
+  truncated: false,
+  truncatedCandidates: false,
+  emptyReason: "clear",
+  guardrails: {},
+  proposals: [],
+  totalRecoveredCapitalMinor: 0,
+  currency: null,
+};
+
+const CLEAN_SHELF = "nothing is sitting with tied-up capital";
+
+describe("emptyPlanCopy", () => {
+  it("reassures only when the shelf really is clear", () => {
+    expect(emptyPlanCopy(base)).toContain(CLEAN_SHELF);
+  });
+
+  it("says nothing has synced when nothing has", () => {
+    expect(emptyPlanCopy({ ...base, emptyReason: "not_scanned" })).toContain("synced");
+  });
+
+  it("★names a disabled ceiling, and does not promise candidates exist", () => {
+    const copy = emptyPlanCopy({ ...base, emptyReason: "markdowns_off" });
+    expect(copy).toContain("switched off");
+    expect(copy).toContain("whether anything qualifies");
+    expect(copy).not.toContain(CLEAN_SHELF);
+  });
+
+  it("★never claims a clean shelf when slow stock was crowded out", () => {
+    const copy = emptyPlanCopy({ ...base, emptyReason: "candidates_truncated" });
+    expect(copy).toContain("ran out of room");
+    expect(copy).not.toContain(CLEAN_SHELF);
+  });
+
+  it("★never claims a clean shelf on a partial scan", () => {
+    const copy = emptyPlanCopy({ ...base, emptyReason: "scan_truncated" });
+    expect(copy).toContain("isn't the whole shelf");
+    expect(copy).not.toContain(CLEAN_SHELF);
+  });
+
+  it("★`none` is unreachable, so it must not map to the reassuring sentence", () => {
+    // It means the plan is NOT empty. Reaching it here is a bug somewhere, and
+    // the worst possible response to a bug is the most comforting sentence.
+    const copy = emptyPlanCopy({ ...base, emptyReason: "none", truncated: true });
+    expect(copy).toContain("isn't the whole shelf");
+  });
+});
+
+describe("emptyPlanCopy — the legacy api path, which is the live one today", () => {
+  /** Production trails master, so until it catches up this is what merchants
+   *  actually see. The first version kept the old two-state behaviour and got
+   *  three of the five causes wrong. */
+  const legacy = (over: Partial<PricingPlan>): PricingPlan => ({
+    ...base,
+    emptyReason: undefined,
+    ...over,
+  });
+
+  it("★a partial scan is not a clean shelf, even with no emptyReason", () => {
+    expect(emptyPlanCopy(legacy({ truncated: true }))).toContain("isn't the whole shelf");
+  });
+
+  it("★a 0% ceiling is not a clean shelf either", () => {
+    const copy = emptyPlanCopy(legacy({ guardrails: { maxDiscountPct: 0 } }));
+    expect(copy).toContain("switched off");
+    expect(copy).not.toContain(CLEAN_SHELF);
+  });
+
+  it("★the ceiling outranks the truncation, matching the api's own ordering", () => {
+    // Leading with the truncation would promise a plan that builds once at-risk
+    // stock clears — which a 0% ceiling never permits.
+    const copy = emptyPlanCopy(legacy({ truncated: true, guardrails: { maxDiscountPct: 0 } }));
+    expect(copy).toContain("switched off");
+  });
+
+  it("nothing synced still wins over everything", () => {
+    expect(
+      emptyPlanCopy(legacy({ scanned: false, truncated: true, guardrails: { maxDiscountPct: 0 } })),
+    ).toContain("synced");
+  });
+
+  it("and reassures when there is genuinely nothing wrong", () => {
+    expect(emptyPlanCopy(legacy({}))).toContain(CLEAN_SHELF);
+  });
+});
+
+describe("partialPlanCopy", () => {
+  it("says nothing about a complete plan", () => {
+    expect(partialPlanCopy(base)).toBeNull();
+  });
+
+  it("★does NOT blame at-risk stock, unlike the empty case", () => {
+    // With proposals present, slow items DID make the set — so the cap was hit
+    // partway through them, which happens with 300 slow products and no at-risk
+    // ones at all. Advice about clearing at-risk stock would be about products
+    // that may not exist.
+    const copy = partialPlanCopy({ ...base, truncatedCandidates: true })!;
+    expect(copy).toContain("ran out of room");
+    expect(copy).not.toContain("at-risk");
+  });
+
+  it("falls back to the scan cap when only that was hit", () => {
+    expect(partialPlanCopy({ ...base, truncated: true })).toContain("larger than one pass");
+  });
+});

--- a/src/lib/pricing-empty-copy.ts
+++ b/src/lib/pricing-empty-copy.ts
@@ -32,17 +32,34 @@ const MARKDOWNS_OFF =
 const SCAN_TRUNCATED =
   "Nothing to mark down among the products Peakhour could scan — but your catalog is larger than one pass covers, so this isn't the whole shelf.";
 /**
- * ★NAMING AT-RISK STOCK IS SOUND HERE, AND ONLY HERE. The api's flag is
- * `slow.length < counts.slow`, which on its own does not say what crowded the
- * slow items out. But this branch is reached only when the plan is EMPTY —
- * meaning ZERO slow items came back while some were counted — and
- * `scoreInventory` sorts at-risk first, slow second. Zero slow returned
- * therefore means the 200 slots were consumed by at-risk products before the
- * sort ever reached slow. Clearing them really is the action that lets a plan
- * build. The NON-EMPTY caveat below cannot make that claim and does not.
+ * ★IT DOES NOT NAME AT-RISK STOCK, AND AN EARLIER VERSION DID — with a comment
+ * arguing that an empty plan meant zero slow items came back, so the 200 slots
+ * must have been consumed by at-risk products. That argument is false. The api
+ * computes this reason BEFORE the proposal loop, and a plan also ends up empty
+ * when slow items WERE examined and every one was filtered out for being out of
+ * stock, unpriced, or clamped to nothing (`pricer.ts`). Worse, `scoreInventory`
+ * sorts out-of-stock items first inside the slow bucket, so those are the slow
+ * items most likely to survive the cap — a store with 150 at-risk and 300 slow
+ * whose surviving 50 are all zero-stock would have been told its slow stock was
+ * never looked at, and given advice that cannot build a plan.
+ *
+ * What the flag does establish is that some slow products were not examined.
+ * That is what this says.
  */
 const CANDIDATES_TRUNCATED =
-  "Peakhour checked the products needing the most urgent attention first and ran out of room before reaching your slow-moving stock — so this isn't a clean bill of health. Clearing your at-risk products will let a plan build.";
+  "Peakhour checks the most urgent products first and ran out of room, so some of your slow-moving stock wasn't examined — this isn't a clean bill of health.";
+
+/**
+ * ★AN `emptyReason` THIS BUILD DOES NOT KNOW. The api's own switch omits a
+ * `default` so a new reason is a compile error there; this mirror cannot have
+ * that, because the api can ship a sixth reason to an SPA that has not
+ * redeployed. Falling back to the flag-based derivation would then answer with
+ * the reassuring sentence for a cause it has never heard of — reinstating
+ * exactly the false all-clear this whole change removes. Saying less is the
+ * only safe answer.
+ */
+const UNKNOWN_REASON =
+  "No markdowns to show right now. If you were expecting some, contact support — Peakhour reported a reason this page doesn't recognise yet.";
 
 /**
  * The ordering, re-derived — for an api that predates `emptyReason` ONLY.
@@ -68,6 +85,14 @@ function legacyEmptyCopy(plan: PricingPlan): string {
 }
 
 export function emptyPlanCopy(plan: PricingPlan): string {
+  // ★"THE API IS OLD" AND "THE API SAID SOMETHING NEW" ARE OPPOSITE SITUATIONS,
+  // and one `default` arm was treating them as the same. An absent field means
+  // an api that predates it, where the legacy flags genuinely can explain three
+  // of the five causes and CLEAR is a correct answer. An unrecognised VALUE
+  // means the api knows something this build does not — and answering that with
+  // the reassuring sentence is the bug this file exists to remove.
+  if (plan.emptyReason === undefined) return legacyEmptyCopy(plan);
+
   switch (plan.emptyReason) {
     case "not_scanned":
       return NOT_SCANNED;
@@ -80,12 +105,11 @@ export function emptyPlanCopy(plan: PricingPlan): string {
     case "clear":
       return CLEAR;
     // ★`none` MEANS THE PLAN IS NOT EMPTY, so reaching it here is impossible by
-    // construction — and mapping an impossible state onto the single most
-    // reassuring sentence is the worst available default. It falls through to
-    // the legacy derivation, which reasons from the flags rather than assuming.
+    // construction — which makes it a bug, and the worst possible response to a
+    // bug is the most comforting sentence available.
     case "none":
     default:
-      return legacyEmptyCopy(plan);
+      return UNKNOWN_REASON;
   }
 }
 

--- a/src/lib/pricing-empty-copy.ts
+++ b/src/lib/pricing-empty-copy.ts
@@ -1,0 +1,110 @@
+import type { PricingPlan } from "@/hooks/use-commerce-pricer";
+
+/**
+ * What to say when the markdown plan is empty, and what to say above a plan
+ * that is not empty but is not the whole shelf either.
+ *
+ * ★AN EMPTY PLAN HAS FIVE CAUSES AND ONLY ONE OF THEM IS GOOD NEWS. The Pricing
+ * panel used to render the reassuring one — "nothing is sitting with tied-up
+ * capital" — for all of them, keyed off `scanned` alone.
+ *
+ * ★THE ORDERING IS THE API'S, NOT OURS. `emptyReason` is decided in
+ * `services/commerce/pricer.ts` from the flags it has just computed, precisely
+ * so four surfaces stop each re-deriving it and each being one missed branch
+ * from a false all-clear. This module chooses words, not causes — with one
+ * deliberate exception, `legacyEmptyReason`, which exists only for an api that
+ * predates the field.
+ *
+ * ★EXTRACTED SO IT CAN BE TESTED. It was a seven-branch pure function living
+ * inside a React component, while the api shipped nine tests for the same
+ * decision. The repo already co-locates `src/lib/*-rules.ts` tests for exactly
+ * this shape.
+ */
+
+const CLEAR =
+  "No slow stock to mark down right now — nothing is sitting with tied-up capital.";
+const NOT_SCANNED =
+  "No products have synced yet. Your markdown plan appears once your catalog and recent orders sync.";
+const MARKDOWNS_OFF =
+  // ★DOES NOT PROMISE CANDIDATES EXIST — the plan carries no slow count, so
+  // "raise it to see your candidates" would assert something unknowable.
+  "Markdowns are switched off — your clearance ceiling is 0%, so nothing is being proposed. Raise it to see whether anything qualifies.";
+const SCAN_TRUNCATED =
+  "Nothing to mark down among the products Peakhour could scan — but your catalog is larger than one pass covers, so this isn't the whole shelf.";
+/**
+ * ★NAMING AT-RISK STOCK IS SOUND HERE, AND ONLY HERE. The api's flag is
+ * `slow.length < counts.slow`, which on its own does not say what crowded the
+ * slow items out. But this branch is reached only when the plan is EMPTY —
+ * meaning ZERO slow items came back while some were counted — and
+ * `scoreInventory` sorts at-risk first, slow second. Zero slow returned
+ * therefore means the 200 slots were consumed by at-risk products before the
+ * sort ever reached slow. Clearing them really is the action that lets a plan
+ * build. The NON-EMPTY caveat below cannot make that claim and does not.
+ */
+const CANDIDATES_TRUNCATED =
+  "Peakhour checked the products needing the most urgent attention first and ran out of room before reaching your slow-moving stock — so this isn't a clean bill of health. Clearing your at-risk products will let a plan build.";
+
+/**
+ * The ordering, re-derived — for an api that predates `emptyReason` ONLY.
+ *
+ * ★THIS IS THE LIVE PATH TODAY, which is why it is not a token fallback. The
+ * production api trails master, so until it catches up every merchant sees
+ * this branch — and the first version of it kept the old two-state behaviour,
+ * keyed off `scanned` alone. That meant a partial-scan store still heard
+ * "nothing is sitting with tied-up capital", and a store with a 0% ceiling
+ * heard it directly beneath a "Discount ceiling 0%" badge.
+ *
+ * `truncated` and `guardrails.maxDiscountPct` are both sent by the OLD api, so
+ * three of the five causes are recoverable without it. `candidates_truncated`
+ * is not — that flag is new — and its absence is the honest limit of this path.
+ */
+function legacyEmptyCopy(plan: PricingPlan): string {
+  if (!plan.scanned) return NOT_SCANNED;
+  if (plan.guardrails.maxDiscountPct != null && plan.guardrails.maxDiscountPct <= 0) {
+    return MARKDOWNS_OFF;
+  }
+  if (plan.truncated) return SCAN_TRUNCATED;
+  return CLEAR;
+}
+
+export function emptyPlanCopy(plan: PricingPlan): string {
+  switch (plan.emptyReason) {
+    case "not_scanned":
+      return NOT_SCANNED;
+    case "markdowns_off":
+      return MARKDOWNS_OFF;
+    case "candidates_truncated":
+      return CANDIDATES_TRUNCATED;
+    case "scan_truncated":
+      return SCAN_TRUNCATED;
+    case "clear":
+      return CLEAR;
+    // ★`none` MEANS THE PLAN IS NOT EMPTY, so reaching it here is impossible by
+    // construction — and mapping an impossible state onto the single most
+    // reassuring sentence is the worst available default. It falls through to
+    // the legacy derivation, which reasons from the flags rather than assuming.
+    case "none":
+    default:
+      return legacyEmptyCopy(plan);
+  }
+}
+
+/**
+ * The caveat above a plan that HAS proposals but is not the whole shelf — the
+ * quieter failure, because such a plan looks complete.
+ *
+ * ★IT DOES NOT BLAME AT-RISK STOCK, unlike the empty case. With proposals
+ * present, slow items DID make the candidate set, so the cap was reached partway
+ * through them — which happens on a catalog of 300 slow products and no at-risk
+ * ones at all. "Clear your at-risk stock" would be advice about products that
+ * may not exist.
+ */
+export function partialPlanCopy(plan: PricingPlan): string | null {
+  if (plan.truncatedCandidates) {
+    return "Peakhour checks the most urgent products first and ran out of room, so there may be slow-moving stock this plan hasn't reached.";
+  }
+  if (plan.truncated) {
+    return "Your catalog is larger than one pass covers, so this plan is built from the products that were scanned.";
+  }
+  return null;
+}


### PR DESCRIPTION
fix(pricing): the panel told four different stores the same reassuring thing

The Pricing panel rendered "No slow stock to mark down right now — nothing is
sitting with tied-up capital" for every empty plan, keyed off `scanned` alone.
An empty plan has five causes and only one of them is good news:

- nothing has synced;
- the clearance ceiling is 0%, so the Pricer proposes nothing whatever is on
  the shelf;
- slow stock existed but was crowded out of the candidate set — the scan
  returns at-risk products first and stops at 200;
- the catalog scan itself hit its cap, so the shelf examined was partial;
- and, only then, a genuinely clear shelf.

Three of those were being told their inventory was fine on the strength of
products nobody looked at.

★THE ORDERING IS NOT THIS PANEL'S TO RE-DERIVE, and re-deriving it is how four
surfaces each ended up one missed branch from a false all-clear. The api decides
which cause the merchant can act on (`emptyReason`, from
`services/commerce/pricer.ts`); this only chooses the words, in its own voice
and its own space.

★AND IT FALLS BACK, because the SPA and the api deploy separately. Against an
api that predates the field the panel keeps its old two-state behaviour rather
than rendering an empty string.

Two smaller claims fixed while here, both the same shape — a sentence that was
true often enough to look right:

- ★A NON-EMPTY PLAN CAN BE PARTIAL TOO, and that is the quieter failure because
  it looks complete. A truncated scan or a crowded-out candidate set is invisible
  from a table that renders whatever it was given; it now says so above the rows.
- ★"Every markdown stays within these" was unconditional, so it printed with no
  ceiling set (nothing to stay within) and with a ceiling of 0 (no markdowns to
  stay within anything). It is now shown only when there is a real ceiling — and
  the ceiling badge reads "not set" rather than "—%", matching the margin floor
  beside it.

Verified: `npx tsc --noEmit` clean; `npm run build` exit 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

