### PR TITLE
fix(dashboard): stop the product telling reviewers it is unfinished

### DIFF
--- a/src/app/(site)/dashboard/overview/page.tsx
+++ b/src/app/(site)/dashboard/overview/page.tsx
@@ -36,6 +36,7 @@ import { RecommendationsCard } from "@/components/dashboard/recommendations-card
 import { BrandMirrorCard } from "@/components/dashboard/brand-mirror-card";
 import { AskCard } from "@/components/dashboard/ask-card";
 import { PageShell, PageHeader } from "@/components/dashboard/page-shell";
+import { cn } from "@/lib/utils";
 import { OvernightRibbon } from "@/components/dashboard/overnight-ribbon";
 import { WaitingForYou } from "@/components/dashboard/waiting-for-you";
 import { PeaksTrendCard } from "@/components/dashboard/peaks-trend-card";
@@ -239,23 +240,30 @@ export default function OverviewPage() {
           loading={isLoading}
           href="/dashboard/content"
         />
+        {/* Zero campaigns is a real, correct number — so it shows as 0 with
+            the next step beside it, rather than the apologetic "Not started
+            yet" that made a working tile look like an unbuilt one. */}
         <KpiCard
           label="Active Campaigns"
           value={stats?.campaigns.active}
           change={
             stats?.campaigns.total
               ? `${stats.campaigns.total} total`
-              : "Not started yet"
+              : "Launch your first"
           }
           icon={Megaphone}
           series={2}
           loading={isLoading}
           href="/dashboard/ads?channel=linkedin"
         />
+        {/* Customers has no data source yet — outcomes attribution needs an
+            ads connection. It used to render a hardcoded "--" in the headline
+            slot, which is the single clearest way to tell someone software is
+            unfinished. `unavailable` renders the same tile as an invitation
+            instead: no fake figure, and the reason is the call to action. */}
         <KpiCard
           label="Customers"
-          value="--"
-          change="Connect ads to track"
+          unavailable="Connect ads to start tracking"
           icon={Users}
           series={3}
           loading={isLoading}
@@ -512,6 +520,7 @@ function KpiCard({
   label,
   value,
   change,
+  unavailable,
   icon: Icon,
   series,
   loading,
@@ -520,6 +529,13 @@ function KpiCard({
   label: string;
   value?: number | string;
   change?: string;
+  /**
+   * This metric has no data source yet — say what would switch it on rather
+   * than printing a placeholder figure. A dash or an em-dash in a headline
+   * slot reads as broken software; an invitation reads as a next step, and
+   * both are honest about there being no number.
+   */
+  unavailable?: string;
   icon: React.ElementType;
   series: PillarSeries;
   loading: boolean;
@@ -540,16 +556,35 @@ function KpiCard({
             </div>
             <ArrowUpRight className="h-4 w-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors" />
           </div>
-          <div className="text-2xl font-bold tabular-nums tracking-tight">
-            {loading ? (
-              <span className="inline-block h-8 w-14 animate-pulse rounded-lg bg-muted" />
-            ) : (
-              (value ?? 0)
+          {/* An unavailable metric keeps the tile's shape but drops the
+              number entirely — the label leads, and the reason takes the
+              slot the figure would have held. */}
+          {!unavailable && (
+            <div className="text-2xl font-bold tabular-nums tracking-tight">
+              {loading ? (
+                <span className="inline-block h-8 w-14 animate-pulse rounded-lg bg-muted" />
+              ) : (
+                (value ?? 0)
+              )}
+            </div>
+          )}
+          <p
+            className={cn(
+              "text-xs font-medium text-muted-foreground",
+              unavailable ? "text-sm font-semibold text-foreground" : "mt-0.5",
             )}
-          </div>
-          <p className="text-xs font-medium text-muted-foreground mt-0.5">{label}</p>
-          {change && (
-            <p className="text-[11px] text-muted-foreground/70 mt-1">{change}</p>
+          >
+            {label}
+          </p>
+          {unavailable ? (
+            <p className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-brand-label">
+              {unavailable}
+              <ArrowRight className="size-3" aria-hidden />
+            </p>
+          ) : (
+            change && (
+              <p className="text-[11px] text-muted-foreground/70 mt-1">{change}</p>
+            )
           )}
         </CardContent>
       </Card>

--- a/src/components/dev/cron-toolbar.tsx
+++ b/src/components/dev/cron-toolbar.tsx
@@ -21,6 +21,15 @@
  *      NEXT_PUBLIC_VERCEL_ENV === "production" — the api endpoint also
  *      server-side-blocks prod, so this is layered protection.
  *
+ * SINCE 2026-08: outside production it is additionally OPT-IN, via `?dev=1`
+ * (remembered per browser; `?dev=0` clears it). The requirement above is
+ * unchanged — every cron-fed page still mounts the toolbar and every
+ * engineer still gets it in one URL param. What changed is the default,
+ * because env-only gating meant the preview links the team reviews the
+ * product on always carried a row of buttons labelled `discovery-runner` /
+ * `jobs-runner` above the content, and "why does this look like it's still
+ * in development?" turned out to be largely that.
+ *
  * Layout: a separate visual band (border-dashed, subtle bg) above the
  * page action buttons. Keeps cron triggers out of the primary action
  * row (was the source of the "Re-analyse 53 incomplete" header
@@ -32,7 +41,7 @@
  *     onTriggered={() => queryClient.invalidateQueries(...)}
  *   />
  */
-import { useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -98,6 +107,68 @@ interface Props {
 
 function isProductionEnv(): boolean {
   return process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+}
+
+/**
+ * Explicit opt-in for the dev cron controls.
+ *
+ * Environment alone used to decide this, which meant every preview URL — the
+ * ones the team reviews the product on — rendered a row of buttons labelled
+ * `discovery-runner` / `jobs-runner` above the page content. Nothing else on
+ * screen said "unfinished software" half as loudly, and it said it about a
+ * build that was fine.
+ *
+ * The toolbar stays exactly as available to the people who need it (Vercel
+ * Cron only fires on production, so previews genuinely cannot exercise these
+ * paths without it) — it just has to be asked for now:
+ *
+ *   ?dev=1   turn on, and remember it for this browser
+ *   ?dev=0   turn off again
+ *
+ * Production is still blocked outright, and the api route server-side blocks
+ * prod as well, so this narrows the audience without weakening either layer.
+ */
+const DEV_TOOLS_KEY = "peakhour.dev-tools";
+const DEV_TOOLS_EVENT = "peakhour:dev-tools";
+
+/** Pure read — safe to call during render, writes nothing. */
+function readDevToolsFlag(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (new URLSearchParams(window.location.search).get("dev") === "1") return true;
+    return window.localStorage.getItem(DEV_TOOLS_KEY) === "1";
+  } catch {
+    // Storage can throw in locked-down browser modes. A dev affordance is
+    // never worth breaking the page over.
+    return false;
+  }
+}
+
+function subscribeDevToolsFlag(onChange: () => void) {
+  window.addEventListener("storage", onChange);
+  window.addEventListener(DEV_TOOLS_EVENT, onChange);
+  return () => {
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener(DEV_TOOLS_EVENT, onChange);
+  };
+}
+
+function useDevToolsEnabled(): boolean {
+  // Persisting the switch is a write, never a setState — so this stays clear
+  // of the cascading-render rule the repo lints for.
+  useEffect(() => {
+    let param: string | null = null;
+    try {
+      param = new URLSearchParams(window.location.search).get("dev");
+      if (param === "1") window.localStorage.setItem(DEV_TOOLS_KEY, "1");
+      else if (param === "0") window.localStorage.removeItem(DEV_TOOLS_KEY);
+    } catch {
+      return;
+    }
+    if (param !== null) window.dispatchEvent(new Event(DEV_TOOLS_EVENT));
+  }, []);
+
+  return useSyncExternalStore(subscribeDevToolsFlag, readDevToolsFlag, () => false);
 }
 
 // Module-scoped re-entry guard. Per-instance refs would still race in
@@ -177,6 +248,9 @@ export function CronToolbar({
   // double-fire, so this was only ever confusing — but /cms/crons now renders
   // 56 buttons, which makes it easy to hit.
   const [runningCrons, setRunningCrons] = useState<ReadonlySet<string>>(new Set());
+  // Opt-in switch — see useDevToolsEnabled. Called unconditionally, like the
+  // state above, so the gate below decides rendering and never mounting.
+  const devToolsEnabled = useDevToolsEnabled();
   const startRunning = (cron: string) =>
     setRunningCrons((prev) => new Set(prev).add(cron));
   const stopRunning = (cron: string) =>
@@ -186,7 +260,7 @@ export function CronToolbar({
       return next;
     });
 
-  if (isProductionEnv() || crons.length === 0) return null;
+  if (isProductionEnv() || !devToolsEnabled || crons.length === 0) return null;
 
   /**
    * What to do with a dev-cron response, for EVERY path that gets one.


### PR DESCRIPTION
## The feedback

> "Why does the dashboard look like it is work in progress or in development?"

I went looking for the cause rather than reaching for the design. **Two of the loudest reasons had nothing to do with how it looks.**

## 1. Developer chrome, on screen, in every review environment

`CronToolbar` was gated on environment alone — it hid only when `NEXT_PUBLIC_VERCEL_ENV === "production"`. So every preview URL, which is exactly where the team reviews the product, rendered a row of buttons labelled `discovery-runner`, `jobs-runner`, `tag-catchup` above the page content.

Nothing else on screen said "unfinished software" half as loudly — and it said it about a build that was fine.

**Now opt-in outside production:** `?dev=1` turns it on and is remembered per browser, `?dev=0` clears it.

The 2026-05-28 architecture requirement is untouched: every cron-fed page still mounts the toolbar, and an engineer still gets it in one URL param — a smaller ask than the CLI it exists to replace. Production stays blocked outright and the api still refuses in prod server-side, so this narrows the audience without weakening either layer.

The component's header claimed *"renders nothing when VERCEL_ENV is production"*. That sentence is updated rather than left contradicting the code — same lesson as api#1070.

Persisting the switch is a **write, never a setState**, and the read goes through `useSyncExternalStore`, so the flag survives navigation without tripping the cascading-render rule.

## 2. A dash where a number belongs

The Customers KPI rendered a hardcoded `value="--"`. That is the single clearest way to tell someone software is unfinished.

The tile now takes `unavailable`, **drops the figure entirely**, and puts the reason where the number was — *"Connect ads to start tracking"*. No invented metric, and the honest gap reads as a next step rather than a defect.

Active Campaigns said *"Not started yet"* beneath a real, correct `0`. Zero is a fact; the apology made a working tile look unbuilt. It now says *"Launch your first"*.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 379 passed / 24 files
- `npx next build` — exit 0
- `npx eslint src` — 31 problems, **identical to master's baseline**

## Still outstanding from the diagnosis

These two were the cheap half. The rest, in order:

1. **Seed the review tenant** — crons don't run in dev, so the ribbon says "nothing moved", the queue is clear and the Peaks chart is flat. The team is reviewing an empty database and reading emptiness as incompleteness. Probably the largest single remaining factor.
2. **Let the home graduate** — 5 of the 13 blocks are onboarding scaffolding; they should collapse to one entry once setup completes.
3. **Recompose the overview** into the weighted grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
