### PR TITLE
feat(design): the dashboard nav wears the brand, without changing what it says

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -460,6 +460,102 @@
 }
 
 /*
+ * Dashboard navigation — the brand treatment, applied to the generated
+ * sidebar rather than baked into it.
+ *
+ * Keyed on the data attributes ui/sidebar.tsx already emits
+ * (`data-slot="sidebar-menu-button"` + `data-active`), so `shadcn add
+ * sidebar` can overwrite that file and this survives untouched. Nothing here
+ * changes the nav's structure, items, order or hierarchy — only how it looks.
+ *
+ * The active item gets the gold rail the marketing surface uses for the same
+ * job (see .u-rail): a 2px molten hairline, here vertical, plus a warm tint
+ * instead of the neutral --sidebar-accent. Hover slides 2px and lifts the
+ * icon, which is the same micro-interaction the pillar cards use, so the
+ * product and the site move alike.
+ */
+@layer components {
+  [data-slot="sidebar-menu-button"],
+  [data-slot="sidebar-menu-sub-button"] {
+    position: relative;
+    transition:
+      background-color var(--dur-micro) var(--motion-ease-soft),
+      color var(--dur-micro) var(--motion-ease-soft),
+      transform var(--dur-micro) var(--motion-ease-brand);
+  }
+
+  /* The rail. Scaled from 0 so it wipes in rather than snapping. */
+  [data-slot="sidebar-menu-button"]::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    height: 62%;
+    width: 2.5px;
+    border-radius: 0 3px 3px 0;
+    background-image: var(--brand-gradient);
+    transform: translateY(-50%) scaleY(0);
+    transform-origin: center;
+    transition: transform var(--dur-move) var(--motion-ease-brand);
+  }
+  [data-slot="sidebar-menu-button"][data-active="true"]::before {
+    transform: translateY(-50%) scaleY(1);
+  }
+
+  /* Warm tint in place of the neutral accent, and the icon picks up the
+     brand so the eye lands on the row without reading the label. */
+  [data-slot="sidebar-menu-button"][data-active="true"] {
+    background-color: color-mix(in oklab, var(--brand) 13%, transparent);
+    color: var(--sidebar-foreground);
+  }
+  [data-slot="sidebar-menu-button"][data-active="true"] svg {
+    color: var(--brand-label);
+  }
+  [data-slot="sidebar-menu-sub-button"][data-active="true"] {
+    background-color: color-mix(in oklab, var(--brand) 10%, transparent);
+    color: var(--sidebar-foreground);
+    font-weight: 600;
+  }
+
+  @media (hover: hover) {
+    [data-slot="sidebar-menu-button"]:hover:not([data-active="true"]),
+    [data-slot="sidebar-menu-sub-button"]:hover:not([data-active="true"]) {
+      background-color: color-mix(in oklab, var(--brand) 8%, transparent);
+      transform: translateX(2px);
+    }
+    [data-slot="sidebar-menu-button"]:hover svg {
+      transform: scale(1.1);
+    }
+  }
+  [data-slot="sidebar-menu-button"] svg {
+    transition: transform var(--dur-move) var(--motion-ease-brand);
+  }
+
+  /* Section labels read as instrument type, matching the console. */
+  [data-slot="sidebar-group-label"] {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.6rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-slot="sidebar-menu-button"],
+    [data-slot="sidebar-menu-sub-button"],
+    [data-slot="sidebar-menu-button"]::before,
+    [data-slot="sidebar-menu-button"] svg {
+      transition: none;
+    }
+    @media (hover: hover) {
+      [data-slot="sidebar-menu-button"]:hover:not([data-active="true"]),
+      [data-slot="sidebar-menu-sub-button"]:hover:not([data-active="true"]) {
+        transform: none;
+      }
+    }
+  }
+}
+
+/*
  * Animated conic-gradient ring used by <UpgradeButton variant="pill" />.
  * @property is required so browsers can interpolate the custom angle
  * value at the requested 60fps; without it the conic-gradient would


### PR DESCRIPTION
## Scope: a skin, nothing else

The sidebar was the last surface still reading as stock shadcn — a neutral grey accent on the active row, no relationship to the gold the rest of the product now uses.

**No item is added, removed, reordered or regrouped. No hierarchy changes. `layout.tsx` is not touched.** The only changed file is `globals.css` (+96 lines).

## Applied, not baked in

The rules key on the data attributes `ui/sidebar.tsx` already emits — `data-slot="sidebar-menu-button"` plus `data-active` — so `npx shadcn add sidebar` can overwrite that primitive and this survives. That's the rule [`components/ui/README.md`](src/components/ui/README.md) sets out, being followed rather than described.

## What changes

- The active row gets the **gold rail** the marketing surface uses for the same job (`.u-rail`) — here vertical, wiping in rather than snapping
- A **warm brand tint** replaces the neutral `--sidebar-accent`, and the active icon takes `--brand-label`, so the eye finds the row without reading it
- **Hover** slides 2px and scales the icon — the same micro-interaction the pillar cards use, so the product and the site move alike
- **Group labels** set in mono, matching the console's instrument type

Pointer-guarded, so nothing is defined for touch that touch can't reach. Every transition drops under `prefers-reduced-motion`.

## One note for review

The active tint compiles as `background-color: var(--brand)` with the 13% `color-mix` inside an `@supports` block — so a browser without `color-mix` would show **solid gold** rather than a tint. That's the same shape every `/opacity` utility in the last four PRs already produces, so it adds no new dependency, but it's real and worth knowing.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 379 passed / 24 files
- `npx next build` — exit 0
- Rules confirmed present in the compiled CSS
- `git diff --name-only master` → `src/app/globals.css` only; `ui/sidebar.tsx` and `layout.tsx` unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
