### PR TITLE
feat(dashboard): Peaks spend gets a 30-day chart on the overview

### DIFF
--- a/src/app/(site)/dashboard/overview/page.tsx
+++ b/src/app/(site)/dashboard/overview/page.tsx
@@ -38,6 +38,7 @@ import { AskCard } from "@/components/dashboard/ask-card";
 import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
 import { OvernightRibbon } from "@/components/dashboard/overnight-ribbon";
 import { WaitingForYou } from "@/components/dashboard/waiting-for-you";
+import { PeaksTrendCard } from "@/components/dashboard/peaks-trend-card";
 import { useHomeSummary } from "@/hooks/use-home-summary";
 
 interface DashboardStats {
@@ -265,11 +266,16 @@ export default function OverviewPage() {
       {/* Every decision the platform is holding, in one list. Cross-pillar:
           a failed post and an unread pricing recommendation ask the same
           thing of the same person, so they belong in the same queue. */}
-      <WaitingForYou
-        items={home?.needsYou}
-        total={home?.kpis.needsYou}
-        isLoading={homeLoading}
-      />
+      {/* The queue and the spend sit side by side: what needs a decision,
+          and what the decisions have been costing. */}
+      <div className="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
+        <WaitingForYou
+          items={home?.needsYou}
+          total={home?.kpis.needsYou}
+          isLoading={homeLoading}
+        />
+        <PeaksTrendCard />
+      </div>
 
       {/* Two-column layout */}
       <div className="grid gap-4 lg:grid-cols-5">

--- a/src/components/dashboard/peaks-trend-card.tsx
+++ b/src/components/dashboard/peaks-trend-card.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { TrendChart } from "@/components/viz/trend-chart";
+import { useCreditsHistory } from "@/hooks/use-credits";
+
+/**
+ * Peaks spent, last 30 days.
+ *
+ * Composition only — GET /v1/dashboard/credits/history already returns daily
+ * totals and components/viz/trend-chart.tsx already draws a theme-aware,
+ * tooltipped day-grain area. Nothing new is fetched or drawn here.
+ *
+ * Two decisions worth knowing:
+ *
+ * 1. The series is --brand-strong, not --chart-1. Peaks is the platform's
+ *    currency rather than a pillar, and --chart-1 *means* Commerce in the
+ *    validated series palette — borrowing it would say this chart is about
+ *    Commerce. --brand-strong is theme-stable and measures 3.3:1 on a light
+ *    card and 5.1:1 on a dark one, clearing the 3:1 a non-text mark needs in
+ *    both. (--brand itself is 2.1:1 on white, which is exactly why the token
+ *    file keeps --brand-label around for small text.)
+ *
+ * 2. Missing days are filled with zero. The api aggregates ts_usage_meters by
+ *    day, so a day with no AI usage produces no row at all. Charting the rows
+ *    as-is would silently compress the x-axis — three scattered days of use
+ *    would draw as three adjacent points and read like continuous activity.
+ *    A quiet day is data.
+ */
+
+const DAYS = 30;
+
+/** "YYYY-MM-DD" in UTC, matching the api's $dateToString bucket. */
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function PeaksTrendCard({ className }: { className?: string }) {
+  const { data, isLoading } = useCreditsHistory();
+
+  const series = useMemo(() => {
+    const byDay = new Map<string, number>();
+    for (const row of data?.days ?? []) byDay.set(row.date, row.peaks);
+
+    const today = new Date();
+    return Array.from({ length: DAYS }, (_, i) => {
+      const d = new Date(today.getTime() - (DAYS - 1 - i) * 86_400_000);
+      const key = isoDay(d);
+      return { date: key, peaks: byDay.get(key) ?? 0 };
+    });
+  }, [data]);
+
+  const total = data?.total ?? 0;
+  const spentToday = series[series.length - 1]?.peaks ?? 0;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-2">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+          <CardTitle className="text-base font-semibold">Peaks spent</CardTitle>
+          <span className="text-xs text-muted-foreground">
+            <span className="font-mono font-semibold tabular-nums text-foreground">
+              {total.toLocaleString()}
+            </span>{" "}
+            in 30 days
+            {spentToday > 0 && (
+              <>
+                {" · "}
+                <span className="font-mono font-semibold tabular-nums text-foreground">
+                  {spentToday.toLocaleString()}
+                </span>{" "}
+                today
+              </>
+            )}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-[180px] animate-pulse rounded-lg bg-muted" />
+        ) : (
+          <TrendChart
+            data={series}
+            height={180}
+            series={[{ key: "peaks", label: "Peaks", color: "var(--brand-strong)" }]}
+            emptyLabel="No AI usage yet — your first Peaks will chart here."
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## The answer to the question I went to check

**There was no api story here.** I expected one — the ribbon needed a whole endpoint extension. Instead:

- `GET /v1/dashboard/credits/history` already returns daily totals over 30 days
- `useCreditsHistory()` already calls it
- `components/viz/trend-chart.tsx` already draws a theme-aware, tooltipped, day-grain area **with its own empty state**

So this is composition, not plumbing. Worth knowing for the remaining viz work — the primitives are in better shape than the colour layer was.

## Two decisions worth the reader's time

**The series is `--brand-strong`, not `--chart-1`.** Peaks is the platform's *currency*, not a pillar — and `--chart-1` **means Commerce** in the validated series palette, so borrowing it would quietly claim this chart is about Commerce.

| token | light card | dark card |
|---|---|---|
| `--brand-strong` | **3.28:1** | **5.09:1** |
| `--brand` | 2.13:1 ✗ | — |

`--brand-strong` is theme-stable and clears the 3:1 a non-text mark needs in both. `--brand` failing at 2.13:1 is exactly why the token file keeps `--brand-label` around for small text.

**Missing days are filled with zero.** The api aggregates `ts_usage_meters` by day, so a day with no AI usage produces **no row at all**. Charting the rows as they arrive would silently compress the x-axis — three scattered days of use would draw as three adjacent points and read as continuous activity. A quiet day is data. That densification is the only real logic in the file.

## Placement

Beside the queue, in a `1.15fr / 0.85fr` row: what needs a decision, and what the decisions have been costing.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 379 passed / 24 files
- `npx next build` — exit 0
- `npx eslint src` — 31 problems, **identical to master's baseline**, none in the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
