### PR TITLE
fix(design): the one gradient the status pass could not see

### DIFF
--- a/src/app/(site)/dashboard/content/autopilot/_components/commerce-lane.tsx
+++ b/src/app/(site)/dashboard/content/autopilot/_components/commerce-lane.tsx
@@ -24,7 +24,7 @@ import type { CommerceLane as CommerceLaneData } from "@/hooks/use-home-summary"
 function MoneyLoopCard({ data }: { data: CommerceLaneData }) {
   const live = data.moneyLoop && typeof data.moneyLoop.revenueAttributed === "number";
   return (
-    <Card className="gap-0 overflow-hidden border-success/30 bg-linear-to-br from-emerald-50 to-background p-5 dark:from-emerald-950/40">
+    <Card className="gap-0 overflow-hidden border-success/30 bg-linear-to-br from-success/10 to-background p-5">
       <div className="flex items-center gap-2">
         <span className="inline-flex size-7 items-center justify-center rounded-full bg-success/15 text-success-on-tint">
           <IndianRupee className="size-4" />


### PR DESCRIPTION
The status conversion (#491) mapped `bg`/`text`/`border`/`ring` prefixes but **not** `from`/`via`/`to`, so one gradient survived every sweep:

```diff
- from-emerald-50 to-background p-5 dark:from-emerald-950/40
+ from-success/10 to-background p-5
```

It was the only raw Tailwind colour left in `src`. The `dark:` twin goes with it — the token is theme-aware and the light half was already `to-background`.

**The colour audit now reads zero.** All 871 raw utilities the dashboard started with are semantic tokens, across #490, #491, #492, #493 and this.

Verified: `tsc` clean · 379 tests pass · `next build` exit 0 · zero raw colour utilities in `src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
