### PR TITLE
feat(growth): turn the audience engine on, and build Outcomes v1

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -50,7 +50,6 @@ import { EmptyState } from "@/components/molecules/empty-state";
 import {
   AlertTriangle,
   Archive,
-  Library,
   Megaphone,
   Pause,
   Play,
@@ -652,6 +651,16 @@ function CampaignRow({
               <RefreshCw className={`size-3 ${sync.isPending ? "animate-spin" : ""}`} />
             </Button>
           ) : null}
+          {/* ★ONE DOOR, AND IT OPENS ON WHAT WE SUGGEST. This used to be two
+              buttons — "Set audience" straight into a blank LinkedIn facet
+              picker, and "Saved" into the library beside it — which made
+              hand-picking URNs the default route and the engine's own
+              recommendations the thing you had to know to look for. The picker
+              now leads with our suggestions, offers the customer's own
+              audiences under them, and keeps the facet editor as the escape
+              hatch it should always have been.
+
+              Applying spends nothing either way — a draft stays a draft. */}
           {canTarget ? (
             <Button
               type="button"
@@ -659,30 +668,15 @@ function CampaignRow({
               variant="outline"
               className="h-7 px-2 text-xs"
               disabled={busy}
-              title={hasAudience ? "Edit audience targeting" : "Set audience targeting (required before the campaign can serve)"}
-              onClick={() => setTargetingOpen(true)}
+              title={
+                hasAudience
+                  ? "Change who sees this campaign"
+                  : "Set the audience (required before the campaign can serve)"
+              }
+              onClick={() => setLibraryOpen(true)}
             >
               <Target className="mr-1 size-3" />
               {hasAudience ? "Audience" : "Set audience"}
-            </Button>
-          ) : null}
-          {/* ★AND THE OTHER WAY TO GET AN AUDIENCE, WHICH THE LIBRARY EXISTS
-              FOR (G4). Every boosted campaign has taken whatever the engine
-              proposed at the moment it was created; the rows a customer had
-              already built, imported or corrected could not be put on anything.
-              Applying spends nothing — a draft stays a draft. */}
-          {canTarget ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7 px-2 text-xs"
-              disabled={busy}
-              title="Use an audience you already have"
-              onClick={() => setLibraryOpen(true)}
-            >
-              <Library className="mr-1 size-3" />
-              Saved
             </Button>
           ) : null}
           {canActivate ? (
@@ -748,6 +742,10 @@ function CampaignRow({
             // so this changes nothing today; it is what stops the picker being
             // wrong the day a campaign list carries a second channel.
             platform={campaign.platform}
+            // The facet editor, handed the campaign this picker was opened
+            // for. Ownership stays here: nesting one modal inside another is
+            // how a Cancel closes the wrong dialog.
+            onBuildByHand={() => setTargetingOpen(true)}
           />
         ) : null}
 

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -742,6 +742,11 @@ function CampaignRow({
             // so this changes nothing today; it is what stops the picker being
             // wrong the day a campaign list carries a second channel.
             platform={campaign.platform}
+            // ★WHAT THIS CAMPAIGN IS FOR, so the picker can lead with the
+            // audiences worked out for that and not merely with everything we
+            // have ever suggested. `ad_campaigns.objective` is the same
+            // four-value enum the planner takes, so nothing maps between them.
+            objective={campaign.objective}
             // The facet editor, handed the campaign this picker was opened
             // for. Ownership stays here: nesting one modal inside another is
             // how a Cancel closes the wrong dialog.

--- a/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
@@ -70,8 +70,16 @@ export function AudienceSetCard({ set }: { set: AudienceSet }) {
                 <ChevronRight className="ml-0.5 inline size-3.5 align-baseline" aria-hidden="true" />
               </Link>
             </h3>
-            {set.description && (
-              <p className="mt-0.5 text-sm text-muted-foreground break-words">{set.description}</p>
+            {/* ★THE ENGINE'S OWN SENTENCE ABOUT WHO THESE PEOPLE ARE, WHICH IT
+                HAS WRITTEN ON EVERY PLANNED SET SINCE B2 AND NOTHING HAS EVER
+                DRAWN. `explanation` is §15's prose — the half a customer can
+                actually judge — and `description` is the one-line label under
+                it. Preferring the prose is the difference between a card that
+                argues for an audience and one that files it. */}
+            {(set.explanation ?? set.description) && (
+              <p className="mt-0.5 text-sm text-muted-foreground break-words">
+                {set.explanation ?? set.description}
+              </p>
             )}
           </div>
           {/* ★THE ORIGIN BADGE IS THE BRIEF'S OWN DISTINCTION AND IT LEADS.

--- a/src/app/(site)/dashboard/growth/audiences/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Users } from "lucide-react";
+import { Sparkles, Users } from "lucide-react";
 import { ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { EmptyState } from "@/components/molecules/empty-state";
+import { DiscoverAudiencesDialog } from "@/components/audience/discover-audiences-dialog";
 import { useAudienceSets } from "@/hooks/use-audience-library";
 import { platformLabel, LIBRARY_CHANNELS } from "@/lib/audience-library-rules";
 import type { AudienceSetsQuery } from "@/lib/api/audiences";
@@ -86,6 +87,7 @@ export default function AudienceLibraryPage() {
   const [status, setStatus] = useState<string>(ALL);
   const [platform, setPlatform] = useState<string>(ALL);
   const [offset, setOffset] = useState(0);
+  const [discoverOpen, setDiscoverOpen] = useState(false);
 
   // ★DEBOUNCED, BECAUSE EVERY KEYSTROKE IS A COLLECTION SCAN. `GET /sets`
   // cannot use an index for `createdAt` ordering once a channel filter exists
@@ -152,13 +154,28 @@ export default function AudienceLibraryPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">Audiences</h2>
-        <p className="text-muted-foreground">
-          Every audience we&apos;ve suggested, read off your past campaigns, or you&apos;ve
-          built by hand — reusable on any campaign, on any channel.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Audiences</h2>
+          <p className="text-muted-foreground">
+            Every audience we&apos;ve suggested, read off your past campaigns, or you&apos;ve
+            built by hand — reusable on any campaign, on any channel.
+          </p>
+        </div>
+        {/* ★THE PRIMARY ACTION ON THIS PAGE IS NOT "ADD ONE". A library a
+            customer has to fill themselves is a filing cabinet; the engine's
+            whole claim is that it can tell them who to target from what it
+            already knows about the business, with no campaign history at all.
+            That call existed and nothing on any screen made it. */}
+        <Button className="shrink-0" onClick={() => setDiscoverOpen(true)}>
+          <Sparkles className="mr-1.5 size-4" aria-hidden="true" />
+          Find audiences
+        </Button>
       </div>
+
+      {discoverOpen && (
+        <DiscoverAudiencesDialog open={discoverOpen} onOpenChange={setDiscoverOpen} />
+      )}
 
       <div className="flex flex-wrap gap-2">
         <Input
@@ -254,13 +271,18 @@ export default function AudienceLibraryPage() {
               ? "This page is past the end of your library now."
               : filtered
                 ? "Try a different search, or clear the filters to see everything in your library."
-                : "When Peakhour suggests an audience for a campaign, or reads the ones you've already run, they'll be kept here so you can use them again."
+                : // ★NOT "THEY'LL TURN UP", WHICH WAS THE OLD COPY AND WAS NOT
+                  // TRUE. It told a customer to wait for suggestions that
+                  // nothing on any screen had ever asked for, so an empty
+                  // library stayed empty and read as an engine with no ideas.
+                  // The empty state is where the action belongs.
+                  "We can work out who you should be targeting from what we already know about your business — no past campaigns needed."
           }
           {...(pastTheEnd
             ? { action: { label: "Back to the start", onClick: () => setOffset(0) } }
             : filtered
               ? { action: { label: "Clear filters", onClick: clearFilters } }
-              : {})}
+              : { action: { label: "Find audiences", onClick: () => setDiscoverOpen(true) } })}
         />
       ) : (
         <>

--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -37,6 +38,9 @@ import {
 } from "@/hooks/use-analytics-insights";
 import { OAuthConnectResult } from "@/components/integrations/oauth-connect-result";
 import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
+import { WhatCountsAsAWinDialog } from "@/components/growth/what-counts-as-a-win-dialog";
+import { growthApi } from "@/lib/api/growth";
+import { analyticsActions, type AnalyticsAction } from "@/lib/analytics-actions";
 
 interface ConnectionStatus {
   provider: string;
@@ -134,6 +138,23 @@ export default function AnalyticsInsightsPage() {
   // digest). Only fetched once the connection is working.
   const insightsQ = useAnalyticsInsights(selectedPropertyId, isWorking);
 
+  // ★HAS ANYONE SAID WHAT A GOOD RESULT LOOKS LIKE? It decides whether this
+  // page shows a conversions figure at all. A permanent "Conversions: 0" over
+  // real traffic reads as a verdict on the customer's marketing when it is our
+  // own missing setup step — the same rule Outcomes follows, reading the same
+  // field so the two surfaces cannot disagree.
+  const winQ = useQuery({
+    queryKey: ["growth-win-options", "analytics"],
+    queryFn: () => growthApi.winOptions(),
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+  // ★UNKNOWN COUNTS AS CONFIGURED WHILE THE READ IS IN FLIGHT OR FAILED. The
+  // alternative flashes "nothing is counting your outcomes" at a business that
+  // has counted them for months, which is a worse lie than a briefly missing
+  // prompt.
+  const winConfigured = winQ.data ? winQ.data.current !== null : true;
+
   // Single toolbar instance survives the loading→loaded transition so
   // the dev trigger is reachable during the very query its data refreshes,
   // and so the toolbar's in-flight state isn't lost on remount.
@@ -203,6 +224,85 @@ export default function AnalyticsInsightsPage() {
         </Card>
       ) : (
         <>
+          {/* ★THE READING COMES FIRST AND THE PLUMBING COMES LAST. The property
+              picker used to be the first card on this page: a settings screen —
+              account id, Sync now, a "Use this" button per property — sitting
+              above everything a customer actually came to read. It is a
+              once-a-year job and it is now at the bottom, collapsed. */}
+          <AnalyticsData query={insightsQ} winConfigured={winConfigured} />
+
+          {ASK_ENABLED && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Sparkles className="size-4 text-primary" />
+                  Ask Peakhour about your analytics
+                </CardTitle>
+                <p className="text-xs text-muted-foreground">
+                  Ask in plain language — answers are grounded in this property&apos;s real GA4 + Search Console
+                  data (no made-up numbers).
+                </p>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {[
+                  "How's my website traffic and search doing?",
+                  "What should I do to get more search traffic?",
+                  "Which pages get the most visitors?",
+                ].map((q) => (
+                  <Button key={q} asChild variant="outline" size="sm">
+                    <Link href={`/dashboard/ask?q=${encodeURIComponent(q)}`}>{q}</Link>
+                  </Button>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          <details className="rounded-lg border">
+            <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium">
+              <span className="inline-flex items-center gap-2">
+                <LineChart className="size-4" aria-hidden="true" />
+                Connection &amp; property
+                <span className="font-normal text-muted-foreground">
+                  {status.account?.name ?? status.account?.externalId}
+                  {status.lastSyncAt
+                    ? ` · synced ${new Date(status.lastSyncAt).toLocaleDateString()}`
+                    : ""}
+                </span>
+              </span>
+            </summary>
+            <div className="border-t p-4">
+              <ConnectionPanel
+                status={status}
+                properties={properties}
+                selectedPropertyId={selectedPropertyId}
+                syncMut={syncMut}
+                setPropertyMut={setPropertyMut}
+              />
+            </div>
+          </details>
+        </>
+      )}
+    </PageShell>
+  );
+}
+
+/** The GA4 connection and property picker. Unchanged in behaviour — only in
+ *  where it sits, which is under a disclosure at the foot of the page. */
+function ConnectionPanel({
+  status,
+  properties,
+  selectedPropertyId,
+  syncMut,
+  setPropertyMut,
+}: {
+  status: ConnectionStatus;
+  properties: Array<{ propertyId: string; displayName: string; currencyCode?: string }>;
+  selectedPropertyId: string | undefined;
+  syncMut: { isPending: boolean; mutate: () => void };
+  setPropertyMut: { isPending: boolean; variables?: string; mutate: (id: string) => void };
+}) {
+  return (
+    <>
           <Card>
             <CardHeader className="flex flex-row items-center justify-between">
               <div>
@@ -297,37 +397,7 @@ export default function AnalyticsInsightsPage() {
               </div>
             </CardContent>
           </Card>
-
-          <AnalyticsData query={insightsQ} />
-
-          {ASK_ENABLED && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Sparkles className="size-4 text-primary" />
-                  Ask Peakhour about your analytics
-                </CardTitle>
-                <p className="text-xs text-muted-foreground">
-                  Ask in plain language — answers are grounded in this property&apos;s real GA4 + Search Console
-                  data (no made-up numbers).
-                </p>
-              </CardHeader>
-              <CardContent className="flex flex-wrap gap-2">
-                {[
-                  "How's my website traffic and search doing?",
-                  "What should I do to get more search traffic?",
-                  "Which pages get the most visitors?",
-                ].map((q) => (
-                  <Button key={q} asChild variant="outline" size="sm">
-                    <Link href={`/dashboard/ask?q=${encodeURIComponent(q)}`}>{q}</Link>
-                  </Button>
-                ))}
-              </CardContent>
-            </Card>
-          )}
-        </>
-      )}
-    </PageShell>
+    </>
   );
 }
 
@@ -388,6 +458,12 @@ function FunnelTile({
   );
 }
 
+const ACTION_DOT: Record<AnalyticsAction["severity"], string> = {
+  critical: "bg-red-500",
+  attention: "bg-amber-500",
+  opportunity: "bg-emerald-500",
+};
+
 const MOVEMENT_DOT: Record<Ga4Digest["movements"][number]["kind"], string> = {
   surging: "bg-emerald-500",
   new: "bg-emerald-500",
@@ -397,10 +473,13 @@ const MOVEMENT_DOT: Record<Ga4Digest["movements"][number]["kind"], string> = {
 
 function AnalyticsData({
   query,
+  winConfigured,
 }: {
   query: { data?: AnalyticsInsightsResponse; isLoading: boolean; isError: boolean };
+  winConfigured: boolean;
 }) {
   const { data, isLoading, isError } = query;
+  const [winOpen, setWinOpen] = useState(false);
 
   if (isLoading) {
     return (
@@ -414,7 +493,8 @@ function AnalyticsData({
     return (
       <Card>
         <CardContent className="py-6 text-sm text-muted-foreground">
-          Couldn&apos;t load your analytics right now — try a sync above.
+          Couldn&apos;t load your analytics right now — try a sync from Connection &amp;
+          property below.
         </CardContent>
       </Card>
     );
@@ -423,7 +503,8 @@ function AnalyticsData({
     return (
       <Card>
         <CardContent className="py-6 text-sm text-muted-foreground">
-          No GA4 property is selected yet. Pick one in the connection above to start seeing metrics.
+          No GA4 property is selected yet. Pick one under Connection &amp; property below to
+          start seeing your numbers.
         </CardContent>
       </Card>
     );
@@ -445,8 +526,13 @@ function AnalyticsData({
   const funnelWindow = data.period ?? "last 30 days";
   const windowLabel = data.trendWindowDays ? `last ${data.trendWindowDays} days` : "recent";
 
+  // What to do about all this — deterministic, from the data already here.
+  const actions = analyticsActions(data, { winConfigured });
+
   return (
     <div className="space-y-6">
+      {winOpen && <WhatCountsAsAWinDialog open={winOpen} onOpenChange={setWinOpen} />}
+
       {/* ── What's happening (week-over-week digest) ── */}
       {d && (
         <Card>
@@ -469,22 +555,79 @@ function AnalyticsData({
         </Card>
       )}
 
+      {/* ── What to do next ────────────────────────────────────────────
+          ★DETERMINISTIC AND FREE, ABOVE THE PAID GLOSS. The card below this is
+          model-written and Peaks-metered, so a customer only ever sees it if
+          they already suspected there was something worth reading. "What should
+          I do next" is the one thing on an analytics screen that must not sit
+          behind a spend, so it is computed from the numbers already on this
+          response and shown to everybody. */}
+      {actions.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">What to do about it</h3>
+          {actions.map((a) => (
+            <Card key={a.id}>
+              <CardContent className="flex flex-col items-start gap-3 p-4 sm:flex-row sm:items-center">
+                <span
+                  className={`mt-1.5 size-2 shrink-0 rounded-full sm:mt-0 ${ACTION_DOT[a.severity]}`}
+                  aria-hidden="true"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">{a.title}</p>
+                  <p className="mt-0.5 text-sm text-muted-foreground">{a.detail}</p>
+                </div>
+                {a.opensWinDialog ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="shrink-0"
+                    onClick={() => setWinOpen(true)}
+                  >
+                    {a.cta}
+                  </Button>
+                ) : a.href && a.cta ? (
+                  <Button asChild size="sm" variant="outline" className="shrink-0">
+                    <Link href={a.href}>
+                      {a.cta}
+                      <ArrowRight className="ml-1.5 size-3.5" aria-hidden="true" />
+                    </Link>
+                  </Button>
+                ) : null}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
       {/* ── Tier-2 "Explain this" (user-triggered, Peaks-metered) ── */}
       <ExplainCard surface="ga4" resource={data.property} />
 
-      {/* ── Funnel top-line ── */}
-      {/* Totals over the funnel window (30d). We deliberately DON'T show a WoW
-          delta chip here: the digest is 7d-vs-7d, so pairing a 7d delta with a
-          30d magnitude would misread ("45,000 ↑12%" implies the 45k grew 12%).
-          The week-over-week story lives in the digest banner above. */}
+      {/* ── Two numbers, not four ──────────────────────────────────────
+          ★PEOPLE AND WHETHER THEY STAYED. Sessions-vs-users is a distinction
+          only an analyst cares about, and raw event count is a diagnostic —
+          both were tiles here and both are now behind the disclosure below.
+          ★CONVERSIONS IS GONE UNLESS SOMETHING IS COUNTING. Quests' tile read a
+          permanent 0 for ninety days because their property has no key event:
+          our missing setup step, rendered as a verdict on their marketing. The
+          action list above asks the question instead. */}
       {funnel && (
         <div className="space-y-2">
           <p className="text-xs text-muted-foreground">Totals · {funnelWindow}</p>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <FunnelTile icon={<Users className="h-4 w-4" />} label="Sessions" value={funnel.sessions} />
-            <FunnelTile icon={<Users className="h-4 w-4" />} label="Users" value={funnel.totalUsers} />
-            <FunnelTile icon={<Activity className="h-4 w-4" />} label="Engagement" value={funnel.engagementRatePct} suffix="%" />
-            <FunnelTile icon={<Target className="h-4 w-4" />} label="Conversions" value={funnel.conversions} />
+          <div className="grid grid-cols-2 gap-3">
+            <FunnelTile icon={<Users className="h-4 w-4" />} label="People" value={funnel.totalUsers} />
+            <FunnelTile
+              icon={<Activity className="h-4 w-4" />}
+              label="Stayed and read something"
+              value={funnel.engagementRatePct}
+              suffix="%"
+            />
+            {winConfigured && funnel.conversions > 0 && (
+              <FunnelTile
+                icon={<Target className="h-4 w-4" />}
+                label="Outcomes"
+                value={funnel.conversions}
+              />
+            )}
           </div>
         </div>
       )}

--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -39,7 +39,7 @@ import {
 import { OAuthConnectResult } from "@/components/integrations/oauth-connect-result";
 import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 import { WhatCountsAsAWinDialog } from "@/components/growth/what-counts-as-a-win-dialog";
-import { growthApi } from "@/lib/api/growth";
+import { growthApi, type WinDefinition } from "@/lib/api/growth";
 import { analyticsActions, type AnalyticsAction } from "@/lib/analytics-actions";
 
 interface ConnectionStatus {
@@ -161,11 +161,7 @@ export default function AnalyticsInsightsPage() {
   // alternative flashes "nothing is counting your outcomes" at a business that
   // has counted them for months, which is a worse lie than a briefly missing
   // prompt.
-  const winConfigured = winQ.data ? winDefinition !== undefined : true;
-  // ★AND THE GA4 FIGURE IS ONLY THE ANSWER WHEN GA4 IS WHAT THEY CHOSE. A
-  // business counting inbox leads has a number on Outcomes that this tile would
-  // contradict — same word, two figures, from the one product.
-  const showGa4Conversions = winDefinition?.source === "analytics_key_event";
+  const winKnown = winQ.data !== undefined;
 
   // Single toolbar instance survives the loading→loaded transition so
   // the dev trigger is reachable during the very query its data refreshes,
@@ -241,11 +237,7 @@ export default function AnalyticsInsightsPage() {
               account id, Sync now, a "Use this" button per property — sitting
               above everything a customer actually came to read. It is a
               once-a-year job and it is now at the bottom, collapsed. */}
-          <AnalyticsData
-            query={insightsQ}
-            winConfigured={winConfigured}
-            showGa4Conversions={showGa4Conversions}
-          />
+          <AnalyticsData query={insightsQ} winDefinition={winDefinition} winKnown={winKnown} />
 
           {ASK_ENABLED && (
             <Card>
@@ -489,14 +481,13 @@ const MOVEMENT_DOT: Record<Ga4Digest["movements"][number]["kind"], string> = {
 
 function AnalyticsData({
   query,
-  winConfigured,
-  showGa4Conversions,
+  winDefinition,
+  winKnown,
 }: {
   query: { data?: AnalyticsInsightsResponse; isLoading: boolean; isError: boolean };
-  winConfigured: boolean;
-  /** GA4's own conversion count is only THIS business's answer when a GA4 key
-   *  event is what they chose to count. */
-  showGa4Conversions: boolean;
+  winDefinition: WinDefinition | undefined;
+  /** False while the settings read is in flight or has failed. */
+  winKnown: boolean;
 }) {
   const { data, isLoading, isError } = query;
   const [winOpen, setWinOpen] = useState(false);
@@ -545,6 +536,29 @@ function AnalyticsData({
   const trend = data.trend ?? [];
   const funnelWindow = data.period ?? "last 30 days";
   const windowLabel = data.trendWindowDays ? `last ${data.trendWindowDays} days` : "recent";
+
+  /**
+   * ★THE SAME RULE THE OUTCOMES API APPLIES, BECAUSE THE TWO SURFACES MUST NOT
+   * DISAGREE ABOUT THE SAME BUSINESS. `classifyConversions` treats a property
+   * that has EVER converted as configured even with no explicit definition —
+   * so keying this page purely on the definition put "23 wins" on Outcomes and
+   * "nothing here is counting outcomes" here, in the same session, about the
+   * same account. A conversion we can see is something counting, whether or not
+   * anybody named it.
+   */
+  const somethingCounts = winDefinition !== undefined || (funnel?.conversions ?? 0) > 0;
+  const winConfigured = winKnown ? somethingCounts : true;
+  /**
+   * ★AND GA4's OWN FIGURE IS ONLY THE ANSWER WHEN GA4 IS WHAT THEY CHOSE. A
+   * business counting inbox leads has a number on Outcomes that this tile would
+   * contradict — same word, two figures, from one product. With no explicit
+   * choice, a GA4 conversion count IS what Outcomes falls back to, so showing
+   * it agrees.
+   */
+  const showGa4Conversions =
+    winDefinition === undefined
+      ? (funnel?.conversions ?? 0) > 0
+      : winDefinition.source === "analytics_key_event";
 
   // What to do about all this — deterministic, from the data already here.
   const actions = analyticsActions(data, { winConfigured });

--- a/src/app/(site)/dashboard/insights/analytics/page.tsx
+++ b/src/app/(site)/dashboard/insights/analytics/page.tsx
@@ -143,17 +143,29 @@ export default function AnalyticsInsightsPage() {
   // real traffic reads as a verdict on the customer's marketing when it is our
   // own missing setup step — the same rule Outcomes follows, reading the same
   // field so the two surfaces cannot disagree.
+  //
+  // ★READ FROM `/growth/settings`, NOT `/growth/win-options`. They answer the
+  // same question here, but win-options refreshes an OAuth token and calls
+  // Google's Admin API to LIST key events — work this page has no use for and
+  // would have paid for on every single view. That listing is what the dialog's
+  // `enabled: open` gate exists to defer; calling it from the page defeated the
+  // gate entirely. Settings is a Mongo projection.
   const winQ = useQuery({
-    queryKey: ["growth-win-options", "analytics"],
-    queryFn: () => growthApi.winOptions(),
+    queryKey: ["growth-settings"],
+    queryFn: () => growthApi.settings(),
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
   });
+  const winDefinition = winQ.data?.settings.winDefinition;
   // ★UNKNOWN COUNTS AS CONFIGURED WHILE THE READ IS IN FLIGHT OR FAILED. The
   // alternative flashes "nothing is counting your outcomes" at a business that
   // has counted them for months, which is a worse lie than a briefly missing
   // prompt.
-  const winConfigured = winQ.data ? winQ.data.current !== null : true;
+  const winConfigured = winQ.data ? winDefinition !== undefined : true;
+  // ★AND THE GA4 FIGURE IS ONLY THE ANSWER WHEN GA4 IS WHAT THEY CHOSE. A
+  // business counting inbox leads has a number on Outcomes that this tile would
+  // contradict — same word, two figures, from the one product.
+  const showGa4Conversions = winDefinition?.source === "analytics_key_event";
 
   // Single toolbar instance survives the loading→loaded transition so
   // the dev trigger is reachable during the very query its data refreshes,
@@ -229,7 +241,11 @@ export default function AnalyticsInsightsPage() {
               account id, Sync now, a "Use this" button per property — sitting
               above everything a customer actually came to read. It is a
               once-a-year job and it is now at the bottom, collapsed. */}
-          <AnalyticsData query={insightsQ} winConfigured={winConfigured} />
+          <AnalyticsData
+            query={insightsQ}
+            winConfigured={winConfigured}
+            showGa4Conversions={showGa4Conversions}
+          />
 
           {ASK_ENABLED && (
             <Card>
@@ -474,9 +490,13 @@ const MOVEMENT_DOT: Record<Ga4Digest["movements"][number]["kind"], string> = {
 function AnalyticsData({
   query,
   winConfigured,
+  showGa4Conversions,
 }: {
   query: { data?: AnalyticsInsightsResponse; isLoading: boolean; isError: boolean };
   winConfigured: boolean;
+  /** GA4's own conversion count is only THIS business's answer when a GA4 key
+   *  event is what they chose to count. */
+  showGa4Conversions: boolean;
 }) {
   const { data, isLoading, isError } = query;
   const [winOpen, setWinOpen] = useState(false);
@@ -621,7 +641,7 @@ function AnalyticsData({
               value={funnel.engagementRatePct}
               suffix="%"
             />
-            {winConfigured && funnel.conversions > 0 && (
+            {showGa4Conversions && funnel.conversions > 0 && (
               <FunnelTile
                 icon={<Target className="h-4 w-4" />}
                 label="Outcomes"

--- a/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
+++ b/src/app/(site)/dashboard/optimizer/_components/adjustments-board.tsx
@@ -219,18 +219,177 @@ export function AdjustmentsBoard() {
       </p>
 
       {rows.length === 0 ? (
-        <EmptyState
-          icon={Sparkles}
-          title="No reviews yet"
-          description={
-            optimizerEnabled
-              ? "Run this week's review now, or wait for Monday. It needs some published posts or campaigns to analyse."
-              : "Turn the optimizer on above to get a review every Monday — at most three small proposals, and you decide every one."
-          }
-        />
+        <SampleRun optimizerEnabled={optimizerEnabled} />
       ) : (
         rows.map((run) => <RunCard key={run._id} run={run} onChanged={invalidate} />)
       )}
+    </div>
+  );
+}
+
+/**
+ * What a review looks like, before this business has had one.
+ *
+ * ★A BARE "NO REVIEWS YET" WAS TRUE AND USELESS. On a test account with no
+ * spend and nothing published, the optimizer's honest answer is "a quiet week"
+ * — every week — so the empty state was the ONLY thing anyone could see, and it
+ * described the feature without showing it. Whether this is worth turning on is
+ * a judgement about the proposals, and nobody could form one.
+ *
+ * ★IT IS MARKED AS AN EXAMPLE IN THREE PLACES AND ITS CONTROLS DO NOTHING. A
+ * worked example that a customer could mistake for a real finding about their
+ * own account is far worse than no example: they would go looking in Campaign
+ * Manager for a budget split that does not exist. The card is labelled, the
+ * copy says so, and Approve/Dismiss are disabled with a reason on hover.
+ */
+const SAMPLE_PROPOSALS: Array<{
+  type: OptimizerProposal["type"];
+  summary: string;
+  evidence: string[];
+  expectedEffect: string;
+  rollbackCondition: string;
+}> = [
+  {
+    type: "budget_resplit",
+    summary:
+      "Move ₹40/day from “Turnaround Horizon” to “Aviation Ops Leaders” — it is getting three times the clicks for the same spend.",
+    evidence: [
+      "“Aviation Ops Leaders”: 1,240 impressions, 38 clicks (3.1% CTR) at ₹60/day",
+      "“Turnaround Horizon”: 1,190 impressions, 11 clicks (0.9% CTR) at ₹60/day",
+    ],
+    expectedEffect: "Roughly 20 more clicks a week at the same total spend.",
+    rollbackCondition: "Put it back if the winner's CTR drops below 2% for a full week.",
+  },
+  {
+    type: "posting_cadence",
+    summary:
+      "Publish on Tuesday and Thursday mornings instead of Friday afternoons — your Friday posts reach about a third as many people.",
+    evidence: [
+      "Tue/Thu 9–11am: 6 posts, 214 average impressions",
+      "Fri after 3pm: 5 posts, 71 average impressions",
+    ],
+    expectedEffect: "Same number of posts, materially more people seeing them.",
+    rollbackCondition: "Revert if two weeks of Tue/Thu posts under-perform the Friday average.",
+  },
+];
+
+function SampleRun({ optimizerEnabled }: { optimizerEnabled: boolean }) {
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-dashed bg-muted/20 p-4">
+        <p className="text-sm font-medium">No reviews yet — here&apos;s what one looks like</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {optimizerEnabled
+            ? "Run this week's review whenever you like. Until there are published posts or campaigns with real delivery to compare, the honest answer will be “a quiet week” — the optimizer needs at least two independent signals before it will propose anything, on purpose. One good post is not a trend."
+            : "Turn the optimizer on above and it reviews this business every Monday. It needs at least two independent signals before it will propose anything, on purpose — one good post is not a trend."}
+        </p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardHeader className="pb-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-base font-semibold leading-none text-muted-foreground">
+              Example review
+            </h3>
+            <span className="text-[11px] text-muted-foreground">
+              Made-up numbers · nothing here is about your account
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3 pt-0">
+          {SAMPLE_PROPOSALS.map((p) => (
+            <SampleProposalRow key={p.type} proposal={p} />
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+/** The real row's structure with no mutation behind it. Kept as its own
+ *  component rather than a `sample` flag on `ProposalRow`: a live card that can
+ *  be put into a mode where its Approve does nothing is one prop away from
+ *  doing nothing on a real proposal. */
+function SampleProposalRow({
+  proposal,
+}: {
+  proposal: (typeof SAMPLE_PROPOSALS)[number];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const detailId = `sample-detail-${proposal.type}`;
+  return (
+    <div className="rounded-md border border-dashed p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              example
+            </span>
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              {TYPE_LABEL[proposal.type] ?? proposal.type}
+            </Badge>
+          </div>
+          <p className="text-sm font-medium">{proposal.summary}</p>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:underline"
+            aria-expanded={expanded}
+            aria-controls={detailId}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? (
+              <ChevronUp aria-hidden="true" className="size-3" />
+            ) : (
+              <ChevronDown aria-hidden="true" className="size-3" />
+            )}
+            {expanded ? "Hide the numbers" : "See the numbers behind it"}
+          </button>
+          {expanded ? (
+            <div id={detailId} className="space-y-1.5 rounded-md bg-muted/30 p-2 text-xs">
+              <div>
+                <p className="font-medium">Evidence</p>
+                <ul className="list-disc pl-4 text-muted-foreground">
+                  {proposal.evidence.map((e, i) => (
+                    <li key={i}>{e}</li>
+                  ))}
+                </ul>
+              </div>
+              <p>
+                <span className="font-medium">Expected effect:</span>{" "}
+                <span className="text-muted-foreground">{proposal.expectedEffect}</span>
+              </p>
+              <p>
+                <span className="font-medium">Rollback if:</span>{" "}
+                <span className="text-muted-foreground">{proposal.rollbackCondition}</span>
+              </p>
+            </div>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            className="h-7 px-2 text-xs"
+            disabled
+            title="This is an example — there is nothing to approve"
+          >
+            <Check aria-hidden="true" className="mr-1 size-3" />
+            Approve
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-xs"
+            disabled
+            title="This is an example — there is nothing to dismiss"
+          >
+            <X aria-hidden="true" className="mr-1 size-3" />
+            Dismiss
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(site)/dashboard/outcomes/page.tsx
+++ b/src/app/(site)/dashboard/outcomes/page.tsx
@@ -1,24 +1,339 @@
-import { TrendingUp } from "lucide-react";
+"use client";
 
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ArrowDownRight,
+  ArrowRight,
+  ArrowUpRight,
+  Lightbulb,
+  Minus,
+  TrendingUp,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { useAuth } from "@/providers/auth-provider";
+import { growthApi, type OutcomesResponse } from "@/lib/api/growth";
+import { platformLabel } from "@/lib/audience-library-rules";
+
+/**
+ * Outcomes (v1) — what happened, what it means, and what to do next.
+ *
+ * ★THE ORDER IS THE ARGUMENT. One sentence about what happened; then the things
+ * that need a person; then what moved; and the numbers LAST, small, because a
+ * customer who wanted a metrics dashboard already has two of them (their ad
+ * platform's and their analytics'). This page exists to be the one that tells
+ * them what to do about it.
+ *
+ * ★IT IS USEFUL BEFORE ANY MONEY IS SPENT, which was the whole reason it could
+ * not ship earlier. Every version of this page that started from ad performance
+ * had nothing to say to a business in its first months — the state every
+ * business is in when it most needs to know whether the work is landing. Reach
+ * and attention carry it; paid appears when there is spend.
+ *
+ * ★AND A MISSING CONVERSION IS NAMED, NEVER RENDERED AS A ZERO. The api sends
+ * `configured: false` with a reason and no number precisely so this page cannot
+ * put "0 enquiries" over real traffic, which reads as a verdict on the
+ * customer's marketing when it is our own missing setup step.
+ */
+
+/** The two windows worth offering. A picker with six options is a settings
+ *  screen; these are "the last month" and "the last quarter". */
+const WINDOWS = [
+  { days: 28, label: "28 days" },
+  { days: 90, label: "90 days" },
+] as const;
+
+const NUM = new Intl.NumberFormat("en-US");
+
+const SEVERITY: Record<
+  OutcomesResponse["nextActions"][number]["severity"],
+  { dot: string; icon: typeof AlertTriangle; label: string }
+> = {
+  critical: { dot: "bg-red-500", icon: AlertTriangle, label: "Needs you now" },
+  attention: { dot: "bg-amber-500", icon: AlertTriangle, label: "Worth a look" },
+  opportunity: { dot: "bg-emerald-500", icon: Lightbulb, label: "Opportunity" },
+};
+
+const DIRECTION_ICON = {
+  up: ArrowUpRight,
+  down: ArrowDownRight,
+  flat: Minus,
+} as const;
 
 export default function OutcomesPage() {
+  const { business } = useAuth();
+  const [days, setDays] = useState<number>(28);
+
+  const outcomes = useQuery({
+    // Business in the key for the same reason every other business-scoped hook
+    // pins it: the route is business-scoped server-side, and a key that does
+    // not say which business is one cache clear away from showing another's.
+    queryKey: ["growth-outcomes", business?._id ?? "none", days],
+    queryFn: () => growthApi.outcomes(days),
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
   return (
     <div className="space-y-6">
-      <CronToolbar crons={["outcome-backfill", "per-stream-effectiveness-rollup"]} />
-      <div>
-        <h2 className="text-2xl font-bold">Outcomes</h2>
-        <p className="text-muted-foreground">
-          Track real business results, not vanity metrics
-        </p>
+      {/* The two crons that put the numbers on this page there. */}
+      <CronToolbar crons={["performance-sync", "ad-campaign-monitor", "linkedin-post-sync"]} />
+
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Outcomes</h2>
+          <p className="text-muted-foreground">
+            What your marketing actually did, and what to do about it next.
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-1 rounded-md border p-0.5">
+          {WINDOWS.map((w) => (
+            <Button
+              key={w.days}
+              type="button"
+              size="sm"
+              variant={days === w.days ? "secondary" : "ghost"}
+              className="h-7 px-3 text-xs"
+              aria-pressed={days === w.days}
+              onClick={() => setDays(w.days)}
+            >
+              {w.label}
+            </Button>
+          ))}
+        </div>
       </div>
 
-      <EmptyState
-        icon={TrendingUp}
-        title="Coming Soon"
-        description={'No more confusing dashboards with CTR and ROAS. We\'ll show you "23 new customers this week at $12 each" \u2014 numbers that make sense.'}
-      />
+      {outcomes.isPending ? (
+        <div className="space-y-4">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      ) : outcomes.isError ? (
+        <EmptyState
+          icon={TrendingUp}
+          title="We couldn't work out your outcomes"
+          description="That's on us — nothing has been changed. Try again in a moment."
+          action={{ label: "Try again", onClick: () => void outcomes.refetch() }}
+        />
+      ) : (
+        <OutcomesBody data={outcomes.data} />
+      )}
+    </div>
+  );
+}
+
+function OutcomesBody({ data }: { data: OutcomesResponse }) {
+  const { reach, attention, conversions, nextActions, movements } = data;
+  const nothingHappened =
+    reach.organic.posts === 0 && reach.paid === null && (reach.site?.sessions ?? 0) === 0;
+
+  return (
+    <div className="space-y-6">
+      {/* ── What happened ──────────────────────────────────────────────── */}
+      <Card>
+        <CardContent className="p-5">
+          <p className="text-lg leading-relaxed font-medium text-balance">{data.headline}</p>
+          {movements.length > 0 && (
+            <ul className="mt-4 space-y-1.5">
+              {movements.map((m, i) => {
+                const Icon = DIRECTION_ICON[m.direction];
+                return (
+                  <li key={`${m.direction}-${i}`} className="flex items-start gap-2 text-sm">
+                    <Icon
+                      className={`mt-0.5 size-4 shrink-0 ${
+                        m.direction === "up"
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : m.direction === "down"
+                            ? "text-red-600 dark:text-red-400"
+                            : "text-muted-foreground"
+                      }`}
+                      aria-hidden="true"
+                    />
+                    <span className="text-muted-foreground">{m.text}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── What to do next ────────────────────────────────────────────
+          ★ABOVE THE NUMBERS, ALWAYS. This is the half of the page that is
+          worth opening; a customer who reads only one block should read this
+          one. Every item names the row it came from — a recommendation that
+          cannot be traced to a fact about their own account is advice, and
+          advice is exactly what this page exists not to be. */}
+      {nextActions.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">What needs you</h3>
+          <div className="space-y-2">
+            {nextActions.map((a) => {
+              const s = SEVERITY[a.severity];
+              return (
+                <Card key={a.id}>
+                  <CardContent className="flex flex-col items-start gap-3 p-4 sm:flex-row sm:items-center">
+                    <span
+                      className={`mt-1.5 size-2 shrink-0 rounded-full sm:mt-0 ${s.dot}`}
+                      aria-hidden="true"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium">
+                        <span className="sr-only">{s.label}: </span>
+                        {a.title}
+                      </p>
+                      <p className="mt-0.5 text-sm text-muted-foreground">{a.detail}</p>
+                    </div>
+                    {a.href && a.cta && (
+                      <Button asChild size="sm" variant="outline" className="shrink-0">
+                        <Link href={a.href}>
+                          {a.cta}
+                          <ArrowRight className="ml-1.5 size-3.5" aria-hidden="true" />
+                        </Link>
+                      </Button>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* ── Did it turn into anything? ─────────────────────────────────── */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold">Did it turn into anything?</h3>
+        <Card>
+          <CardContent className="p-5">
+            {conversions.configured ? (
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <span className="text-3xl font-semibold tabular-nums">
+                  {NUM.format(conversions.count)}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {conversions.count === 1 ? "win" : "wins"} counted
+                  {conversions.costPer !== null && conversions.currency
+                    ? ` · ${conversions.currency} ${conversions.costPer.toFixed(2)} each in ad spend`
+                    : ""}
+                </span>
+              </div>
+            ) : (
+              // ★NO NUMBER HERE, AND THAT IS THE FEATURE. A business whose
+              // property has no key event has not had zero enquiries — nobody
+              // has ever counted one. Printing "0" over 11,851 people who saw
+              // their posts turns our missing setup step into a verdict on
+              // their marketing.
+              <div className="space-y-3">
+                <p className="text-sm">{conversions.message}</p>
+                <Button asChild size="sm" variant="outline">
+                  <Link
+                    href={
+                      conversions.reason === "not_connected"
+                        ? "/dashboard/integrations"
+                        : "/dashboard/insights/analytics"
+                    }
+                  >
+                    {conversions.reason === "not_connected"
+                      ? "Connect analytics"
+                      : "Set up what counts as a win"}
+                    <ArrowRight className="ml-1.5 size-3.5" aria-hidden="true" />
+                  </Link>
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ── The numbers, small and last ────────────────────────────────── */}
+      {!nothingHappened && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">The numbers behind it</h3>
+          <Card>
+            <CardContent className="divide-y p-0">
+              <Figure
+                label="Saw your posts"
+                value={NUM.format(reach.organic.impressions)}
+                note={
+                  reach.organic.posts > 0
+                    ? `across ${reach.organic.posts} post${reach.organic.posts === 1 ? "" : "s"}` +
+                      (reach.organic.byPlatform.length > 1
+                        ? ` on ${reach.organic.byPlatform.map((p) => platformLabel(p.platform)).join(" and ")}`
+                        : "")
+                    : "nothing published in this window"
+                }
+              />
+              <Figure
+                label="Reacted, commented or shared"
+                value={NUM.format(attention.organic.engagements)}
+                note={
+                  attention.organic.ratePct !== null
+                    ? `${attention.organic.ratePct}% of everyone who saw you`
+                    : undefined
+                }
+              />
+              {/* ★A SITE BLOCK ONLY WHEN ANALYTICS IS CONNECTED, and dated when
+                  the data has stopped moving — the number is still true, it is
+                  just true about three weeks ago, and a figure without that
+                  caveat is the one people plan against. */}
+              {reach.site && (
+                <Figure
+                  label="Visited your site"
+                  value={NUM.format(reach.site.sessions)}
+                  note={
+                    reach.site.stale && reach.site.dataThrough
+                      ? `${NUM.format(reach.site.users)} people · only counted up to ${new Date(reach.site.dataThrough).toLocaleDateString(undefined, { day: "numeric", month: "short" })}`
+                      : `${NUM.format(reach.site.users)} people`
+                  }
+                />
+              )}
+              {/* ★PAID APPEARS WHEN THERE IS PAID. A row of zeros for a business
+                  that has never advertised is a section pretending to be a
+                  measurement. */}
+              {reach.paid && (
+                <Figure
+                  label="Saw your ads"
+                  value={NUM.format(reach.paid.impressions)}
+                  note={
+                    `${reach.paid.campaigns} campaign${reach.paid.campaigns === 1 ? "" : "s"}` +
+                    (reach.paid.currency
+                      ? ` · ${reach.paid.currency} ${NUM.format(Math.round(reach.paid.spend))} spent`
+                      : "")
+                  }
+                />
+              )}
+              {attention.paid && (
+                <Figure
+                  label="Clicked an ad"
+                  value={NUM.format(attention.paid.clicks)}
+                  note={attention.paid.ctrPct !== null ? `${attention.paid.ctrPct}% of who saw them` : undefined}
+                />
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One figure, as a sentence rather than a tile. Deliberately not a KPI card:
+ *  a grid of big numbers is the thing this page exists to replace. */
+function Figure({ label, value, note }: { label: string; value: string; note?: string }) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 px-5 py-3">
+      <span className="text-sm">{label}</span>
+      <span className="flex items-baseline gap-2">
+        <span className="text-lg font-semibold tabular-nums">{value}</span>
+        {note && <span className="text-xs text-muted-foreground">{note}</span>}
+      </span>
     </div>
   );
 }

--- a/src/app/(site)/dashboard/outcomes/page.tsx
+++ b/src/app/(site)/dashboard/outcomes/page.tsx
@@ -18,6 +18,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/molecules/empty-state";
 import { CronToolbar } from "@/components/dev/cron-toolbar";
+import { WhatCountsAsAWinDialog } from "@/components/growth/what-counts-as-a-win-dialog";
 import { useAuth } from "@/providers/auth-provider";
 import { growthApi, type OutcomesResponse } from "@/lib/api/growth";
 import { platformLabel } from "@/lib/audience-library-rules";
@@ -129,13 +130,27 @@ export default function OutcomesPage() {
   );
 }
 
+/** Naive plural for a customer-supplied noun. Deliberately not a library: the
+ *  label is theirs and short ("enquiry", "demo request", "new lead"), and a
+ *  wrong "s" is a smaller cost than a dependency that would also get the
+ *  irregular cases wrong in a language we did not ask them to type in. */
+function plural(label: string, n: number): string {
+  if (n === 1) return label;
+  if (/(s|x|z|ch|sh)$/i.test(label)) return `${label}es`;
+  if (/[^aeiou]y$/i.test(label)) return `${label.slice(0, -1)}ies`;
+  return `${label}s`;
+}
+
 function OutcomesBody({ data }: { data: OutcomesResponse }) {
   const { reach, attention, conversions, nextActions, movements } = data;
+  const [winOpen, setWinOpen] = useState(false);
   const nothingHappened =
     reach.organic.posts === 0 && reach.paid === null && (reach.site?.sessions ?? 0) === 0;
 
   return (
     <div className="space-y-6">
+      {winOpen && <WhatCountsAsAWinDialog open={winOpen} onOpenChange={setWinOpen} />}
+
       {/* ── What happened ──────────────────────────────────────────────── */}
       <Card>
         <CardContent className="p-5">
@@ -213,16 +228,34 @@ function OutcomesBody({ data }: { data: OutcomesResponse }) {
         <Card>
           <CardContent className="p-5">
             {conversions.configured ? (
-              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                <span className="text-3xl font-semibold tabular-nums">
-                  {NUM.format(conversions.count)}
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-2">
+                <span className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <span className="text-3xl font-semibold tabular-nums">
+                    {NUM.format(conversions.count)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {/* ★THEIR WORD FOR IT, NOT OURS. `label` is the whole reason
+                        that field is stored — without it this reads "23
+                        generate_lead", which is the machine's name for the
+                        thing. Plain "wins" only while nobody has chosen. */}
+                    {conversions.label
+                      ? plural(conversions.label, conversions.count)
+                      : conversions.count === 1
+                        ? "win"
+                        : "wins"}
+                    {conversions.costPer !== null && conversions.currency
+                      ? ` · ${conversions.currency} ${conversions.costPer.toFixed(2)} each in ad spend`
+                      : ""}
+                  </span>
                 </span>
-                <span className="text-sm text-muted-foreground">
-                  {conversions.count === 1 ? "win" : "wins"} counted
-                  {conversions.costPer !== null && conversions.currency
-                    ? ` · ${conversions.currency} ${conversions.costPer.toFixed(2)} each in ad spend`
-                    : ""}
-                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setWinOpen(true)}
+                >
+                  Change what counts
+                </Button>
               </div>
             ) : (
               // ★NO NUMBER HERE, AND THAT IS THE FEATURE. A business whose
@@ -232,19 +265,15 @@ function OutcomesBody({ data }: { data: OutcomesResponse }) {
               // their marketing.
               <div className="space-y-3">
                 <p className="text-sm">{conversions.message}</p>
-                <Button asChild size="sm" variant="outline">
-                  <Link
-                    href={
-                      conversions.reason === "not_connected"
-                        ? "/dashboard/integrations"
-                        : "/dashboard/insights/analytics"
-                    }
-                  >
-                    {conversions.reason === "not_connected"
-                      ? "Connect analytics"
-                      : "Set up what counts as a win"}
-                    <ArrowRight className="ml-1.5 size-3.5" aria-hidden="true" />
-                  </Link>
+                {/* ★THE SAME BUTTON WHICHEVER REASON IT IS. Both roads end at
+                    the same decision, and the dialog is what knows whether the
+                    analytics half is reachable — sending "not connected" to
+                    Integrations instead would make the customer solve OUR
+                    plumbing before they can answer a question about their own
+                    business, when the inbox option needs no connection at all. */}
+                <Button size="sm" variant="outline" onClick={() => setWinOpen(true)}>
+                  Tell us what counts as a win
+                  <ArrowRight className="ml-1.5 size-3.5" aria-hidden="true" />
                 </Button>
               </div>
             )}

--- a/src/components/audience/discover-audiences-dialog.tsx
+++ b/src/components/audience/discover-audiences-dialog.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Check, Sparkles } from "lucide-react";
-import { ApiError } from "@/lib/api";
+import { useAudiencePlan, planRefusalCopy } from "@/hooks/use-audience-plan";
 import {
-  reconnectHref,
-  ADS_LINKEDIN_PATH,
-  LINKEDIN_ADS_PROVIDER,
-} from "@/lib/integrations-connect";
-import { toastUnhandledApiError } from "@/lib/toast-errors";
-import {
-  audiencesApi,
   AUDIENCE_OBJECTIVES,
   type AudienceObjective,
   type AudiencePlanResponse,
@@ -73,33 +65,6 @@ const OBJECTIVE_COPY: Record<AudienceObjective, { label: string; hint: string }>
   },
 };
 
-/**
- * What to say when a plan cannot be built, and whether the customer can do
- * anything about it.
- *
- * ★THE TWO THAT ARE NOT FAILURES AT ALL COME BACK AS 200s. `no_geography` is a
- * question for the customer and `registry_empty` is our own unmigrated
- * database; the api records both as a plan row rather than pretending nothing
- * was asked, and neither should be dressed as an error here.
- */
-function refusalCopy(reason: string, message: string): { title: string; body: string } {
-  switch (reason) {
-    case "no_profile":
-      return {
-        title: "We don't know enough about you yet",
-        body: "Build your business profile first — it's what every audience is worked out from.",
-      };
-    case "no_geography":
-    case "geo_unresolved":
-      return {
-        title: "We need to know where you operate",
-        body: "Set the countries on Your Business and we'll work the audiences out from there.",
-      };
-    default:
-      return { title: "We couldn't build a plan", body: message };
-  }
-}
-
 export function DiscoverAudiencesDialog({
   open,
   onOpenChange,
@@ -111,51 +76,17 @@ export function DiscoverAudiencesDialog({
    *  rule the api's own surface follows. */
   platform?: string;
 }) {
-  const queryClient = useQueryClient();
   const [objective, setObjective] = useState<AudienceObjective>("lead_generation");
   const [result, setResult] = useState<AudiencePlanResponse | null>(null);
 
-  const plan = useMutation({
-    mutationFn: () => audiencesApi.plan({ objective, platform }),
-    onSuccess: (res) => {
+  const plan = useAudiencePlan({
+    onPlanned: (res) => {
       setResult(res);
-      // Every planned audience is a library row now, so the list behind this
-      // dialog is stale the moment the request returns.
-      void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
       if (res.sets.length > 0) {
         toast.success(
           `${res.sets.length} audience${res.sets.length === 1 ? "" : "s"} added to your library.`,
           { description: "Nothing is running — put one on a campaign when you're ready." },
         );
-      }
-    },
-    onError: (err) => {
-      const code = err instanceof ApiError ? err.code : undefined;
-      if (code === "NOT_CONNECTED" || code === "NEEDS_REAUTH") {
-        // ★A REAL PRODUCT CONSTRAINT, SAID PLAINLY. The engine reasons about
-        // the business on its own, but it will not hand over an audience it
-        // cannot resolve to real entities and size against the platform — a
-        // made-up reach is the number a customer divides their budget by. So
-        // an ads connection is a prerequisite, and this is the one error on
-        // this surface with a fix the customer can perform.
-        toast.error("Connect your ads account first.", {
-          description:
-            "We size every audience against the real platform rather than estimating it, so we need the connection before we can suggest any.",
-          action: {
-            label: "Connect",
-            onClick: () => {
-              window.location.href = reconnectHref(ADS_LINKEDIN_PATH, LINKEDIN_ADS_PROVIDER);
-            },
-          },
-        });
-      } else if (code === "RATE_LIMITED") {
-        toast.error("Give us a moment — we're still working out the last one.");
-      } else if (code === "PLATFORM_UNSUPPORTED") {
-        toast.error(
-          (err as ApiError).message || "We can't plan audiences for that channel yet.",
-        );
-      } else {
-        toastUnhandledApiError(err, "build an audience plan", "LinkedIn");
       }
     },
   });
@@ -231,7 +162,7 @@ export function DiscoverAudiencesDialog({
               >
                 Cancel
               </Button>
-              <Button type="button" onClick={() => plan.mutate()} disabled={plan.isPending}>
+              <Button type="button" onClick={() => plan.mutate({ objective, platform })} disabled={plan.isPending}>
                 {/* Named rather than a spinner-with-"Loading": this really does
                     take the better part of a minute — a model call plus up to
                     four rounds of platform lookups and reach counts — and a
@@ -259,7 +190,7 @@ function PlanSummary({ result }: { result: AudiencePlanResponse }) {
     (result.strategist?.rejected?.length ?? 0) + (result.strategist?.dropped?.length ?? 0);
 
   if (result.refusal) {
-    const copy = refusalCopy(result.refusal.reason, result.refusal.message);
+    const copy = planRefusalCopy(result.refusal.reason, result.refusal.message);
     return (
       <div className="space-y-1.5 rounded-md border p-3">
         <p className="text-sm font-medium">{copy.title}</p>

--- a/src/components/audience/discover-audiences-dialog.tsx
+++ b/src/components/audience/discover-audiences-dialog.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Check, Sparkles } from "lucide-react";
+import { ApiError } from "@/lib/api";
+import {
+  reconnectHref,
+  ADS_LINKEDIN_PATH,
+  LINKEDIN_ADS_PROVIDER,
+} from "@/lib/integrations-connect";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+import {
+  audiencesApi,
+  AUDIENCE_OBJECTIVES,
+  type AudienceObjective,
+  type AudiencePlanResponse,
+} from "@/lib/api/audiences";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Ask Peakhour who this business should be targeting.
+ *
+ * ★THE FEATURE THIS PRODUCT WAS SOLD ON, TURNED ON. `POST /v1/audiences/plan`
+ * has shipped the entire chain since B2 — hypotheses reasoned in business
+ * language, resolved deterministically against the platform's own typeahead,
+ * counted for real reach, scored, argued against, and explained in prose — and
+ * no client had ever called it, so `biz_audience_plans` was empty in every
+ * environment and the Audiences page could only ever list what a customer had
+ * typed in themselves.
+ *
+ * ★ONE QUESTION, WHICH IS DECISION D13. The engine already knows the industry,
+ * the market type, the seniorities that matter and where the business operates
+ * — it read them off the site, the business record and the published content.
+ * The one thing it cannot infer is what this particular push is FOR, so that is
+ * the only thing asked. Geography is deliberately NOT asked here: the profile
+ * carries it with its evidence tier, and correcting it belongs on Your Business
+ * where the correction is recorded as a stated fact rather than a one-off
+ * override.
+ *
+ * ★IT SPENDS NOTHING AND TOUCHES NO CAMPAIGN. The result is a set of named,
+ * reusable library rows. Putting one on a campaign is a separate act, and
+ * activating that campaign is a further one.
+ */
+
+/** What each objective means, in the customer's terms rather than the ad
+ *  platform's. The keys are the api's enum — see `AUDIENCE_OBJECTIVES`. */
+const OBJECTIVE_COPY: Record<AudienceObjective, { label: string; hint: string }> = {
+  lead_generation: {
+    label: "Get enquiries",
+    hint: "People who could buy, close enough to the decision to fill in a form.",
+  },
+  website_traffic: {
+    label: "Get visitors",
+    hint: "A wider group worth bringing to the site to see what you do.",
+  },
+  brand_awareness: {
+    label: "Get known",
+    hint: "The market you want to be recognised in, whether or not they act today.",
+  },
+  engagement: {
+    label: "Get engagement",
+    hint: "People likely to read, react and follow — the audience that compounds.",
+  },
+};
+
+/**
+ * What to say when a plan cannot be built, and whether the customer can do
+ * anything about it.
+ *
+ * ★THE TWO THAT ARE NOT FAILURES AT ALL COME BACK AS 200s. `no_geography` is a
+ * question for the customer and `registry_empty` is our own unmigrated
+ * database; the api records both as a plan row rather than pretending nothing
+ * was asked, and neither should be dressed as an error here.
+ */
+function refusalCopy(reason: string, message: string): { title: string; body: string } {
+  switch (reason) {
+    case "no_profile":
+      return {
+        title: "We don't know enough about you yet",
+        body: "Build your business profile first — it's what every audience is worked out from.",
+      };
+    case "no_geography":
+    case "geo_unresolved":
+      return {
+        title: "We need to know where you operate",
+        body: "Set the countries on Your Business and we'll work the audiences out from there.",
+      };
+    default:
+      return { title: "We couldn't build a plan", body: message };
+  }
+}
+
+export function DiscoverAudiencesDialog({
+  open,
+  onOpenChange,
+  platform = "linkedin",
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The channel to resolve against. A parameter, never a path segment — same
+   *  rule the api's own surface follows. */
+  platform?: string;
+}) {
+  const queryClient = useQueryClient();
+  const [objective, setObjective] = useState<AudienceObjective>("lead_generation");
+  const [result, setResult] = useState<AudiencePlanResponse | null>(null);
+
+  const plan = useMutation({
+    mutationFn: () => audiencesApi.plan({ objective, platform }),
+    onSuccess: (res) => {
+      setResult(res);
+      // Every planned audience is a library row now, so the list behind this
+      // dialog is stale the moment the request returns.
+      void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
+      if (res.sets.length > 0) {
+        toast.success(
+          `${res.sets.length} audience${res.sets.length === 1 ? "" : "s"} added to your library.`,
+          { description: "Nothing is running — put one on a campaign when you're ready." },
+        );
+      }
+    },
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "NOT_CONNECTED" || code === "NEEDS_REAUTH") {
+        // ★A REAL PRODUCT CONSTRAINT, SAID PLAINLY. The engine reasons about
+        // the business on its own, but it will not hand over an audience it
+        // cannot resolve to real entities and size against the platform — a
+        // made-up reach is the number a customer divides their budget by. So
+        // an ads connection is a prerequisite, and this is the one error on
+        // this surface with a fix the customer can perform.
+        toast.error("Connect your ads account first.", {
+          description:
+            "We size every audience against the real platform rather than estimating it, so we need the connection before we can suggest any.",
+          action: {
+            label: "Connect",
+            onClick: () => {
+              window.location.href = reconnectHref(ADS_LINKEDIN_PATH, LINKEDIN_ADS_PROVIDER);
+            },
+          },
+        });
+      } else if (code === "RATE_LIMITED") {
+        toast.error("Give us a moment — we're still working out the last one.");
+      } else if (code === "PLATFORM_UNSUPPORTED") {
+        toast.error(
+          (err as ApiError).message || "We can't plan audiences for that channel yet.",
+        );
+      } else {
+        toastUnhandledApiError(err, "build an audience plan", "LinkedIn");
+      }
+    },
+  });
+
+  /** Closing throws the summary away — the audiences themselves are already in
+   *  the library, so nothing is lost, and reopening should not show a stale
+   *  result from a previous session. */
+  function close(next: boolean) {
+    if (!next && plan.isPending) return;
+    if (!next) {
+      setResult(null);
+      plan.reset();
+    }
+    onOpenChange(next);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="size-4" aria-hidden="true" />
+            Find audiences worth targeting
+          </DialogTitle>
+          <DialogDescription>
+            We already know your industry, your market and where you operate. Tell us what
+            this push is for and we&apos;ll work out who to put in front of it — sized
+            against the real platform, not estimated. Nothing starts spending.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          <PlanSummary result={result} />
+        ) : (
+          <div className="space-y-2">
+            {AUDIENCE_OBJECTIVES.map((key) => {
+              const copy = OBJECTIVE_COPY[key];
+              const picked = objective === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setObjective(key)}
+                  aria-pressed={picked}
+                  disabled={plan.isPending}
+                  className={`w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/50 disabled:opacity-60 ${
+                    picked ? "border-primary bg-muted/40" : ""
+                  }`}
+                >
+                  <span className="flex items-center gap-1.5 text-sm font-medium">
+                    {copy.label}
+                    {picked && <Check className="size-3.5 text-primary" aria-hidden="true" />}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">{copy.hint}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <DialogFooter>
+          {result ? (
+            <Button type="button" onClick={() => close(false)}>
+              See them in your library
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => close(false)}
+                disabled={plan.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="button" onClick={() => plan.mutate()} disabled={plan.isPending}>
+                {/* Named rather than a spinner-with-"Loading": this really does
+                    take the better part of a minute — a model call plus up to
+                    four rounds of platform lookups and reach counts — and a
+                    button that says nothing for that long reads as broken. */}
+                {plan.isPending ? "Working out who to target…" : "Find audiences"}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * What the session produced.
+ *
+ * ★INCLUDING WHAT IT DID NOT. A portfolio that started as five ideas and lost
+ * four to resolution would otherwise render as a single audience reading "this
+ * is all there was" — so the discarded ideas are counted, and the refusal, when
+ * there is one, is a sentence rather than an empty list.
+ */
+function PlanSummary({ result }: { result: AudiencePlanResponse }) {
+  const lost =
+    (result.strategist?.rejected?.length ?? 0) + (result.strategist?.dropped?.length ?? 0);
+
+  if (result.refusal) {
+    const copy = refusalCopy(result.refusal.reason, result.refusal.message);
+    return (
+      <div className="space-y-1.5 rounded-md border p-3">
+        <p className="text-sm font-medium">{copy.title}</p>
+        <p className="text-sm text-muted-foreground">{copy.body}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">
+        {result.sets.length} audience{result.sets.length === 1 ? "" : "s"} are in your library
+        now.
+      </p>
+      <ul className="max-h-[40vh] space-y-2 overflow-y-auto pr-1">
+        {result.sets.map((s, i) => (
+          <li key={s.id ?? `${s.label}-${i}`} className="rounded-md border p-3">
+            <p className="text-sm font-medium">{s.label}</p>
+            {/* The engine's own sentence about who these people are, which is
+                the half a customer can actually judge. */}
+            {(s.explanation ?? s.description) && (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {s.explanation ?? s.description}
+              </p>
+            )}
+            {/* ★AND ITS OBJECTION TO ITSELF, shown rather than acted on. */}
+            {s.critique?.length ? (
+              <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                Worth knowing: {s.critique.join(" ")}
+              </p>
+            ) : null}
+            {/* ★A SET WITH NO ID DID NOT REACH THE LIBRARY. It is a real
+                audience and worth reading, but nothing can be applied to a
+                campaign from it — and rendering it identically to the others
+                is what would make that discovery happen at activation time. */}
+            {s.id === null && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                We couldn&apos;t save this one — run it again to keep it.
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+      {lost > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {lost} further idea{lost === 1 ? "" : "s"} didn&apos;t survive — either the evidence
+          was too thin or the channel couldn&apos;t express them.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -26,6 +26,7 @@ import { classifyApplyError } from "@/lib/audience-apply-errors";
 import { SEARCH_MAX } from "@/app/(site)/dashboard/growth/audiences/filters";
 import {
   audienceLibraryApi,
+  AUDIENCE_OBJECTIVES,
   type AudienceObjective,
   type AudienceSet,
 } from "@/lib/api/audiences";
@@ -126,6 +127,22 @@ export function UseSavedAudienceDialog({
   const [q, setQ] = useState("");
   const [chosen, setChosen] = useState<AudienceSet | null>(null);
   const [discoverOpen, setDiscoverOpen] = useState(false);
+
+  /**
+   * The campaign's objective, but only if the planner would take it.
+   *
+   * ★`ManagedCampaign.objective` IS `BoostObjective | (string & {})` — a legacy
+   * row, or one created by a path that widened its own vocabulary, can carry
+   * anything. `PlanBody.objective` is a strict `z.enum`, so casting and posting
+   * it produced a 400 and a generic "couldn't build an audience plan" toast for
+   * a campaign whose only fault was being old. Narrowing here means an
+   * unrecognised objective degrades to "no objective" — the section falls back
+   * to "What Peakhour suggests" and the fresh-run button is not offered, which
+   * is honest rather than broken.
+   */
+  const planObjective = AUDIENCE_OBJECTIVES.includes(objective as AudienceObjective)
+    ? (objective as AudienceObjective)
+    : undefined;
 
   /**
    * Work out recommendations for THIS campaign, right here.
@@ -290,7 +307,7 @@ export function UseSavedAudienceDialog({
    * gated on having seen everything.
    */
   const ours = rows.filter((r) => originIsOurs(r.source));
-  const recommended = objective ? ours.filter((r) => r.objective === objective) : [];
+  const recommended = planObjective ? ours.filter((r) => r.objective === planObjective) : [];
   const otherSuggestions = ours.filter((r) => !recommended.includes(r));
   const theirs = rows.filter((r) => !originIsOurs(r.source));
   /**
@@ -300,7 +317,17 @@ export function UseSavedAudienceDialog({
    * model call on that basis would be a claim we cannot source — the same
    * accepted-then-ignored-filter failure one layer up.
    */
-  const canOfferPlan = recommended.length === 0 && !search && total <= PAGE;
+  //
+  // ★AND `ours` HAS TO BE EMPTY TOO WHEN THERE IS NO OBJECTIVE TO MATCH ON. A
+  // legacy campaign carrying no objective makes `recommended` empty by
+  // construction — so this offered "we haven't worked out any audiences for
+  // this business yet", plus a button that spends a model call, directly above
+  // an "Other suggestions" list of those very audiences.
+  const canOfferPlan =
+    recommended.length === 0 &&
+    (planObjective ? true : ours.length === 0) &&
+    !search &&
+    total <= PAGE;
 
   return (
     <Dialog
@@ -360,9 +387,8 @@ export function UseSavedAudienceDialog({
                   this?" is the default, and the customer's own filing is the
                   alternative to it rather than the other way round. */}
               <Section
-                title={
-                  objective
-                    ? `Recommended for ${objectiveLabel(objective)}`
+                title={ planObjective
+                    ? `Recommended for ${objectiveLabel(planObjective)}`
                     : "What Peakhour suggests"
                 }
                 icon={Sparkles}
@@ -370,11 +396,11 @@ export function UseSavedAudienceDialog({
                   // Only offered once we HAVE some — a "get fresh ones" button
                   // above an empty section is the same click as the panel
                   // below it, twice.
-                  recommended.length > 0 && objective ? (
+                  recommended.length > 0 && planObjective ? (
                     <button
                       type="button"
                       disabled={plan.isPending}
-                      onClick={() => plan.mutate({ objective: objective as AudienceObjective, platform })}
+                      onClick={() => plan.mutate({ objective: planObjective, platform })}
                       className="text-xs font-medium text-primary hover:underline disabled:opacity-60"
                     >
                       {plan.isPending ? "Working…" : "Work out fresh ones"}
@@ -385,8 +411,8 @@ export function UseSavedAudienceDialog({
                   canOfferPlan ? (
                     <div className="space-y-2 rounded-md border border-dashed p-3">
                       <p className="text-xs text-muted-foreground">
-                        {objective
-                          ? `We haven't worked out who to target for ${objectiveLabel(objective)} yet. We can do it now from what we already know about your business — no past campaigns needed.`
+                        {planObjective
+                          ? `We haven't worked out who to target for ${objectiveLabel(planObjective)} yet. We can do it now from what we already know about your business — no past campaigns needed.`
                           : "We haven't worked out any audiences for this business yet. We can do it from what we already know about you — no past campaigns needed."}
                       </p>
                       <Button
@@ -395,9 +421,9 @@ export function UseSavedAudienceDialog({
                         variant="outline"
                         disabled={plan.isPending}
                         onClick={() =>
-                          objective
+                          planObjective
                             ? plan.mutate({
-                                objective: objective as AudienceObjective,
+                                objective: planObjective,
                                 platform,
                               })
                             : setDiscoverOpen(true)

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Check, Library } from "lucide-react";
+import { Check, PencilLine, Sparkles, Target } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,13 +29,28 @@ import { useAudienceSets } from "@/hooks/use-audience-library";
 import {
   audienceShape,
   channelNotes,
+  originIsOurs,
   originLabel,
   platformLabel,
   reachReading,
 } from "@/lib/audience-library-rules";
+import { DiscoverAudiencesDialog } from "./discover-audiences-dialog";
 
 /**
- * Put an audience you already have on this campaign (G4).
+ * Set this campaign's audience (G4).
+ *
+ * ★WHAT PEAKHOUR SUGGESTS COMES FIRST, AND THAT ORDER IS THE PRODUCT. This
+ * surface used to be the SECOND of two buttons — "Set audience" opened a blank
+ * facet picker and "Saved" opened this list — so the default path through a
+ * campaign was a customer hand-picking LinkedIn URNs while an engine that had
+ * already worked out who to target sat one button to the right. The two are now
+ * one dialog in the order the engine actually works: our recommendations, then
+ * the audiences they own, then the hand-built escape hatch.
+ *
+ * ★AND AN EMPTY RECOMMENDATIONS LIST IS AN ACTION, NOT A BLANK. A business
+ * nobody has run a planning session for has no suggestions to show, and the fix
+ * — ask for some — is one call away and belongs here rather than on another
+ * page.
  *
  * ★THE LIBRARY'S WHOLE POINT, AND UNTIL NOW IT HAD NO WAY IN. `biz_audience_sets`
  * exists so an audience built once can be reused on a campaign created months
@@ -75,6 +90,7 @@ export function UseSavedAudienceDialog({
   campaignName,
   platform,
   onApplied,
+  onBuildByHand,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -82,10 +98,16 @@ export function UseSavedAudienceDialog({
   campaignName: string;
   platform: string;
   onApplied?: () => void;
+  /** Hand off to the facet editor. Kept as a callback rather than rendering the
+   *  editor here: the two dialogs are owned by the campaign row, which is the
+   *  only thing that knows the campaign's full shape, and nesting one modal
+   *  inside another is how a Cancel closes the wrong one. */
+  onBuildByHand?: () => void;
 }) {
   const queryClient = useQueryClient();
   const [q, setQ] = useState("");
   const [chosen, setChosen] = useState<AudienceSet | null>(null);
+  const [discoverOpen, setDiscoverOpen] = useState(false);
   // ★DEBOUNCED, LIKE THE LIBRARY PAGE. `GET /sets` runs a regex `find` AND a
   // `countDocuments` per request, over a query the api itself documents as a
   // blocking-sort collection scan — so an undebounced picker double-scans a
@@ -198,6 +220,24 @@ export function UseSavedAudienceDialog({
    */
   const selected = chosen && rows.some((r) => r.id === chosen.id) ? chosen : null;
 
+  /**
+   * ★OURS FIRST, THEIRS SECOND, AND THE HEADINGS SAY WHICH IS WHICH. The api
+   * takes ONE `source` value, so two server-side queries would be needed to
+   * fetch the two groups separately — for a picker that already caps at twenty
+   * and searches to narrow, partitioning the page is the same answer for one
+   * request instead of two.
+   */
+  const suggested = rows.filter((r) => originIsOurs(r.source));
+  const theirs = rows.filter((r) => !originIsOurs(r.source));
+  /**
+   * ★"WE HAVE NEVER SUGGESTED ANY" IS ONLY SAYABLE WHEN THIS PAGE IS THE WHOLE
+   * LIBRARY. Past twenty rows an empty top section might just mean the
+   * customer's own audiences filled the page, and offering to go and generate
+   * more on that basis would be a claim we cannot source — the same
+   * accepted-then-ignored-filter failure one layer up.
+   */
+  const noSuggestionsAnywhere = suggested.length === 0 && !search && total <= PAGE;
+
   return (
     <Dialog
       open={open}
@@ -209,13 +249,13 @@ export function UseSavedAudienceDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Library className="size-4" aria-hidden="true" />
-            Use a saved audience
+            <Target className="size-4" aria-hidden="true" />
+            Set the audience
           </DialogTitle>
           <DialogDescription>
-            Put one of your existing audiences on &ldquo;{campaignName}&rdquo;. This replaces
-            the campaign&apos;s whole audience and starts no spending — activate it when
-            you&apos;re ready.
+            Who should see &ldquo;{campaignName}&rdquo;? Pick one of ours or one of yours —
+            it replaces the campaign&apos;s whole audience and starts no spending, so you
+            activate when you&apos;re ready.
           </DialogDescription>
         </DialogHeader>
 
@@ -223,8 +263,8 @@ export function UseSavedAudienceDialog({
           value={q}
           onChange={(e) => setQ(e.target.value.slice(0, SEARCH_MAX))}
           maxLength={SEARCH_MAX}
-          placeholder="Search your audiences…"
-          aria-label="Search your audiences"
+          placeholder="Search audiences…"
+          aria-label="Search audiences"
         />
 
         {total > PAGE && (
@@ -255,65 +295,197 @@ export function UseSavedAudienceDialog({
                 : `None of your saved audiences has been worked out for ${platformLabel(platform)} yet — open one from Audiences and check this channel first.`}
             </p>
           ) : (
-            rows.map((set) => {
-              const channel = set.channels.find((c) => c.platform === platform);
-              const shape = audienceShape(set);
-              const picked = chosen?.id === set.id;
-              return (
-                <button
-                  key={set.id}
-                  type="button"
-                  onClick={() => setChosen(set)}
-                  className={`w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/50 ${
-                    picked ? "border-primary bg-muted/40" : ""
-                  }`}
-                  aria-pressed={picked}
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <span className="text-sm font-medium">{set.name}</span>
-                    <span className="flex items-center gap-1.5">
-                      {picked && <Check className="size-3.5 text-primary" aria-hidden="true" />}
-                      <Badge variant="outline" className="text-[10px] font-normal">
-                        {originLabel(set.source)}
-                      </Badge>
-                    </span>
-                  </div>
-                  {shape.length > 0 && (
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {shape.map((r) => `${r.label}: ${r.values.join(", ")}`).join(" · ")}
-                    </p>
-                  )}
-                  {/* The reach on THIS channel, and what it could not express —
-                      both of which are what the customer is choosing between. */}
-                  {channel && (
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {[reachReading(channel).text, ...channelNotes(channel)].join(" · ")}
-                    </p>
-                  )}
-                </button>
-              );
-            })
+            <>
+              {/* ★PEAKHOUR'S OWN SUGGESTIONS LEAD. This is the whole reordering:
+                  the engine's answer to "who should see this?" is the default,
+                  and the customer's own filing is the alternative to it rather
+                  than the other way round. */}
+              <Section
+                title="What Peakhour suggests"
+                icon={Sparkles}
+                empty={
+                  noSuggestionsAnywhere ? (
+                    <div className="space-y-2 rounded-md border border-dashed p-3">
+                      <p className="text-xs text-muted-foreground">
+                        We haven&apos;t worked out any audiences for this business yet — we
+                        can do it from what we already know about you, with no past
+                        campaigns needed.
+                      </p>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setDiscoverOpen(true)}
+                      >
+                        <Sparkles className="mr-1.5 size-3.5" aria-hidden="true" />
+                        Find audiences
+                      </Button>
+                    </div>
+                  ) : null
+                }
+              >
+                {suggested.map((set) => (
+                  <AudienceOption
+                    key={set.id}
+                    set={set}
+                    platform={platform}
+                    picked={chosen?.id === set.id}
+                    onPick={() => setChosen(set)}
+                  />
+                ))}
+              </Section>
+
+              <Section title="Yours" icon={PencilLine} empty={null}>
+                {theirs.map((set) => (
+                  <AudienceOption
+                    key={set.id}
+                    set={set}
+                    platform={platform}
+                    picked={chosen?.id === set.id}
+                    onPick={() => setChosen(set)}
+                  />
+                ))}
+              </Section>
+            </>
           )}
         </div>
 
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={apply.isPending}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={!selected || apply.isPending}
-            onClick={() => selected && apply.mutate(selected.id)}
-          >
-            {apply.isPending ? "Applying…" : "Use this audience"}
-          </Button>
+        {discoverOpen && (
+          <DiscoverAudiencesDialog
+            open={discoverOpen}
+            onOpenChange={setDiscoverOpen}
+            platform={platform}
+          />
+        )}
+
+        <DialogFooter className="sm:justify-between">
+          {/* ★THE HAND-BUILT PATH STAYS, AND IT STAYS SUBORDINATE. It is the
+              right answer for a customer who knows exactly which twelve job
+              titles they want, and the wrong DEFAULT for everyone else — which
+              is what it was when it had the primary button and its own tab
+              stop ahead of every suggestion we had already made. */}
+          {onBuildByHand ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={apply.isPending}
+              onClick={() => {
+                onOpenChange(false);
+                onBuildByHand();
+              }}
+            >
+              <PencilLine className="mr-1.5 size-3.5" aria-hidden="true" />
+              Build one by hand
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={apply.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!selected || apply.isPending}
+              onClick={() => selected && apply.mutate(selected.id)}
+            >
+              {apply.isPending ? "Applying…" : "Use this audience"}
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * A titled group of options, or the caller's own sentence when it has none.
+ *
+ * ★AN EMPTY GROUP DISAPPEARS RATHER THAN RENDERING AN EMPTY HEADING, unless the
+ * caller supplied something to say in its place — a heading over nothing reads
+ * as a list that failed to load.
+ */
+function Section({
+  title,
+  icon: Icon,
+  empty,
+  children,
+}: {
+  title: string;
+  icon: typeof Sparkles;
+  empty: React.ReactNode;
+  children: React.ReactNode[];
+}) {
+  if (children.length === 0 && empty === null) return null;
+  return (
+    <section className="space-y-2">
+      <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Icon className="size-3.5" aria-hidden="true" />
+        {title}
+      </h3>
+      {children.length > 0 ? children : empty}
+    </section>
+  );
+}
+
+/** One audience, as something to choose. */
+function AudienceOption({
+  set,
+  platform,
+  picked,
+  onPick,
+}: {
+  set: AudienceSet;
+  platform: string;
+  picked: boolean;
+  onPick: () => void;
+}) {
+  const channel = set.channels.find((c) => c.platform === platform);
+  const shape = audienceShape(set);
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      className={`w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/50 ${
+        picked ? "border-primary bg-muted/40" : ""
+      }`}
+      aria-pressed={picked}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-medium">{set.name}</span>
+        <span className="flex items-center gap-1.5">
+          {picked && <Check className="size-3.5 text-primary" aria-hidden="true" />}
+          <Badge variant="outline" className="text-[10px] font-normal">
+            {originLabel(set.source)}
+          </Badge>
+        </span>
+      </div>
+      {/* ★THE ENGINE'S SENTENCE ABOUT WHO THESE PEOPLE ARE, WHERE THE CHOICE IS
+          ACTUALLY MADE. `explanation` has been written on every planned set
+          since B2 and returned by `GET /sets` all along; this picker showed a
+          row of raw attribute values instead, which is the targeting rather
+          than the idea. */}
+      {set.explanation && (
+        <p className="mt-1 text-xs text-muted-foreground">{set.explanation}</p>
+      )}
+      {shape.length > 0 && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          {shape.map((r) => `${r.label}: ${r.values.join(", ")}`).join(" · ")}
+        </p>
+      )}
+      {/* The reach on THIS channel, and what it could not express — both of
+          which are what the customer is choosing between. */}
+      {channel && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          {[reachReading(channel).text, ...channelNotes(channel)].join(" · ")}
+        </p>
+      )}
+    </button>
   );
 }

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -24,11 +24,17 @@ import {
 } from "@/lib/toast-errors";
 import { classifyApplyError } from "@/lib/audience-apply-errors";
 import { SEARCH_MAX } from "@/app/(site)/dashboard/growth/audiences/filters";
-import { audienceLibraryApi, type AudienceSet } from "@/lib/api/audiences";
+import {
+  audienceLibraryApi,
+  type AudienceObjective,
+  type AudienceSet,
+} from "@/lib/api/audiences";
 import { useAudienceSets } from "@/hooks/use-audience-library";
+import { useAudiencePlan, planRefusalCopy } from "@/hooks/use-audience-plan";
 import {
   audienceShape,
   channelNotes,
+  objectiveLabel,
   originIsOurs,
   originLabel,
   platformLabel,
@@ -89,6 +95,7 @@ export function UseSavedAudienceDialog({
   campaignId,
   campaignName,
   platform,
+  objective,
   onApplied,
   onBuildByHand,
 }: {
@@ -97,6 +104,17 @@ export function UseSavedAudienceDialog({
   campaignId: string;
   campaignName: string;
   platform: string;
+  /**
+   * What THIS campaign is for. `ad_campaigns.objective` and the planner's
+   * `objective` are the same four-value enum, so no mapping sits between them —
+   * a campaign built to get enquiries is matched against audiences planned to
+   * get enquiries.
+   *
+   * Optional because a legacy row may carry none, and a recommendation section
+   * that silently matched everything would be worse than one that says it
+   * cannot tell.
+   */
+  objective?: string;
   onApplied?: () => void;
   /** Hand off to the facet editor. Kept as a callback rather than rendering the
    *  editor here: the two dialogs are owned by the campaign row, which is the
@@ -108,6 +126,34 @@ export function UseSavedAudienceDialog({
   const [q, setQ] = useState("");
   const [chosen, setChosen] = useState<AudienceSet | null>(null);
   const [discoverOpen, setDiscoverOpen] = useState(false);
+
+  /**
+   * Work out recommendations for THIS campaign, right here.
+   *
+   * ★THE OBJECTIVE IS NOT ASKED FOR, BECAUSE THE CAMPAIGN ALREADY ANSWERS IT.
+   * The Audiences page has to ask — it is planning cold. Here the campaign
+   * carries `objective` in the very enum the planner takes, so asking again
+   * would be the surface making the customer re-type something it is holding.
+   *
+   * ★AND IT DOES NOT FIRE ON OPEN. One run is a strong-model call plus up to
+   * four rounds of platform typeaheads and reach counts — the better part of a
+   * minute, and metered. Opening a dialog is not consent to spend that, and a
+   * modal that hangs for forty seconds before showing anything reads as broken.
+   * Stored recommendations render instantly; a fresh run is a button.
+   */
+  const plan = useAudiencePlan({
+    onPlanned: (res) => {
+      if (res.refusal) {
+        const copy = planRefusalCopy(res.refusal.reason, res.refusal.message);
+        toast.warning(copy.title, { description: copy.body });
+        return;
+      }
+      toast.success(
+        `${res.sets.length} audience${res.sets.length === 1 ? "" : "s"} worked out for this campaign.`,
+        { description: "Nothing is running — pick one and it still won't start spending." },
+      );
+    },
+  });
   // ★DEBOUNCED, LIKE THE LIBRARY PAGE. `GET /sets` runs a regex `find` AND a
   // `countDocuments` per request, over a query the api itself documents as a
   // blocking-sort collection scan — so an undebounced picker double-scans a
@@ -221,22 +267,40 @@ export function UseSavedAudienceDialog({
   const selected = chosen && rows.some((r) => r.id === chosen.id) ? chosen : null;
 
   /**
-   * ★OURS FIRST, THEIRS SECOND, AND THE HEADINGS SAY WHICH IS WHICH. The api
-   * takes ONE `source` value, so two server-side queries would be needed to
-   * fetch the two groups separately — for a picker that already caps at twenty
-   * and searches to narrow, partitioning the page is the same answer for one
-   * request instead of two.
+   * ★THREE GROUPS, AND THE MIDDLE ONE EXISTS SO NOTHING DISAPPEARS.
+   *
+   * "Recommended for this campaign" is ours AND planned for this campaign's
+   * objective — the only group that can honestly carry that heading, because an
+   * audience worked out to get reach is a different suggestion from one worked
+   * out to get enquiries and presenting the first as a recommendation for the
+   * second is the collapse this engine exists not to make.
+   *
+   * "Other suggestions" catches everything else we proposed. Dropping those
+   * rows would be tidier and would quietly hide audiences a customer paid a
+   * model call for.
+   *
+   * "Saved" is what the customer chose to keep — one they built by hand, or one
+   * read off a campaign they actually ran. Neither has an objective, because
+   * nobody planned them.
+   *
+   * The api takes ONE `source` value and no objective filter, so this partitions
+   * the page rather than issuing three queries. Honest limit: past `PAGE` rows
+   * the groups describe this page, not the library — which is what the count
+   * line above says, and why the "we have never suggested any" prompt below is
+   * gated on having seen everything.
    */
-  const suggested = rows.filter((r) => originIsOurs(r.source));
+  const ours = rows.filter((r) => originIsOurs(r.source));
+  const recommended = objective ? ours.filter((r) => r.objective === objective) : [];
+  const otherSuggestions = ours.filter((r) => !recommended.includes(r));
   const theirs = rows.filter((r) => !originIsOurs(r.source));
   /**
-   * ★"WE HAVE NEVER SUGGESTED ANY" IS ONLY SAYABLE WHEN THIS PAGE IS THE WHOLE
-   * LIBRARY. Past twenty rows an empty top section might just mean the
-   * customer's own audiences filled the page, and offering to go and generate
-   * more on that basis would be a claim we cannot source — the same
+   * ★"NOTHING HAS BEEN WORKED OUT FOR THIS CAMPAIGN" IS ONLY SAYABLE WHEN THIS
+   * PAGE IS THE WHOLE LIBRARY. Past `PAGE` rows an empty top section might just
+   * mean the customer's own audiences filled the page, and offering to spend a
+   * model call on that basis would be a claim we cannot source — the same
    * accepted-then-ignored-filter failure one layer up.
    */
-  const noSuggestionsAnywhere = suggested.length === 0 && !search && total <= PAGE;
+  const canOfferPlan = recommended.length === 0 && !search && total <= PAGE;
 
   return (
     <Dialog
@@ -285,46 +349,72 @@ export function UseSavedAudienceDialog({
             <p className="text-sm text-muted-foreground">
               We couldn&apos;t load your audiences just now.
             </p>
-          ) : rows.length === 0 ? (
-            // ★TWO EMPTIES AGAIN, AND THEY ARE NOT THE SAME SENTENCE. "Nothing
-            // matches that search" is not "you have no audiences that work
-            // here", and the second is not "you have no audiences".
+          ) : rows.length === 0 && search ? (
             <p className="text-sm text-muted-foreground">
-              {search
-                ? "Nothing in your library matches that."
-                : `None of your saved audiences has been worked out for ${platformLabel(platform)} yet — open one from Audiences and check this channel first.`}
+              Nothing in your library matches that.
             </p>
           ) : (
             <>
-              {/* ★PEAKHOUR'S OWN SUGGESTIONS LEAD. This is the whole reordering:
-                  the engine's answer to "who should see this?" is the default,
-                  and the customer's own filing is the alternative to it rather
-                  than the other way round. */}
+              {/* ★PEAKHOUR'S RECOMMENDATIONS FOR *THIS* CAMPAIGN LEAD. This is
+                  the whole reordering: the engine's answer to "who should see
+                  this?" is the default, and the customer's own filing is the
+                  alternative to it rather than the other way round. */}
               <Section
-                title="What Peakhour suggests"
+                title={
+                  objective
+                    ? `Recommended for ${objectiveLabel(objective)}`
+                    : "What Peakhour suggests"
+                }
                 icon={Sparkles}
+                action={
+                  // Only offered once we HAVE some — a "get fresh ones" button
+                  // above an empty section is the same click as the panel
+                  // below it, twice.
+                  recommended.length > 0 && objective ? (
+                    <button
+                      type="button"
+                      disabled={plan.isPending}
+                      onClick={() => plan.mutate({ objective: objective as AudienceObjective, platform })}
+                      className="text-xs font-medium text-primary hover:underline disabled:opacity-60"
+                    >
+                      {plan.isPending ? "Working…" : "Work out fresh ones"}
+                    </button>
+                  ) : null
+                }
                 empty={
-                  noSuggestionsAnywhere ? (
+                  canOfferPlan ? (
                     <div className="space-y-2 rounded-md border border-dashed p-3">
                       <p className="text-xs text-muted-foreground">
-                        We haven&apos;t worked out any audiences for this business yet — we
-                        can do it from what we already know about you, with no past
-                        campaigns needed.
+                        {objective
+                          ? `We haven't worked out who to target for ${objectiveLabel(objective)} yet. We can do it now from what we already know about your business — no past campaigns needed.`
+                          : "We haven't worked out any audiences for this business yet. We can do it from what we already know about you — no past campaigns needed."}
                       </p>
                       <Button
                         type="button"
                         size="sm"
                         variant="outline"
-                        onClick={() => setDiscoverOpen(true)}
+                        disabled={plan.isPending}
+                        onClick={() =>
+                          objective
+                            ? plan.mutate({
+                                objective: objective as AudienceObjective,
+                                platform,
+                              })
+                            : setDiscoverOpen(true)
+                        }
                       >
                         <Sparkles className="mr-1.5 size-3.5" aria-hidden="true" />
-                        Find audiences
+                        {/* ★NAMED, NOT A SPINNER. This is a strong-model call
+                            plus up to four rounds of platform lookups — the
+                            better part of a minute — and a control that says
+                            nothing for that long reads as broken. */}
+                        {plan.isPending ? "Working out who to target…" : "Get recommendations"}
                       </Button>
                     </div>
                   ) : null
                 }
               >
-                {suggested.map((set) => (
+                {recommended.map((set) => (
                   <AudienceOption
                     key={set.id}
                     set={set}
@@ -335,7 +425,26 @@ export function UseSavedAudienceDialog({
                 ))}
               </Section>
 
-              <Section title="Yours" icon={PencilLine} empty={null}>
+              {/* ★NOT DROPPED, BECAUSE THEY ARE STILL AUDIENCES WE PROPOSED.
+                  An audience planned for a different objective may not wear the
+                  recommendation heading — but hiding it would quietly bin work
+                  a customer already paid a model call for. */}
+              <Section title="Other suggestions" icon={Sparkles} empty={null}>
+                {otherSuggestions.map((set) => (
+                  <AudienceOption
+                    key={set.id}
+                    set={set}
+                    platform={platform}
+                    picked={chosen?.id === set.id}
+                    onPick={() => setChosen(set)}
+                  />
+                ))}
+              </Section>
+
+              {/* ★ONLY WHAT THE CUSTOMER CHOSE TO KEEP. One they built by hand,
+                  or one read off a campaign they actually ran — the badge on
+                  each row says which. Nothing we proposed appears here. */}
+              <Section title="Saved" icon={PencilLine} empty={null}>
                 {theirs.map((set) => (
                   <AudienceOption
                     key={set.id}
@@ -415,20 +524,25 @@ function Section({
   title,
   icon: Icon,
   empty,
+  action,
   children,
 }: {
   title: string;
   icon: typeof Sparkles;
   empty: React.ReactNode;
+  action?: React.ReactNode;
   children: React.ReactNode[];
 }) {
   if (children.length === 0 && empty === null) return null;
   return (
     <section className="space-y-2">
-      <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-        <Icon className="size-3.5" aria-hidden="true" />
-        {title}
-      </h3>
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <Icon className="size-3.5" aria-hidden="true" />
+          {title}
+        </h3>
+        {action}
+      </div>
       {children.length > 0 ? children : empty}
     </section>
   );

--- a/src/components/audience/use-saved-audience-dialog.tsx
+++ b/src/components/audience/use-saved-audience-dialog.tsx
@@ -410,10 +410,22 @@ export function UseSavedAudienceDialog({
                 empty={
                   canOfferPlan ? (
                     <div className="space-y-2 rounded-md border border-dashed p-3">
+                      {/* ★"NONE FOR THIS CHANNEL" IS NOT "NONE AT ALL", AND THE
+                          DELETED BRANCH SAID SO. `GET /sets` filters on
+                          `resolutions.<platform>`, so a customer with a full
+                          library and nothing resolved for THIS channel got
+                          `total: 0` — and the first cut of this panel told them
+                          we had never worked out any audiences for their
+                          business, over a button that spends a strong-model
+                          call on that false premise. Running a plan is still
+                          the right offer; the sentence above it has to be
+                          true. */}
                       <p className="text-xs text-muted-foreground">
-                        {planObjective
-                          ? `We haven't worked out who to target for ${objectiveLabel(planObjective)} yet. We can do it now from what we already know about your business — no past campaigns needed.`
-                          : "We haven't worked out any audiences for this business yet. We can do it from what we already know about you — no past campaigns needed."}
+                        {total === 0 && rows.length === 0
+                          ? `None of your audiences has been worked out for ${platformLabel(platform)} yet. We can work some out now from what we already know about your business — no past campaigns needed.`
+                          : planObjective
+                            ? `We haven't worked out who to target for ${objectiveLabel(planObjective)} yet. We can do it now from what we already know about your business — no past campaigns needed.`
+                            : "We haven't worked out any audiences for this business yet. We can do it from what we already know about you — no past campaigns needed."}
                       </p>
                       <Button
                         type="button"

--- a/src/components/growth/what-counts-as-a-win-dialog.tsx
+++ b/src/components/growth/what-counts-as-a-win-dialog.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Check, ExternalLink, Inbox, Target } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuth } from "@/providers/auth-provider";
+import { growthApi, type WinOptionsResponse } from "@/lib/api/growth";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+
+/**
+ * What counts as a win for this business.
+ *
+ * ★THE MISSING SETUP STEP BEHIND EVERY OUTCOME CLAIM IN THE PRODUCT. Outcomes,
+ * the analytics dashboard and the optimizer all want to say whether the work
+ * turned into anything, and none of them could, because nothing anywhere
+ * recorded what "anything" means. Quests Travel has 1,447 sessions and 966
+ * users over ninety days and zero recorded conversions — not because nobody
+ * enquired, but because their analytics property has no key event and nothing
+ * ever offered them another way to say so.
+ *
+ * ★A DIALOG RATHER THAN A PAGE, ON PURPOSE. It is one decision, taken once,
+ * reached from the two surfaces that need it. A route and a nav item for that
+ * is a permanent piece of furniture for a five-second job — and the nav is
+ * being edited elsewhere, so adding to it unasked would collide.
+ *
+ * ★IT OFFERS ONLY WHAT WE CAN ACTUALLY COUNT. Two options, each with a live
+ * counter behind it. A third that merely sounded right — "form submissions",
+ * "newsletter signups" — would be the same promise the old "23 new customers at
+ * $12 each" copy made, and this dialog exists because that promise had nothing
+ * behind it.
+ */
+
+type Choice = "analytics_key_event" | "inbox_lead";
+
+/** A default name for the thing being counted, so the field is never empty on
+ *  open. The customer's own word wins; this is only a starting point. */
+function defaultLabel(choice: Choice, eventName?: string): string {
+  if (choice === "inbox_lead") return "new lead";
+  if (!eventName) return "enquiry";
+  // "generate_lead" → "generate lead". Deliberately NOT title-cased or
+  // prettified further: it is a suggestion the customer is expected to
+  // overwrite, and dressing up a machine name makes it look decided.
+  return eventName.replace(/[_-]+/g, " ").trim() || "enquiry";
+}
+
+export function WhatCountsAsAWinDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { business } = useAuth();
+  const queryClient = useQueryClient();
+
+  const options = useQuery({
+    queryKey: ["growth-win-options", business?._id ?? "none"],
+    // ★NOT FETCHED UNTIL THE DIALOG IS OPEN. Listing key events is a live call
+    // to Google's Admin API; firing it on every render of a page that merely
+    // LINKS here would spend a customer's quota on a screen nobody opened.
+    enabled: open,
+    queryFn: () => growthApi.winOptions(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const [choice, setChoice] = useState<Choice | null>(null);
+  const [eventName, setEventName] = useState<string>("");
+  const [label, setLabel] = useState<string>("");
+  /** Whether the customer has typed their own name for it. Once they have, no
+   *  later default may overwrite it — changing the key event must not silently
+   *  rename something they deliberately called "demo request". */
+  const [labelTouched, setLabelTouched] = useState(false);
+
+  const current = options.data?.current ?? null;
+  const events = options.data?.keyEvents.events ?? [];
+
+  /**
+   * Seed the form from whatever is already saved, the moment the fetch lands.
+   *
+   * ★ADJUSTED DURING RENDER, NOT IN AN EFFECT. The values depend on a request,
+   * so there is nothing to seed at mount — but doing it in an effect is a
+   * cascading render (React's own guidance, and the lint rule that enforces it
+   * here). Keying on the fetched value means it runs once per distinct answer
+   * and never fights the customer's typing afterwards.
+   *
+   * ★AND THERE IS NO RESET-ON-CLOSE, DELIBERATELY. Both callers render this as
+   * `{open && <WhatCountsAsAWinDialog …/>}`, so closing unmounts it and the
+   * next open starts clean. A caller that kept it mounted would need one — it
+   * is called out here rather than guarded, because the guard would be an
+   * effect again.
+   */
+  const seedKey = options.data ? JSON.stringify(current) : null;
+  const [seededFor, setSeededFor] = useState<string | null>(null);
+  if (seedKey !== null && seededFor !== seedKey) {
+    setSeededFor(seedKey);
+    setChoice(current?.source ?? null);
+    setEventName(current?.eventName ?? "");
+    setLabel(current?.label ?? "");
+    setLabelTouched(current !== null);
+  }
+
+  function pick(next: Choice, event?: string) {
+    setChoice(next);
+    if (next === "inbox_lead") setEventName("");
+    else if (event !== undefined) setEventName(event);
+    if (!labelTouched) setLabel(defaultLabel(next, event ?? eventName));
+  }
+
+  const save = useMutation({
+    mutationFn: () =>
+      growthApi.updateSettings({
+        winDefinition:
+          choice === null
+            ? null
+            : {
+                source: choice,
+                ...(choice === "analytics_key_event" ? { eventName } : {}),
+                label: label.trim(),
+              },
+      }),
+    onSuccess: () => {
+      // Outcomes reads this on every render, and the analytics page decides
+      // whether to show a conversions figure from it.
+      void queryClient.invalidateQueries({ queryKey: ["growth-outcomes"] });
+      void queryClient.invalidateQueries({ queryKey: ["growth-win-options"] });
+      void queryClient.invalidateQueries({ queryKey: ["growth-settings"] });
+      toast.success(`We'll count ${label.trim() || "wins"} from now on.`, {
+        description:
+          "Outcomes will start reporting them — historical periods count them too, wherever the data goes back.",
+      });
+      onOpenChange(false);
+    },
+    onError: (err) => toastUnhandledApiError(err, "save what counts as a win"),
+  });
+
+  const valid =
+    choice !== null &&
+    label.trim().length > 0 &&
+    (choice === "inbox_lead" || eventName.length > 0);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && save.isPending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Target className="size-4" aria-hidden="true" />
+            What counts as a win?
+          </DialogTitle>
+          <DialogDescription>
+            Tell us what a good outcome looks like for your business and we&apos;ll count it
+            everywhere — instead of showing you a zero because nobody ever said.
+          </DialogDescription>
+        </DialogHeader>
+
+        {options.isPending ? (
+          <div className="space-y-2">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : options.isError ? (
+          <p className="text-sm text-muted-foreground">
+            We couldn&apos;t load your options just now. Try again in a moment.
+          </p>
+        ) : (
+          <div className="max-h-[50vh] space-y-4 overflow-y-auto pr-1">
+            <AnalyticsSection
+              keyEvents={options.data.keyEvents}
+              events={events}
+              selectedEvent={choice === "analytics_key_event" ? eventName : ""}
+              onPick={(e) => pick("analytics_key_event", e)}
+            />
+
+            <section className="space-y-2">
+              <h3 className="text-xs font-medium text-muted-foreground">
+                Or count it from your inbox
+              </h3>
+              <button
+                type="button"
+                aria-pressed={choice === "inbox_lead"}
+                onClick={() => pick("inbox_lead")}
+                className={`flex w-full items-start gap-2.5 rounded-md border p-3 text-left transition-colors hover:bg-muted/50 ${
+                  choice === "inbox_lead" ? "border-primary bg-muted/40" : ""
+                }`}
+              >
+                <Inbox className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5 text-sm font-medium">
+                    A new lead in your Inbox
+                    {choice === "inbox_lead" && (
+                      <Check className="size-3.5 text-primary" aria-hidden="true" />
+                    )}
+                  </span>
+                  {/* ★NOTHING TO CONNECT AND NOTHING TO CONFIGURE. This is the
+                      option that works for a business with no analytics at all,
+                      which is why it is offered rather than assumed away. */}
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    Every enquiry that reaches your Inbox — from WhatsApp, a form, or a reply.
+                    Nothing to set up.
+                  </span>
+                </span>
+              </button>
+            </section>
+
+            {choice && (
+              <div className="space-y-1.5 border-t pt-3">
+                <Label htmlFor="win-label">What do you call it?</Label>
+                <Input
+                  id="win-label"
+                  value={label}
+                  maxLength={80}
+                  onChange={(e) => {
+                    setLabel(e.target.value);
+                    setLabelTouched(true);
+                  }}
+                  placeholder="enquiry"
+                />
+                {/* ★THIS IS WHY THE FIELD EXISTS. Without it Outcomes reads
+                    "23 generate_lead this week", which is the machine's name
+                    for the thing rather than the customer's. */}
+                <p className="text-xs text-muted-foreground">
+                  We&apos;ll use your word for it: &ldquo;12 {label.trim() || "enquiries"} this
+                  month&rdquo;.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter className="sm:justify-between">
+          {/* Clearing is offered only when there is something to clear, and it
+              unsets rather than storing a "none" — so "nobody has chosen" stays
+              the single reading of absence. */}
+          {current ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={save.isPending}
+              onClick={() => {
+                setChoice(null);
+                save.mutate();
+              }}
+            >
+              Stop counting
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={save.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!valid || save.isPending}
+              onClick={() => save.mutate()}
+            >
+              {save.isPending ? "Saving…" : "Count this"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * The analytics half.
+ *
+ * ★FOUR STATES, AND THREE OF THEM ARE NOT "NO OPTIONS". A property with key
+ * events; a property with none; no property picked; and no connection at all.
+ * Rendering the last three identically would tell somebody to go and create a
+ * key event when the real problem is that we never asked, or that they have
+ * one and simply have not chosen a property.
+ */
+function AnalyticsSection({
+  keyEvents,
+  events,
+  selectedEvent,
+  onPick,
+}: {
+  keyEvents: WinOptionsResponse["keyEvents"];
+  events: Array<{ eventName: string; custom: boolean }>;
+  selectedEvent: string;
+  onPick: (eventName: string) => void;
+}) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-xs font-medium text-muted-foreground">Count it in your analytics</h3>
+
+      {!keyEvents.available ? (
+        <div className="space-y-2 rounded-md border border-dashed p-3">
+          <p className="text-xs text-muted-foreground">
+            {keyEvents.reason === "not_connected"
+              ? "Google Analytics isn't connected, so we can't read what your site already counts."
+              : keyEvents.reason === "no_property"
+                ? "Analytics is connected but no property is picked yet, so there's nothing for us to read."
+                : "We couldn't reach Google just now — the inbox option below still works."}
+          </p>
+          {keyEvents.reason !== "lookup_failed" && (
+            <Button asChild size="sm" variant="outline">
+              <Link
+                href={
+                  keyEvents.reason === "not_connected"
+                    ? "/dashboard/integrations"
+                    : "/dashboard/insights/analytics"
+                }
+              >
+                {keyEvents.reason === "not_connected" ? "Connect analytics" : "Pick a property"}
+              </Link>
+            </Button>
+          )}
+        </div>
+      ) : events.length === 0 ? (
+        // ★"WE ASKED AND THERE ARE NONE" IS THE ANSWER THAT EXPLAINS THE ZERO.
+        // It is also the common case for a small business, and it is genuinely
+        // fixed in GA4 rather than here — so it links out rather than pretending
+        // we can create one.
+        <div className="space-y-2 rounded-md border border-dashed p-3">
+          <p className="text-xs text-muted-foreground">
+            Your analytics property has no key events, which is exactly why nothing has ever
+            been counted. You can mark one in Google Analytics — Admin → Events → toggle
+            &ldquo;Mark as key event&rdquo; — and it&apos;ll appear here.
+          </p>
+          <Button asChild size="sm" variant="outline">
+            <a href="https://analytics.google.com" target="_blank" rel="noreferrer">
+              Open Analytics
+              <ExternalLink className="ml-1.5 size-3" aria-hidden="true" />
+            </a>
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {events.map((e) => (
+            <button
+              key={e.eventName}
+              type="button"
+              aria-pressed={selectedEvent === e.eventName}
+              onClick={() => onPick(e.eventName)}
+              className={`flex w-full items-center justify-between gap-2 rounded-md border p-3 text-left transition-colors hover:bg-muted/50 ${
+                selectedEvent === e.eventName ? "border-primary bg-muted/40" : ""
+              }`}
+            >
+              <span className="min-w-0">
+                <span className="block truncate font-mono text-sm">{e.eventName}</span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  {e.custom ? "You marked this one" : "Set up by Google Analytics"}
+                </span>
+              </span>
+              {selectedEvent === e.eventName && (
+                <Check className="size-4 shrink-0 text-primary" aria-hidden="true" />
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/growth/what-counts-as-a-win-dialog.tsx
+++ b/src/components/growth/what-counts-as-a-win-dialog.tsx
@@ -122,28 +122,39 @@ export function WhatCountsAsAWinDialog({
     if (!labelTouched) setLabel(defaultLabel(next, event ?? eventName));
   }
 
+  /**
+   * ★THE DEFINITION IS A MUTATION VARIABLE, NOT A CLOSURE OVER STATE, and that
+   * is a bug fix rather than a style choice. "Stop counting" used to call
+   * `setChoice(null)` and then `save.mutate()` in the same handler — but state
+   * updates are not applied before the handler finishes, so `mutationFn` still
+   * closed over the OLD choice and re-saved the very definition it was meant to
+   * clear. Counting never stopped, and the toast cheerfully said "we'll count
+   * enquiries from now on" about the button that turns that off.
+   */
   const save = useMutation({
-    mutationFn: () =>
-      growthApi.updateSettings({
-        winDefinition:
-          choice === null
-            ? null
-            : {
-                source: choice,
-                ...(choice === "analytics_key_event" ? { eventName } : {}),
-                label: label.trim(),
-              },
-      }),
+    mutationFn: (definition: Parameters<typeof growthApi.updateSettings>[0]["winDefinition"]) =>
+      growthApi.updateSettings({ winDefinition: definition }),
     onSuccess: () => {
       // Outcomes reads this on every render, and the analytics page decides
       // whether to show a conversions figure from it.
       void queryClient.invalidateQueries({ queryKey: ["growth-outcomes"] });
       void queryClient.invalidateQueries({ queryKey: ["growth-win-options"] });
       void queryClient.invalidateQueries({ queryKey: ["growth-settings"] });
-      toast.success(`We'll count ${label.trim() || "wins"} from now on.`, {
-        description:
-          "Outcomes will start reporting them — historical periods count them too, wherever the data goes back.",
-      });
+      // ★THE TOAST READS THE VARIABLE THAT WAS SENT, not the form state. Same
+      // reason as the mutationFn above: after a "Stop counting" the form still
+      // holds the label that was just cleared, and congratulating somebody on
+      // counting the thing they have switched off is the same bug wearing
+      // different words.
+      if (save.variables === null || save.variables === undefined) {
+        toast.success("We've stopped counting outcomes.", {
+          description: "Outcomes will say nothing is being counted until you pick something.",
+        });
+      } else {
+        toast.success(`We'll count ${save.variables.label} from now on.`, {
+          description:
+            "Outcomes will start reporting them — historical periods count them too, wherever the data goes back.",
+        });
+      }
       onOpenChange(false);
     },
     onError: (err) => toastUnhandledApiError(err, "save what counts as a win"),
@@ -258,10 +269,7 @@ export function WhatCountsAsAWinDialog({
               variant="ghost"
               size="sm"
               disabled={save.isPending}
-              onClick={() => {
-                setChoice(null);
-                save.mutate();
-              }}
+              onClick={() => save.mutate(null)}
             >
               Stop counting
             </Button>
@@ -280,7 +288,14 @@ export function WhatCountsAsAWinDialog({
             <Button
               type="button"
               disabled={!valid || save.isPending}
-              onClick={() => save.mutate()}
+              onClick={() =>
+                choice &&
+                save.mutate({
+                  source: choice,
+                  ...(choice === "analytics_key_event" ? { eventName } : {}),
+                  label: label.trim(),
+                })
+              }
             >
               {save.isPending ? "Saving…" : "Count this"}
             </Button>

--- a/src/hooks/use-audience-plan.ts
+++ b/src/hooks/use-audience-plan.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import {
+  reconnectHref,
+  ADS_LINKEDIN_PATH,
+  LINKEDIN_ADS_PROVIDER,
+} from "@/lib/integrations-connect";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+import {
+  audiencesApi,
+  type AudienceObjective,
+  type AudiencePlanResponse,
+} from "@/lib/api/audiences";
+
+/**
+ * Run a planning session — the engine working out who this business should be
+ * targeting.
+ *
+ * ★SHARED, BECAUSE TWO SURFACES ASK THE SAME QUESTION FOR DIFFERENT REASONS.
+ * The Audiences page asks it cold, so it has to ASK for the objective. The
+ * campaign picker already knows the objective — the campaign carries one, and
+ * `ad_campaigns.objective` is the same four-value enum `POST /plan` takes — so
+ * it must not ask again. What they share is everything after the objective:
+ * the call, the cache invalidation, and an error vocabulary in which exactly
+ * one failure has a fix the customer can perform.
+ *
+ * ★IT IS SLOW AND IT COSTS, AND CALLERS MUST SAY SO. One request is a
+ * strong-model call plus up to four rounds of platform typeaheads and reach
+ * counts. Never fire it on mount.
+ */
+export function useAudiencePlan(opts?: { onPlanned?: (res: AudiencePlanResponse) => void }) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: { objective: AudienceObjective; platform?: string }) =>
+      audiencesApi.plan(body),
+    onSuccess: (res) => {
+      // Every planned audience is a library row now, so every list of them is
+      // stale the moment this returns.
+      void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
+      opts?.onPlanned?.(res);
+    },
+    onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "NOT_CONNECTED" || code === "NEEDS_REAUTH") {
+        // ★A REAL PRODUCT CONSTRAINT, SAID PLAINLY. The engine reasons about
+        // the business on its own, but it will not hand over an audience it
+        // cannot resolve to real entities and size against the platform — a
+        // made-up reach is the number a customer divides their budget by. So
+        // an ads connection is a prerequisite, and this is the one error on
+        // this path with a fix the customer can perform.
+        toast.error("Connect your ads account first.", {
+          description:
+            "We size every audience against the real platform rather than estimating it, so we need the connection before we can suggest any.",
+          action: {
+            label: "Connect",
+            onClick: () => {
+              window.location.href = reconnectHref(ADS_LINKEDIN_PATH, LINKEDIN_ADS_PROVIDER);
+            },
+          },
+        });
+      } else if (code === "RATE_LIMITED") {
+        toast.error("Give us a moment — we're still working out the last one.");
+      } else if (code === "PLATFORM_UNSUPPORTED") {
+        toast.error((err as ApiError).message || "We can't plan audiences for that channel yet.");
+      } else {
+        toastUnhandledApiError(err, "build an audience plan", "LinkedIn");
+      }
+    },
+  });
+}
+
+/**
+ * What to say when a plan comes back refused, and whether the customer can do
+ * anything about it.
+ *
+ * ★THE TWO THAT ARE NOT FAILURES AT ALL COME BACK AS 200s. `no_geography` is a
+ * question for the customer and `registry_empty` is our own unmigrated
+ * database; the api records both as a plan row rather than pretending nothing
+ * was asked, and neither should be dressed as an error.
+ */
+export function planRefusalCopy(
+  reason: string,
+  message: string,
+): { title: string; body: string } {
+  switch (reason) {
+    case "no_profile":
+      return {
+        title: "We don't know enough about you yet",
+        body: "Build your business profile first — it's what every audience is worked out from.",
+      };
+    case "no_geography":
+    case "geo_unresolved":
+      return {
+        title: "We need to know where you operate",
+        body: "Set the countries on Your Business and we'll work the audiences out from there.",
+      };
+    default:
+      return { title: "We couldn't build a plan", body: message };
+  }
+}

--- a/src/hooks/use-audience-plan.ts
+++ b/src/hooks/use-audience-plan.ts
@@ -5,9 +5,11 @@ import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
 import {
   reconnectHref,
+  adsProviderFor,
   ADS_LINKEDIN_PATH,
   LINKEDIN_ADS_PROVIDER,
 } from "@/lib/integrations-connect";
+import { platformLabel } from "@/lib/audience-library-rules";
 import { toastUnhandledApiError } from "@/lib/toast-errors";
 import {
   audiencesApi,
@@ -43,8 +45,24 @@ export function useAudiencePlan(opts?: { onPlanned?: (res: AudiencePlanResponse)
       void queryClient.invalidateQueries({ queryKey: ["audience-sets"] });
       opts?.onPlanned?.(res);
     },
-    onError: (err) => {
+    onError: (err, variables) => {
       const code = err instanceof ApiError ? err.code : undefined;
+      /**
+       * ★THE CHANNEL THE REQUEST WAS FOR, NOT A CONSTANT.
+       *
+       * The hook threads `platform` all the way into the request and then said
+       * "LinkedIn" in every error — so the day an X campaign uses this, a
+       * customer whose X Ads connection is stale is told to reconnect LinkedIn,
+       * and the Connect button takes them to the LinkedIn ads page. The api and
+       * the X audience adapter both support it today; this is the same
+       * storage-key-in-a-headline defect the sibling apply path passes
+       * `platformLabel(platform)` to avoid.
+       *
+       * Latent right now — every campaign in the ads panel is LinkedIn — which
+       * is exactly why it would have shipped.
+       */
+      const platform = variables.platform ?? "linkedin";
+      const channel = platformLabel(platform);
       if (code === "NOT_CONNECTED" || code === "NEEDS_REAUTH") {
         // ★A REAL PRODUCT CONSTRAINT, SAID PLAINLY. The engine reasons about
         // the business on its own, but it will not hand over an audience it
@@ -52,13 +70,19 @@ export function useAudiencePlan(opts?: { onPlanned?: (res: AudiencePlanResponse)
         // made-up reach is the number a customer divides their budget by. So
         // an ads connection is a prerequisite, and this is the one error on
         // this path with a fix the customer can perform.
-        toast.error("Connect your ads account first.", {
+        toast.error(`Connect your ${channel} ads account first.`, {
           description:
             "We size every audience against the real platform rather than estimating it, so we need the connection before we can suggest any.",
           action: {
             label: "Connect",
             onClick: () => {
-              window.location.href = reconnectHref(ADS_LINKEDIN_PATH, LINKEDIN_ADS_PROVIDER);
+              // The ads hub is one surface with a `?channel=` parameter, so the
+              // return path follows the platform too.
+              const returnTo = `/dashboard/ads?channel=${encodeURIComponent(platform)}`;
+              window.location.href = reconnectHref(
+                platform === "linkedin" ? ADS_LINKEDIN_PATH : returnTo,
+                adsProviderFor(platform) ?? LINKEDIN_ADS_PROVIDER,
+              );
             },
           },
         });
@@ -67,7 +91,7 @@ export function useAudiencePlan(opts?: { onPlanned?: (res: AudiencePlanResponse)
       } else if (code === "PLATFORM_UNSUPPORTED") {
         toast.error((err as ApiError).message || "We can't plan audiences for that channel yet.");
       } else {
-        toastUnhandledApiError(err, "build an audience plan", "LinkedIn");
+        toastUnhandledApiError(err, "build an audience plan", channel);
       }
     },
   });

--- a/src/lib/analytics-actions.test.ts
+++ b/src/lib/analytics-actions.test.ts
@@ -27,7 +27,7 @@ const CONFIGURED = { winConfigured: true };
 
 describe("analyticsActions", () => {
   it("★leads with the missing win definition, because every other number depends on it", () => {
-    const actions = analyticsActions({ funnel: funnel(), channels: [], pages: [] }, {
+    const actions = analyticsActions({ funnel: funnel(), channels: [], pages: [], lockedPages: 0 }, {
       winConfigured: false,
     });
     expect(actions.map((a) => a.id)).toContain("no-win-defined");
@@ -37,7 +37,7 @@ describe("analyticsActions", () => {
   });
 
   it("says nothing about wins once one is configured", () => {
-    const actions = analyticsActions({ funnel: funnel(), channels: [], pages: [] }, CONFIGURED);
+    const actions = analyticsActions({ funnel: funnel(), channels: [], pages: [], lockedPages: 0 }, CONFIGURED);
     expect(actions.map((a) => a.id)).not.toContain("no-win-defined");
   });
 
@@ -53,6 +53,7 @@ describe("analyticsActions", () => {
           { channel: "Organic Search", sessions: 45, conversions: 0 },
         ],
         pages: [],
+        lockedPages: 0,
       },
       CONFIGURED,
     );
@@ -68,6 +69,7 @@ describe("analyticsActions", () => {
           { channel: "Direct", sessions: 20, conversions: 0 },
         ],
         pages: [],
+        lockedPages: 0,
       },
       CONFIGURED,
     );
@@ -86,6 +88,7 @@ describe("analyticsActions", () => {
           { channel: "Referral", sessions: 100 - top, conversions: 0 },
         ],
         pages: [],
+        lockedPages: 0,
       },
       CONFIGURED,
     );
@@ -100,6 +103,7 @@ describe("analyticsActions", () => {
         funnel: funnel(),
         channels: [],
         pages: [{ pagePath: "/", views: 500, engagementRatePct: 70, conversions: 0 }],
+        lockedPages: 0,
       },
       CONFIGURED,
     );
@@ -115,6 +119,7 @@ describe("analyticsActions", () => {
           { pagePath: "/guides/turnaround", views: 500, engagementRatePct: 70, conversions: 0 },
           { pagePath: "/about", views: 100, engagementRatePct: 40, conversions: 0 },
         ],
+        lockedPages: 0,
       },
       CONFIGURED,
     );
@@ -122,15 +127,47 @@ describe("analyticsActions", () => {
     expect(hit?.title).toContain("/guides/turnaround");
   });
 
+  it("★says nothing about page concentration when the page list is truncated", () => {
+    // The regression this guards, and it would have hit nearly every Free
+    // business: the api sends the top THREE pages and puts the rest behind
+    // `lockedPages`. Computing a share against that list would announce "83% of
+    // everything read on your site is this one page" about a denominator we
+    // chose — a confident, checkable, wrong number, on the plan most customers
+    // are on.
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [],
+        pages: [
+          { pagePath: "/guides/turnaround", views: 500, engagementRatePct: 70, conversions: 0 },
+          { pagePath: "/about", views: 100, engagementRatePct: 40, conversions: 0 },
+        ],
+        lockedPages: 41,
+      },
+      CONFIGURED,
+    );
+    expect(actions.map((a) => a.id)).not.toContain("page-concentration");
+  });
+
   it("flags low engagement, and stays quiet on healthy engagement", () => {
     const low = analyticsActions(
-      { funnel: funnel({ engagementRatePct: LOW_ENGAGEMENT_PCT - 1 }), channels: [], pages: [] },
+      {
+        funnel: funnel({ engagementRatePct: LOW_ENGAGEMENT_PCT - 1 }),
+        channels: [],
+        pages: [],
+        lockedPages: 0,
+      },
       CONFIGURED,
     );
     expect(low.map((a) => a.id)).toContain("low-engagement");
 
     const fine = analyticsActions(
-      { funnel: funnel({ engagementRatePct: LOW_ENGAGEMENT_PCT }), channels: [], pages: [] },
+      {
+        funnel: funnel({ engagementRatePct: LOW_ENGAGEMENT_PCT }),
+        channels: [],
+        pages: [],
+        lockedPages: 0,
+      },
       CONFIGURED,
     );
     expect(fine.map((a) => a.id)).not.toContain("low-engagement");
@@ -141,7 +178,12 @@ describe("analyticsActions", () => {
     // "100% of visits end without engagement" about nobody is the sort of
     // confident nonsense that makes a customer stop trusting the whole page.
     const actions = analyticsActions(
-      { funnel: funnel({ sessions: 0, engagementRatePct: 0 }), channels: [], pages: [] },
+      {
+        funnel: funnel({ sessions: 0, engagementRatePct: 0 }),
+        channels: [],
+        pages: [],
+        lockedPages: 0,
+      },
       CONFIGURED,
     );
     expect(actions.map((a) => a.id)).not.toContain("low-engagement");
@@ -156,6 +198,7 @@ describe("analyticsActions", () => {
         funnel: funnel(),
         channels: [],
         pages: [],
+        lockedPages: 0,
         digest: {
           hasComparison: false,
           headline: "",
@@ -179,6 +222,7 @@ describe("analyticsActions", () => {
         funnel: funnel({ engagementRatePct: 20 }),
         channels: [{ channel: "Direct", sessions: 100, conversions: 0 }],
         pages: [],
+        lockedPages: 0,
         digest: {
           hasComparison: true,
           headline: "",

--- a/src/lib/analytics-actions.test.ts
+++ b/src/lib/analytics-actions.test.ts
@@ -4,6 +4,7 @@ import {
   CHANNEL_CONCENTRATION,
   LOW_ENGAGEMENT_PCT,
   NOTABLE_DROP_PCT,
+  PAGE_CONCENTRATION,
 } from "./analytics-actions";
 
 /**
@@ -125,6 +126,11 @@ describe("analyticsActions", () => {
     );
     const hit = actions.find((a) => a.id === "page-concentration");
     expect(hit?.title).toContain("/guides/turnaround");
+    // ★AND THE HEADLINE'S CLAIM IS TRUE. It says "most of the work", so the
+    // threshold has to be a majority — a card whose title says "most" over a
+    // detail line reading "31%" disagrees with itself in two lines.
+    expect(hit?.title).toContain("most of the work");
+    expect(PAGE_CONCENTRATION).toBeGreaterThan(0.5 - Number.EPSILON);
   });
 
   it("★says nothing about page concentration when the page list is truncated", () => {

--- a/src/lib/analytics-actions.test.ts
+++ b/src/lib/analytics-actions.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyticsActions,
+  CHANNEL_CONCENTRATION,
+  LOW_ENGAGEMENT_PCT,
+  NOTABLE_DROP_PCT,
+} from "./analytics-actions";
+
+/**
+ * The thresholds, because every one of them is a claim about somebody's
+ * business. Set too low and the page becomes the nine-insights metric
+ * dashboard it exists to replace; set too high and it says nothing when
+ * something is genuinely wrong. Neither failure is visible in a screenshot.
+ */
+
+const funnel = (over: Partial<{ sessions: number; engagementRatePct: number }> = {}) => ({
+  sessions: 1000,
+  totalUsers: 800,
+  engagedSessions: 600,
+  engagementRatePct: 60,
+  conversions: 0,
+  eventCount: 5000,
+  ...over,
+});
+
+const CONFIGURED = { winConfigured: true };
+
+describe("analyticsActions", () => {
+  it("★leads with the missing win definition, because every other number depends on it", () => {
+    const actions = analyticsActions({ funnel: funnel(), channels: [], pages: [] }, {
+      winConfigured: false,
+    });
+    expect(actions.map((a) => a.id)).toContain("no-win-defined");
+    // It opens the dialog rather than navigating: the decision is the same
+    // whichever surface you reached it from.
+    expect(actions.find((a) => a.id === "no-win-defined")?.opensWinDialog).toBe(true);
+  });
+
+  it("says nothing about wins once one is configured", () => {
+    const actions = analyticsActions({ funnel: funnel(), channels: [], pages: [] }, CONFIGURED);
+    expect(actions.map((a) => a.id)).not.toContain("no-win-defined");
+  });
+
+  it("★does not call an ordinary traffic mix a concentration", () => {
+    // The failure this guards: most small businesses are direct- or
+    // search-dominated, and telling every one of them they are over-reliant is
+    // noise dressed as a finding.
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [
+          { channel: "Direct", sessions: 55, conversions: 0 },
+          { channel: "Organic Search", sessions: 45, conversions: 0 },
+        ],
+        pages: [],
+      },
+      CONFIGURED,
+    );
+    expect(actions.map((a) => a.id).join()).not.toContain("channel-concentration");
+  });
+
+  it("names a genuine single-channel dependency", () => {
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [
+          { channel: "Organic Social", sessions: 80, conversions: 0 },
+          { channel: "Direct", sessions: 20, conversions: 0 },
+        ],
+        pages: [],
+      },
+      CONFIGURED,
+    );
+    const hit = actions.find((a) => a.id.startsWith("channel-concentration"));
+    expect(hit?.title).toContain("80%");
+    expect(hit?.title).toContain("Organic Social");
+  });
+
+  it("fires exactly at the threshold, not just past it", () => {
+    const top = Math.round(CHANNEL_CONCENTRATION * 100);
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [
+          { channel: "Direct", sessions: top, conversions: 0 },
+          { channel: "Referral", sessions: 100 - top, conversions: 0 },
+        ],
+        pages: [],
+      },
+      CONFIGURED,
+    );
+    expect(actions.some((a) => a.id.startsWith("channel-concentration"))).toBe(true);
+  });
+
+  it("★never calls a single page a concentration", () => {
+    // One page is 100% of one page. That is arithmetic, not a finding, and
+    // shipping it would put a confident recommendation on every brand-new site.
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [],
+        pages: [{ pagePath: "/", views: 500, engagementRatePct: 70, conversions: 0 }],
+      },
+      CONFIGURED,
+    );
+    expect(actions.map((a) => a.id)).not.toContain("page-concentration");
+  });
+
+  it("names the page carrying the site when there are others to compare", () => {
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [],
+        pages: [
+          { pagePath: "/guides/turnaround", views: 500, engagementRatePct: 70, conversions: 0 },
+          { pagePath: "/about", views: 100, engagementRatePct: 40, conversions: 0 },
+        ],
+      },
+      CONFIGURED,
+    );
+    const hit = actions.find((a) => a.id === "page-concentration");
+    expect(hit?.title).toContain("/guides/turnaround");
+  });
+
+  it("flags low engagement, and stays quiet on healthy engagement", () => {
+    const low = analyticsActions(
+      { funnel: funnel({ engagementRatePct: LOW_ENGAGEMENT_PCT - 1 }), channels: [], pages: [] },
+      CONFIGURED,
+    );
+    expect(low.map((a) => a.id)).toContain("low-engagement");
+
+    const fine = analyticsActions(
+      { funnel: funnel({ engagementRatePct: LOW_ENGAGEMENT_PCT }), channels: [], pages: [] },
+      CONFIGURED,
+    );
+    expect(fine.map((a) => a.id)).not.toContain("low-engagement");
+  });
+
+  it("★says nothing about engagement on a site with no sessions", () => {
+    // A brand-new property reports engagementRatePct 0 over 0 sessions.
+    // "100% of visits end without engagement" about nobody is the sort of
+    // confident nonsense that makes a customer stop trusting the whole page.
+    const actions = analyticsActions(
+      { funnel: funnel({ sessions: 0, engagementRatePct: 0 }), channels: [], pages: [] },
+      CONFIGURED,
+    );
+    expect(actions.map((a) => a.id)).not.toContain("low-engagement");
+  });
+
+  it("★ignores a delta when there is no comparison to make", () => {
+    // `hasComparison: false` is a first week, not a flat one. Reading
+    // `trend.sessions.deltaPct` regardless is how a new property gets told its
+    // traffic collapsed.
+    const actions = analyticsActions(
+      {
+        funnel: funnel(),
+        channels: [],
+        pages: [],
+        digest: {
+          hasComparison: false,
+          headline: "",
+          trend: {
+            sessions: { now: 10, prev: 0, deltaPct: NOTABLE_DROP_PCT - 20 },
+            totalUsers: { now: 10, prev: 0, deltaPct: null },
+            conversions: { now: 0, prev: 0, deltaPct: null },
+            engagementRate: { now: 0.5, prev: 0.5, delta: null },
+          },
+          movements: [],
+        },
+      },
+      CONFIGURED,
+    );
+    expect(actions.map((a) => a.id)).not.toContain("sessions-drop");
+  });
+
+  it("puts the most severe finding first", () => {
+    const actions = analyticsActions(
+      {
+        funnel: funnel({ engagementRatePct: 20 }),
+        channels: [{ channel: "Direct", sessions: 100, conversions: 0 }],
+        pages: [],
+        digest: {
+          hasComparison: true,
+          headline: "",
+          trend: {
+            sessions: { now: 50, prev: 100, deltaPct: -50 },
+            totalUsers: { now: 40, prev: 90, deltaPct: -55 },
+            conversions: { now: 0, prev: 0, deltaPct: null },
+            engagementRate: { now: 0.2, prev: 0.4, delta: -0.2 },
+          },
+          movements: [],
+        },
+      },
+      { winConfigured: false },
+    );
+    expect(actions[0]?.severity).toBe("critical");
+    expect(actions[0]?.id).toBe("sessions-drop");
+  });
+});

--- a/src/lib/analytics-actions.ts
+++ b/src/lib/analytics-actions.ts
@@ -59,7 +59,10 @@ export const LOW_ENGAGEMENT_PCT = 40;
 export const NOTABLE_DROP_PCT = -25;
 
 export function analyticsActions(
-  data: Pick<AnalyticsInsightsResponse, "funnel" | "channels" | "pages" | "digest">,
+  data: Pick<
+    AnalyticsInsightsResponse,
+    "funnel" | "channels" | "pages" | "digest" | "lockedPages"
+  >,
   opts: { winConfigured: boolean },
 ): AnalyticsAction[] {
   const actions: AnalyticsAction[] = [];
@@ -104,9 +107,17 @@ export function analyticsActions(
   }
 
   // ── One page IS the site ────────────────────────────────────────────────
+  //
+  // ★ONLY WHEN WE HAVE THE WHOLE LIST. `pages` is TRUNCATED on the Free plan —
+  // the api sends the top three and puts the rest behind `lockedPages` — so the
+  // denominator here would be three pages rather than the site. Every Free
+  // business with more than one page would be told a single page is "56% of
+  // everything read on your site", computed against a list we chose. A share is
+  // only sayable when nothing is missing from underneath it.
   const totalViews = pages.reduce((sum, p) => sum + p.views, 0);
   const topPage = [...pages].sort((a, b) => b.views - a.views)[0];
-  if (topPage && totalViews > 0) {
+  const haveEveryPage = (data.lockedPages ?? 0) === 0;
+  if (topPage && totalViews > 0 && haveEveryPage) {
     const share = topPage.views / totalViews;
     // ★AND ONLY WHEN THERE IS SOMETHING TO BE CONCENTRATED AGAINST. A single
     // page is 100% of one page, which is arithmetic rather than a finding.

--- a/src/lib/analytics-actions.ts
+++ b/src/lib/analytics-actions.ts
@@ -1,0 +1,159 @@
+import type { AnalyticsInsightsResponse } from "@/hooks/use-analytics-insights";
+
+/**
+ * What a customer should DO about their web analytics, derived from the numbers
+ * the dashboard already has.
+ *
+ * ★DETERMINISTIC AND FREE, WHICH IS THE POINT. The page already carries a
+ * model-written gloss (`ExplainCard`) — it is metered, so a customer clicks it
+ * only if they already suspect there is something worth reading, and most never
+ * will. "What should I do next" is the one thing on an analytics screen that
+ * must never sit behind a spend. So it is computed here, from data already on
+ * the response, at no cost.
+ *
+ * ★EXTRACTED SO THE JUDGEMENT CAN BE TESTED. This repo runs vitest in node with
+ * no DOM by design, so the rendering is not what gets asserted — the thresholds
+ * are, and every one of them is a claim about somebody's business that a badly
+ * chosen constant turns into confident noise.
+ *
+ * ★AND THE LIST IS SHORT ON PURPOSE. Four rules, each of which a non-marketer
+ * can act on this week. A screen that surfaces nine "insights" is the metric
+ * dashboard this page is trying to stop being, wearing different clothes.
+ */
+
+export interface AnalyticsAction {
+  id: string;
+  severity: "critical" | "attention" | "opportunity";
+  title: string;
+  detail: string;
+  href?: string;
+  cta?: string;
+  /** Opens the "what counts as a win" dialog rather than navigating. */
+  opensWinDialog?: boolean;
+}
+
+/**
+ * Share of sessions from ONE channel above which the concentration is the
+ * story. Two thirds is deliberately high: most small businesses are direct- or
+ * search-dominated and telling every one of them they are over-reliant would be
+ * noise rather than a finding.
+ */
+export const CHANNEL_CONCENTRATION = 0.66;
+
+/** Share of page views on ONE page above which that page IS the site, as far as
+ *  visitors are concerned. */
+export const PAGE_CONCENTRATION = 0.3;
+
+/**
+ * Engagement rate below which most visits are bounces.
+ *
+ * ★GA4's OWN DEFINITION, NOT A ROUND NUMBER WE LIKED. An engaged session is one
+ * lasting 10+ seconds, or with a key event, or with 2+ page views — so below
+ * this most people are arriving and leaving without reading anything, which is
+ * a content or an expectation problem rather than a traffic one.
+ */
+export const LOW_ENGAGEMENT_PCT = 40;
+
+/** A week-over-week fall past this is worth naming as a thing to look at
+ *  rather than leaving in the movements list. */
+export const NOTABLE_DROP_PCT = -25;
+
+export function analyticsActions(
+  data: Pick<AnalyticsInsightsResponse, "funnel" | "channels" | "pages" | "digest">,
+  opts: { winConfigured: boolean },
+): AnalyticsAction[] {
+  const actions: AnalyticsAction[] = [];
+  const funnel = data.funnel;
+  const channels = data.channels ?? [];
+  const pages = data.pages ?? [];
+
+  // ── Nothing is counting outcomes ────────────────────────────────────────
+  //
+  // ★FIRST, BECAUSE EVERY OTHER NUMBER ON THE PAGE IS WORTH LESS WITHOUT IT.
+  // Traffic with no definition of a win is a number nobody can act on, and the
+  // page has been showing a permanent "Conversions: 0" tile over real visitors
+  // rather than saying so.
+  if (!opts.winConfigured) {
+    actions.push({
+      id: "no-win-defined",
+      severity: "attention",
+      title: "Nothing here is counting outcomes",
+      detail:
+        "We can see who visits, but not what you'd call a good result. Tell us once and every number on this page gets an answer to “so what?”.",
+      cta: "Tell us what counts",
+      opensWinDialog: true,
+    });
+  }
+
+  // ── One channel is doing all the work ───────────────────────────────────
+  const totalSessions = channels.reduce((sum, c) => sum + c.sessions, 0);
+  const topChannel = [...channels].sort((a, b) => b.sessions - a.sessions)[0];
+  if (topChannel && totalSessions > 0) {
+    const share = topChannel.sessions / totalSessions;
+    if (share >= CHANNEL_CONCENTRATION) {
+      actions.push({
+        id: `channel-concentration-${topChannel.channel}`,
+        severity: "attention",
+        title: `${Math.round(share * 100)}% of your visitors come from ${topChannel.channel}`,
+        detail:
+          "That's one road in. If it narrows — an algorithm change, a link that stops being shared — the traffic goes with it. Worth building a second one before you need it.",
+        href: "/dashboard/content",
+        cta: "Plan content",
+      });
+    }
+  }
+
+  // ── One page IS the site ────────────────────────────────────────────────
+  const totalViews = pages.reduce((sum, p) => sum + p.views, 0);
+  const topPage = [...pages].sort((a, b) => b.views - a.views)[0];
+  if (topPage && totalViews > 0) {
+    const share = topPage.views / totalViews;
+    // ★AND ONLY WHEN THERE IS SOMETHING TO BE CONCENTRATED AGAINST. A single
+    // page is 100% of one page, which is arithmetic rather than a finding.
+    if (share >= PAGE_CONCENTRATION && pages.length > 1) {
+      actions.push({
+        id: "page-concentration",
+        severity: "opportunity",
+        title: `${topPage.pagePath} is doing most of the work`,
+        detail: `${Math.round(share * 100)}% of everything read on your site is this one page. Whatever it does right is the thing worth doing again.`,
+        href: "/dashboard/content",
+        cta: "Make more like it",
+      });
+    }
+  }
+
+  // ── People arrive and leave ─────────────────────────────────────────────
+  if (funnel && funnel.sessions > 0 && funnel.engagementRatePct < LOW_ENGAGEMENT_PCT) {
+    actions.push({
+      id: "low-engagement",
+      severity: "attention",
+      title: `${Math.round(100 - funnel.engagementRatePct)}% of visits end without engagement`,
+      detail:
+        "People are arriving and leaving within a few seconds. Usually the page isn't answering the question that brought them — the search terms they used are the fastest way to find out what it was.",
+      href: "/dashboard/insights/search-console",
+      cta: "See what they searched",
+    });
+  }
+
+  // ── Something fell, and it is worth a look ──────────────────────────────
+  const sessionsDelta = data.digest?.hasComparison ? data.digest.trend.sessions.deltaPct : null;
+  if (sessionsDelta !== null && sessionsDelta !== undefined && sessionsDelta <= NOTABLE_DROP_PCT) {
+    actions.push({
+      id: "sessions-drop",
+      severity: "critical",
+      // ★"BY MORE THAN A QUARTER" RATHER THAN THE FIGURE, because the exact
+      // percentage is already in the movements list right above this and a
+      // headline restating it makes the same fact look like two findings.
+      title: "Visits fell by more than a quarter this week",
+      detail:
+        "The movements above name which pages and channels moved. A fall this size is usually one of them rather than everything at once.",
+      href: "/dashboard/insights/search-console",
+      cta: "Check search",
+    });
+  }
+
+  // ★MOST SEVERE FIRST, and stable within a severity so the list does not
+  // reshuffle between renders of the same data.
+  const order = { critical: 0, attention: 1, opportunity: 2 } as const;
+  return actions.sort((a, b) => order[a.severity] - order[b.severity]);
+}

--- a/src/lib/analytics-actions.ts
+++ b/src/lib/analytics-actions.ts
@@ -40,9 +40,18 @@ export interface AnalyticsAction {
  */
 export const CHANNEL_CONCENTRATION = 0.66;
 
-/** Share of page views on ONE page above which that page IS the site, as far as
- *  visitors are concerned. */
-export const PAGE_CONCENTRATION = 0.3;
+/**
+ * Share of page views on ONE page above which that page IS the site, as far as
+ * visitors are concerned.
+ *
+ * ★A MAJORITY, BECAUSE THE HEADLINE SAYS "MOST OF THE WORK". At 0.3 a four-page
+ * site with a 31% top page was told one page was doing most of the work while
+ * the detail line underneath quoted 31% — the card disagreeing with itself in
+ * two lines. Either the number or the word had to move, and "most" is the part
+ * worth keeping: a page carrying a third of a site is not a finding anybody can
+ * act on differently from one carrying a quarter.
+ */
+export const PAGE_CONCENTRATION = 0.5;
 
 /**
  * Engagement rate below which most visits are bounces.

--- a/src/lib/api/audiences.test.ts
+++ b/src/lib/api/audiences.test.ts
@@ -25,7 +25,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock("@/lib/api", () => ({ api: { get: h.get, post: h.post, patch: h.patch } }));
 
-const { audiencesApi } = await import("./audiences");
+const { audiencesApi, AUDIENCE_OBJECTIVES } = await import("./audiences");
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -76,5 +76,37 @@ describe("audiencesApi", () => {
     ]);
     const body = h.patch.mock.calls[0]![1] as { corrections: Array<{ field: string }> };
     expect(body.corrections.map((c) => c.field)).toEqual(["icp", "painPoints"]);
+  });
+
+  it("plans a portfolio on the platform-agnostic path", async () => {
+    h.post.mockResolvedValue({ planId: "p1", sets: [], refusal: null });
+    await audiencesApi.plan({ objective: "lead_generation" });
+    expect(h.post).toHaveBeenCalledWith("/v1/audiences/plan", {
+      objective: "lead_generation",
+    });
+  });
+
+  it("★does not send a `geo` key when the caller has none", async () => {
+    // The api treats an ABSENT `geo` as "use what the profile says" and an
+    // EMPTY array as the user saying none of these apply — the same
+    // distinction `/propose` makes. A client that helpfully defaulted the key
+    // to `[]` would turn "we inferred India" into "the user told us nowhere",
+    // and the plan would refuse with `no_geography`.
+    h.post.mockResolvedValue({ planId: null, sets: [], refusal: null });
+    await audiencesApi.plan({ objective: "engagement", platform: "linkedin" });
+    const body = h.post.mock.calls[0]![1] as Record<string, unknown>;
+    expect("geo" in body).toBe(false);
+  });
+
+  it("★offers exactly the objectives the api's enum accepts", async () => {
+    // A value the server does not recognise is a 400, which a customer reads
+    // as "the button is broken" — the same accepted-then-ignored failure the
+    // library's filters are built around. Mirrored from `PlanBody.objective`.
+    expect([...AUDIENCE_OBJECTIVES]).toEqual([
+      "lead_generation",
+      "brand_awareness",
+      "website_traffic",
+      "engagement",
+    ]);
   });
 });

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -175,6 +175,80 @@ export interface ProposalResponse {
   } | null;
 }
 
+/**
+ * What a planning session may be run FOR. The api's own enum
+ * (`PlanBody.objective`), and it is short on purpose: D13 settled v1's input as
+ * "objective + confirmed geography", one screen, no facet-picking. Anything
+ * this list does not contain is a 400, so it is never widened here first.
+ */
+export const AUDIENCE_OBJECTIVES = [
+  "lead_generation",
+  "brand_awareness",
+  "website_traffic",
+  "engagement",
+] as const;
+
+export type AudienceObjective = (typeof AUDIENCE_OBJECTIVES)[number];
+
+/**
+ * ONE audience out of a planning session, as `POST /plan` returns it.
+ *
+ * ★`id` IS NULLABLE AND THAT IS THE WHOLE POINT OF READING IT. The api builds
+ * the portfolio, then persists it — and a persistence failure degrades the
+ * answer instead of destroying it, because the sets cost a strong-model call
+ * and four rounds of platform typeaheads. A set with an id is in the library
+ * and can be put on a campaign; a set WITHOUT one can only be read. Rendering
+ * the two identically is exactly the failure the api's `persisted` flag exists
+ * to make visible.
+ */
+export interface PlannedAudience {
+  id: string | null;
+  label: string;
+  description?: string;
+  rationale?: string;
+  archetype?: string;
+  /** §15's prose — who this audience is, in the customer's own terms. It may
+   *  not restate a reach or a score; the writer refuses prose that does. */
+  explanation?: string;
+  /** The engine arguing AGAINST its own suggestion — too narrow, too broad,
+   *  overlapping, evidence-free. Nothing is filtered or reordered because of
+   *  it: showing the customer the objection beats letting an unreviewable
+   *  model call quietly drop an audience. */
+  critique?: string[];
+  /** Platform-sourced only. `belowFloor` carries NO number, deliberately. */
+  reach?: { supported: boolean; value?: number; belowFloor?: boolean; fetchedAt?: string };
+  /** What we wanted to express and the channel could not. Surfaced, never
+   *  dropped — a lost include makes the audience BROADER, not narrower. */
+  unresolved?: Array<{ attribute: string; value: string; reason: string }>;
+  basis?: Array<{ attribute: string; values: string[] }>;
+  scores?: Record<string, number>;
+}
+
+/**
+ * A planning session.
+ *
+ * ★A REFUSAL IS A 200 WITH A REASON, like `/propose`. "We don't know where you
+ * operate" is a question for the customer, not a failed request, and a client
+ * that renders it as an error hides the one thing they could fix.
+ *
+ * ★AND `strategist` IS NOT DEBUG OUTPUT. `rejected` + `dropped` are the ideas
+ * that did not survive — a five-hypothesis plan that loses four would otherwise
+ * render as a one-audience portfolio reading "this is all there was".
+ */
+export interface AudiencePlanResponse {
+  planId: string | null;
+  sets: PlannedAudience[];
+  /** True only when EVERY set landed in the library. A partial write still
+   *  returns ids for the ones that did. */
+  persisted?: boolean;
+  refusal: { reason: string; message: string } | null;
+  strategist?: {
+    generated: boolean;
+    rejected?: Array<{ label?: string; reason: string }>;
+    dropped?: Array<{ label?: string; reason: string }>;
+  };
+}
+
 export const audiencesApi = {
   /** What we understand about this business. `profile: null` is a first-class
    *  answer — nobody has asked for audiences yet — not an error. */
@@ -198,6 +272,37 @@ export const audiencesApi = {
    */
   propose: (body: { geo?: string[] } = {}) =>
     api.post<ProposalResponse>("/v1/audiences/propose", body),
+
+  /**
+   * Discover a PORTFOLIO of audiences from what we already understand about
+   * this business (§8).
+   *
+   * ★THE HERO FEATURE, AND UNTIL THIS METHOD NOTHING HAD EVER CALLED IT. The
+   * api has shipped the whole chain since B2 — strategist hypotheses in
+   * business language, deterministic resolution against the platform's own
+   * typeahead, real reach counts, deterministic scoring, an adversarial
+   * critique, overlap exclusions and plain-English prose — and `grep -rn
+   * "/v1/audiences/plan" src` returned nothing, so `biz_audience_plans` had
+   * zero rows in every environment. The Audiences page therefore showed only
+   * what a customer had typed in themselves, which reads as a filing cabinet
+   * rather than a strategist.
+   *
+   * ★IT NEEDS NO CAMPAIGN HISTORY. The inputs are the business profile (built
+   * from the site, the business record and published content) plus an
+   * objective; a business that has never advertised gets a full portfolio.
+   *
+   * ★IT WRITES, AND IT SPENDS NOTHING. Each audience is persisted as a named,
+   * reusable library row — that is what makes it appliable to a campaign
+   * later — but no campaign is touched and no budget moves. Applying is a
+   * separate act and activating is a further one.
+   *
+   * Expensive by construction (a strong-model call plus up to four rounds of
+   * platform typeaheads and reach calls), which is why the api rate-limits it
+   * per org and why this is an explicit action rather than something a page
+   * fires on mount.
+   */
+  plan: (body: { objective: AudienceObjective; platform?: string; geo?: string[] }) =>
+    api.post<AudiencePlanResponse>("/v1/audiences/plan", body),
 
   correctProfile: (corrections: CorrectionInput[]) =>
     api.patch<{ profile: AudienceProfile }>("/v1/audiences/profile", { corrections }),
@@ -271,6 +376,26 @@ export interface AudienceSet {
     cites?: string[];
   };
   channels: AudienceChannel[];
+  /**
+   * §15's prose — who this audience is, in the customer's own terms.
+   *
+   * ★WRITTEN BY THE ENGINE ON EVERY PLANNED SET SINCE B2, STORED ON THE ROW,
+   * RETURNED BY `GET /sets`, AND NEVER DECLARED HERE — so the library rendered
+   * chips of attribute values where a sentence explaining the idea already
+   * existed. The three fields below are the same shape of omission: the api
+   * passes the whole document through `serializeSet`, and a field this type
+   * does not name is a field no card can draw.
+   */
+  explanation?: string;
+  /** Why the engine thinks this audience is worth running, one line. */
+  rationale?: string;
+  /** The engine's own objections to its suggestion. Never used to filter or
+   *  reorder — an objection is shown, not acted on. */
+  critique?: string[];
+  /** Deterministic quality scoring (§9). Same profile, objective and registry →
+   *  same numbers; absent when the config collection was unreadable, and its
+   *  absence is the honest answer rather than a zero. */
+  scores?: Record<string, number>;
   /** Every hand-correction to this audience's targeting. The count is the
    *  interesting figure on a list: an audience corrected four times is one we
    *  keep getting wrong. */

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -369,6 +369,20 @@ export interface AudienceSet {
   description?: string;
   source: AudienceSource;
   status: AudienceSetStatus;
+  /**
+   * What the planning session that produced this audience was FOR.
+   *
+   * ★THE ONE FIELD THAT MAKES "RECOMMENDED FOR THIS CAMPAIGN" SAYABLE.
+   * `ad_campaigns.objective` and `PlanBody.objective` are the same four-value
+   * enum, so a campaign and an audience can be matched on it directly with no
+   * mapping table in between — and an audience planned to get enquiries is a
+   * genuinely different suggestion from one planned to get reach.
+   *
+   * Absent on an audience nobody planned: one built by hand, or read off a
+   * campaign that ran. That absence is why they belong under "Saved" rather
+   * than under a recommendation heading.
+   */
+  objective?: AudienceObjective;
   archetype?: string;
   hypothesis?: {
     attributes: AudienceHypothesisAttribute[];

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -26,6 +26,54 @@ export type ProposalStatus = "proposed" | "approved" | "dismissed" | "applied" |
  *  `proposed` — fix the cause (reconnect / envelope) and decide again. */
 export type DecisionStatus = "approved" | "dismissed" | "applied" | "failed" | "retryable";
 
+/**
+ * Outcomes (v1).
+ *
+ * ★THE ABSENCES ARE TYPED, WHICH IS THE WHOLE POINT OF THIS SHAPE. `paid: null`
+ * is "this business has no paid channel", not "zero"; `conversions.configured:
+ * false` carries a REASON and no count, so no client can render a business
+ * nobody has ever counted a win for as one that had none. Those are different
+ * facts and only one of them is a verdict on the customer's marketing.
+ */
+export interface OutcomesResponse {
+  period: { days: number; since: string; until: string };
+  reach: {
+    organic: {
+      impressions: number;
+      posts: number;
+      byPlatform: Array<{ platform: string; impressions: number; posts: number }>;
+    };
+    paid: { impressions: number; campaigns: number; spend: number; currency?: string } | null;
+    site: {
+      sessions: number;
+      users: number;
+      /** Null on a first period AND on stale data — a comparison computed
+       *  across a sync that stopped is the most confident wrong number a
+       *  dashboard can produce. */
+      sessionsDeltaPct: number | null;
+      dataThrough: string | null;
+      stale: boolean;
+    } | null;
+  };
+  attention: {
+    organic: { engagements: number; clicks: number; ratePct: number | null };
+    paid: { clicks: number; ctrPct: number | null } | null;
+  };
+  conversions:
+    | { configured: true; count: number; source: "analytics"; costPer: number | null; currency?: string }
+    | { configured: false; reason: "not_connected" | "no_key_event"; message: string };
+  headline: string;
+  movements: Array<{ direction: "up" | "down" | "flat"; text: string }>;
+  nextActions: Array<{
+    id: string;
+    severity: "critical" | "attention" | "opportunity";
+    title: string;
+    detail: string;
+    href?: string;
+    cta?: string;
+  }>;
+}
+
 export interface GrowthSettings {
   optimizerEnabled?: boolean;
   autonomyLevel?: number;
@@ -113,6 +161,20 @@ export const growthApi = {
     }>(
       `/v1/growth/adjustments/${runId}/proposals/${proposalId}/${decision}`,
     ),
+
+  /**
+   * What happened, what it means, and what to do next (Outcomes v1).
+   *
+   * ★DETERMINISTIC AND FREE. Every figure is read off rows the platform already
+   * holds — no model call in the path, so no per-view cost and no chance of a
+   * sentence that disagrees with the number beside it.
+   *
+   * ★AND IT SPEAKS BEFORE ANY MONEY IS SPENT. `reach.paid` is null rather than
+   * a block of zeros until a campaign has actually served; organic reach and
+   * site traffic carry the page until then, which is the state a business is in
+   * for its first months.
+   */
+  outcomes: (days = 28) => api.get<OutcomesResponse>(`/v1/growth/outcomes?days=${days}`),
 
   /** Per-business growth settings (the optimizer opt-in and the advertising
    *  declaration live here), plus the notice version in force. */

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -60,7 +60,17 @@ export interface OutcomesResponse {
     paid: { clicks: number; ctrPct: number | null } | null;
   };
   conversions:
-    | { configured: true; count: number; source: "analytics"; costPer: number | null; currency?: string }
+    | {
+        configured: true;
+        count: number;
+        source: "analytics" | "inbox";
+        /** What the customer calls it. Present only once they've chosen — the
+         *  page says "wins" until then, because naming it for them is how a
+         *  headline ends up reading "23 generate_lead this week". */
+        label?: string;
+        costPer: number | null;
+        currency?: string;
+      }
     | { configured: false; reason: "not_connected" | "no_key_event"; message: string };
   headline: string;
   movements: Array<{ direction: "up" | "down" | "flat"; text: string }>;
@@ -72,6 +82,33 @@ export interface OutcomesResponse {
     href?: string;
     cta?: string;
   }>;
+}
+
+/** What a business counts as a win. Absent until they've chosen — and absence
+ *  is never rendered as a zero. */
+export interface WinDefinition {
+  source: "analytics_key_event" | "inbox_lead";
+  eventName?: string;
+  label: string;
+  setAt?: string;
+}
+
+/**
+ * The choices on offer, and only ones we can genuinely count.
+ *
+ * ★`keyEvents.available: false` IS NOT AN EMPTY LIST. "We asked your property
+ * and it has none" and "we couldn't ask" are different sentences, and the
+ * `reason` says which — a screen that collapsed them would tell somebody to go
+ * and create a key event they may already have.
+ */
+export interface WinOptionsResponse {
+  current: WinDefinition | null;
+  keyEvents: {
+    available: boolean;
+    reason?: "not_connected" | "no_property" | "lookup_failed";
+    events: Array<{ eventName: string; custom: boolean }>;
+  };
+  inbox: { available: boolean };
 }
 
 export interface GrowthSettings {
@@ -176,6 +213,9 @@ export const growthApi = {
    */
   outcomes: (days = 28) => api.get<OutcomesResponse>(`/v1/growth/outcomes?days=${days}`),
 
+  /** What this business could count as a win, and what it currently does. */
+  winOptions: () => api.get<WinOptionsResponse>("/v1/growth/win-options"),
+
   /** Per-business growth settings (the optimizer opt-in and the advertising
    *  declaration live here), plus the notice version in force. */
   settings: () => api.get<GrowthSettingsResponse>("/v1/growth/settings"),
@@ -194,5 +234,12 @@ export const growthApi = {
     optimizerEnabled?: boolean;
     weeklyBudgetEnvelope?: number | null;
     notPolitical?: boolean;
+    /** `null` clears it — and clearing is an unset server-side, so "nobody has
+     *  chosen" stays the single reading of absence. */
+    winDefinition?: {
+      source: WinDefinition["source"];
+      eventName?: string;
+      label: string;
+    } | null;
   }) => api.patch<GrowthSettingsResponse>("/v1/growth/settings", patch),
 };

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -112,6 +112,11 @@ export interface WinOptionsResponse {
 }
 
 export interface GrowthSettings {
+  /** What this business counts as a win, if anything. Read from here rather
+   *  than from `winOptions()` wherever a surface only needs to know WHETHER one
+   *  is set — this comes off a Mongo projection, while `winOptions()` refreshes
+   *  an OAuth token and calls Google's Admin API. */
+  winDefinition?: WinDefinition;
   optimizerEnabled?: boolean;
   autonomyLevel?: number;
   weeklyBudgetEnvelope?: number;

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -128,6 +128,31 @@ export function attributeLabel(attribute: string): string {
   return ATTRIBUTE_LABEL[attribute] ?? attribute.replace(/_/g, " ");
 }
 
+/**
+ * What a planning objective is called, in the customer's terms rather than the
+ * ad platform's.
+ *
+ * ★SHARED, BECAUSE TWO SURFACES NAME THE SAME FOUR THINGS. The discovery
+ * dialog offers them as a choice; the campaign picker uses one as a heading
+ * ("Recommended for getting enquiries"). Two copies drift, and the drift shows
+ * up as a customer picking "Get enquiries" and being shown a section headed
+ * "Lead generation".
+ *
+ * An objective we do not recognise renders under its own identifier rather than
+ * vanishing — the api's enum is the authority and a value it adds before this
+ * map does must still be nameable.
+ */
+const OBJECTIVE_LABEL: Record<string, string> = {
+  lead_generation: "getting enquiries",
+  website_traffic: "getting visitors",
+  brand_awareness: "getting known",
+  engagement: "getting engagement",
+};
+
+export function objectiveLabel(objective: string): string {
+  return OBJECTIVE_LABEL[objective] ?? objective.replace(/_/g, " ");
+}
+
 /** Channel display names. Unknown platforms render under their own key rather
  *  than being hidden — a channel we cannot name is still a channel this
  *  audience works on. */


### PR DESCRIPTION
Four Growth changes. Needs peakhour-api#1068 for the Outcomes page.

## 1. The audience engine had no button

`POST /v1/audiences/plan` has shipped the whole chain since B2 — strategist hypotheses reasoned in business language, resolved deterministically against LinkedIn's own typeahead, counted for real reach, scored, argued against by a critic, de-overlapped, explained in prose, persisted as reusable library rows. It needs no campaign history.

`grep -rn "/v1/audiences/plan" src` returned **nothing**. `biz_audience_plans` holds zero rows in every environment. The Audiences page could only ever list what someone typed in by hand, and its empty state told them to wait for suggestions nothing was ever going to ask for.

- `audiencesApi.plan()` — the first caller the route has ever had.
- `DiscoverAudiencesDialog` — one question, because the engine already knows the industry, market, seniorities and geography. A refusal is a 200 with a reason and renders as one.
- A missing ads connection is the one error with a customer-performable fix, and it says *why* we need it: we size audiences against the real platform rather than estimating, because a made-up reach is the number a customer divides their budget by.

## 2. "Set audience" leads with what this campaign is for

It was two buttons — **"Set audience"** opened a blank LinkedIn facet picker, and our recommendations were behind a smaller one labelled **"Saved"**. So the default path was a person hand-picking URNs while an engine that had already worked out who to target sat one button to the right.

This has already cost a live campaign: *"Boost: Air India Limited…"* has been active since 30 July with no audience at all, because the Apply button in that facet dialog stays disabled until a location is picked and someone activated anyway.

Now one dialog, three groups:
- **Recommended for getting enquiries** — ours, planned for *this campaign's* objective. `ad_campaigns.objective` and `PlanBody.objective` are the same four-value enum, so they match directly with no mapping table.
- **Other suggestions** — exists so nothing disappears; dropping them would quietly bin work a customer paid a model call for.
- **Saved** — only what the customer chose to keep. Nothing we proposed lands there.

The section can work out fresh recommendations in place. It does **not** ask for the objective (the campaign answers it) and does **not** fire on open — one run is a strong-model call plus up to four rounds of platform typeaheads, and opening a dialog is not consent to spend that.

## 3. Outcomes v1

The page said "Coming Soon" and promised *"23 new customers this week at $12 each"*. For Quests Travel that renders 0 customers and no cost per customer — 0 conversions across 90 days and all 7 GA4 channels, because their property has no key event.

The order is the argument: one sentence about what happened, then what needs a person, then what moved, then the numbers last and small. "Did it turn into anything?" is either a real count or a **named absence with no number in it**.

## 4. Optimizer shows its work before it has any

The bare "No reviews yet" was true and useless: on a test account the optimizer's honest answer is "a quiet week" every week, so the empty state was the only thing anyone could ever see. It now renders a worked example in the real card's shape — real evidence / expected-effect / rollback structure — marked as an example in three places with Approve and Dismiss disabled and a reason on hover.

`SampleProposalRow` is its own component rather than a `sample` flag on `ProposalRow`: a live card that can be put into a mode where Approve does nothing is one prop away from doing nothing on a real proposal.

## Also

`AudienceSet.explanation` / `rationale` / `critique` / `scores` / `objective` were written on every planned set since B2 and returned by `GET /sets` all along — no client type declared them, so no card could draw them. The library card and the campaign picker now read the prose the engine has been writing for months.

Type-checks, lints clean, 276 lib tests pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)