### PR TITLE
fix(cms): two crons the api ships that this UI could not name

### DIFF
--- a/src/app/(site)/cms/crons/page.tsx
+++ b/src/app/(site)/cms/crons/page.tsx
@@ -36,6 +36,9 @@ interface DevCronList {
    *  this page and the api deploy separately; absent simply means no cron is
    *  pre-confirmed here and the api's own refusal is the backstop. */
   requiresConfirmation?: string[];
+  /** Crons only staff may fire. ★Also what tells the two DANGERS apart:
+   *  outside our database, or irreversibly inside it. */
+  requiresInternalUser?: string[];
 }
 
 export default function CmsCronsPage() {
@@ -112,7 +115,11 @@ export default function CmsCronsPage() {
               `requiresConfirmation` comes straight from the api so the
               dangerous ones ask before firing rather than 400-ing into a
               "try again" that can never succeed. */}
-          <CronToolbar crons={data.crons} requiresConfirmation={data.requiresConfirmation} />
+          <CronToolbar
+            crons={data.crons}
+            requiresConfirmation={data.requiresConfirmation}
+            requiresInternalUser={data.requiresInternalUser}
+          />
           <Card>
             <CardContent className="pt-6">
               <div className="grid gap-2">
@@ -122,6 +129,7 @@ export default function CmsCronsPage() {
                   // identical cron reads as dangerous above and ordinary in the
                   // list right below, which teaches people to ignore the ⚠️.
                   const guarded = data.requiresConfirmation?.includes(name) ?? false;
+                  const internalOnly = data.requiresInternalUser?.includes(name) ?? false;
                   return (
                     <div
                       key={name}
@@ -132,8 +140,16 @@ export default function CmsCronsPage() {
                           {guarded ? `⚠️ ${meta.label}` : meta.label}
                         </span>
                         {guarded ? (
-                          <span className="text-xs font-medium text-amber-600 dark:text-amber-500">
-                            Reaches outside Peakhour — asks before running
+                          <span
+                            className={
+                              internalOnly
+                                ? "text-xs font-medium text-red-600 dark:text-red-500"
+                                : "text-xs font-medium text-amber-600 dark:text-amber-500"
+                            }
+                          >
+                            {internalOnly
+                              ? "Erases data inside Peakhour, irreversibly, across every tenant on this environment — staff only"
+                              : "Reaches outside Peakhour — asks before running"}
                           </span>
                         ) : null}
                         <span className="text-xs text-muted-foreground">

--- a/src/app/(site)/cms/crons/page.tsx
+++ b/src/app/(site)/cms/crons/page.tsx
@@ -137,9 +137,12 @@ export default function CmsCronsPage() {
                     >
                       <div className="flex flex-col">
                         <span className="font-medium text-sm">
-                          {guarded ? `⚠️ ${meta.label}` : meta.label}
+                          {guarded || internalOnly ? `⚠️ ${meta.label}` : meta.label}
                         </span>
-                        {guarded ? (
+                        {/* ★`guarded || internalOnly` — the api's two sets are
+                            independent, and a cron listed only in
+                            `requiresInternalUser` rendered unmarked. */}
+                        {guarded || internalOnly ? (
                           <span
                             className={
                               internalOnly

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -690,6 +690,18 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     description:
       "Refreshes long-lived Meta tokens for connections nothing has touched recently, so a dormant account doesn't quietly expire and need reconnecting.",
   },
+  "commerce-order-pii-sweep": {
+    label: "Erase expired shopper details",
+    frequency: "Runs daily at 3:40am UTC",
+    description:
+      "Removes the shopper's phone and name from orders older than the retention window — they exist so a delivery can be confirmed, which is a purpose measured in days. The order itself stays: line items, totals and dates are the merchant's own records.",
+  },
+  "org-deletion-executor": {
+    label: "Close accounts that asked to be closed",
+    frequency: "Runs daily at 3:50am UTC",
+    description:
+      "Carries out account and workspace closures whose promised date has arrived, erasing the tenant's data. It never brings a date forward — a request made under a 30-day promise keeps its 30 days.",
+  },
   "shopify-voice-card-learn": {
     label: "Learn store voice",
     frequency: "Runs daily at 3:45am UTC",

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -808,6 +808,16 @@ function plural(count: number, noun: string): string {
  * generic "<label> complete") whenever there's no summarizer, the body
  * isn't parseable, or the summarizer opts out. Never throws.
  */
+/** Whether this cron has a summarizer at all.
+ *
+ *  ★"NO SUMMARY" AND "THE SUMMARY WAS LOST" ARE DIFFERENT, and the toast needs
+ *  to tell them apart: most crons legitimately have no summarizer and a generic
+ *  "complete" is right for them, while a cron that HAS one and returned an
+ *  unreadable (truncated) body has hidden whatever it was going to say. */
+export function hasSummarizer(cron: string): boolean {
+  return typeof CRON_METADATA[cron]?.summarize === "function";
+}
+
 export function summarizeCronBody(
   cron: string,
   body: string,

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -695,12 +695,63 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
     frequency: "Runs daily at 3:40am UTC",
     description:
       "Removes the shopper's phone and name from orders older than the retention window — they exist so a delivery can be confirmed, which is a purpose measured in days. The order itself stays: line items, totals and dates are the merchant's own records.",
+    /**
+     * ★`exhausted: false` IS NOT A SUCCESS, and without this it toasted as one.
+     * It means the sweep hit its time budget with rows still due — shopper phone
+     * numbers retained past the window we publish. The api logs a warning nobody
+     * watching this button would see; a green "complete" over it is the worst
+     * available answer.
+     */
+    summarize: (data) => {
+      const d = data as { erased?: number; scanned?: number; exhausted?: boolean } | null;
+      if (!d || typeof d.erased !== "number") return null;
+      const erased = `${d.erased} order${d.erased === 1 ? "" : "s"} cleared`;
+      // ★level: "warning", NOT A BARE STRING. A summarizer that returns a
+      // string renders a GREEN toast whatever it says, so "PII is still
+      // retained" would arrive dressed as a success.
+      return d.exhausted === false
+        ? {
+            message: `${erased}, but the sweep ran out of time with more still due — run it again.`,
+            level: "warning" as const,
+          }
+        : `${erased}. Nothing is left past the retention window.`;
+    },
   },
   "org-deletion-executor": {
     label: "Close accounts that asked to be closed",
     frequency: "Runs daily at 3:50am UTC",
     description:
       "Carries out account and workspace closures whose promised date has arrived, erasing the tenant's data. It never brings a date forward — a request made under a 30-day promise keeps its 30 days.",
+    /**
+     * ★A TICK IS NOT THE SAME AS "EVERYONE WAS CLOSED". The handler answers 200
+     * with counts, and `failed`, `refused` or an undrained backlog all mean a
+     * customer has been promised an erasure that has not happened. That is the
+     * one outcome this button must never render as a plain success.
+     */
+    summarize: (data) => {
+      const d = data as
+        | { completed?: number; failed?: number; refused?: number; deferred?: number; drained?: boolean }
+        | null;
+      if (!d || typeof d.completed !== "number") return null;
+      const done = `${d.completed} closure${d.completed === 1 ? "" : "s"} carried out`;
+      const stuck = [
+        d.failed ? `${d.failed} failed` : "",
+        d.refused ? `${d.refused} refused` : "",
+        d.deferred ? `${d.deferred} deferred` : "",
+      ].filter(Boolean);
+      if (stuck.length) {
+        return {
+          message: `${done}, but ${stuck.join(", ")} — those customers are past their promised date.`,
+          level: "warning" as const,
+        };
+      }
+      return d.drained === false
+        ? {
+            message: `${done}, and more are still due — run it again.`,
+            level: "warning" as const,
+          }
+        : `${done}. Nothing is past its promised date.`;
+    },
   },
   "shopify-voice-card-learn": {
     label: "Learn store voice",

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -69,6 +69,20 @@ interface Props {
    * fire by accident — the api refuses and the toast says exactly why.
    */
   requiresConfirmation?: readonly string[];
+  /**
+   * Crons a non-staff user cannot fire at all - the api answers `INTERNAL_ONLY`.
+   *
+   * ★SENT FOR THE SAME REASON AS `requiresConfirmation`, AND IGNORED UNTIL NOW.
+   * Without it the toolbar renders a button whose only possible outcome is a
+   * 403: a preview user confirms an irreversible-erasure prompt and is then
+   * told "Please try again in a moment", which can never succeed.
+   *
+   * ★AND IT IS ALSO WHAT MAKES THE WARNING TRUE. The one fixed sentence this
+   * chrome showed for every guarded cron - "effects outside Peakhour" - is
+   * exactly backwards for `org-deletion-executor`, whose danger is INSIDE our
+   * own database. The api's two sets are the only signal that tells them apart.
+   */
+  requiresInternalUser?: readonly string[];
   /** Optional callback fired ONLY when the cron handler responded 2xx
    *  (result.ok === true). Host pages typically use this to invalidate
    *  the React Query keys whose data the cron just mutated; invalidating
@@ -105,20 +119,49 @@ const inFlightCrons = new Set<string>();
  * consequence line is always appended; it is the only part guaranteed to be
  * true and useful for a cron we have never heard of.
  */
-function confirmText(cron: string, meta: { label: string; description: string }): string {
+function confirmText(
+  cron: string,
+  meta: { label: string; description: string },
+  internalOnly: boolean,
+): string {
   const known = cron in CRON_METADATA;
   return [
     meta.label,
     "",
     known ? meta.description : `The "${cron}" cron.`,
     "",
-    "This one has effects outside Peakhour — it can reach real customers or an external provider.",
+    dangerSentence(internalOnly),
     "",
     "Run it now?",
   ].join("\n");
 }
 
-export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props) {
+/**
+ * What the warning actually means for THIS cron.
+ *
+ * ★ONE FIXED SENTENCE WAS WRONG FOR THE MOST DANGEROUS CRON WE HAVE. Every
+ * guarded cron said "effects outside Peakhour - real customers or an external
+ * provider", which is true of the billing and e-invoice ones and precisely
+ * backwards for `org-deletion-executor`: its danger is inside our own database,
+ * it erases every tenant past its closure date on this environment - other
+ * people's dev orgs included - and nothing undoes it. Making that button
+ * legible without making its warning true would have been the worse half of
+ * the change that named it.
+ *
+ * Derived from the api's own two sets, so there is no third list to drift.
+ */
+export function dangerSentence(internalOnly: boolean): string {
+  return internalOnly
+    ? "This one erases data INSIDE Peakhour and cannot be undone. It acts on every tenant on this environment whose deletion date has passed, including other people's."
+    : "This one has effects outside Peakhour - it can reach real customers or an external provider.";
+}
+
+export function CronToolbar({
+  crons,
+  requiresConfirmation,
+  requiresInternalUser,
+  onTriggered,
+}: Props) {
   // Hooks must run unconditionally; the production gate decides what to
   // render below, not whether to mount.
   //
@@ -194,7 +237,8 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
     // separate tenant but has real stores on it, and these send real email /
     // hit a real tax portal — a one-click toolbar is the wrong shape for that.
     const needsConfirm = requiresConfirmation?.includes(cron) ?? false;
-    if (needsConfirm && !window.confirm(confirmText(cron, meta))) {
+    const internalOnly = requiresInternalUser?.includes(cron) ?? false;
+    if (needsConfirm && !window.confirm(confirmText(cron, meta, internalOnly))) {
       return;
     }
     inFlightCrons.add(cron);
@@ -220,7 +264,7 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
         // that could never help: /cms/crons is the only surface that passes
         // `requiresConfirmation`, so it is exactly where they already are.
         // Ask properly and retry once instead.
-        if (window.confirm(confirmText(cron, meta))) {
+        if (window.confirm(confirmText(cron, meta, requiresInternalUser?.includes(cron) ?? false))) {
           try {
             const retry = await api.post<DevCronResult>(`/v1/dev/cron/${cron}`, { confirm: cron });
             handleResult(cron, meta.label, retry);
@@ -274,6 +318,10 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
             // whole change exists to remove: the api would add a sixth
             // dangerous cron and b2c would render it unmarked.
             const guarded = requiresConfirmation?.includes(cron) ?? false;
+            // ★THE API SAYS WHICH DANGER, and the two are opposite: outside our
+            // database, or irreversibly inside it. One fixed sentence for both
+            // was pointing the wrong way at the only cron that erases tenants.
+            const internalOnly = requiresInternalUser?.includes(cron) ?? false;
             return (
               <Tooltip key={cron}>
                 <TooltipTrigger asChild>
@@ -299,7 +347,9 @@ export function CronToolbar({ crons, requiresConfirmation, onTriggered }: Props)
                       is a warning nobody can act on. */}
                   {guarded ? (
                     <p className="text-xs mt-1 font-medium">
-                      ⚠️ Reaches outside Peakhour — asks before running.
+                      {internalOnly
+                        ? "⚠️ Erases data inside Peakhour, irreversibly, across every tenant on this environment. Staff only."
+                        : "⚠️ Reaches outside Peakhour — asks before running."}
                     </p>
                   ) : null}
                   <p className="text-[10px] text-muted-foreground mt-1 font-mono">

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -43,7 +43,12 @@ import {
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
-import { CRON_METADATA, getCronMetadata, summarizeCronBody } from "./cron-metadata";
+import {
+  CRON_METADATA,
+  getCronMetadata,
+  hasSummarizer,
+  summarizeCronBody,
+} from "./cron-metadata";
 
 interface DevCronResult {
   cron: string;
@@ -202,8 +207,22 @@ export function CronToolbar({
       // none is configured) so a no-op stops reading as a green success. The
       // raw body + timing still go to the dev console for debugging.
       const summary = summarizeCronBody(cron, res.body);
+      // ★A TRUNCATED BODY IS NOT A SUCCESS FOR A CRON THAT HAS A SUMMARIZER,
+      // and it fails hardest on exactly the runs that matter. The api caps the
+      // body at 4000 chars, so `org-deletion-executor` blows past it precisely
+      // when several closures FAILED (each carries a long reason string) —
+      // JSON.parse throws, the summary comes back null, and the toast reads
+      // "Close accounts that asked to be closed complete" over customers still
+      // waiting past their promised date. When we expected a summary and could
+      // not have one, say that rather than assuming the best.
+      const truncatedSummary =
+        res.truncated && !summary && hasSummarizer(cron)
+          ? `${label} ran, but the result was too long to read back — check the console before assuming it finished cleanly.`
+          : null;
       if (summary?.level === "warning") {
         toast.warning(summary.message);
+      } else if (truncatedSummary) {
+        toast.warning(truncatedSummary);
       } else {
         toast.success(summary?.message ?? `${label} complete`);
       }
@@ -275,6 +294,14 @@ export function CronToolbar({
             });
           }
         }
+      } else if (code === "INTERNAL_ONLY") {
+        // ★THE ONE REFUSAL A RETRY CANNOT FIX, and it arrives AFTER the user
+        // has clicked through an irreversible-erasure confirmation. "Please try
+        // again in a moment" is the worst possible thing to say there: it is
+        // false, and it invites the click again.
+        toast.error(`${meta.label} is staff-only`, {
+          description: "Your account can't fire this cron. Nothing ran.",
+        });
       } else if (code === "DEV_ONLY") {
         toast.error("Cron triggers are disabled here", {
           description: "This environment is treated as production.",
@@ -334,7 +361,11 @@ export function CronToolbar({
                     disabled={disabled}
                     aria-busy={running}
                   >
-                    {running ? "Running…" : guarded ? `⚠️ ${meta.label}` : meta.label}
+                    {running
+                      ? "Running…"
+                      : guarded || internalOnly
+                        ? `⚠️ ${meta.label}`
+                        : meta.label}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent className="max-w-xs">
@@ -345,7 +376,12 @@ export function CronToolbar({
                   <p className="text-xs mt-1">{meta.description}</p>
                   {/* Says what the ⚠️ MEANS. An unexplained emoji on a button
                       is a warning nobody can act on. */}
-                  {guarded ? (
+                  {/* ★`guarded || internalOnly`, NOT `guarded` ALONE. The api's two
+                      sets are independent; a cron listed only in
+                      `requiresInternalUser` rendered completely unmarked, which
+                      is the drift the "derived from the api's own sets" claim
+                      says cannot happen. */}
+                  {guarded || internalOnly ? (
                     <p className="text-xs mt-1 font-medium">
                       {internalOnly
                         ? "⚠️ Erases data inside Peakhour, irreversibly, across every tenant on this environment. Staff only."


### PR DESCRIPTION
fix(cms): two crons the api ships that this UI could not name

The b2c suite was red on master. `cron-metadata.test.ts` reads
`peakhour-api/vercel.json` across the repo boundary and requires a friendly
label for every scheduled cron; two had none:

- `commerce-order-pii-sweep` — erases the shopper's phone and name from orders
  past the retention window (the order body stays; it is the merchant's record);
- `org-deletion-executor` — carries out account and workspace closures whose
  promised date has arrived.

Both shipped on the api side and neither reached this list, so `/cms/crons`
rendered them as raw handler names with "(undocumented schedule)" — on the two
crons in the estate that ERASE CUSTOMER DATA, which are the last two anybody
should have to guess about before pressing.

The descriptions are written from what the handlers actually do, not from their
names: the PII sweep's says the order survives and the person does not, and the
deletion executor's says it never brings a date forward — a request made under a
30-day promise keeps its 30 days.

★This is the guard working, not failing. It exists because the list had drifted
to 35 entries against 56 crons once before. It only runs locally (the sibling
checkout is not present in CI, where it skips), so a red suite in a dev
workspace is the only signal there is.

Verified: `npx tsc --noEmit` clean, `npm run build` exit 0, and the full b2c
suite is back to green — 361 passed across 23 files, from 360/1-failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

