### PR TITLE
feat(site): the hero asks the visitor's own question, and a page answers it

### DIFF
--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -18,7 +18,8 @@ import {
 } from "lucide-react";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
-import { Reveal, RevealNoScript } from "@/components/marketing/reveal";
+import { Reveal } from "@/components/marketing/reveal";
+import { RevealNoScript } from "@/components/marketing/reveal-noscript";
 import { pageMetadata } from "@/lib/seo";
 import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
@@ -34,8 +35,10 @@ import {
 
 export const metadata = pageMetadata({
   title: "See how Peakhour works — one intelligence layer for your whole business",
+  // Kept under ~160 characters: past that, search engines truncate it and the
+  // last clause — which is the actual promise — is what gets cut.
   description:
-    "Peakhour connects to the tools you already use, understands your business automatically, and connects signals across sales, content, marketing, support and presence — so the next action comes to you instead of you hunting for it.",
+    "Peakhour connects to the tools you already use, learns how your business runs, and links what happens across it — so the next action comes to you.",
   path: "/how-it-works",
 });
 
@@ -215,9 +218,10 @@ export default async function HowItWorks() {
               </h2>
             </Reveal>
 
-            <ol className="relative mt-12 flex flex-col gap-8 sm:gap-10">
-              {/* The spine. Sits behind the numbered nodes, stopping level with
-                  the last one so it doesn't trail past the final card. */}
+            {/* The spine lives on this wrapper, NOT inside the <ol> — an
+                ordered list may only contain <li> (plus <script>/<template>),
+                so a decorative <span> in there is invalid markup. */}
+            <div className="relative mt-12">
               <span
                 aria-hidden
                 className="pointer-events-none absolute bottom-10 left-6 top-6 w-px overflow-hidden bg-linear-to-b from-brand/70 via-brand/40 to-transparent sm:left-7"
@@ -225,38 +229,51 @@ export default async function HowItWorks() {
                 <span className="flow-spine-pulse absolute inset-x-0 -top-16 h-16 animate-[flow-spine-pulse_5s_linear_infinite] bg-linear-to-b from-transparent via-brand to-transparent" />
               </span>
 
-              {PLATFORM_FLOW.map((s, i) => {
-                const Icon = FLOW_ICONS[s.id];
-                return (
-                  <Reveal
-                    as="li"
-                    key={s.id}
-                    // Small stagger only — six items at 80ms each still land
-                    // inside half a second of the section coming into view.
-                    delay={Math.min(i, 3) * 80}
-                    className="relative grid grid-cols-[3rem_1fr] items-start gap-4 sm:grid-cols-[3.5rem_1fr] sm:gap-6"
-                  >
-                    <div className="flex size-12 items-center justify-center rounded-2xl bg-brand-gradient shadow-lg shadow-brand/20 sm:size-14">
-                      <Icon className="size-5 text-brand-contrast sm:size-6" strokeWidth={2} aria-hidden />
-                    </div>
-                    <div className="pt-1">
-                      <p
-                        className="text-xs font-bold uppercase tracking-[0.2em] text-brand-label"
-                        aria-hidden
-                      >
-                        {s.step}
-                      </p>
-                      <h3 className="mt-1.5 text-xl font-bold tracking-tight sm:text-2xl">
-                        {s.title}
-                      </h3>
-                      <p className="mt-2 max-w-xl text-muted-foreground">
-                        {s.description}
-                      </p>
-                    </div>
-                  </Reveal>
-                );
-              })}
-            </ol>
+              <ol className="flex flex-col gap-8 sm:gap-10">
+                {PLATFORM_FLOW.map((s, i) => {
+                  const Icon = FLOW_ICONS[s.id];
+                  return (
+                    <Reveal
+                      as="li"
+                      key={s.id}
+                      // Small stagger only — six items at 80ms each still land
+                      // inside half a second of the section coming into view.
+                      delay={Math.min(i, 3) * 80}
+                      // `relative` so the li and its gold icon tile paint ABOVE
+                      // the absolutely-positioned spine behind them (positioned
+                      // element, later in tree order) — otherwise the line runs
+                      // straight through every node.
+                      className="relative grid grid-cols-[3rem_1fr] items-start gap-4 sm:grid-cols-[3.5rem_1fr] sm:gap-6"
+                    >
+                      <div className="flex size-12 items-center justify-center rounded-2xl bg-brand-gradient shadow-lg shadow-brand/20 sm:size-14">
+                        <Icon
+                          className="size-5 text-brand-contrast sm:size-6"
+                          strokeWidth={2}
+                          aria-hidden
+                        />
+                      </div>
+                      <div className="pt-1">
+                        {/* aria-hidden: the <ol> already numbers these for a
+                            screen reader, and "01" read aloud before "1." is
+                            just the same fact twice. */}
+                        <p
+                          className="text-xs font-bold uppercase tracking-[0.2em] text-brand-label"
+                          aria-hidden
+                        >
+                          {s.step}
+                        </p>
+                        <h3 className="mt-1.5 text-xl font-bold tracking-tight sm:text-2xl">
+                          {s.title}
+                        </h3>
+                        <p className="mt-2 max-w-xl text-muted-foreground">
+                          {s.description}
+                        </p>
+                      </div>
+                    </Reveal>
+                  );
+                })}
+              </ol>
+            </div>
           </div>
         </section>
 
@@ -403,8 +420,10 @@ export default async function HowItWorks() {
                     </li>
                   ))}
                 </ul>
+                {/* "Six" here and in the heading above both track the length of
+                    SCATTERED_TOOLS — see the warning on that constant. */}
                 <p className="mt-5 text-muted-foreground">
-                  Eight tabs, eight partial answers, and a nagging sense that the
+                  Six tabs, six partial answers, and a nagging sense that the
                   thing that actually matters is in the one you didn&rsquo;t
                   open.
                 </p>

--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -131,8 +131,15 @@ export default async function HowItWorks() {
 
             {/* Before / after — the single most important picture on the page.
                 Left: five products that each only know their own corner.
-                Right: the same five wired into one layer. */}
-            <Reveal className="mt-14 grid gap-4 lg:mt-16 lg:grid-cols-2 lg:gap-6">
+                Right: the same five wired into one layer.
+
+                Deliberately NOT wrapped in <Reveal>. On a desktop viewport this
+                sits in the first screenful and is a candidate for the LCP
+                element; hiding it at opacity 0 until an observer fires would
+                delay that metric to buy a fade nobody scrolled to earn. Reveals
+                start at the section below, where there is actually a scroll to
+                respond to. */}
+            <div className="mt-14 grid gap-4 lg:mt-16 lg:grid-cols-2 lg:gap-6">
               {/* Today */}
               <div className="rounded-3xl border border-dashed bg-muted/30 p-6 sm:p-8">
                 <p className="text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground">
@@ -145,11 +152,15 @@ export default async function HowItWorks() {
                   {PILLAR_MARKS.map((p) => {
                     const Icon = p.icon;
                     return (
-                      <div key={p.name} className="flex flex-col items-center gap-2">
+                      // min-w-0 + break-words: `grid-cols-5` tracks are
+                      // minmax(0,1fr), so at ~320px each cell is ~43px while
+                      // "Commerce" needs ~45px — without these the label
+                      // spills out of its cell instead of wrapping.
+                      <div key={p.name} className="flex min-w-0 flex-col items-center gap-2">
                         <div className="flex aspect-square w-full items-center justify-center rounded-xl border border-dashed bg-background text-muted-foreground">
                           <Icon className="size-4 sm:size-5" strokeWidth={1.75} aria-hidden />
                         </div>
-                        <span className="text-center text-[0.6rem] font-semibold leading-tight text-muted-foreground sm:text-xs">
+                        <span className="break-words text-center text-[0.6rem] font-semibold leading-tight text-muted-foreground sm:text-xs">
                           {p.name}
                         </span>
                         {/* A stub that goes nowhere — the visual point of this
@@ -177,11 +188,15 @@ export default async function HowItWorks() {
                   {PILLAR_MARKS.map((p) => {
                     const Icon = p.icon;
                     return (
-                      <div key={p.name} className="flex flex-col items-center gap-2">
+                      // min-w-0 + break-words: `grid-cols-5` tracks are
+                      // minmax(0,1fr), so at ~320px each cell is ~43px while
+                      // "Commerce" needs ~45px — without these the label
+                      // spills out of its cell instead of wrapping.
+                      <div key={p.name} className="flex min-w-0 flex-col items-center gap-2">
                         <div className="flex aspect-square w-full items-center justify-center rounded-xl border border-brand/40 bg-brand/10 text-brand">
                           <Icon className="size-4 sm:size-5" strokeWidth={1.75} aria-hidden />
                         </div>
-                        <span className="text-center text-[0.6rem] font-semibold leading-tight text-zinc-300 sm:text-xs">
+                        <span className="break-words text-center text-[0.6rem] font-semibold leading-tight text-zinc-300 sm:text-xs">
                           {p.name}
                         </span>
                         {/* Gold lead-in — every pillar runs into the bar below. */}
@@ -200,7 +215,7 @@ export default async function HowItWorks() {
                   between them.
                 </p>
               </div>
-            </Reveal>
+            </div>
           </div>
         </section>
 
@@ -429,18 +444,22 @@ export default async function HowItWorks() {
                 </p>
               </Reveal>
 
-              {/* After: the panel. Illustrative, so it is one picture to a
-                  screen reader — the "buttons" are styled spans with no
-                  behaviour, exactly like the landing hero's pillar console. */}
+              {/* After: the panel.
+
+                  NOT role="img" — the landing hero's pillar console uses that
+                  because its rows are pure decoration (invented statuses), but
+                  these four rows ARE the argument: they're the concrete
+                  examples of what Peakhour brings you instead of a dashboard.
+                  Collapsing them into one alt string would hand a screen-reader
+                  user a summary of the page's best content instead of the
+                  content. So it's a real list, and the styled action chips —
+                  which are inert spans, not buttons — get an sr-only prefix so
+                  "Create content" doesn't read as a dangling fragment. */}
               <Reveal delay={120}>
                 <p className="text-sm font-bold uppercase tracking-[0.18em] text-brand-label">
                   With Peakhour
                 </p>
-                <div
-                  className="mt-5 overflow-hidden rounded-2xl border border-white/10 bg-zinc-900 p-4 shadow-2xl sm:p-5"
-                  role="img"
-                  aria-label="Peakhour bringing four suggested next actions to the founder, each drawn from a different part of the business"
-                >
+                <div className="mt-5 overflow-hidden rounded-2xl border border-white/10 bg-zinc-900 p-4 shadow-2xl sm:p-5">
                   <div className="flex items-center justify-between px-1 pb-3 text-[0.7rem] font-bold uppercase tracking-[0.18em] text-zinc-400">
                     <span>Worth your attention</span>
                     <span className="flex items-center gap-1.5 text-emerald-400">
@@ -448,27 +467,32 @@ export default async function HowItWorks() {
                       live
                     </span>
                   </div>
-                  <div className="flex flex-col gap-2.5">
+                  <ul className="flex flex-col gap-2.5">
                     {NEXT_ACTIONS.map((row) => {
                       const Icon = PILLAR_ICON[row.pillar];
                       return (
-                        <div
+                        <li
                           key={row.observation}
                           className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-xl border border-white/10 bg-white/4 px-3.5 py-3 text-sm"
                         >
                           <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-brand/15 text-brand">
                             {Icon && <Icon className="size-3.5" strokeWidth={2} aria-hidden />}
+                            {/* The pillar is conveyed by icon alone visually —
+                                without this the row loses which part of the
+                                business it came from. */}
+                            <span className="sr-only">{row.pillar}:</span>
                           </span>
                           <span className="min-w-0 flex-1 text-zinc-200">
                             &ldquo;{row.observation}&rdquo;
                           </span>
                           <span className="shrink-0 rounded-lg bg-brand-gradient px-3 py-1.5 text-xs font-bold text-brand-contrast">
+                            <span className="sr-only">Suggested action: </span>
                             {row.action}
                           </span>
-                        </div>
+                        </li>
                       );
                     })}
-                  </div>
+                  </ul>
                   <p className="px-1 pt-4 text-xs text-zinc-400">
                     Illustrative — your list is built from your own business.
                   </p>
@@ -560,7 +584,11 @@ export default async function HowItWorks() {
                   delay={i * 90}
                   className="rounded-2xl border bg-background p-7 transition-[transform,border-color,box-shadow] duration-300 ease-out hover:-translate-y-1 hover:border-brand/50 hover:shadow-lg hover:shadow-brand/15 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                 >
-                  <div className="font-serif text-4xl font-normal italic text-brand-gradient" aria-hidden>
+                  {/* NOT aria-hidden (unlike the flow spine's "01", where the
+                      <ol> already numbers each item): these three are plain
+                      divs, so the digit is the only thing carrying their
+                      order. */}
+                  <div className="font-serif text-4xl font-normal italic text-brand-gradient">
                     {s.step}
                   </div>
                   <h3 className="mt-3 text-lg font-bold tracking-tight">{s.title}</h3>

--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -1,17 +1,80 @@
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import {
+  ArrowRight,
+  ArrowDown,
+  Brain,
+  Check,
+  MapPin,
+  MessageSquare,
+  PenLine,
+  Plug,
+  Radar,
+  ShoppingBag,
+  SlidersHorizontal,
+  TrendingUp,
+  Waypoints,
+  Wind,
+  Zap,
+} from "lucide-react";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
+import { Reveal, RevealNoScript } from "@/components/marketing/reveal";
 import { pageMetadata } from "@/lib/seo";
 import { getPublicCatalog, signupCta } from "@/lib/catalog";
 import { HOW_IT_WORKS_STEPS } from "@/lib/how-it-works";
+import {
+  CONNECTED_SIGNALS,
+  CONTROL_SPLIT,
+  NEXT_ACTIONS,
+  PLATFORM_FLOW,
+  RELIEF_LINES,
+  SCATTERED_TOOLS,
+  UNDERSTANDS,
+} from "@/lib/how-peakhour-works";
 
 export const metadata = pageMetadata({
-  title: "How it works — From Setup to Autopilot in 3 simple steps | Peakhour.ai",
+  title: "See how Peakhour works — one intelligence layer for your whole business",
   description:
-    "Connect what you have, approve the plan, then let Peakhour run and learn. Grounded in your real catalog and content — never guessed from your name.",
+    "Peakhour connects to the tools you already use, understands your business automatically, and connects signals across sales, content, marketing, support and presence — so the next action comes to you instead of you hunting for it.",
   path: "/how-it-works",
 });
+
+/** Icon per flow step — keyed on the step id so the two lists can't drift. */
+const FLOW_ICONS: Record<(typeof PLATFORM_FLOW)[number]["id"], typeof Plug> = {
+  connect: Plug,
+  understand: Brain,
+  "connect-dots": Waypoints,
+  find: Radar,
+  act: Zap,
+  less: Wind,
+};
+
+/**
+ * The five pillars, in brand order. Used by the before/after diagram and the
+ * next-action rows — the point being made there is that these five stop being
+ * five separate products once they share one layer.
+ */
+const PILLAR_MARKS = [
+  { name: "Commerce", icon: ShoppingBag },
+  { name: "Content", icon: PenLine },
+  { name: "Growth", icon: TrendingUp },
+  { name: "Support", icon: MessageSquare },
+  { name: "Presence", icon: MapPin },
+] as const;
+
+const PILLAR_ICON: Record<string, typeof ShoppingBag> = Object.fromEntries(
+  PILLAR_MARKS.map((p) => [p.name, p.icon]),
+);
+
+/** Shared eyebrow — uppercase gold label over the short gradient rule. */
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+      <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+      {children}
+    </span>
+  );
+}
 
 export default async function HowItWorks() {
   const catalog = await getPublicCatalog();
@@ -19,71 +82,516 @@ export default async function HowItWorks() {
 
   return (
     <div className="flex min-h-screen flex-col">
+      <RevealNoScript />
       <Header />
       <main>
-        <section className="py-16 sm:py-24">
-          <div className="mx-auto max-w-3xl px-4 text-center sm:px-6">
-            <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
-              <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
-              How it works
-            </span>
-            <h1 className="mt-4 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl">
-              From Setup to Autopilot.{" "}
-              <span className="font-serif font-normal italic text-brand-gradient">
-                In 3 simple steps.
-              </span>
-            </h1>
-            <p className="mx-auto mt-5 max-w-xl text-lg text-muted-foreground">
-              No lengthy setup, no agency onboarding. Connect your tools, approve
-              the plan, and Peakhour starts working — grounded in your real
-              business from the first minute.
-            </p>
-          </div>
-        </section>
-
-        <section className="border-t bg-muted/30 py-20">
-          <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 sm:px-6">
-            {HOW_IT_WORKS_STEPS.map((s) => (
-              <div
-                key={s.step}
-                className="grid gap-6 rounded-2xl border bg-background p-7 transition-all hover:border-foreground hover:shadow-xl sm:grid-cols-[auto_1fr]"
-              >
-                <div className="font-serif text-5xl font-normal italic text-brand-gradient">
-                  {s.step}
-                </div>
-                <div>
-                  <h2 className="text-xl font-bold tracking-tight">{s.title}</h2>
-                  <p className="mt-2 text-muted-foreground">{s.description}</p>
-                  <p className="mt-3 text-sm text-muted-foreground/80">{s.detail}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="pb-24 pt-20">
+        {/* ── Hero ─────────────────────────────────────────────────────
+            The whole argument in one sentence, then the picture that
+            proves it. Everything below is elaboration. */}
+        <section className="pt-12 pb-14 sm:pt-16 sm:pb-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6">
-            <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl">
-              <h2 className="mx-auto max-w-2xl text-3xl font-extrabold tracking-tight text-pretty sm:text-4xl">
-                See it work on{" "}
+            <div className="mx-auto max-w-3xl text-center">
+              <Eyebrow>How Peakhour works</Eyebrow>
+              <h1 className="mt-5 text-4xl font-extrabold leading-[1.05] tracking-tight text-pretty sm:text-5xl lg:text-6xl">
+                Most tools show you one channel.{" "}
                 <span className="font-serif font-normal italic text-brand-gradient">
-                  your business.
+                  Peakhour connects the whole business.
+                </span>
+              </h1>
+              <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
+                Connect the tools you already run on. Peakhour learns how your
+                business actually works, links what is happening across every
+                part of it, and brings you the next thing worth doing — from one
+                place.
+              </p>
+              <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
+                {!cta.disabled && (
+                  <Link
+                    href={cta.href}
+                    className="group inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-6 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 motion-reduce:transition-none"
+                  >
+                    {cta.label}
+                    <ArrowRight
+                      className="size-4 transition-transform group-hover:translate-x-1 motion-reduce:transition-none"
+                      aria-hidden
+                    />
+                  </Link>
+                )}
+                <Link
+                  href="/pricing"
+                  className="inline-flex items-center rounded-xl border-2 px-6 py-3 text-sm font-bold transition-colors hover:border-brand hover:text-brand"
+                >
+                  See pricing
+                </Link>
+              </div>
+            </div>
+
+            {/* Before / after — the single most important picture on the page.
+                Left: five products that each only know their own corner.
+                Right: the same five wired into one layer. */}
+            <Reveal className="mt-14 grid gap-4 lg:mt-16 lg:grid-cols-2 lg:gap-6">
+              {/* Today */}
+              <div className="rounded-3xl border border-dashed bg-muted/30 p-6 sm:p-8">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                  Most tools
+                </p>
+                <p className="mt-2 text-lg font-bold tracking-tight">
+                  Five products. Five separate views.
+                </p>
+                <div className="mt-7 grid grid-cols-5 gap-1.5 sm:gap-3">
+                  {PILLAR_MARKS.map((p) => {
+                    const Icon = p.icon;
+                    return (
+                      <div key={p.name} className="flex flex-col items-center gap-2">
+                        <div className="flex aspect-square w-full items-center justify-center rounded-xl border border-dashed bg-background text-muted-foreground">
+                          <Icon className="size-4 sm:size-5" strokeWidth={1.75} aria-hidden />
+                        </div>
+                        <span className="text-center text-[0.6rem] font-semibold leading-tight text-muted-foreground sm:text-xs">
+                          {p.name}
+                        </span>
+                        {/* A stub that goes nowhere — the visual point of this
+                            half of the diagram. */}
+                        <span className="h-6 w-px bg-border sm:h-8" aria-hidden />
+                      </div>
+                    );
+                  })}
+                </div>
+                <p className="mt-3 border-t border-dashed pt-4 text-sm text-muted-foreground">
+                  Each one only knows its own corner. Joining them up is your job
+                  — every morning, across every tab.
+                </p>
+              </div>
+
+              {/* With Peakhour */}
+              <div className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 p-6 text-zinc-100 shadow-2xl sm:p-8">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand">
+                  With Peakhour
+                </p>
+                <p className="mt-2 text-lg font-bold tracking-tight">
+                  The same five, sharing one brain.
+                </p>
+                <div className="mt-7 grid grid-cols-5 gap-1.5 sm:gap-3">
+                  {PILLAR_MARKS.map((p) => {
+                    const Icon = p.icon;
+                    return (
+                      <div key={p.name} className="flex flex-col items-center gap-2">
+                        <div className="flex aspect-square w-full items-center justify-center rounded-xl border border-brand/40 bg-brand/10 text-brand">
+                          <Icon className="size-4 sm:size-5" strokeWidth={1.75} aria-hidden />
+                        </div>
+                        <span className="text-center text-[0.6rem] font-semibold leading-tight text-zinc-300 sm:text-xs">
+                          {p.name}
+                        </span>
+                        {/* Gold lead-in — every pillar runs into the bar below. */}
+                        <span className="h-6 w-px bg-brand/60 sm:h-8" aria-hidden />
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="mt-3 flex items-center justify-center gap-2 rounded-xl bg-brand-gradient px-4 py-3 text-center text-sm font-bold text-brand-contrast">
+                  <Waypoints className="size-4 shrink-0" strokeWidth={2.25} aria-hidden />
+                  One Peakhour intelligence layer
+                </div>
+                <p className="mt-4 text-sm text-zinc-400">
+                  Because they share it, each part of your business can inform
+                  the others — automatically, without you carrying the context
+                  between them.
+                </p>
+              </div>
+            </Reveal>
+          </div>
+        </section>
+
+        {/* ── The flow ─────────────────────────────────────────────────
+            Six steps down a gold spine, with a pulse travelling it. */}
+        <section className="border-t bg-muted/30 py-14 sm:py-20">
+          <div className="mx-auto max-w-4xl px-4 sm:px-6">
+            <Reveal className="max-w-2xl">
+              <Eyebrow>End to end</Eyebrow>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                From plugging it in to{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  having less on your plate.
                 </span>
               </h2>
-              <p className="mx-auto mt-4 max-w-xl text-zinc-400">
-                A free plan on every pillar. No credit card. Your first Peaks are
-                on us.
+            </Reveal>
+
+            <ol className="relative mt-12 flex flex-col gap-8 sm:gap-10">
+              {/* The spine. Sits behind the numbered nodes, stopping level with
+                  the last one so it doesn't trail past the final card. */}
+              <span
+                aria-hidden
+                className="pointer-events-none absolute bottom-10 left-6 top-6 w-px overflow-hidden bg-linear-to-b from-brand/70 via-brand/40 to-transparent sm:left-7"
+              >
+                <span className="flow-spine-pulse absolute inset-x-0 -top-16 h-16 animate-[flow-spine-pulse_5s_linear_infinite] bg-linear-to-b from-transparent via-brand to-transparent" />
+              </span>
+
+              {PLATFORM_FLOW.map((s, i) => {
+                const Icon = FLOW_ICONS[s.id];
+                return (
+                  <Reveal
+                    as="li"
+                    key={s.id}
+                    // Small stagger only — six items at 80ms each still land
+                    // inside half a second of the section coming into view.
+                    delay={Math.min(i, 3) * 80}
+                    className="relative grid grid-cols-[3rem_1fr] items-start gap-4 sm:grid-cols-[3.5rem_1fr] sm:gap-6"
+                  >
+                    <div className="flex size-12 items-center justify-center rounded-2xl bg-brand-gradient shadow-lg shadow-brand/20 sm:size-14">
+                      <Icon className="size-5 text-brand-contrast sm:size-6" strokeWidth={2} aria-hidden />
+                    </div>
+                    <div className="pt-1">
+                      <p
+                        className="text-xs font-bold uppercase tracking-[0.2em] text-brand-label"
+                        aria-hidden
+                      >
+                        {s.step}
+                      </p>
+                      <h3 className="mt-1.5 text-xl font-bold tracking-tight sm:text-2xl">
+                        {s.title}
+                      </h3>
+                      <p className="mt-2 max-w-xl text-muted-foreground">
+                        {s.description}
+                      </p>
+                    </div>
+                  </Reveal>
+                );
+              })}
+            </ol>
+          </div>
+        </section>
+
+        {/* ── What it understands ──────────────────────────────────────
+            Step 02 made concrete: the eleven things you'd otherwise have
+            to explain to a new hire. */}
+        <section className="py-14 sm:py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <Reveal className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 p-8 text-zinc-100 shadow-2xl sm:p-12">
+              <div className="max-w-2xl">
+                <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand">
+                  <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+                  After you connect
+                </span>
+                <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                  You don&rsquo;t brief it.{" "}
+                  <span className="font-serif font-normal italic text-brand-gradient">
+                    It reads the business.
+                  </span>
+                </h2>
+                <p className="mt-4 text-zinc-400">
+                  No onboarding questionnaire, no brand deck, no spreadsheet of
+                  products to upload. Within minutes of connecting, Peakhour has
+                  picked up:
+                </p>
+              </div>
+              <ul className="mt-9 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+                {UNDERSTANDS.map((item, i) => (
+                  <Reveal
+                    as="li"
+                    key={item}
+                    delay={Math.min(i, 5) * 60}
+                    className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/4 px-4 py-3 text-sm font-medium transition-colors hover:border-brand/50"
+                  >
+                    <Check className="size-4 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                    {item}
+                  </Reveal>
+                ))}
+              </ul>
+              <p className="mt-7 border-t border-white/10 pt-6 text-sm text-zinc-400">
+                All of it read from what you already have — not guessed from your
+                business name.
+              </p>
+            </Reveal>
+          </div>
+        </section>
+
+        {/* ── Connected signals ────────────────────────────────────────
+            The payoff of the shared layer: something noticed over here
+            changes what you should do over there. */}
+        <section className="border-t bg-muted/30 py-14 sm:py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <Reveal className="max-w-2xl">
+              <Eyebrow>Connecting the dots</Eyebrow>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                One thing happens here.{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  It changes what you do there.
+                </span>
+              </h2>
+              <p className="mt-4 text-muted-foreground">
+                None of these are things a single tool can see, because none of
+                them happen in a single tool.
+              </p>
+            </Reveal>
+
+            <div className="mt-11 grid gap-4 lg:grid-cols-2">
+              {CONNECTED_SIGNALS.map((s, i) => {
+                const FromIcon = PILLAR_ICON[s.from];
+                const ToIcon = PILLAR_ICON[s.to];
+                return (
+                  <Reveal
+                    key={s.id}
+                    delay={Math.min(i, 3) * 70}
+                    className={
+                      "group flex flex-col gap-4 rounded-2xl border bg-background p-6 transition-[transform,border-color,box-shadow] duration-300 ease-out hover:-translate-y-1 hover:border-brand/50 hover:shadow-lg hover:shadow-brand/15 motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:p-7 " +
+                      // The last card is alone on the final row at lg — let it
+                      // span so the grid doesn't end on a half-empty line.
+                      (i === CONNECTED_SIGNALS.length - 1 &&
+                      CONNECTED_SIGNALS.length % 2 === 1
+                        ? "lg:col-span-2"
+                        : "")
+                    }
+                  >
+                    {/* Route chip — the two parts of the business being joined. */}
+                    <div className="flex items-center gap-2 text-[0.65rem] font-bold uppercase tracking-[0.15em] text-muted-foreground">
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-soft px-2.5 py-1 text-brand-ink">
+                        {FromIcon && <FromIcon className="size-3" strokeWidth={2.5} aria-hidden />}
+                        {s.from}
+                      </span>
+                      <ArrowRight className="size-3.5 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-soft px-2.5 py-1 text-brand-ink">
+                        {ToIcon && <ToIcon className="size-3" strokeWidth={2.5} aria-hidden />}
+                        {s.to}
+                      </span>
+                    </div>
+
+                    <p className="text-lg font-bold leading-snug tracking-tight">
+                      {s.signal}
+                    </p>
+                    <p className="flex gap-2.5 font-serif text-base italic leading-relaxed text-muted-foreground">
+                      <ArrowDown className="mt-1 size-4 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                      {s.connection}
+                    </p>
+                    <p className="mt-auto flex items-start gap-2.5 rounded-xl border border-brand/25 bg-brand/6 px-4 py-3 text-sm font-semibold">
+                      <Zap className="mt-0.5 size-4 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                      {s.suggestion}
+                    </p>
+                  </Reveal>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Next actions come to you ─────────────────────────────────
+            The daily experience: stop opening six dashboards to find out
+            what needs attention. */}
+        <section className="py-14 sm:py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <Reveal className="max-w-2xl">
+              <Eyebrow>Your morning</Eyebrow>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                Stop opening six dashboards to work out{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  what needs you today.
+                </span>
+              </h2>
+            </Reveal>
+
+            <div className="mt-11 grid items-start gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:gap-10">
+              {/* Before: the scatter. */}
+              <Reveal>
+                <p className="text-sm font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                  Today
+                </p>
+                <ul className="mt-5 flex flex-wrap gap-2">
+                  {SCATTERED_TOOLS.map((tool) => (
+                    <li
+                      key={tool}
+                      className="rounded-lg border border-dashed px-3 py-2 text-sm font-medium text-muted-foreground"
+                    >
+                      {tool}
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-5 text-muted-foreground">
+                  Eight tabs, eight partial answers, and a nagging sense that the
+                  thing that actually matters is in the one you didn&rsquo;t
+                  open.
+                </p>
+              </Reveal>
+
+              {/* After: the panel. Illustrative, so it is one picture to a
+                  screen reader — the "buttons" are styled spans with no
+                  behaviour, exactly like the landing hero's pillar console. */}
+              <Reveal delay={120}>
+                <p className="text-sm font-bold uppercase tracking-[0.18em] text-brand-label">
+                  With Peakhour
+                </p>
+                <div
+                  className="mt-5 overflow-hidden rounded-2xl border border-white/10 bg-zinc-900 p-4 shadow-2xl sm:p-5"
+                  role="img"
+                  aria-label="Peakhour bringing four suggested next actions to the founder, each drawn from a different part of the business"
+                >
+                  <div className="flex items-center justify-between px-1 pb-3 text-[0.7rem] font-bold uppercase tracking-[0.18em] text-zinc-400">
+                    <span>Worth your attention</span>
+                    <span className="flex items-center gap-1.5 text-emerald-400">
+                      <span className="size-1.5 rounded-full bg-emerald-400" aria-hidden />
+                      live
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-2.5">
+                    {NEXT_ACTIONS.map((row) => {
+                      const Icon = PILLAR_ICON[row.pillar];
+                      return (
+                        <div
+                          key={row.observation}
+                          className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-xl border border-white/10 bg-white/4 px-3.5 py-3 text-sm"
+                        >
+                          <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-brand/15 text-brand">
+                            {Icon && <Icon className="size-3.5" strokeWidth={2} aria-hidden />}
+                          </span>
+                          <span className="min-w-0 flex-1 text-zinc-200">
+                            &ldquo;{row.observation}&rdquo;
+                          </span>
+                          <span className="shrink-0 rounded-lg bg-brand-gradient px-3 py-1.5 text-xs font-bold text-brand-contrast">
+                            {row.action}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <p className="px-1 pt-4 text-xs text-zinc-400">
+                    Illustrative — your list is built from your own business.
+                  </p>
+                </div>
+              </Reveal>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Control ──────────────────────────────────────────────────
+            The reassurance the whole page has been earning the right to
+            make: automation takes the repetition, never the decisions. */}
+        <section className="border-t bg-muted/30 py-14 sm:py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <Reveal className="max-w-2xl">
+              <Eyebrow>You stay in charge</Eyebrow>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                Automatic where it&rsquo;s repetitive.{" "}
+                <span className="font-serif font-normal italic text-brand-gradient">
+                  Yours where it counts.
+                </span>
+              </h2>
+            </Reveal>
+
+            <div className="mt-11 grid gap-4 md:grid-cols-2">
+              <Reveal className="rounded-2xl border bg-background p-7">
+                <div className="flex items-center gap-3">
+                  <span className="flex size-10 items-center justify-center rounded-xl bg-brand-gradient shadow-inner">
+                    <Zap className="size-4.5 text-brand-contrast" strokeWidth={2.25} aria-hidden />
+                  </span>
+                  <h3 className="text-lg font-bold tracking-tight">
+                    Peakhour just handles
+                  </h3>
+                </div>
+                <ul className="mt-5 flex flex-col gap-3">
+                  {CONTROL_SPLIT.automatic.map((item) => (
+                    <li key={item} className="flex gap-3 text-sm text-muted-foreground">
+                      <Check className="mt-0.5 size-4 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </Reveal>
+
+              <Reveal delay={100} className="rounded-2xl border bg-background p-7">
+                <div className="flex items-center gap-3">
+                  <span className="flex size-10 items-center justify-center rounded-xl bg-brand-gradient shadow-inner">
+                    <SlidersHorizontal
+                      className="size-4.5 text-brand-contrast"
+                      strokeWidth={2.25}
+                      aria-hidden
+                    />
+                  </span>
+                  <h3 className="text-lg font-bold tracking-tight">You decide</h3>
+                </div>
+                <ul className="mt-5 flex flex-col gap-3">
+                  {CONTROL_SPLIT.yours.map((item) => (
+                    <li key={item} className="flex gap-3 text-sm text-muted-foreground">
+                      <Check className="mt-0.5 size-4 shrink-0 text-brand" strokeWidth={2.5} aria-hidden />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </Reveal>
+            </div>
+
+            <Reveal className="mt-6 rounded-2xl border border-brand/25 bg-brand/6 px-6 py-5 text-center text-sm font-medium sm:text-base">
+              Autonomy is a dial you turn up as trust grows — not a switch you
+              flip on day one.
+            </Reveal>
+          </div>
+        </section>
+
+        {/* ── Getting started ──────────────────────────────────────────
+            The practical landing: the same three onboarding steps the
+            homepage promises, so the two surfaces can't drift. */}
+        <section className="py-14 sm:py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <Reveal className="max-w-2xl">
+              <Eyebrow>Getting started</Eyebrow>
+              <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-pretty lg:text-4xl">
+                Your first hour, not your first quarter.
+              </h2>
+            </Reveal>
+            <div className="mt-10 grid gap-4 md:grid-cols-3">
+              {HOW_IT_WORKS_STEPS.map((s, i) => (
+                <Reveal
+                  key={s.step}
+                  delay={i * 90}
+                  className="rounded-2xl border bg-background p-7 transition-[transform,border-color,box-shadow] duration-300 ease-out hover:-translate-y-1 hover:border-brand/50 hover:shadow-lg hover:shadow-brand/15 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                >
+                  <div className="font-serif text-4xl font-normal italic text-brand-gradient" aria-hidden>
+                    {s.step}
+                  </div>
+                  <h3 className="mt-3 text-lg font-bold tracking-tight">{s.title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    {s.description}
+                  </p>
+                  <p className="mt-3 border-t pt-3 text-sm text-muted-foreground/80">
+                    {s.detail}
+                  </p>
+                </Reveal>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Close ────────────────────────────────────────────────────
+            What the visitor is actually buying: the relief, not the
+            feature list. */}
+        <section className="pb-16 sm:pb-24">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <Reveal className="overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 px-6 py-16 text-center text-zinc-100 shadow-2xl sm:py-20">
+              <ul className="mx-auto flex max-w-md flex-col gap-2 text-2xl font-extrabold tracking-tight sm:text-3xl">
+                {RELIEF_LINES.map((line, i) => (
+                  <Reveal as="li" key={line} delay={i * 140}>
+                    {line}
+                  </Reveal>
+                ))}
+              </ul>
+              <p className="mx-auto mt-7 max-w-xl font-serif text-3xl font-normal italic text-brand-gradient sm:text-4xl">
+                More time to actually build the business.
+              </p>
+              <p className="mx-auto mt-8 max-w-md border-t border-white/10 pt-8 text-zinc-400">
+                Your business already has the signals. Peakhour connects them.
               </p>
               {!cta.disabled && (
                 <Link
                   href={cta.href}
-                  className="group mt-8 inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-7 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+                  className="group mt-8 inline-flex items-center gap-2 rounded-xl bg-brand-gradient px-7 py-3.5 text-sm font-bold text-brand-contrast shadow-sm transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 motion-reduce:transition-none"
                 >
-                  {cta.label}
-                  <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" aria-hidden />
+                  {cta.label} — all five pillars
+                  <ArrowRight
+                    className="size-4 transition-transform group-hover:translate-x-1 motion-reduce:transition-none"
+                    aria-hidden
+                  />
                 </Link>
               )}
-            </div>
+              <p className="mt-5 text-sm text-zinc-400">
+                A free plan on every pillar. No credit card.
+              </p>
+            </Reveal>
           </div>
         </section>
       </main>

--- a/src/app/(site)/launch-partner/launch-partner-form.tsx
+++ b/src/app/(site)/launch-partner/launch-partner-form.tsx
@@ -7,18 +7,28 @@ import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 
 /**
  * Launch-partner apply form. Applying lands a waitlist_signups row
  * (POST /v1/waitlist/signup). Ops approves in the CMS, which unlocks
  * magic-link sign-in.
  *
- * Deliberately email-only: we don't ask the applicant to pick Commerce vs
- * Marketing or fill in business details. When they arrive from a Shopify /
- * WordPress link the `source` is already known (passed as a prop from the
- * server page's ?source param) and the API derives the product cohort from
- * it — Shopify → Commerce, WordPress → Marketing — so the choice is never
- * put to the user.
+ * ONE required field (email) and ONE optional one — the free-text "what would
+ * you love Peakhour to take off your plate?", which lands in the existing
+ * `businessContext` column. Everything else we want about an early applicant
+ * is derived, never asked:
+ *
+ *   • Product cohort — from `source`. A Shopify link means Commerce, a
+ *     WordPress link means Marketing; the API derives it, so the applicant is
+ *     never made to choose.
+ *   • Country — from the Vercel edge geo header, resolved on the server page
+ *     and passed in as a prop.
+ *   • Business domain — already sitting in the work email for most applicants.
+ *
+ * That is the whole rule for this form: a field earns its place only if the
+ * answer can't be derived AND it changes what we build. Adding a business/
+ * website input or a country dropdown fails both halves.
  */
 type SignupSource = "shopify" | "wordpress" | "direct";
 
@@ -28,8 +38,19 @@ const SOURCE_PRODUCT: Partial<Record<SignupSource, string>> = {
   wordpress: "Peakhour Marketing",
 };
 
-export function LaunchPartnerForm({ source = "direct" }: { source?: SignupSource }) {
+/** Mirrors waitlist_signups.businessContext (max 2048) — the API rejects more. */
+const CONTEXT_MAX = 2048;
+
+export function LaunchPartnerForm({
+  source = "direct",
+  /** ISO-3166 alpha-2 resolved from the edge geo header by the server page. */
+  country,
+}: {
+  source?: SignupSource;
+  country?: string;
+}) {
   const [email, setEmail] = useState("");
+  const [context, setContext] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<{
     referralCode: string;
@@ -44,6 +65,9 @@ export function LaunchPartnerForm({ source = "direct" }: { source?: SignupSource
     }
     setSubmitting(true);
     try {
+      // Trimmed and capped client-side so a paste of an essay fails here with
+      // a visible counter rather than as a 400 from the API's 2048 limit.
+      const trimmedContext = context.trim().slice(0, CONTEXT_MAX);
       const body: Record<string, unknown> = {
         email,
         intent: "general",
@@ -52,6 +76,11 @@ export function LaunchPartnerForm({ source = "direct" }: { source?: SignupSource
         // Entry surface — the API derives the product cohort from it, so the
         // applicant is never asked to choose Commerce vs Marketing.
         signupSource: source,
+        // Optional; omitted entirely when blank so an untouched field doesn't
+        // write an empty string into the qualitative dataset.
+        ...(trimmedContext ? { businessContext: trimmedContext } : {}),
+        // Derived, never asked. Absent in local dev and on any non-Vercel edge.
+        ...(country ? { country } : {}),
       };
 
       const r = await api.post<{
@@ -182,6 +211,26 @@ export function LaunchPartnerForm({ source = "direct" }: { source?: SignupSource
           onChange={(e) => setEmail(e.target.value)}
           required
           className="h-11"
+        />
+      </div>
+
+      {/* The one optional field. Labelled as optional in the label itself (not
+          only in a placeholder, which vanishes on focus and is invisible to a
+          screen reader), and the submit button never depends on it — a blank
+          answer costs the applicant nothing. */}
+      <div className="space-y-2">
+        <Label htmlFor="lp-context" className="flex flex-wrap items-baseline gap-x-2">
+          What would you love Peakhour to take off your plate?
+          <span className="text-xs font-normal text-muted-foreground">Optional</span>
+        </Label>
+        <Textarea
+          id="lp-context"
+          rows={3}
+          maxLength={CONTEXT_MAX}
+          placeholder="One line is plenty — e.g. answering the same WhatsApp questions all day."
+          value={context}
+          onChange={(e) => setContext(e.target.value)}
+          className="resize-none"
         />
       </div>
 

--- a/src/app/(site)/launch-partner/launch-partner-form.tsx
+++ b/src/app/(site)/launch-partner/launch-partner-form.tsx
@@ -65,8 +65,10 @@ export function LaunchPartnerForm({
     }
     setSubmitting(true);
     try {
-      // Trimmed and capped client-side so a paste of an essay fails here with
-      // a visible counter rather than as a 400 from the API's 2048 limit.
+      // The textarea's maxLength already stops typing past the limit, but it
+      // does NOT bound a programmatic paste in every browser — and trimming
+      // whitespace can only shorten. Belt and braces so an over-long value
+      // becomes a truncated application rather than a 400 from the API.
       const trimmedContext = context.trim().slice(0, CONTEXT_MAX);
       const body: Record<string, unknown> = {
         email,

--- a/src/app/(site)/launch-partner/page.tsx
+++ b/src/app/(site)/launch-partner/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { ArrowLeft } from "lucide-react";
 import { SITE } from "@/lib/utils";
 import { LaunchPartnerForm } from "./launch-partner-form";
@@ -26,13 +27,31 @@ function normalizeSource(raw?: string): "shopify" | "wordpress" | "direct" {
   return raw === "shopify" || raw === "wordpress" ? raw : "direct";
 }
 
+/**
+ * ISO-3166 alpha-2 from Vercel's edge geo header, or undefined when it's
+ * absent (local dev, a non-Vercel edge) or malformed.
+ *
+ * Deliberately NOT the `countryFrom` shape the /pricing pages use: that one
+ * falls back to the literal "DEFAULT", which is a pricing-resolver sentinel.
+ * The waitlist endpoint validates `country` as /^[A-Z]{2}$/, so "DEFAULT"
+ * would fail the whole signup — an omitted field is the only safe fallback.
+ *
+ * Read here rather than asked on the form: geography is one of the two things
+ * we genuinely want from an early applicant, and it's the one we can get for
+ * free. A country dropdown would cost a field and buy nothing extra.
+ */
+function geoCountry(header: string | null): string | undefined {
+  return header && /^[A-Za-z]{2}$/.test(header) ? header.toUpperCase() : undefined;
+}
+
 export default async function LaunchPartnerPage({
   searchParams,
 }: {
   searchParams: Promise<{ source?: string }>;
 }) {
-  const { source } = await searchParams;
+  const [{ source }, h] = await Promise.all([searchParams, headers()]);
   const signupSource = normalizeSource(source);
+  const country = geoCountry(h.get("x-vercel-ip-country"));
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 py-16 text-center">
       <div
@@ -56,7 +75,7 @@ export default async function LaunchPartnerPage({
           hands-on setup.
         </p>
 
-        <LaunchPartnerForm source={signupSource} />
+        <LaunchPartnerForm source={signupSource} country={country} />
 
         <a
           href="/coming-soon"

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -291,20 +291,34 @@ export default async function Home({
               scroll on phones. */}
           <div className="mx-auto grid max-w-6xl items-center gap-10 px-4 sm:gap-14 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
             <div className="min-w-0">
+              {/* The eyebrow now carries the old H1 ("Five AI pillars. One
+                  platform. Free to start.") — it is the positioning badge, and
+                  the H1 above it is the visitor's problem stated back to them.
+                  Keep the three sentences: they are the shortest complete
+                  statement of what Peakhour is and what it costs to try. */}
               <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
                 <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
-                The AI business platform for growing brands
+                Five AI pillars. One platform. Free to start.
               </span>
               <h1 className="mt-5 text-4xl font-extrabold leading-[1.03] tracking-tight text-pretty sm:text-5xl lg:text-6xl">
-                Five AI pillars. One platform.{" "}
+                Still running one business across{" "}
                 <span className="font-serif italic font-normal text-brand-gradient">
-                  Free to start.
+                  10 different tools?
                 </span>
               </h1>
-              <p className="mt-5 max-w-xl text-lg text-muted-foreground">
-                Peakhour runs the work a growing business can&rsquo;t hire for yet —
-                selling, publishing, advertising, answering, and being found — with
-                AI that learns your brand and reports back in plain language.
+              {/* Two ranks, deliberately: the first line is the value
+                  proposition and sits at foreground weight so it reads as the
+                  answer to the question above; the second line names the five
+                  pillars in plain words and stays muted so it supports rather
+                  than competes. Neither is a second headline — no display
+                  sizing, no serif accent, both well under the H1. */}
+              <p className="mt-5 max-w-xl text-lg font-medium text-foreground">
+                Peakhour runs the work your growing business can&rsquo;t hire a
+                team for yet.
+              </p>
+              <p className="mt-2.5 max-w-xl text-lg text-muted-foreground">
+                One unified AI platform for sales, content, marketing, customer
+                support and online presence.
               </p>
               <div className="mt-8 flex flex-wrap items-center gap-4">
                 {cta.disabled ? (
@@ -321,11 +335,17 @@ export default async function Home({
                     <ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
                   </Link>
                 )}
+                {/* Secondary CTA points at the story page, not at /peaks. A
+                    visitor who has just read "10 different tools?" is asking
+                    how this works, not how the AI currency is metered — and
+                    /how-it-works is the page that answers it. Peaks are still
+                    one click away from there, from /pricing and from the
+                    footer. */}
                 <Link
-                  href="/peaks"
+                  href="/how-it-works"
                   className="inline-flex items-center gap-2 rounded-xl border-2 px-6 py-3 text-sm font-bold transition-colors hover:border-brand hover:text-brand"
                 >
-                  See how Peaks work
+                  See how Peakhour works
                 </Link>
               </div>
               {/* Shared with /auth — the pitch must not change at the point
@@ -573,6 +593,44 @@ export default async function Home({
                   </div>
                 </div>
               ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Who's behind it — a quiet credibility beat between "here's the
+            product" and the ask. Deliberately small: one panel, no photo, no
+            logo wall, no press strip. A pre-launch product can't show customer
+            proof honestly, and the founder's track record is the one piece of
+            proof that is true today.
+
+            Text-only by design — there's no founder portrait in /public, and a
+            stock headshot on a credibility section would undercut the exact
+            thing the section exists to establish. */}
+        <section className="border-t bg-muted/30 py-12 sm:py-16">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <div className="mx-auto flex max-w-3xl flex-col gap-6 rounded-3xl border bg-background p-7 sm:flex-row sm:items-start sm:gap-7 sm:p-9">
+              {/* Monogram rather than an avatar — same gold tile the pillar
+                  cards use, so it reads as part of the brand system. */}
+              <div
+                className="flex size-14 shrink-0 items-center justify-center rounded-2xl bg-brand-gradient text-lg font-extrabold tracking-tight text-brand-contrast shadow-inner"
+                aria-hidden
+              >
+                PC
+              </div>
+              <div className="min-w-0">
+                <span className="inline-flex items-center gap-2.5 text-xs font-bold uppercase tracking-[0.2em] text-brand-label">
+                  <span className="h-0.5 w-7 bg-brand-gradient" aria-hidden />
+                  Who&rsquo;s behind it
+                </span>
+                <h2 className="mt-3 text-xl font-bold tracking-tight text-pretty sm:text-2xl">
+                  Built by someone who knows what it takes to run a business.
+                </h2>
+                <p className="mt-3 text-muted-foreground">
+                  Peakhour comes from Prashant Chothani, CEO &amp; Managing
+                  Director of Travelxp and Media Worldwide — with decades spent
+                  building, scaling and innovating across global businesses.
+                </p>
+              </div>
             </div>
           </div>
         </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -237,3 +237,65 @@
     --ring-angle: 360deg;
   }
 }
+
+/*
+ * Scroll-reveal for the marketing story pages — see <Reveal> in
+ * components/marketing/reveal.tsx, which owns the data-shown flip.
+ *
+ * The hidden state lives in CSS rather than in the component's className so
+ * the reduced-motion override below can neutralise it with NO JavaScript at
+ * all: a visitor who prefers reduced motion sees the full page from the first
+ * paint, not after hydration. (The no-JS case is covered separately by
+ * <RevealNoScript>.)
+ */
+@layer components {
+  .reveal {
+    opacity: 0;
+    transform: translateY(1.25rem);
+    /* Long, decelerating ease — the content settles rather than snapping. */
+    transition:
+      opacity 700ms cubic-bezier(0.16, 1, 0.3, 1),
+      transform 700ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .reveal[data-shown="true"] {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/*
+ * Gold pulse that travels down the flow spine on /how-it-works — the one piece
+ * of ambient motion on the page, standing in for "signal moving through the
+ * platform". Purely decorative; the spine reads fine without it.
+ */
+@keyframes flow-spine-pulse {
+  /* `top` rather than translateY: the spine's height depends on how many
+     steps the page renders, and a percentage translate resolves against the
+     PULSE's own height (4rem), not the spine's — so a transform could never
+     reach the bottom of a spine whose length isn't known here. */
+  0% {
+    top: -4rem;
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  88% {
+    opacity: 1;
+  }
+  100% {
+    top: 100%;
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  .flow-spine-pulse {
+    display: none;
+  }
+}

--- a/src/components/marketing/reveal-noscript.tsx
+++ b/src/components/marketing/reveal-noscript.tsx
@@ -1,0 +1,32 @@
+/**
+ * The `<noscript>` escape hatch for pages that use <Reveal>. Without it, a
+ * visitor with JavaScript disabled gets a page of invisible sections — the
+ * observer never runs, so `.reveal` stays at opacity 0 forever.
+ *
+ * Two deliberate details:
+ *
+ *  • It lives in its own file, NOT in reveal.tsx. That module is marked
+ *    "use client", and everything exported from it is therefore a client
+ *    component — including this one. A `<noscript>` rendered by a client
+ *    component is a hydration hazard: with scripting ENABLED the browser
+ *    parses noscript content as a single text node, so React hydrates against
+ *    a text node where it rendered an element. Server-only sidesteps it.
+ *  • `suppressHydrationWarning` belts-and-braces the same point for the RSC
+ *    reconciliation pass. Either outcome is correct here — the rule is static
+ *    and applies (or doesn't) identically — so a console warning would be pure
+ *    noise.
+ *
+ * Rendered per page rather than from the root layout, so the rule only ships
+ * on pages that actually hide something.
+ */
+export function RevealNoScript() {
+  return (
+    <noscript suppressHydrationWarning>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: ".reveal{opacity:1!important;transform:none!important}",
+        }}
+      />
+    </noscript>
+  );
+}

--- a/src/components/marketing/reveal.tsx
+++ b/src/components/marketing/reveal.tsx
@@ -93,23 +93,3 @@ export function Reveal({
     </Tag>
   );
 }
-
-/**
- * The `<noscript>` escape hatch for pages that use <Reveal>. Without it a
- * visitor with JS disabled gets a page of invisible sections — the reveal
- * never runs, and `.reveal` stays at opacity 0 forever.
- *
- * Rendered from the page (not the root layout) so the rule only ships where
- * something is actually hidden.
- */
-export function RevealNoScript() {
-  return (
-    <noscript>
-      <style
-        dangerouslySetInnerHTML={{
-          __html: ".reveal{opacity:1!important;transform:none!important}",
-        }}
-      />
-    </noscript>
-  );
-}

--- a/src/components/marketing/reveal.tsx
+++ b/src/components/marketing/reveal.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Scroll-triggered reveal for the marketing surface — the story pages read as
+ * a sequence, and content that arrives as you reach it is what makes them read
+ * that way rather than as one long wall.
+ *
+ * Deliberately hand-rolled on IntersectionObserver rather than pulling in an
+ * animation library: this is the only motion primitive the marketing pages
+ * need, and it costs ~1kB instead of ~40kB on a page whose whole job is to
+ * load fast for a first-time visitor.
+ *
+ * Three things keep it safe to hide content behind:
+ *
+ *  1. `prefers-reduced-motion` is handled in CSS (globals.css), so a
+ *     reduced-motion visitor sees everything at full opacity even before this
+ *     component mounts — the preference is honoured with no JS at all.
+ *  2. A `<noscript>` rule on the pages that use it neutralises `.reveal`
+ *     entirely, so a no-JS visitor gets the whole page.
+ *  3. The observer is disconnected after the first intersection — this is an
+ *     entrance, not a scrubbed animation, and re-hiding content that scrolls
+ *     back off-screen is both distracting and a way to lose it permanently if
+ *     the observer ever misfires.
+ */
+export function Reveal({
+  children,
+  className,
+  /** Stagger, in ms, applied as a transition-delay. Keep under ~400ms: past
+   *  that the delay outlasts the scroll and the item appears to be missing. */
+  delay = 0,
+  /** Render as a different element when the parent's layout needs one (a list
+   *  item inside a <ul>, say) — a stray <div> there is invalid markup. */
+  as: Tag = "div",
+}: {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+  as?: "div" | "li" | "section";
+}) {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    /**
+     * The reveal is a DOM effect, NOT React state. Flipping the attribute
+     * directly rather than through setState buys three things on a page that
+     * mounts several dozen of these: no re-render per element, no cascading
+     * render warning from the react-hooks lint rules, and the "already
+     * revealed" fact stored in the DOM — which is exactly where the CSS that
+     * reads it lives. React never renders `data-shown` itself, so nothing
+     * reconciles the attribute back away.
+     */
+    const show = () => {
+      el.dataset.shown = "true";
+    };
+    // No IntersectionObserver (very old browser, a stripped in-app webview):
+    // show it rather than leaving the section permanently blank.
+    if (typeof IntersectionObserver === "undefined") {
+      show();
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          show();
+          observer.disconnect();
+        }
+      },
+      // A negative bottom margin holds the reveal until the element is
+      // properly in view — firing on the first pixel means the animation is
+      // over before the visitor has looked at it.
+      { rootMargin: "0px 0px -12% 0px", threshold: 0.05 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+    // Mount only: the observer disconnects itself on the first intersection,
+    // and re-running would re-observe an element that is already revealed.
+  }, []);
+
+  return (
+    <Tag
+      // One cast rather than a generic ref type per tag: the union of the three
+      // allowed elements is always an HTMLElement, which is all the effect uses.
+      ref={ref as React.Ref<never>}
+      className={cn("reveal", className)}
+      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+/**
+ * The `<noscript>` escape hatch for pages that use <Reveal>. Without it a
+ * visitor with JS disabled gets a page of invisible sections — the reveal
+ * never runs, and `.reveal` stays at opacity 0 forever.
+ *
+ * Rendered from the page (not the root layout) so the rule only ships where
+ * something is actually hidden.
+ */
+export function RevealNoScript() {
+  return (
+    <noscript>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: ".reveal{opacity:1!important;transform:none!important}",
+        }}
+      />
+    </noscript>
+  );
+}

--- a/src/lib/how-peakhour-works.ts
+++ b/src/lib/how-peakhour-works.ts
@@ -160,6 +160,11 @@ export const NEXT_ACTIONS = [
  * attention. Names only — this list exists to be recognised, and the section
  * that renders it deliberately makes no claim about which are connected today
  * (the homepage integrations grid is catalog-driven and does that honestly).
+ *
+ * ⚠️ SIX entries, and the count is load-bearing: the section heading above it
+ * reads "six dashboards" and the caption beneath it reads "Six tabs". Adding a
+ * seventh name here silently makes both lines wrong. Change the list and the
+ * copy together, or don't change either.
  */
 export const SCATTERED_TOOLS = [
   "Store",
@@ -168,8 +173,6 @@ export const SCATTERED_TOOLS = [
   "Ads manager",
   "Google",
   "Reviews",
-  "Analytics",
-  "Inbox",
 ] as const;
 
 /**

--- a/src/lib/how-peakhour-works.ts
+++ b/src/lib/how-peakhour-works.ts
@@ -1,0 +1,200 @@
+/**
+ * Content for the standalone "See how Peakhour works" page (/how-it-works).
+ *
+ * This page explains the PLATFORM LOGIC — connect, understand, connect the
+ * dots, find what matters, act, and hand the founder less to manage. It is
+ * deliberately NOT a feature page: everything a single pillar does lives on
+ * /commerce, /content, /growth, /support and /presence, and repeating it here
+ * would turn the one page that explains the whole idea into a sixth feature
+ * list. If you're tempted to add a capability bullet, it belongs on a pillar
+ * page instead.
+ *
+ * Copy lives here rather than inline in the page for the same reason
+ * HOW_IT_WORKS_STEPS and PILLAR_CONSOLE_ROWS do: it is brand messaging that
+ * gets edited far more often than the layout around it, and a data file is a
+ * reviewable diff.
+ *
+ * ⚠️ Every example below is ILLUSTRATIVE — a plausible day, not a claim about
+ * live data or a shipped screen. Keep them generic (no named customer, no
+ * specific figure we'd have to stand behind) so nothing here becomes a promise
+ * the product has to keep.
+ */
+
+/**
+ * The six-step spine of the page. This is the whole argument in order, and the
+ * order is load-bearing: understanding has to precede connecting, connecting
+ * has to precede finding, and the payoff step ("less to manage") only lands
+ * once the five before it have been earned.
+ */
+export const PLATFORM_FLOW = [
+  {
+    id: "connect",
+    step: "01",
+    title: "Connect your business",
+    description:
+      "Sign in to the tools you already run on — your store, your site, WhatsApp, your social accounts, your ad accounts, your Google listing. One click each, no data exports, no setup project.",
+  },
+  {
+    id: "understand",
+    step: "02",
+    title: "Peakhour understands it",
+    description:
+      "It reads what is actually there rather than asking you to describe it — how you write, who buys from you, what you sell, what is moving, what people ask.",
+  },
+  {
+    id: "connect-dots",
+    step: "03",
+    title: "Peakhour connects the dots",
+    description:
+      "Everything lands in one place, so what happens in one part of your business can inform another. Stock knows what your ads are doing. Content knows what your customers keep asking.",
+  },
+  {
+    id: "find",
+    step: "04",
+    title: "Peakhour finds what matters",
+    description:
+      "Out of thousands of small signals, only a handful change what you should do this week. Peakhour is looking for those, all the time, so you don't have to go hunting.",
+  },
+  {
+    id: "act",
+    step: "05",
+    title: "Peakhour suggests or takes action",
+    description:
+      "Some things come to you as a recommendation you approve in one tap. The repetitive ones it simply handles, once you've told it that it can.",
+  },
+  {
+    id: "less",
+    step: "06",
+    title: "You have less to manage",
+    description:
+      "Fewer tabs open, fewer dashboards to reconcile, fewer things you have to remember to check. The work still happens.",
+  },
+] as const;
+
+/**
+ * What Peakhour picks up on its own once the connections are in place. These
+ * are the eleven things the founder would otherwise have to explain to a new
+ * hire — which is exactly the point of the section that renders them.
+ */
+export const UNDERSTANDS = [
+  "Your brand voice",
+  "Your writing style",
+  "Your audience",
+  "Your products",
+  "Your stock health",
+  "Your sales",
+  "Your customer conversations",
+  "Your content performance",
+  "Your ad performance",
+  "Your reviews",
+  "Your business information",
+] as const;
+
+/**
+ * The heart of the page: one thing observed in a corner of the business
+ * changing what you should do somewhere else. `signal` is what happened,
+ * `connection` is the link only a shared intelligence layer can make, and
+ * `suggestion` is what lands in front of the founder.
+ *
+ * `from` / `to` name the two parts of the business being joined — they're what
+ * makes the row read as a CONNECTION rather than a single tool being clever.
+ */
+export const CONNECTED_SIGNALS = [
+  {
+    id: "repeat-question",
+    from: "Support",
+    to: "Content",
+    signal: "Customers keep asking the same question about a product.",
+    connection: "Peakhour notices the pattern across every conversation, not just the last one.",
+    suggestion: "Publish a piece that answers it — once, properly, everywhere.",
+  },
+  {
+    id: "slow-mover",
+    from: "Commerce",
+    to: "Growth",
+    signal: "A product is moving more slowly than it should.",
+    connection: "Peakhour puts your stock position next to what your marketing is actually doing.",
+    suggestion: "Give it a push before the stock ages.",
+  },
+  {
+    id: "breakout-reel",
+    from: "Content",
+    to: "Growth",
+    signal: "One Reel is performing far better than the rest.",
+    connection: "Peakhour spots the outlier while it's still fresh.",
+    suggestion: "Put money behind it and use it as ad creative.",
+  },
+  {
+    id: "demand-vs-stock",
+    from: "Support",
+    to: "Commerce",
+    signal: "Customers keep asking for something you're low on.",
+    connection: "Peakhour compares what people are asking for with what you actually have.",
+    suggestion: "Look at reordering before you're out.",
+  },
+  {
+    id: "review-theme",
+    from: "Presence",
+    to: "the business",
+    signal: "Reviews keep mentioning the same issue.",
+    connection: "Peakhour reads them as a theme rather than as one-star events.",
+    suggestion: "Here's the thing worth fixing, in your own words.",
+  },
+] as const;
+
+/**
+ * The "brought to you" list — the same idea as CONNECTED_SIGNALS, but framed
+ * as the founder's actual inbox: a plain-language observation and the single
+ * next action attached to it. Rendered as a product panel, so keep the
+ * observations short enough to sit on one line at tablet width.
+ */
+export const NEXT_ACTIONS = [
+  { pillar: "Support", observation: "Customers keep asking about this product.", action: "Create content" },
+  { pillar: "Commerce", observation: "Stock is moving slowly.", action: "Promote it" },
+  { pillar: "Growth", observation: "This creative is outperforming.", action: "Use it in your campaign" },
+  { pillar: "Presence", observation: "Your business information needs updating.", action: "Fix it" },
+] as const;
+
+/**
+ * The tools a founder currently opens one at a time to work out what needs
+ * attention. Names only — this list exists to be recognised, and the section
+ * that renders it deliberately makes no claim about which are connected today
+ * (the homepage integrations grid is catalog-driven and does that honestly).
+ */
+export const SCATTERED_TOOLS = [
+  "Store",
+  "WhatsApp",
+  "Instagram",
+  "Ads manager",
+  "Google",
+  "Reviews",
+  "Analytics",
+  "Inbox",
+] as const;
+
+/**
+ * What is safe to hand over versus what stays the founder's call. The split is
+ * the promise of the page's control section: automation earns its way in on
+ * the repetitive work, and never quietly takes the decisions.
+ */
+export const CONTROL_SPLIT = {
+  automatic: [
+    "Watching every channel for what changed",
+    "Drafting the post, the reply, the description",
+    "Keeping your listing and catalog in step",
+    "Chasing the routine follow-up",
+  ],
+  yours: [
+    "What you sell, and at what price",
+    "What goes out in your name",
+    "Where the budget goes",
+    "How much you hand over, and when",
+  ],
+} as const;
+
+/** The emotional close. Three lines of relief, then the one line of payoff. */
+export const RELIEF_LINES = [
+  "Less keeping track.",
+  "Less switching between tools.",
+  "Less mental load.",
+] as const;


### PR DESCRIPTION
## What changed

**1. Homepage hero — the approved messaging.** The old H1 ("Five AI pillars. One platform. Free to start.") led with what we are rather than what the visitor is living with. It moves to the eyebrow, where it still works as the positioning badge, and the H1 becomes the problem stated back to them. The value proposition follows in two ranks — the promise at foreground weight, the five pillars in plain words underneath, muted — so the second line reads as the answer to the question, not as a rival headline. Primary CTA is untouched (`{cta.label} — all five pillars`, still stage-driven).

**2. Secondary CTA → `/how-it-works`.** It pointed at `/peaks`. Someone who has just read "10 different tools?" is asking how this works, not how the AI currency is metered. Peaks stays one click away from the footer, `/pricing` and the pillar pages.

**3. `/how-it-works` rebuilt as the story page.** Not a sixth feature list — the pillar pages own the features, and repeating them here would waste the one page that can explain the actual idea. It runs: before/after diagram (five products that each know only their own corner, vs. the same five sharing one layer) → the six-step flow down an animated gold spine → the eleven things Peakhour picks up without being briefed → five connected-signal cards → the next-actions panel → the control split → getting started → the emotional close.

**4. Founder credibility beat** on the homepage, between the product and the ask. Small on purpose, and text-only: there's no founder portrait in `/public`, and a stock headshot on a credibility section would undercut the thing it exists to establish.

**5. Waitlist — one optional field, one derived one.** Free-text "what would you love Peakhour to take off your plate?" lands in `waitlist_signups.businessContext`, which has existed since the collection was written and had no b2c surface writing to it — **zero schema and zero API change**. Country stops being a question and becomes a derivation from the Vercel edge geo header. Business/website deliberately not added: for most applicants it's already in the work email.

## Motion

A ~1kB `IntersectionObserver` reveal rather than an animation library. It flips a `data-` attribute instead of React state, so ~40 of them cost no re-renders. `prefers-reduced-motion` is honoured **in CSS**, before hydration; a server-only `<noscript>` rule covers the case where the observer never runs. The hero diagram is deliberately outside it (LCP).

## Review

Two full rounds, manual, each with its own fix commit — `ea25993` and `fee392f`. Round 1: a decorative `<span>` sitting directly inside an `<ol>`, a `<noscript>` rendered from a `"use client"` module (hydration hazard), a "six dashboards" heading over eight chips. Round 2: `role="img"` hiding the panel's real copy from screen readers behind a summary with a hardcoded count, `aria-hidden` digits that were the only order carrier, and a 5-col grid that would spill "Commerce" out of its cell at 320px.

⚠️ **Subagent review rounds were not run** — this session is configured not to invoke the Agent tool. Both rounds were manual reads, end to end.

## Verification

`tsc --noEmit` clean · `eslint` clean on all changed files · `next build` compiles · all three routes render 200 under `next start`, with the hero copy, the diagram, the noscript rule and the sr-only prefixes confirmed in the served HTML. One `<h1>`, six `<h2>`, no `<span>` inside `<ol>`.

Not covered: no browser screenshot pass — no headless browser in this environment. The reveal timing, the spine pulse and the dark-theme rendering are worth a human eye on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)