### PR TITLE
feat(dashboard): the overview answers what happened overnight, and what is waiting

### DIFF
--- a/src/app/(site)/dashboard/overview/page.tsx
+++ b/src/app/(site)/dashboard/overview/page.tsx
@@ -36,6 +36,9 @@ import { RecommendationsCard } from "@/components/dashboard/recommendations-card
 import { BrandMirrorCard } from "@/components/dashboard/brand-mirror-card";
 import { AskCard } from "@/components/dashboard/ask-card";
 import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
+import { OvernightRibbon } from "@/components/dashboard/overnight-ribbon";
+import { WaitingForYou } from "@/components/dashboard/waiting-for-you";
+import { useHomeSummary } from "@/hooks/use-home-summary";
 
 interface DashboardStats {
   content: {
@@ -106,6 +109,10 @@ export default function OverviewPage() {
     enabled: !!org && !!business,
   });
 
+  // The overnight ribbon and the cross-pillar queue both come from
+  // /v1/home/summary — one round trip, already polled on a 60s cadence.
+  const { data: home, isLoading: homeLoading } = useHomeSummary();
+
   const onboardingComplete = stats?.onboarding?.completed;
   const hasContent = (stats?.content.total ?? 0) > 0;
 
@@ -169,6 +176,10 @@ export default function OverviewPage() {
           ) : undefined
         }
       />
+
+      {/* What ran overnight. Sits directly under the header because it
+          answers the question the page is opened to ask. */}
+      <OvernightRibbon activity={home?.activity} />
 
       {/* Discovery progress strip — only visible while a bg job is alive */}
       {discovery?.activeJob && (
@@ -250,6 +261,15 @@ export default function OverviewPage() {
           href="/dashboard/outcomes"
         />
       </div>
+
+      {/* Every decision the platform is holding, in one list. Cross-pillar:
+          a failed post and an unread pricing recommendation ask the same
+          thing of the same person, so they belong in the same queue. */}
+      <WaitingForYou
+        items={home?.needsYou}
+        total={home?.kpis.needsYou}
+        isLoading={homeLoading}
+      />
 
       {/* Two-column layout */}
       <div className="grid gap-4 lg:grid-cols-5">

--- a/src/components/dashboard/overnight-ribbon.tsx
+++ b/src/components/dashboard/overnight-ribbon.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { ShoppingBag, PenLine, TrendingUp, MessagesSquare, MapPin } from "lucide-react";
+import type { ActivityCount, ActivityMetric, Pillar } from "@/hooks/use-home-summary";
+import { cn } from "@/lib/utils";
+
+/**
+ * "While you were away" — what the platform did on its own overnight.
+ *
+ * This is the first question a business owner opens the dashboard to answer,
+ * and until now nothing on the page could. Backed by the `activity` block on
+ * GET /v1/home/summary, which returns counts and a stable `metric` key; the
+ * wording is here rather than in the api so a sentence has one home.
+ *
+ * Rendered on the always-dark instrument surface (--ink), the same material
+ * as the console on the marketing hero — the panel is a picture of the
+ * product, so it does not follow the page theme.
+ */
+
+/** The noun for each metric, singular and plural. */
+const COPY: Record<ActivityMetric, [one: string, many: string]> = {
+  actions_executed: ["action taken", "actions taken"],
+  published: ["post published", "posts published"],
+  drafted: ["draft written", "drafts written"],
+  leads_captured: ["lead captured", "leads captured"],
+  conversations_resolved: ["conversation closed", "conversations closed"],
+  reviews_replied: ["review answered", "reviews answered"],
+};
+
+const PILLAR_ICON: Record<Pillar, React.ElementType> = {
+  commerce: ShoppingBag,
+  content: PenLine,
+  growth: TrendingUp,
+  support: MessagesSquare,
+  presence: MapPin,
+};
+
+/**
+ * Subscribes to the reduced-motion preference rather than sampling it once,
+ * so flipping the OS setting takes effect without a reload.
+ *
+ * useSyncExternalStore, not useState+useEffect: setting state synchronously
+ * inside an effect is what `react-hooks/set-state-in-effect` exists to stop,
+ * and a media query is exactly the "external store" this hook is for. The
+ * server snapshot reports "not reduced" — the safe default, since the count
+ * only ever runs on the client.
+ */
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function usePrefersReducedMotion() {
+  const subscribe = useCallback((onChange: () => void) => {
+    const mq = window.matchMedia(REDUCED_MOTION_QUERY);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(REDUCED_MOTION_QUERY).matches,
+    () => false,
+  );
+}
+
+/**
+ * Counts from 0 to `to` once, when the element first reaches the viewport.
+ *
+ * Motion means change: a figure animates because it moved. Under
+ * prefers-reduced-motion the number is simply read — and because the initial
+ * state is derived rather than assigned in an effect, that path renders the
+ * final value on the very first paint instead of flashing zero.
+ */
+function useCountUp(to: number, enabled: boolean) {
+  const [value, setValue] = useState(() => (enabled ? 0 : to));
+  const ref = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let frame = 0;
+    // setValue lands in a rAF callback, never synchronously in the effect
+    // body — the distinction the lint rule is drawing.
+    const run = () => {
+      const start = performance.now();
+      const duration = 600 + Math.min(to, 200) * 2;
+      const step = (now: number) => {
+        const p = Math.min(1, (now - start) / duration);
+        setValue(Math.round(to * (1 - Math.pow(1 - p, 3))));
+        if (p < 1) frame = requestAnimationFrame(step);
+      };
+      frame = requestAnimationFrame(step);
+    };
+
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      run(); // no observer to wait for — count immediately
+      return () => cancelAnimationFrame(frame);
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0]?.isIntersecting) return;
+        io.disconnect();
+        run();
+      },
+      { threshold: 0.4 },
+    );
+    io.observe(el);
+    return () => {
+      io.disconnect();
+      cancelAnimationFrame(frame);
+    };
+  }, [to, enabled]);
+
+  return { ref, value };
+}
+
+function Figure({ count, metric, pillar, animate }: ActivityCount & { animate: boolean }) {
+  const { ref, value } = useCountUp(count, animate);
+  const Icon = PILLAR_ICON[pillar];
+  const [one, many] = COPY[metric];
+  return (
+    <span className="flex items-baseline gap-1.5 text-sm text-on-ink-dim">
+      <Icon className="size-3.5 shrink-0 self-center text-brand" aria-hidden />
+      <span ref={ref} className="text-base font-bold tabular-nums text-on-ink">
+        {value}
+      </span>
+      {count === 1 ? one : many}
+    </span>
+  );
+}
+
+export function OvernightRibbon({
+  activity,
+  className,
+}: {
+  activity: { pillars: ActivityCount[]; windowHours: number } | undefined;
+  className?: string;
+}) {
+  const animate = !usePrefersReducedMotion();
+
+  if (!activity) return null;
+
+  // Only the pillars that actually did something get a figure. The api sends
+  // every pillar including the quiet ones so this component — not the api —
+  // decides what silence looks like.
+  const moved = activity.pillars.filter((p) => p.count > 0);
+
+  return (
+    <section
+      aria-label={`What Peakhour did in the last ${activity.windowHours} hours`}
+      className={cn(
+        "flex flex-wrap items-center gap-x-6 gap-y-2 rounded-xl border border-ink-line bg-ink px-4 py-3 shadow-elev-2",
+        className,
+      )}
+    >
+      <span className="flex items-center gap-2 font-mono text-[0.65rem] font-semibold uppercase tracking-[0.15em] text-brand">
+        <span className="relative flex size-1.5">
+          <span className="absolute inline-flex size-full rounded-full bg-success opacity-75 motion-safe:animate-ping" />
+          <span className="relative inline-flex size-1.5 rounded-full bg-success" />
+        </span>
+        While you were away
+      </span>
+
+      {moved.length === 0 ? (
+        // A quiet night is an answer, not an empty state. Saying nothing here
+        // would read as a panel that failed to load.
+        <span className="text-sm text-on-ink-dim">
+          Nothing moved overnight — your pillars are caught up.
+        </span>
+      ) : (
+        moved.map((p) => (
+          <Figure key={`${p.pillar}-${p.metric}`} {...p} animate={animate} />
+        ))
+      )}
+    </section>
+  );
+}

--- a/src/components/dashboard/waiting-for-you.tsx
+++ b/src/components/dashboard/waiting-for-you.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ShoppingBag,
+  PenLine,
+  TrendingUp,
+  MessagesSquare,
+  MapPin,
+  AlertCircle,
+  PlugZap,
+  Check,
+  ArrowRight,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Pillar, RailItem, RailItemType } from "@/hooks/use-home-summary";
+import { cn } from "@/lib/utils";
+
+/**
+ * "Waiting for you" — every decision the platform is holding, in one list.
+ *
+ * Backed by the `needsYou` rail on GET /v1/home/summary, which is now
+ * cross-pillar: a failed post and an unread pricing recommendation sit in the
+ * same queue because they ask the same thing of the same person.
+ *
+ * Each row carries its pillar, so the origin reads at a glance without the
+ * label having to say it. Colour comes from --chart-*, the same tokens the
+ * pillar series use in charts, so a row and a bar for one pillar agree.
+ */
+
+const PILLAR_ICON: Record<Pillar, React.ElementType> = {
+  commerce: ShoppingBag,
+  content: PenLine,
+  growth: TrendingUp,
+  support: MessagesSquare,
+  presence: MapPin,
+};
+
+/** Pillar → chart series token, in the platform's canonical order. */
+const PILLAR_TINT: Record<Pillar, string> = {
+  commerce: "bg-chart-1/12 text-chart-1 dark:bg-chart-1/18",
+  content: "bg-chart-2/12 text-chart-2 dark:bg-chart-2/18",
+  growth: "bg-chart-3/12 text-chart-3 dark:bg-chart-3/18",
+  support: "bg-chart-4/12 text-chart-4 dark:bg-chart-4/18",
+  presence: "bg-chart-5/12 text-chart-5 dark:bg-chart-5/18",
+};
+
+/**
+ * What the row is asking for. `reconnect` and `failed` are things that broke;
+ * `approve` is a judgement call. The verb differs because the ask differs.
+ */
+const TYPE_META: Record<RailItemType, { verb: string; icon: React.ElementType }> = {
+  reconnect: { verb: "Reconnect", icon: PlugZap },
+  failed: { verb: "Fix", icon: AlertCircle },
+  approve: { verb: "Review", icon: Check },
+};
+
+export function WaitingForYou({
+  items,
+  total,
+  isLoading,
+  className,
+}: {
+  items: RailItem[] | undefined;
+  /** Uncapped count — the rail itself is capped at 8 by the api. */
+  total: number | undefined;
+  isLoading?: boolean;
+  className?: string;
+}) {
+  const rows = items ?? [];
+  const count = total ?? rows.length;
+
+  return (
+    <Card className={cn("overflow-hidden", className)}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base font-semibold">Waiting for you</CardTitle>
+          {!isLoading && count > 0 && (
+            <span className="font-mono text-xs tabular-nums text-muted-foreground">
+              {count} {count === 1 ? "item" : "items"}
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        {isLoading ? (
+          <>
+            <span className="h-14 animate-pulse rounded-xl bg-muted" />
+            <span className="h-14 animate-pulse rounded-xl bg-muted" />
+          </>
+        ) : rows.length === 0 ? (
+          // The honest empty state: nothing is stuck, and the AI has not
+          // stopped. "No items" alone reads like something failed to load.
+          <p className="rounded-xl border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+            Queue clear. Your pillars keep working — new decisions land here.
+          </p>
+        ) : (
+          rows.map((item) => {
+            const PillarIcon = PILLAR_ICON[item.pillar] ?? PenLine;
+            const meta = TYPE_META[item.type];
+            const TypeIcon = meta.icon;
+            return (
+              <Link
+                key={`${item.type}-${item.refId}`}
+                href={item.ctaHref}
+                className="group u-lift flex items-center gap-3 rounded-xl border bg-card p-3"
+              >
+                <span
+                  className={cn(
+                    "flex size-9 shrink-0 items-center justify-center rounded-lg transition-transform duration-300 ease-brand group-hover:-rotate-6 group-hover:scale-110 motion-reduce:transition-none motion-reduce:group-hover:rotate-0 motion-reduce:group-hover:scale-100",
+                    PILLAR_TINT[item.pillar] ?? PILLAR_TINT.content,
+                  )}
+                >
+                  <PillarIcon className="size-4" aria-hidden />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-semibold">{item.title}</span>
+                  <span className="flex items-center gap-1.5 text-xs capitalize text-muted-foreground">
+                    <TypeIcon className="size-3 shrink-0" aria-hidden />
+                    {item.pillar}
+                    {item.channel ? ` · ${item.channel}` : ""}
+                  </span>
+                </span>
+                <span className="flex shrink-0 items-center gap-1 text-xs font-bold text-brand-label">
+                  {meta.verb}
+                  <ArrowRight className="size-3.5 transition-transform duration-300 ease-brand group-hover:translate-x-1 motion-reduce:transition-none" />
+                </span>
+              </Link>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-home-summary.ts
+++ b/src/hooks/use-home-summary.ts
@@ -18,12 +18,43 @@ export type AutopilotState = "working" | "waiting" | "stalled";
 export type ChannelHealth = "healthy" | "attention" | "disconnected";
 export type RailItemType = "reconnect" | "failed" | "approve";
 
+/** Which pillar a queued decision came from. Stamped by the api. */
+export type Pillar = "commerce" | "content" | "growth" | "support" | "presence";
+
 export interface RailItem {
   type: RailItemType;
   channel: string;
   refId: string;
   title: string;
   ctaHref: string;
+  pillar: Pillar;
+}
+
+/**
+ * What the platform did on its own overnight. The api sends counts and a
+ * stable `metric` key only — the wording lives here, in the component that
+ * renders it, so a sentence has one home.
+ */
+export type ActivityMetric =
+  | "actions_executed"
+  | "published"
+  | "drafted"
+  | "leads_captured"
+  | "conversations_resolved"
+  | "reviews_replied";
+
+export interface ActivityCount {
+  pillar: Pillar;
+  metric: ActivityMetric;
+  count: number;
+}
+
+export interface Activity {
+  /** ISO timestamp for the start of the window. */
+  since: string;
+  windowHours: number;
+  /** Every pillar, including the quiet ones at zero. */
+  pillars: ActivityCount[];
 }
 
 export interface ChannelWidget {
@@ -63,6 +94,7 @@ export interface HomeSummary {
     scheduledUpcoming: number;
   };
   autopilot: { state: AutopilotState; reason: string; lastRunAt: string | null };
+  activity: Activity;
   needsYou: RailItem[];
   channels: ChannelWidget[];
   commerce: CommerceLane | null;


### PR DESCRIPTION
Nine PRs of substrate later — **this is the first one you can see.**

## The ribbon

*"While you were away"*, directly under the page header, because it answers the question the dashboard is opened to ask. Backed by the `activity` block from api#1069.

Figures count up on first view — motion means change, so a number animates because it moved. A quiet night **says so out loud** ("Nothing moved overnight — your pillars are caught up") rather than rendering an empty strip that reads as a panel which failed to load.

It sits on `--ink`, the always-dark instrument surface named in #492. That token existed for exactly this: a picture of the product, which doesn't follow the page theme — the same material as the console on the marketing hero.

## The queue

*"Waiting for you"* — every decision the platform is holding, in one list. Cross-pillar since api#1070: a failed post and an unread pricing recommendation ask the same thing of the same person, so they stop living on separate pages.

Each row wears its pillar's `--chart-*` tint, so a row and a bar for one pillar agree by construction. The empty state says the AI hasn't stopped — "No items" reads like a failure.

## Copy lives here, not in the api

The api sends counts and a stable `metric` key; the wording is in the component. Two homes for one sentence is how copy drifts.

## Two lint fixes worth naming

Both were the rule catching something real, not being appeased:

- **Reduced motion** is read through `useSyncExternalStore` rather than sampled once in an effect — so flipping the OS setting now takes effect **without a reload**
- **The count-up's initial value** is derived rather than assigned in an effect — so the reduced-motion path paints the final number immediately instead of **flashing zero**

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 379 passed / 24 files
- `npx next build` — exit 0
- `npx eslint src` — 31 problems, **identical to master's baseline**, none in the new files

## Requires

api#1069 and api#1070, both merged. `activity` and `pillar` are optional-by-omission on older responses only in the sense that the types now expect them — if this deploys against an api older than those merges, the ribbon renders nothing (guarded by `if (!activity) return null`) and queue rows fall back to the content tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
