### PR TITLE
fix(growth): the critique rendered as "[object Object]" on the audience card

### DIFF
--- a/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/[id]/page.tsx
@@ -14,6 +14,7 @@ import { audienceLibraryApi } from "@/lib/api/audiences";
 import { useAuth } from "@/providers/auth-provider";
 import {
   audienceShape,
+  critiqueTone,
   detailChannels,
   historyLine,
   originIsOurs,
@@ -119,7 +120,31 @@ export default function AudienceDetailPage({ params }: { params: Promise<{ id: s
                 {originLabel(row.source)}
               </Badge>
             </div>
-            {row.description && <p className="text-muted-foreground">{row.description}</p>}
+            {/* ★THE DEEPER SURFACE MUST NOT SHOW LESS THAN THE CARD THAT LINKS
+                TO IT. This page rendered `description` — the one-line label —
+                while the list card rendered `explanation`, §15's prose about
+                who these people actually are. So clicking through to "find out
+                more" lost the most informative sentence we have. `GET /sets/:id`
+                has always returned both. */}
+            {(row.explanation ?? row.description) && (
+              <p className="text-muted-foreground">{row.explanation ?? row.description}</p>
+            )}
+            {/* ★AND THE ENGINE'S OBJECTIONS TO ITS OWN SUGGESTION, for the same
+                reason. This is the screen somebody opens before putting an
+                audience on a campaign, which makes it the last place an
+                argument against it is still useful. */}
+            {row.critique?.length ? (
+              <ul className="space-y-0.5">
+                {row.critique.map((c, i) => {
+                  const tone = critiqueTone(c.severity);
+                  return (
+                    <li key={`${c.code}-${i}`} className={tone.className}>
+                      <span className="font-medium">{tone.lead}</span> {c.note}
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : null}
             {(() => {
               const history = historyLine(row);
               const outcome = outcomeLine(row.outcome);

--- a/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
@@ -8,6 +8,7 @@ import type { AudienceSet } from "@/lib/api/audiences";
 import {
   audienceShape,
   channelNotes,
+  critiqueTone,
   historyLine,
   originIsOurs,
   originLabel,
@@ -161,19 +162,14 @@ export function AudienceSetCard({ set }: { set: AudienceSet }) {
             because of it. */}
         {set.critique?.length ? (
           <ul className="space-y-0.5">
-            {set.critique.map((c, i) => (
-              <li
-                key={`${c.code}-${i}`}
-                className={
-                  c.severity === "warn"
-                    ? "text-xs text-amber-700 dark:text-amber-300"
-                    : "text-xs text-muted-foreground"
-                }
-              >
-                {c.severity === "warn" ? "Worth knowing: " : ""}
-                {c.note}
-              </li>
-            ))}
+            {set.critique.map((c, i) => {
+              const tone = critiqueTone(c.severity);
+              return (
+                <li key={`${c.code}-${i}`} className={tone.className}>
+                  <span className="font-medium">{tone.lead}</span> {c.note}
+                </li>
+              );
+            })}
           </ul>
         ) : null}
 

--- a/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
+++ b/src/app/(site)/dashboard/growth/audiences/_components/audience-set-card.tsx
@@ -153,6 +153,30 @@ export function AudienceSetCard({ set }: { set: AudienceSet }) {
           )}
         </div>
 
+        {/* ★THE ENGINE ARGUING AGAINST ITS OWN SUGGESTION, on the surface where
+            the customer decides whether to use it. `critique` was typed on this
+            model and read by nothing — a field with a type and no reader, which
+            is the same dead-code shape this whole engine kept producing. It is
+            shown, never acted on: no set is filtered, reordered or downweighted
+            because of it. */}
+        {set.critique?.length ? (
+          <ul className="space-y-0.5">
+            {set.critique.map((c, i) => (
+              <li
+                key={`${c.code}-${i}`}
+                className={
+                  c.severity === "warn"
+                    ? "text-xs text-amber-700 dark:text-amber-300"
+                    : "text-xs text-muted-foreground"
+                }
+              >
+                {c.severity === "warn" ? "Worth knowing: " : ""}
+                {c.note}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
         {(history || outcome) && (
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t pt-2 text-xs text-muted-foreground">
             {history && <span>{history}</span>}

--- a/src/components/audience/discover-audiences-dialog.tsx
+++ b/src/components/audience/discover-audiences-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { Check, Sparkles } from "lucide-react";
+import { critiqueTone } from "@/lib/audience-library-rules";
 import { useAudiencePlan, planRefusalCopy } from "@/hooks/use-audience-plan";
 import {
   AUDIENCE_OBJECTIVES,
@@ -224,19 +225,14 @@ function PlanSummary({ result }: { result: AudiencePlanResponse }) {
                 a customer and the code is for us. */}
             {s.critique?.length ? (
               <ul className="mt-1 space-y-0.5">
-                {s.critique.map((c, ci) => (
-                  <li
-                    key={`${c.code}-${ci}`}
-                    className={
-                      c.severity === "warn"
-                        ? "text-xs text-amber-700 dark:text-amber-300"
-                        : "text-xs text-muted-foreground"
-                    }
-                  >
-                    {c.severity === "warn" ? "Worth knowing: " : ""}
-                    {c.note}
-                  </li>
-                ))}
+                {s.critique.map((c, ci) => {
+                  const tone = critiqueTone(c.severity);
+                  return (
+                    <li key={`${c.code}-${ci}`} className={tone.className}>
+                      <span className="font-medium">{tone.lead}</span> {c.note}
+                    </li>
+                  );
+                })}
               </ul>
             ) : null}
             {/* ★A SET WITH NO ID DID NOT REACH THE LIBRARY. It is a real

--- a/src/components/audience/discover-audiences-dialog.tsx
+++ b/src/components/audience/discover-audiences-dialog.tsx
@@ -216,11 +216,28 @@ function PlanSummary({ result }: { result: AudiencePlanResponse }) {
                 {s.explanation ?? s.description}
               </p>
             )}
-            {/* ★AND ITS OBJECTION TO ITSELF, shown rather than acted on. */}
+            {/* ★AND ITS OBJECTION TO ITSELF, shown rather than acted on.
+                ★`note`, NOT THE OBJECT. A first cut typed this as `string[]` and
+                called `.join(" ")` on it, which put `[object Object]` on the
+                card — the critic has always emitted `{code, note, severity}`.
+                The `code` stays unrendered: `note` is the sentence written for
+                a customer and the code is for us. */}
             {s.critique?.length ? (
-              <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
-                Worth knowing: {s.critique.join(" ")}
-              </p>
+              <ul className="mt-1 space-y-0.5">
+                {s.critique.map((c, ci) => (
+                  <li
+                    key={`${c.code}-${ci}`}
+                    className={
+                      c.severity === "warn"
+                        ? "text-xs text-amber-700 dark:text-amber-300"
+                        : "text-xs text-muted-foreground"
+                    }
+                  >
+                    {c.severity === "warn" ? "Worth knowing: " : ""}
+                    {c.note}
+                  </li>
+                ))}
+              </ul>
             ) : null}
             {/* ★A SET WITH NO ID DID NOT REACH THE LIBRARY. It is a real
                 audience and worth reading, but nothing can be applied to a

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -176,12 +176,6 @@ export interface ProposalResponse {
 }
 
 /**
- * What a planning session may be run FOR. The api's own enum
- * (`PlanBody.objective`), and it is short on purpose: D13 settled v1's input as
- * "objective + confirmed geography", one screen, no facet-picking. Anything
- * this list does not contain is a 400, so it is never widened here first.
- */
-/**
  * One argument the engine makes AGAINST its own suggestion.
  *
  * ★AN OBJECT, NOT A STRING, AND GETTING THAT WRONG PUT `[object Object]` ON A
@@ -192,14 +186,22 @@ export interface ProposalResponse {
  * survived two review rounds and was caught by running the engine for a real
  * business and reading the output.
  *
- * `severity` is the api's own two-value enum. `code` is a closed vocabulary
- * (`geo_mismatch`, `too_narrow`, …) and is deliberately NOT rendered: `note` is
- * the sentence written for a customer, and the code is for us.
+ * `code` is a closed vocabulary (`geo_mismatch`, `too_narrow`, …) and is
+ * deliberately NOT rendered: `note` is the sentence written for a customer, and
+ * the code is for us.
  */
 export interface AudienceCritique {
   code: string;
   note: string;
-  severity: "info" | "warn";
+  /**
+   * ★OPTIONAL, BECAUSE THE SERVER MAY NOT SEND IT. The critic writes it
+   * conditionally and `biz_audience_sets` requires only `code` and `note` — so
+   * a required field here would be the same class of mistake this whole commit
+   * is fixing: a type promising something the server does not guarantee. Both
+   * render sites already survive its absence; typing it as required is what
+   * would make the next `severity.toUpperCase()` compile and then break.
+   */
+  severity?: "info" | "warn";
 }
 
 /**
@@ -220,6 +222,12 @@ export interface AudienceScores {
   computedAt?: string;
 }
 
+/**
+ * What a planning session may be run FOR. The api's own enum
+ * (`PlanBody.objective`), and it is short on purpose: D13 settled v1's input as
+ * "objective + confirmed geography", one screen, no facet-picking. Anything
+ * this list does not contain is a 400, so it is never widened here first.
+ */
 export const AUDIENCE_OBJECTIVES = [
   "lead_generation",
   "brand_awareness",

--- a/src/lib/api/audiences.ts
+++ b/src/lib/api/audiences.ts
@@ -181,6 +181,45 @@ export interface ProposalResponse {
  * "objective + confirmed geography", one screen, no facet-picking. Anything
  * this list does not contain is a 400, so it is never widened here first.
  */
+/**
+ * One argument the engine makes AGAINST its own suggestion.
+ *
+ * ★AN OBJECT, NOT A STRING, AND GETTING THAT WRONG PUT `[object Object]` ON A
+ * CUSTOMER-FACING CARD. `critiquePortfolio` has always emitted
+ * `{ code, note, severity }` — the b2c type declared `string[]` and the cards
+ * called `.join(" ")` on it, which is the exact shape of failure a type that
+ * describes what you *assumed* rather than what the server sends produces. It
+ * survived two review rounds and was caught by running the engine for a real
+ * business and reading the output.
+ *
+ * `severity` is the api's own two-value enum. `code` is a closed vocabulary
+ * (`geo_mismatch`, `too_narrow`, …) and is deliberately NOT rendered: `note` is
+ * the sentence written for a customer, and the code is for us.
+ */
+export interface AudienceCritique {
+  code: string;
+  note: string;
+  severity: "info" | "warn";
+}
+
+/**
+ * The deterministic quality scoring (§9).
+ *
+ * ★ALSO NOT `Record<string, number>`, which is what the first cut said. It
+ * carries a nested `components` map, a human-readable `basisNote` and the
+ * scorer's own version — and a type claiming every value is a number would
+ * make `scores.basisNote` a number to every reader of this file.
+ */
+export interface AudienceScores {
+  quality: number;
+  confidence: number;
+  components?: Record<string, number>;
+  /** Why this score is what it is, in the customer's terms. */
+  basisNote?: string;
+  scorerVersion?: string;
+  computedAt?: string;
+}
+
 export const AUDIENCE_OBJECTIVES = [
   "lead_generation",
   "brand_awareness",
@@ -214,14 +253,14 @@ export interface PlannedAudience {
    *  overlapping, evidence-free. Nothing is filtered or reordered because of
    *  it: showing the customer the objection beats letting an unreviewable
    *  model call quietly drop an audience. */
-  critique?: string[];
+  critique?: AudienceCritique[];
   /** Platform-sourced only. `belowFloor` carries NO number, deliberately. */
   reach?: { supported: boolean; value?: number; belowFloor?: boolean; fetchedAt?: string };
   /** What we wanted to express and the channel could not. Surfaced, never
    *  dropped — a lost include makes the audience BROADER, not narrower. */
   unresolved?: Array<{ attribute: string; value: string; reason: string }>;
   basis?: Array<{ attribute: string; values: string[] }>;
-  scores?: Record<string, number>;
+  scores?: AudienceScores;
 }
 
 /**
@@ -405,11 +444,11 @@ export interface AudienceSet {
   rationale?: string;
   /** The engine's own objections to its suggestion. Never used to filter or
    *  reorder — an objection is shown, not acted on. */
-  critique?: string[];
+  critique?: AudienceCritique[];
   /** Deterministic quality scoring (§9). Same profile, objective and registry →
    *  same numbers; absent when the config collection was unreadable, and its
    *  absence is the honest answer rather than a zero. */
-  scores?: Record<string, number>;
+  scores?: AudienceScores;
   /** Every hand-correction to this audience's targeting. The count is the
    *  interesting figure on a list: an audience corrected four times is one we
    *  keep getting wrong. */

--- a/src/lib/audience-library-rules.test.ts
+++ b/src/lib/audience-library-rules.test.ts
@@ -35,6 +35,7 @@ import { SOURCES, STATUSES, SEARCH_MAX } from "@/app/(site)/dashboard/growth/aud
 import {
   audienceShape,
   channelNotes,
+  critiqueTone,
   detailChannels,
   gapSentence,
   historyLine,
@@ -496,5 +497,38 @@ describe("detailChannels", () => {
       "x",
     ]);
     expect(detailChannels({ channels: [] })).toEqual(["linkedin", "x"]);
+  });
+});
+
+describe("critiqueTone", () => {
+  it("★an absent severity is still an objection, not silence", () => {
+    // The api writes `severity` conditionally and `biz_audience_sets` requires
+    // only `code` and `note`. A missing one still carries a sentence somebody
+    // wrote to be read, so it must get a lead-in — treating it as "no severity,
+    // no framing" is how a real objection renders as description.
+    const tone = critiqueTone(undefined);
+    expect(tone.lead.length).toBeGreaterThan(0);
+    expect(tone).toEqual(critiqueTone("info"));
+  });
+
+  it("★the words and the colour point the same way", () => {
+    // The regression this guards: `warn` once carried the MILDER lead ("Worth
+    // knowing") while `info` carried "One caveat" — so the amber line about
+    // wasting budget read as the gentlest sentence on the card while the colour
+    // shouted. A skimming reader believes the wording.
+    const warn = critiqueTone("warn");
+    const info = critiqueTone("info");
+    expect(warn.lead).not.toBe(info.lead);
+    expect(warn.className).toContain("amber");
+    expect(info.className).not.toContain("amber");
+    // "Careful" outranks "Worth knowing"; pin the direction rather than the
+    // exact copy, so a reword cannot silently re-invert it.
+    expect(warn.lead).toBe("Careful:");
+  });
+
+  it("both severities get a visible lead-in", () => {
+    for (const s of ["info", "warn"] as const) {
+      expect(critiqueTone(s).lead.endsWith(":")).toBe(true);
+    }
   });
 });

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -153,6 +153,29 @@ export function objectiveLabel(objective: string): string {
   return OBJECTIVE_LABEL[objective] ?? objective.replace(/_/g, " ");
 }
 
+/**
+ * How to present one of the engine's objections to its own suggestion.
+ *
+ * ★AN OBJECTION HAS TO LOOK LIKE ONE. The critic's prompt reserves `warn` for
+ * money-or-misleading, so MOST findings are `info` — and rendered as plain
+ * muted text they sat in a stack of muted channel notes and status lines,
+ * indistinguishable from description. A customer skims the card and reads
+ * "targeting generic Software Development will waste budget on irrelevant
+ * impressions" as a feature summary. The lead-in is what makes it an argument.
+ *
+ * ★AND ABSENT SEVERITY IS TREATED AS `info`, NOT AS "NO OBJECTION". The server
+ * writes the field conditionally; a missing one still carries a note somebody
+ * wrote to be read.
+ */
+export function critiqueTone(severity: "info" | "warn" | undefined): {
+  lead: string;
+  className: string;
+} {
+  return severity === "warn"
+    ? { lead: "Worth knowing:", className: "text-xs text-amber-700 dark:text-amber-300" }
+    : { lead: "One caveat:", className: "text-xs text-muted-foreground" };
+}
+
 /** Channel display names. Unknown platforms render under their own key rather
  *  than being hidden — a channel we cannot name is still a channel this
  *  audience works on. */

--- a/src/lib/audience-library-rules.ts
+++ b/src/lib/audience-library-rules.ts
@@ -171,9 +171,15 @@ export function critiqueTone(severity: "info" | "warn" | undefined): {
   lead: string;
   className: string;
 } {
+  // ★THE WORDS AND THE COLOUR HAVE TO POINT THE SAME WAY. A first cut gave
+  // `warn` the milder lead ("Worth knowing") and `info` the stronger one ("One
+  // caveat") — so the amber line about wasting budget on irrelevant impressions
+  // read as the gentlest sentence on the card while the colour shouted. When
+  // the typography and the wording disagree, a skimming reader believes the
+  // wording.
   return severity === "warn"
-    ? { lead: "Worth knowing:", className: "text-xs text-amber-700 dark:text-amber-300" }
-    : { lead: "One caveat:", className: "text-xs text-muted-foreground" };
+    ? { lead: "Careful:", className: "text-xs text-amber-700 dark:text-amber-300" }
+    : { lead: "Worth knowing:", className: "text-xs text-muted-foreground" };
 }
 
 /** Channel display names. Unknown platforms render under their own key rather


### PR DESCRIPTION
Follow-up to #487. Caught by **running the planner for Quests Travel against dev and reading the output** — not by either review round, which is the part worth recording: both rounds checked the code against itself; neither checked the *type* against what the server actually sends.

## The bug

`critiquePortfolio` has always emitted `{ code, note, severity }`. The b2c type declared `critique?: string[]` and the discovery dialog called `.join(" ")` on it — so the engine's argument against its own suggestion, the most interesting sentence on the card, would have rendered as `[object Object]` for every generated audience, in front of a customer.

`scores` was wrong the same way: typed `Record<string, number>` when it carries a nested `components` map, a human-readable `basisNote` and a scorer version. A type claiming every value is a number makes `scores.basisNote` a number to every future reader.

Same mistake twice — a type describing what I assumed rather than what the server sends. Fixed by declaring the real shapes: `AudienceCritique` and `AudienceScores`.

## Verified against the real row

The planner now has run for Quests (plan `6a7c4833724b914ce7ef0692`, 4 audiences). One of the stored critiques:

```json
{ "code": "geo_mismatch", "severity": "warn",
  "note": "Targeting generic Software Development instead of travel-specific technology companies means you'll reach software professionals unrelated to travel, wasting budget on irrelevant impressions." }
```

That is a genuinely useful objection, and it was one deploy away from being `[object Object]`.

## Also

Renders `critique` on the library card. It was typed on `AudienceSet` and read by nothing — a field with a type and no reader, the exact dead-code shape this engine kept producing and that the whole piece of work exists to stop. Shown, never acted on: no set is filtered, reordered or downweighted because of it. `severity` picks the tone; `code` stays unrendered because `note` is written for a customer and the code is for us.

288 lib tests pass, type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)