### PR TITLE
feat(ads): lead forms, and the two things a green tick would hide

### DIFF
--- a/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
@@ -96,6 +96,7 @@ export function LeadFormsPanel() {
   const [designOpen, setDesignOpen] = useState(false);
   const [publishing, setPublishing] = useState<Ask | null>(null);
   const [archiving, setArchiving] = useState<Ask | null>(null);
+  const [editing, setEditing] = useState<Ask | null>(null);
 
   const asks = useQuery({
     queryKey: ["growth-asks"],
@@ -105,13 +106,32 @@ export function LeadFormsPanel() {
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["growth-asks"] });
 
+  /**
+   * ★WHICH ROWS ARE IN FLIGHT, not "is anything in flight".
+   *
+   * One shared mutation reports `isPending` in aggregate and `variables` for
+   * the MOST RECENT call only, so syncing a second row re-enabled the first
+   * one's button mid-request — and that disabled state is the double-fire
+   * guard, not decoration.
+   */
+  const [syncingIds, setSyncingIds] = useState<string[]>([]);
   const sync = useMutation({
     mutationFn: (id: string) => growthApi.syncAsk(id),
+    onMutate: (id: string) => {
+      setSyncingIds((ids) => [...ids, id]);
+    },
+    onSettled: (_data, _err, id) => {
+      setSyncingIds((ids) => ids.filter((x) => x !== id));
+    },
     onSuccess: (res) => {
       invalidate();
       const review = res.ask.channels?.linkedin?.reviewStatus;
       if (review && REVIEW_PROBLEM[review]) toast.warning(REVIEW_PROBLEM[review]);
-      else toast.success("Up to date with LinkedIn.");
+      else if (res.ask.serving === false) {
+        // A form that is not serving for a reason outside the review codes
+        // must not get a success toast beside an amber badge.
+        toast.warning("LinkedIn says this form isn't live. Open it to see where it stands.");
+      } else toast.success("Up to date with LinkedIn.");
     },
     onError: (err) => toastUnhandledApiError(err, "Couldn't check with LinkedIn"),
   });
@@ -143,7 +163,7 @@ export function LeadFormsPanel() {
             title="Couldn't load your lead forms"
             description="Refresh in a moment — nothing has changed on LinkedIn."
           />
-        ) : (asks.data?.asks.length ?? 0) === 0 ? (
+        ) : (asks.data?.asks?.length ?? 0) === 0 ? (
           <EmptyState
             icon={ClipboardList}
             title="No lead forms yet"
@@ -151,22 +171,50 @@ export function LeadFormsPanel() {
             action={{ label: "Design a form", onClick: () => setDesignOpen(true) }}
           />
         ) : (
-          asks.data!.asks.map((ask) => (
+          (asks.data?.asks ?? []).map((ask) => (
             <AskRow
               key={ask._id}
               ask={ask}
               onPublish={() => setPublishing(ask)}
               onArchive={() => setArchiving(ask)}
+              onEdit={() => setEditing(ask)}
               onSync={() => sync.mutate(ask._id)}
-              syncing={sync.isPending && sync.variables === ask._id}
+              syncing={syncingIds.includes(ask._id)}
             />
           ))
         )}
       </CardContent>
 
-      <DesignAskDialog open={designOpen} onOpenChange={setDesignOpen} onDone={invalidate} />
-      <PublishAskDialog ask={publishing} onOpenChange={() => setPublishing(null)} onDone={invalidate} />
-      <ArchiveAskDialog ask={archiving} onOpenChange={() => setArchiving(null)} onDone={invalidate} />
+      {/* ★MOUNTED PER ASK, and this is not tidiness. These dialogs hold the
+          answers a customer types; rendered once for the life of the panel they
+          keep that state across DIFFERENT forms, so publishing form A over
+          WhatsApp and then opening form B presents A's phone number, already
+          valid, one click from being written onto a form LinkedIn will then
+          freeze. `key` makes each open a fresh component — the same pattern
+          BoostCampaignDialog uses one directory over, which is why it has never
+          had this problem. */}
+      {designOpen ? (
+        <DesignAskDialog open onOpenChange={setDesignOpen} onDone={invalidate} />
+      ) : null}
+      {publishing ? (
+        <PublishAskDialog
+          key={publishing._id}
+          ask={publishing}
+          onOpenChange={() => setPublishing(null)}
+          onDone={invalidate}
+        />
+      ) : null}
+      {archiving ? (
+        <ArchiveAskDialog ask={archiving} onOpenChange={() => setArchiving(null)} onDone={invalidate} />
+      ) : null}
+      {editing ? (
+        <EditWordingDialog
+          key={editing._id}
+          ask={editing}
+          onOpenChange={() => setEditing(null)}
+          onDone={invalidate}
+        />
+      ) : null}
     </Card>
   );
 }
@@ -175,18 +223,29 @@ function AskRow({
   ask,
   onPublish,
   onArchive,
+  onEdit,
   onSync,
   syncing,
 }: {
   ask: Ask;
   onPublish: () => void;
   onArchive: () => void;
+  onEdit: () => void;
   onSync: () => void;
   syncing: boolean;
 }) {
   const channel = ask.channels?.linkedin;
   const review = channel?.reviewStatus;
-  const problem = review ? REVIEW_PROBLEM[review] : undefined;
+  const delivery = channel?.leadDelivery;
+  /**
+   * ★TWO DIFFERENT WAYS A LIVE FORM COLLECTS NOTHING, and both have to say so
+   * on the row rather than in a toast the person who published it saw once.
+   * A review rejection stops the ad delivering; a missing Lead Sync grant lets
+   * it deliver perfectly and drops every lead on the floor.
+   */
+  const problem =
+    (review ? REVIEW_PROBLEM[review] : undefined) ??
+    (delivery?.status === "blocked" ? delivery.reason : undefined);
 
   return (
     <div className="rounded-lg border p-4">
@@ -198,7 +257,7 @@ function AskRow({
               <Badge className="bg-muted text-muted-foreground">Draft</Badge>
             ) : ask.status === "archived" ? (
               <Badge className="bg-muted/60 text-muted-foreground">Archived</Badge>
-            ) : ask.serving ? (
+            ) : ask.serving && delivery?.status !== "blocked" ? (
               <Badge className="bg-success/15 text-success-on-tint">Live</Badge>
             ) : (
               <Badge className="bg-warning/15 text-warning-on-tint">Not delivering</Badge>
@@ -210,6 +269,11 @@ function AskRow({
           {ask.status === "draft" ? (
             <Button size="sm" onClick={onPublish}>
               Publish to LinkedIn
+            </Button>
+          ) : null}
+          {ask.status !== "archived" ? (
+            <Button size="sm" variant="outline" onClick={onEdit}>
+              Edit wording
             </Button>
           ) : null}
           {channel ? (
@@ -230,14 +294,19 @@ function AskRow({
       {/* ★THE FAILURE THAT LOOKS HEALTHY. Without this the campaign shows
           active, the budget shows committed, and nothing is delivered. */}
       {problem ? (
-        <div className="mt-3 flex gap-2 rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">
+        <div
+          role="alert"
+          className="mt-3 flex gap-2 rounded-md border border-warning/30 bg-warning/5 p-3 text-sm"
+        >
           <AlertTriangle className="mt-0.5 size-4 shrink-0 text-warning-on-tint" />
           <div>
             <p>{problem}</p>
             {channel?.rejectionReasons?.length ? (
               <ul className="mt-1 list-disc pl-4 text-muted-foreground">
-                {channel.rejectionReasons.map((r) => (
-                  <li key={r}>{r}</li>
+                {channel.rejectionReasons.map((r, i) => (
+                  // Keyed by position: LinkedIn can repeat a reason, and a
+                  // duplicated string would collide as a key.
+                  <li key={`${i}-${r.slice(0, 32)}`}>{r}</li>
                 ))}
               </ul>
             ) : null}
@@ -272,6 +341,8 @@ function DesignAskDialog({
   onOpenChange,
   onDone,
 }: {
+  /** Always true — the parent mounts this only while it is open. Kept on the
+   *  signature so the Dialog's own open/close contract stays explicit. */
   open: boolean;
   onOpenChange: (v: boolean) => void;
   onDone: () => void;
@@ -377,7 +448,7 @@ function PublishAskDialog({
   onOpenChange,
   onDone,
 }: {
-  ask: Ask | null;
+  ask: Ask;
   onOpenChange: () => void;
   onDone: () => void;
 }) {
@@ -388,7 +459,7 @@ function PublishAskDialog({
 
   const publish = useMutation({
     mutationFn: () =>
-      growthApi.publishAsk(ask!._id, {
+      growthApi.publishAsk(ask._id, {
         ...(useWhatsapp ? { whatsapp: { phone: phone.trim(), message: message.trim() } } : {}),
         ...(!useWhatsapp && ctaUrl.trim() ? { ctaUrl: ctaUrl.trim() } : {}),
       }),
@@ -411,7 +482,7 @@ function PublishAskDialog({
   });
 
   return (
-    <Dialog open={!!ask} onOpenChange={() => onOpenChange()}>
+    <Dialog open onOpenChange={() => onOpenChange()}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Publish to LinkedIn</DialogTitle>
@@ -425,11 +496,17 @@ function PublishAskDialog({
 
         <div className="space-y-4">
           <div className="space-y-2">
-            <Label>What happens after they submit?</Label>
-            <div className="flex gap-2">
+            {/* A visual-only "selected" state leaves a screen reader hearing two
+                plain buttons with no indication which is active — on the control
+                that decides where a lead is sent. */}
+            <span id="ask-destination-label" className="text-sm font-medium">
+              What happens after they submit?
+            </span>
+            <div className="flex gap-2" role="group" aria-labelledby="ask-destination-label">
               <Button
                 type="button"
                 size="sm"
+                aria-pressed={useWhatsapp}
                 variant={useWhatsapp ? "default" : "outline"}
                 onClick={() => setUseWhatsapp(true)}
               >
@@ -438,6 +515,7 @@ function PublishAskDialog({
               <Button
                 type="button"
                 size="sm"
+                aria-pressed={!useWhatsapp}
                 variant={!useWhatsapp ? "default" : "outline"}
                 onClick={() => setUseWhatsapp(false)}
               >
@@ -502,17 +580,126 @@ function PublishAskDialog({
   );
 }
 
+/**
+ * Edit the wording.
+ *
+ * ★IT DOES NOT OFFER THE QUESTIONS, AND THE COPY SAYS WHY. LinkedIn freezes a
+ * live form's field list, so a "change the questions" control would be a
+ * button that fails — the same mistake as offering the lead_generation
+ * objective before there was a form to attach. Once published, changing what
+ * you ask means a new form.
+ *
+ * State is keyed off `ask` and reset when a different one opens: a dialog that
+ * kept the previous form's headline would let a customer overwrite one form
+ * with another's copy without noticing.
+ */
+function EditWordingDialog({
+  ask,
+  onOpenChange,
+  onDone,
+}: {
+  ask: Ask;
+  onOpenChange: () => void;
+  onDone: () => void;
+}) {
+  // Initialised straight from props: the parent mounts this per Ask with a
+  // `key`, so there is no previous form's state to reset away from.
+  const [name, setName] = useState(ask.name);
+  const [headline, setHeadline] = useState(ask.content.headline);
+  const [thankYou, setThankYou] = useState(ask.content.thankYou.message);
+
+  const edit = useMutation({
+    mutationFn: () =>
+      growthApi.editAsk(ask._id, {
+        ...(name.trim() && name.trim() !== ask.name ? { name: name.trim() } : {}),
+        ...(headline.trim() && headline.trim() !== ask.content.headline
+          ? { headline: headline.trim() }
+          : {}),
+        ...(thankYou.trim() && thankYou.trim() !== ask.content.thankYou.message
+          ? { thankYouMessage: thankYou.trim() }
+          : {}),
+      }),
+    onSuccess: () => {
+      onDone();
+      onOpenChange();
+      toast.success("Updated.");
+    },
+    onError: (err) => {
+      if (err instanceof ApiError) toast.error(err.message);
+      else toastUnhandledApiError(err, "Couldn't save the change");
+    },
+  });
+
+  const unchanged =
+    name.trim() === ask.name &&
+    headline.trim() === ask.content.headline &&
+    thankYou.trim() === ask.content.thankYou.message;
+
+  return (
+    <Dialog open onOpenChange={() => onOpenChange()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit wording</DialogTitle>
+          <DialogDescription>
+            {ask.status === "published"
+              ? "This form is live, so LinkedIn only allows the wording to change. To change what you ask, create a new form — this one keeps collecting until you archive it."
+              : "Nothing is live yet, so this is just tidying up before you publish."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="ask-edit-name">Name (only you see this)</Label>
+            <Input id="ask-edit-name" value={name} onChange={(e) => setName(e.target.value)} maxLength={256} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ask-edit-headline">Headline</Label>
+            <Input
+              id="ask-edit-headline"
+              value={headline}
+              onChange={(e) => setHeadline(e.target.value)}
+              maxLength={60}
+            />
+            <p className="text-xs text-muted-foreground">
+              {headline.length}/60 — LinkedIn cuts it off after that.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ask-edit-thanks">Thank-you message</Label>
+            <Textarea
+              id="ask-edit-thanks"
+              rows={3}
+              value={thankYou}
+              onChange={(e) => setThankYou(e.target.value)}
+              maxLength={1000}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange()} disabled={edit.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={() => edit.mutate()} disabled={edit.isPending || unchanged}>
+            {edit.isPending ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function ArchiveAskDialog({
   ask,
   onOpenChange,
   onDone,
 }: {
-  ask: Ask | null;
+  ask: Ask;
   onOpenChange: () => void;
   onDone: () => void;
 }) {
   const archive = useMutation({
-    mutationFn: () => growthApi.archiveAsk(ask!._id),
+    mutationFn: () => growthApi.archiveAsk(ask._id),
     onSuccess: () => {
       onDone();
       onOpenChange();
@@ -528,7 +715,7 @@ function ArchiveAskDialog({
   });
 
   return (
-    <AlertDialog open={!!ask} onOpenChange={() => onOpenChange()}>
+    <AlertDialog open onOpenChange={() => onOpenChange()}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Stop collecting with this form?</AlertDialogTitle>

--- a/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
@@ -137,7 +137,13 @@ export function LeadFormsPanel() {
         toast.warning("LinkedIn says this form isn't live. Open it to see where it stands.");
       } else toast.success("Up to date with LinkedIn.");
     },
-    onError: (err) => toastUnhandledApiError(err, "Couldn't check with LinkedIn"),
+    onError: (err) => {
+      // The sync refusals (`NOT_PUBLISHED`, `NOT_CONNECTED`, `NEEDS_REAUTH`)
+      // each carry a sentence naming what to do; a generic "try again" throws
+      // all three away.
+      if (err instanceof ApiError && err.status >= 400 && err.status < 500) toast.error(err.message);
+      else toastUnhandledApiError(err, "Couldn't check with LinkedIn");
+    },
   });
 
   return (
@@ -189,14 +195,19 @@ export function LeadFormsPanel() {
         )}
       </CardContent>
 
-      {/* ★MOUNTED PER ASK, and this is not tidiness. These dialogs hold the
-          answers a customer types; rendered once for the life of the panel they
-          keep that state across DIFFERENT forms, so publishing form A over
-          WhatsApp and then opening form B presents A's phone number, already
-          valid, one click from being written onto a form LinkedIn will then
-          freeze. `key` makes each open a fresh component — the same pattern
-          BoostCampaignDialog uses one directory over, which is why it has never
-          had this problem. */}
+      {/* MOUNTED ONLY WHILE OPEN, AND KEYED BY ASK.
+
+          These dialogs hold what a customer types, so one instance shared
+          across forms carries A's WhatsApp number into B's publish — already
+          filled in, already passing the submit gate, one click from being
+          written onto a form LinkedIn then freezes.
+
+          The alternative — staying mounted and re-seeding in an effect — is
+          what this repo's lint forbids (`set-state-in-effect`), and
+          `BoostCampaignDialog` next door mounts conditionally for the same
+          reason. The cost is Radix's exit animation and its focus return, since
+          it never sees `data-state="closed"`; that is a trade the rest of the
+          app already makes, and the wrong-number bug is not. */}
       {designOpen ? (
         <DesignAskDialog open onOpenChange={setDesignOpen} onDone={invalidate} />
       ) : null}
@@ -209,7 +220,12 @@ export function LeadFormsPanel() {
         />
       ) : null}
       {archiving ? (
-        <ArchiveAskDialog ask={archiving} onOpenChange={() => setArchiving(null)} onDone={invalidate} />
+        <ArchiveAskDialog
+          key={archiving._id}
+          ask={archiving}
+          onOpenChange={() => setArchiving(null)}
+          onDone={invalidate}
+        />
       ) : null}
       {editing ? (
         <EditWordingDialog
@@ -247,9 +263,23 @@ function AskRow({
    * A review rejection stops the ad delivering; a missing Lead Sync grant lets
    * it deliver perfectly and drops every lead on the floor.
    */
+  /**
+   * ★"NOBODY HAS ESTABLISHED IT" IS NOT "IT WORKS". Only `created` and
+   * `existing` are a confirmed subscription; `blocked` is a known refusal,
+   * `unknown` is a check that failed, and ABSENT is a form published before we
+   * recorded the answer at all. Rendering the last two green is the same
+   * "published ✓ over a void" this panel's header refuses — the fact is
+   * three-valued and a boolean badge has to fall the safe way.
+   */
+  const deliveryConfirmed = delivery?.status === "created" || delivery?.status === "existing";
   const problem =
     (review ? REVIEW_PROBLEM[review] : undefined) ??
-    (delivery?.status === "blocked" ? delivery.reason : undefined);
+    (delivery?.status === "blocked"
+      ? delivery.reason
+      : ask.status === "published" && !deliveryConfirmed
+        ? delivery?.reason ??
+          "We haven't been able to confirm that LinkedIn will deliver this form's leads to your Inbox. Press Check."
+        : undefined);
 
   return (
     <div className="rounded-lg border p-4">
@@ -261,7 +291,7 @@ function AskRow({
               <Badge className="bg-muted text-muted-foreground">Draft</Badge>
             ) : ask.status === "archived" ? (
               <Badge className="bg-muted/60 text-muted-foreground">Archived</Badge>
-            ) : ask.serving && delivery?.status !== "blocked" ? (
+            ) : ask.serving && deliveryConfirmed ? (
               <Badge className="bg-success/15 text-success-on-tint">Live</Badge>
             ) : (
               <Badge className="bg-warning/15 text-warning-on-tint">Not delivering</Badge>
@@ -345,8 +375,6 @@ function DesignAskDialog({
   onOpenChange,
   onDone,
 }: {
-  /** Always true — the parent mounts this only while it is open. Kept on the
-   *  signature so the Dialog's own open/close contract stays explicit. */
   open: boolean;
   onOpenChange: (v: boolean) => void;
   onDone: () => void;
@@ -373,8 +401,13 @@ function DesignAskDialog({
       // The designer's own refusals carry a sentence worth showing verbatim —
       // NO_CONTACT_FIELD in particular tells the customer what to add to the
       // brief, which a generic message would throw away.
-      if (err instanceof ApiError && err.status === 422) toast.error(err.message);
-      else toastUnhandledApiError(err, "Couldn't design the form");
+      // 422 is the designer's own refusal (NO_CONTACT_FIELD names what to add
+      // to the brief); ASK_REJECTED is a 502 that means our types drifted from
+      // the schema, so it will fail identically forever and "try again" is the
+      // one thing that cannot help.
+      if (err instanceof ApiError && (err.status === 422 || err.code === "ASK_REJECTED")) {
+        toast.error(err.message);
+      } else toastUnhandledApiError(err, "Couldn't design the form");
     },
   });
 
@@ -447,6 +480,8 @@ function DesignAskDialog({
   );
 }
 
+const DEFAULT_WHATSAPP_MESSAGE = "Hi — I just filled in your form on LinkedIn.";
+
 function PublishAskDialog({
   ask,
   onOpenChange,
@@ -456,9 +491,11 @@ function PublishAskDialog({
   onOpenChange: () => void;
   onDone: () => void;
 }) {
+  // Fresh on every open: the parent keys this component by Ask, so mounting IS
+  // the reset. A number typed for one form cannot arrive on the next one's.
   const [useWhatsapp, setUseWhatsapp] = useState(false);
   const [phone, setPhone] = useState("");
-  const [message, setMessage] = useState("Hi — I just filled in your form on LinkedIn.");
+  const [message, setMessage] = useState(DEFAULT_WHATSAPP_MESSAGE);
   const [ctaUrl, setCtaUrl] = useState("");
 
   const publish = useMutation({
@@ -628,8 +665,8 @@ function EditWordingDialog({
   onOpenChange: () => void;
   onDone: () => void;
 }) {
-  // Initialised straight from props: the parent mounts this per Ask with a
-  // `key`, so there is no previous form's state to reset away from.
+  // Seeded from props at mount; the parent keys this component by Ask, so a
+  // different form always gets a fresh one.
   const [name, setName] = useState(ask.name);
   const [headline, setHeadline] = useState(ask.content.headline);
   const [thankYou, setThankYou] = useState(ask.content.thankYou.message);
@@ -656,6 +693,14 @@ function EditWordingDialog({
     },
   });
 
+  /**
+   * ★AN EMPTIED FIELD IS NOT A CHANGE THIS DIALOG CAN MAKE. There is no way to
+   * clear wording — LinkedIn's renderer skips a falsy value, so the platform
+   * would keep showing the old text while the row said otherwise. Without this
+   * the Save button lit up on an emptied field, sent `{}`, and came back with
+   * "Nothing to update" for someone who had just deleted something.
+   */
+  const incomplete = !name.trim() || !headline.trim() || !thankYou.trim();
   const unchanged =
     name.trim() === ask.name &&
     headline.trim() === ask.content.headline &&
@@ -706,7 +751,10 @@ function EditWordingDialog({
           <Button variant="ghost" onClick={() => onOpenChange()} disabled={edit.isPending}>
             Cancel
           </Button>
-          <Button onClick={() => edit.mutate()} disabled={edit.isPending || unchanged}>
+          <Button
+            onClick={() => edit.mutate()}
+            disabled={edit.isPending || unchanged || incomplete}
+          >
             {edit.isPending ? "Saving…" : "Save"}
           </Button>
         </DialogFooter>

--- a/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
@@ -1,0 +1,549 @@
+"use client";
+
+/**
+ * Lead forms — the Ask, on the Ads hub.
+ *
+ * ★WHAT THIS SURFACE ARGUES, AND WHY IT IS NOT A FORM BUILDER. Campaign
+ * Manager already gives away templates, profile prefill, thank-you CTAs and
+ * hidden fields, so competing on "AI writes your form" is competing on the
+ * commodity half. What it cannot do is tell an advertiser that a question is
+ * not worth its drop-off, because it optimises for SUBMISSIONS and never
+ * learns what became of the lead. We own the qualifier, the Inbox and the win
+ * definition — so every question here carries the reason it exists, and the
+ * questions the designer dropped are shown beside the ones it kept.
+ *
+ * Two states this panel refuses to render as success:
+ *   • a form LinkedIn rejected — the campaign stays active, the budget stays
+ *     committed, and nothing delivers. `serving` comes from the api so every
+ *     surface says the same thing.
+ *   • a live form whose leads cannot reach us because the Lead Sync permission
+ *     has not been granted. "Published ✓" over that is the exact lie this
+ *     whole feature was built to stop telling.
+ */
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+import { toastUnhandledApiError } from "@/lib/toast-errors";
+import { growthApi, type Ask, type AskIntent, type AskQuestion } from "@/lib/api/growth";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { EmptyState } from "@/components/molecules/empty-state";
+import { AlertTriangle, Archive, ClipboardList, RefreshCw, Sparkles } from "lucide-react";
+
+/** What the business is trying to start. Drives the starting question set and
+ *  the recommended button — LinkedIn's own CTA enum happens to name most of
+ *  these, which is a decent sign the taxonomy is the real one. */
+const INTENTS: Array<{ value: AskIntent; label: string; hint: string }> = [
+  { value: "demo_request", label: "Demo request", hint: "They want to see it working on their own data." },
+  { value: "consultation", label: "Consultation booking", hint: "They want to talk to someone first." },
+  { value: "b2b_lead", label: "Business enquiry", hint: "General enquiries you follow up by hand." },
+  { value: "newsletter", label: "Newsletter signup", hint: "One field, nothing more." },
+  { value: "event_registration", label: "Event registration", hint: "A webinar, workshop or launch." },
+  { value: "recruitment", label: "Recruitment", hint: "Candidates applying for a role." },
+  { value: "custom", label: "Something else", hint: "Describe it below and the designer works from that." },
+];
+
+const PURPOSE_LABEL: Record<AskQuestion["purpose"], string> = {
+  contact: "so a human can reply",
+  qualify: "the qualifier scores this",
+  route: "decides who handles it",
+  context: "context for the conversation",
+};
+
+/** Human sentence for LinkedIn's review verdicts. `PENDING` is deliberately
+ *  absent — it is a normal state for a few hours after publishing, and naming
+ *  it as a problem would cry wolf on every new form. */
+const REVIEW_PROBLEM: Record<string, string> = {
+  REJECTED: "LinkedIn rejected this form, so campaigns using it will not deliver.",
+  AUTO_REJECTED: "LinkedIn's automated review rejected this form, so campaigns using it will not deliver.",
+  NEEDS_REVIEW: "LinkedIn has flagged this form for manual review. It will not deliver until that clears.",
+};
+
+export function LeadFormsPanel() {
+  const queryClient = useQueryClient();
+  const [designOpen, setDesignOpen] = useState(false);
+  const [publishing, setPublishing] = useState<Ask | null>(null);
+  const [archiving, setArchiving] = useState<Ask | null>(null);
+
+  const asks = useQuery({
+    queryKey: ["growth-asks"],
+    queryFn: () => growthApi.listAsks(),
+    staleTime: 30_000,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["growth-asks"] });
+
+  const sync = useMutation({
+    mutationFn: (id: string) => growthApi.syncAsk(id),
+    onSuccess: (res) => {
+      invalidate();
+      const review = res.ask.channels?.linkedin?.reviewStatus;
+      if (review && REVIEW_PROBLEM[review]) toast.warning(REVIEW_PROBLEM[review]);
+      else toast.success("Up to date with LinkedIn.");
+    },
+    onError: (err) => toastUnhandledApiError(err, "Couldn't check with LinkedIn"),
+  });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div>
+          <h3 className="text-base font-semibold">Lead forms</h3>
+          <p className="text-sm text-muted-foreground">
+            What you need to know before someone is worth a call — and no more. Every
+            question here has to earn its place.
+          </p>
+        </div>
+        <Button size="sm" onClick={() => setDesignOpen(true)}>
+          <Sparkles className="mr-2 size-4" />
+          New form
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {asks.isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+          </div>
+        ) : asks.isError ? (
+          <EmptyState
+            icon={RefreshCw}
+            title="Couldn't load your lead forms"
+            description="Refresh in a moment — nothing has changed on LinkedIn."
+          />
+        ) : (asks.data?.asks.length ?? 0) === 0 ? (
+          <EmptyState
+            icon={ClipboardList}
+            title="No lead forms yet"
+            description="A lead-generation campaign needs a form to capture with. We'll design one from what your business actually does, and drop the questions nothing downstream reads."
+            action={{ label: "Design a form", onClick: () => setDesignOpen(true) }}
+          />
+        ) : (
+          asks.data!.asks.map((ask) => (
+            <AskRow
+              key={ask._id}
+              ask={ask}
+              onPublish={() => setPublishing(ask)}
+              onArchive={() => setArchiving(ask)}
+              onSync={() => sync.mutate(ask._id)}
+              syncing={sync.isPending && sync.variables === ask._id}
+            />
+          ))
+        )}
+      </CardContent>
+
+      <DesignAskDialog open={designOpen} onOpenChange={setDesignOpen} onDone={invalidate} />
+      <PublishAskDialog ask={publishing} onOpenChange={() => setPublishing(null)} onDone={invalidate} />
+      <ArchiveAskDialog ask={archiving} onOpenChange={() => setArchiving(null)} onDone={invalidate} />
+    </Card>
+  );
+}
+
+function AskRow({
+  ask,
+  onPublish,
+  onArchive,
+  onSync,
+  syncing,
+}: {
+  ask: Ask;
+  onPublish: () => void;
+  onArchive: () => void;
+  onSync: () => void;
+  syncing: boolean;
+}) {
+  const channel = ask.channels?.linkedin;
+  const review = channel?.reviewStatus;
+  const problem = review ? REVIEW_PROBLEM[review] : undefined;
+
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{ask.name}</span>
+            {ask.status === "draft" ? (
+              <Badge className="bg-muted text-muted-foreground">Draft</Badge>
+            ) : ask.status === "archived" ? (
+              <Badge className="bg-muted/60 text-muted-foreground">Archived</Badge>
+            ) : ask.serving ? (
+              <Badge className="bg-success/15 text-success-on-tint">Live</Badge>
+            ) : (
+              <Badge className="bg-warning/15 text-warning-on-tint">Not delivering</Badge>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{ask.content.headline}</p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          {ask.status === "draft" ? (
+            <Button size="sm" onClick={onPublish}>
+              Publish to LinkedIn
+            </Button>
+          ) : null}
+          {channel ? (
+            <Button size="sm" variant="outline" onClick={onSync} disabled={syncing}>
+              <RefreshCw className={`mr-2 size-4 ${syncing ? "animate-spin" : ""}`} />
+              Check
+            </Button>
+          ) : null}
+          {ask.status !== "archived" ? (
+            <Button size="sm" variant="ghost" onClick={onArchive}>
+              <Archive className="size-4" />
+              <span className="sr-only">Archive</span>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {/* ★THE FAILURE THAT LOOKS HEALTHY. Without this the campaign shows
+          active, the budget shows committed, and nothing is delivered. */}
+      {problem ? (
+        <div className="mt-3 flex gap-2 rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-warning-on-tint" />
+          <div>
+            <p>{problem}</p>
+            {channel?.rejectionReasons?.length ? (
+              <ul className="mt-1 list-disc pl-4 text-muted-foreground">
+                {channel.rejectionReasons.map((r) => (
+                  <li key={r}>{r}</li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <ul className="mt-3 space-y-1 text-sm">
+        {ask.content.questions.map((q) => (
+          <li key={q.key} className="flex flex-wrap items-baseline gap-x-2">
+            <span>{q.prompt}</span>
+            {!q.required ? <span className="text-xs text-muted-foreground">(optional)</span> : null}
+            {/* The argument, made visible: a question that cannot say who reads
+                its answer should not be on the form. */}
+            <span className="text-xs text-muted-foreground">— {PURPOSE_LABEL[q.purpose]}: {q.whyAsked}</span>
+          </li>
+        ))}
+      </ul>
+
+      {ask.content.thankYou.ctaKind === "whatsapp" ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          After submitting, they land in a WhatsApp conversation with you — in the same
+          Inbox as everything else.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function DesignAskDialog({
+  open,
+  onOpenChange,
+  onDone,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onDone: () => void;
+}) {
+  const [intent, setIntent] = useState<AskIntent>("demo_request");
+  const [offer, setOffer] = useState("");
+  const [followUp, setFollowUp] = useState("");
+
+  const design = useMutation({
+    mutationFn: () =>
+      growthApi.designAsk({
+        intent,
+        ...(offer.trim() ? { offer: offer.trim() } : {}),
+        ...(followUp.trim() ? { followUp: followUp.trim() } : {}),
+      }),
+    onSuccess: () => {
+      onDone();
+      onOpenChange(false);
+      setOffer("");
+      setFollowUp("");
+      toast.success("Form drafted — read it through, then publish when you're happy.");
+    },
+    onError: (err) => {
+      // The designer's own refusals carry a sentence worth showing verbatim —
+      // NO_CONTACT_FIELD in particular tells the customer what to add to the
+      // brief, which a generic message would throw away.
+      if (err instanceof ApiError && err.status === 422) toast.error(err.message);
+      else toastUnhandledApiError(err, "Couldn't design the form");
+    },
+  });
+
+  const hint = INTENTS.find((i) => i.value === intent)?.hint;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>What do you want to know?</DialogTitle>
+          <DialogDescription>
+            Nothing goes to LinkedIn yet. You&apos;ll see the questions and why each one
+            is there before anything is published.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="ask-intent">What should this form start?</Label>
+            <Select value={intent} onValueChange={(v) => setIntent(v as AskIntent)}>
+              <SelectTrigger id="ask-intent">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {INTENTS.map((i) => (
+                  <SelectItem key={i.value} value={i.value}>
+                    {i.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ask-offer">What are they getting? (optional)</Label>
+            <Textarea
+              id="ask-offer"
+              rows={3}
+              value={offer}
+              onChange={(e) => setOffer(e.target.value)}
+              placeholder="The offer, the page it sits behind, what makes it worth their details."
+            />
+            <p className="text-xs text-muted-foreground">
+              Thin detail means a shorter form, which is usually the right trade anyway.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ask-followup">How do you follow leads up? (optional)</Label>
+            <Input
+              id="ask-followup"
+              value={followUp}
+              onChange={(e) => setFollowUp(e.target.value)}
+              placeholder="e.g. Priya calls them within a day"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={design.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={() => design.mutate()} disabled={design.isPending}>
+            {design.isPending ? "Designing…" : "Design the form"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PublishAskDialog({
+  ask,
+  onOpenChange,
+  onDone,
+}: {
+  ask: Ask | null;
+  onOpenChange: () => void;
+  onDone: () => void;
+}) {
+  const [useWhatsapp, setUseWhatsapp] = useState(false);
+  const [phone, setPhone] = useState("");
+  const [message, setMessage] = useState("Hi — I just filled in your form on LinkedIn.");
+  const [ctaUrl, setCtaUrl] = useState("");
+
+  const publish = useMutation({
+    mutationFn: () =>
+      growthApi.publishAsk(ask!._id, {
+        ...(useWhatsapp ? { whatsapp: { phone: phone.trim(), message: message.trim() } } : {}),
+        ...(!useWhatsapp && ctaUrl.trim() ? { ctaUrl: ctaUrl.trim() } : {}),
+      }),
+    onSuccess: (res) => {
+      onDone();
+      onOpenChange();
+      // ★THE FORM BEING LIVE AND THE LEADS REACHING YOU ARE DIFFERENT FACTS,
+      // and reporting the first as if it covered the second is the failure
+      // this whole build exists to end.
+      if (res.leadDelivery.status === "blocked" || res.leadDelivery.status === "unknown") {
+        toast.warning(res.leadDelivery.reason, { duration: 12_000 });
+      } else {
+        toast.success("Your form is live on LinkedIn and leads will land in your Inbox.");
+      }
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status >= 400 && err.status < 500) toast.error(err.message);
+      else toastUnhandledApiError(err, "Couldn't publish the form");
+    },
+  });
+
+  return (
+    <Dialog open={!!ask} onOpenChange={() => onOpenChange()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Publish to LinkedIn</DialogTitle>
+          <DialogDescription>
+            {/* Not a warning about spend — publishing a form cannot spend anything.
+                It is a warning about the one thing that really is irreversible. */}
+            Once a form is live, LinkedIn will not let its questions be changed. The
+            wording and the thank-you can still be edited; the field list cannot.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>What happens after they submit?</Label>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant={useWhatsapp ? "default" : "outline"}
+                onClick={() => setUseWhatsapp(true)}
+              >
+                Open WhatsApp
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={!useWhatsapp ? "default" : "outline"}
+                onClick={() => setUseWhatsapp(false)}
+              >
+                Send them to a page
+              </Button>
+            </div>
+          </div>
+
+          {useWhatsapp ? (
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <Label htmlFor="ask-phone">Your WhatsApp number</Label>
+                <Input
+                  id="ask-phone"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  placeholder="+91 98765 43210"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ask-message">The message they arrive with</Label>
+                <Input
+                  id="ask-message"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                The conversation lands in your Inbox beside everything else, seconds
+                after they submit — instead of a row waiting for a callback.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label htmlFor="ask-cta">Page to send them to (optional)</Label>
+              <Input
+                id="ask-cta"
+                value={ctaUrl}
+                onChange={(e) => setCtaUrl(e.target.value)}
+                placeholder="https://…"
+              />
+              <p className="text-xs text-muted-foreground">
+                Must start with https:// — they have just typed their details into a form.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange()} disabled={publish.isPending}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => publish.mutate()}
+            disabled={publish.isPending || (useWhatsapp && phone.trim().length < 6)}
+          >
+            {publish.isPending ? "Publishing…" : "Publish"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ArchiveAskDialog({
+  ask,
+  onOpenChange,
+  onDone,
+}: {
+  ask: Ask | null;
+  onOpenChange: () => void;
+  onDone: () => void;
+}) {
+  const archive = useMutation({
+    mutationFn: () => growthApi.archiveAsk(ask!._id),
+    onSuccess: () => {
+      onDone();
+      onOpenChange();
+      toast.success("Form archived — it has stopped collecting.");
+    },
+    onError: (err) => {
+      // ★AN ARCHIVE THAT FAILED MUST NOT READ AS ONE THAT WORKED. The api
+      // refuses to flip the local row when LinkedIn wouldn't archive the form,
+      // precisely so this message can be true.
+      if (err instanceof ApiError) toast.error(err.message);
+      else toastUnhandledApiError(err, "Couldn't archive the form");
+    },
+  });
+
+  return (
+    <AlertDialog open={!!ask} onOpenChange={() => onOpenChange()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop collecting with this form?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Any campaign still using it will stop delivering. Leads already in your
+            Inbox are unaffected.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={archive.isPending}>Keep it</AlertDialogCancel>
+          <AlertDialogAction onClick={() => archive.mutate()} disabled={archive.isPending}>
+            {archive.isPending ? "Archiving…" : "Archive"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/lead-forms-panel.tsx
@@ -60,6 +60,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { EmptyState } from "@/components/molecules/empty-state";
+import { reconnectHref, ADS_LINKEDIN_PATH, LINKEDIN_ADS_PROVIDER } from "@/lib/integrations-connect";
 import { AlertTriangle, Archive, ClipboardList, RefreshCw, Sparkles } from "lucide-react";
 
 /** What the business is trying to start. Drives the starting question set and
@@ -85,6 +86,9 @@ const PURPOSE_LABEL: Record<AskQuestion["purpose"], string> = {
 /** Human sentence for LinkedIn's review verdicts. `PENDING` is deliberately
  *  absent — it is a normal state for a few hours after publishing, and naming
  *  it as a problem would cry wolf on every new form. */
+/** Reconnect CTAs come back HERE, to the surface whose work they unblock. */
+const RECONNECT_HREF = reconnectHref(ADS_LINKEDIN_PATH, LINKEDIN_ADS_PROVIDER);
+
 const REVIEW_PROBLEM: Record<string, string> = {
   REJECTED: "LinkedIn rejected this form, so campaigns using it will not deliver.",
   AUTO_REJECTED: "LinkedIn's automated review rejected this form, so campaigns using it will not deliver.",
@@ -476,6 +480,28 @@ function PublishAskDialog({
       }
     },
     onError: (err) => {
+      const code = err instanceof ApiError ? err.code : undefined;
+      if (code === "PUBLISH_PERSIST_FAILED") {
+        /**
+         * ★THE ONE MESSAGE THAT MUST NOT BE GENERIC, and it is a 502 so it
+         * would otherwise have been. The form EXISTS on LinkedIn and we lost
+         * the record of it; the message carries the id support needs and, more
+         * importantly, tells them not to press Publish again — which is what a
+         * generic "something went wrong, try again" would invite, and would
+         * mint a second form.
+         */
+        toast.error(err instanceof ApiError ? err.message : "", { duration: 30_000 });
+        return;
+      }
+      if (code === "NEEDS_REAUTH") {
+        toast.error("LinkedIn Ads needs reconnecting before this form can be published.", {
+          action: {
+            label: "Reconnect",
+            onClick: () => { window.location.href = RECONNECT_HREF; },
+          },
+        });
+        return;
+      }
       if (err instanceof ApiError && err.status >= 400 && err.status < 500) toast.error(err.message);
       else toastUnhandledApiError(err, "Couldn't publish the form");
     },

--- a/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
+++ b/src/app/(site)/dashboard/ads/_components/linkedin-ads-panel.tsx
@@ -58,6 +58,7 @@ import {
   Target,
 } from "lucide-react";
 import { AudienceCard } from "./audience-card";
+import { LeadFormsPanel } from "./lead-forms-panel";
 import { TargetingDialog, editorTargeting } from "./targeting-dialog";
 import { UseSavedAudienceDialog } from "@/components/audience/use-saved-audience-dialog";
 
@@ -185,6 +186,10 @@ export function LinkedInAdsPanel() {
             </Card>
           ) : null}
           <CampaignsPanel />
+          {/* Below the campaigns, deliberately: a form is the thing a lead-gen
+              campaign needs BEFORE it can exist, but the campaign list is what
+              a returning customer came for. */}
+          <LeadFormsPanel />
         </>
       )}
     </div>

--- a/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/boost-campaign-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
+import { LeadFormPicker } from "@/components/ads/lead-form-picker";
 import { growthApi } from "@/lib/api/growth";
 import {
   LATEST_POLITICAL_DECLARATION_NOTICE,
@@ -67,18 +68,21 @@ import { AudiencePreview, useAudienceProposal } from "./audience-preview";
 const RECONNECT_HREF = reconnectHref("/dashboard/content/linkedin", LINKEDIN_ADS_PROVIDER);
 
 /**
- * Objectives a BOOST can use. `lead_generation` is deliberately absent:
- * LinkedIn requires a lead gen form on every creative under a lead-gen
- * campaign, and sponsoring an existing organic post gives us nowhere to
- * attach one — the server rejects that combination
- * (VALIDATION_LEADGEN_FORM_REQUIRED). Offering it here only ever
- * produced a guaranteed failure. Lead-gen campaigns are built in
- * LinkedIn Campaign Manager; the objective stays valid on other paths.
+ * Objectives a BOOST can use.
+ *
+ * ★`lead_generation` IS BACK, AND ONLY BECAUSE THERE IS SOMETHING TO ATTACH.
+ * LinkedIn requires a lead gen form URN on every creative under a lead-gen
+ * campaign; until Lead forms existed nothing in the product could produce one,
+ * so this option was removed after it had spent a while guaranteeing a
+ * failure. It is now gated on a LIVE form rather than hidden — a business with
+ * no form is told what to make, which is a different thing from being told the
+ * objective does not exist.
  */
 const OBJECTIVES: Array<{ value: BoostObjective; label: string }> = [
   { value: "engagement", label: "Engagement (boost the post)" },
   { value: "brand_awareness", label: "Brand awareness" },
   { value: "website_traffic", label: "Website traffic" },
+  { value: "lead_generation", label: "Lead generation (collect enquiries)" },
 ];
 
 /** How long the boost will wait for the durable declaration write before
@@ -100,6 +104,7 @@ export function BoostCampaignDialog({
   const queryClient = useQueryClient();
   const [name, setName] = useState(defaultName);
   const [objective, setObjective] = useState<BoostObjective>("engagement");
+  const [askId, setAskId] = useState<string>("");
   /**
    * Decision D13's confirmed geography. `undefined` means "use what we inferred
    * from the business", which is the default and today's behaviour; an array —
@@ -180,7 +185,13 @@ export function BoostCampaignDialog({
     /^[A-Za-z]{3}$/.test(currencyCode.trim()) &&
     Number.isFinite(durationNumber) &&
     durationNumber >= 1 &&
-    durationNumber <= 366;
+    durationNumber <= 366 &&
+    // ★A LEAD-GEN BOOST WITHOUT A FORM CANNOT SUCCEED. LinkedIn refuses the
+    // creative, and it does so only AFTER the campaign group and campaign have
+    // been created — so letting the button through would leave two orphan
+    // artefacts in the customer's Campaign Manager for an error the dialog
+    // already knew about.
+    (objective !== "lead_generation" || askId.length > 0);
 
   const boost = useMutation({
     // The declaration answers travel as VARIABLES, not read from state in
@@ -196,6 +207,9 @@ export function BoostCampaignDialog({
         currencyCode: currencyCode.trim().toUpperCase(),
         durationDays: durationNumber,
         notPolitical: vars.notPolitical,
+        // Only meaningful for lead_generation, and the server refuses that
+        // objective without it — see the picker below.
+        ...(objective === "lead_generation" && askId ? { askId } : {}),
         // Sent so the campaign gets the audience the preview showed. Without
         // it the boost would resolve from the profile's own countries and the
         // preview would be a lie about its own effect.
@@ -318,13 +332,29 @@ export function BoostCampaignDialog({
         });
       } else if (code === "RATE_LIMITED") {
         toast.error("LinkedIn is rate-limiting us — give it a minute and try again.");
-      } else if (code === "VALIDATION_LEADGEN_FORM_REQUIRED") {
-        // Defensive only — the objective isn't in OBJECTIVES, so this
-        // dialog can't produce it today. Kept so re-adding the option
-        // fails legibly rather than through the generic branch.
-        toast.error(
-          "Lead-generation campaigns need a LinkedIn lead gen form — pick another objective.",
-        );
+      } else if (
+        code === "VALIDATION_LEADGEN_FORM_REQUIRED" ||
+        code === "ASK_REQUIRED" ||
+        code === "ASK_NOT_PUBLISHED" ||
+        code === "ASK_NOT_FOUND"
+      ) {
+        toast.error("This campaign needs a live lead form.", {
+          description: "Create or publish one under Ads → Lead forms, then boost.",
+          action: {
+            label: "Open Lead forms",
+            onClick: () => { window.location.href = ADS_LINKEDIN_PATH; },
+          },
+        });
+      } else if (code === "ASK_NOT_SERVING" || code === "ASK_WRONG_AD_ACCOUNT") {
+        // ★NOT A GENERIC FAILURE. A rejected form leaves a campaign looking
+        // perfectly healthy while nothing delivers, so the message has to name
+        // the form as the thing to go and look at.
+        toast.error(err instanceof ApiError ? err.message : "That lead form can't be used.", {
+          action: {
+            label: "Open Lead forms",
+            onClick: () => { window.location.href = ADS_LINKEDIN_PATH; },
+          },
+        });
       } else {
         // Everything else: friendly copy keyed on the code, with the
         // request id for support. NOT err.message — see toast-errors.ts
@@ -392,6 +422,10 @@ export function BoostCampaignDialog({
               </SelectContent>
             </Select>
           </div>
+
+          {objective === "lead_generation" ? (
+            <LeadFormPicker value={askId} onChange={setAskId} />
+          ) : null}
 
           {/* The audience this boost will get, BEFORE the money is committed —
               and the single inference the user is asked to confirm. */}

--- a/src/components/ads/lead-form-picker.tsx
+++ b/src/components/ads/lead-form-picker.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * Pick the lead form a lead-generation campaign captures with.
+ *
+ * ★IT ONLY OFFERS FORMS THAT WOULD ACTUALLY SERVE. A form LinkedIn rejected,
+ * or one still sitting as a draft, produces a campaign that goes active with a
+ * committed budget and delivers nothing — the creative sits behind a serving
+ * hold and every local row still reads healthy. Filtering here means the
+ * server's refusal (`ASK_NOT_SERVING`) is a backstop rather than the customer's
+ * first hint, and the empty state names the thing to go and fix.
+ */
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { growthApi } from "@/lib/api/growth";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ADS_LINKEDIN_PATH } from "@/lib/integrations-connect";
+
+export function LeadFormPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (askId: string) => void;
+}) {
+  const asks = useQuery({
+    queryKey: ["growth-asks"],
+    queryFn: () => growthApi.listAsks(),
+    staleTime: 30_000,
+  });
+
+  const usable = (asks.data?.asks ?? []).filter((a) => a.status === "published" && a.serving);
+
+  if (asks.isLoading) {
+    return (
+      <div className="space-y-1.5">
+        <Label>Lead form</Label>
+        <Skeleton className="h-9 w-full" />
+      </div>
+    );
+  }
+
+  if (asks.isError) {
+    return (
+      <div className="space-y-1.5">
+        <Label>Lead form</Label>
+        <p className="text-xs text-muted-foreground">
+          We couldn&apos;t load your lead forms just now. Refresh and try again — nothing
+          has been created.
+        </p>
+      </div>
+    );
+  }
+
+  if (usable.length === 0) {
+    // Two different situations, and the difference matters: nothing at all
+    // versus something that exists and is not delivering. The second sends
+    // them somewhere with an explanation waiting.
+    const hasSomething = (asks.data?.asks ?? []).length > 0;
+    return (
+      <div className="space-y-1.5">
+        <Label>Lead form</Label>
+        <p className="text-xs text-muted-foreground">
+          {hasSomething
+            ? "None of your lead forms is live on LinkedIn right now."
+            : "You need a lead form before you can collect enquiries from an ad."}{" "}
+          <Link href={ADS_LINKEDIN_PATH} className="underline underline-offset-4">
+            {hasSomething ? "Check your forms" : "Create one"}
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor="boost-lead-form">Lead form</Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id="boost-lead-form">
+          <SelectValue placeholder="Choose a form" />
+        </SelectTrigger>
+        <SelectContent>
+          {usable.map((a) => (
+            <SelectItem key={a._id} value={a._id}>
+              {a.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        Answers land in your Inbox, scored, with the questions named — not as a
+        spreadsheet you have to go and fetch.
+      </p>
+    </div>
+  );
+}

--- a/src/components/ads/lead-form-picker.tsx
+++ b/src/components/ads/lead-form-picker.tsx
@@ -12,6 +12,7 @@
  */
 
 import Link from "next/link";
+import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { growthApi } from "@/lib/api/growth";
 import { Label } from "@/components/ui/label";
@@ -38,7 +39,31 @@ export function LeadFormPicker({
     staleTime: 30_000,
   });
 
-  const usable = (asks.data?.asks ?? []).filter((a) => a.status === "published" && a.serving);
+  const usable = useMemo(
+    () =>
+      (asks.data?.asks ?? []).filter(
+        (a) =>
+          a.status === "published" &&
+          a.serving &&
+          a.channels?.linkedin?.leadDelivery?.status !== "blocked",
+      ),
+    [asks.data],
+  );
+
+  /**
+   * ★A SELECTION THE PICKER NO LONGER OFFERS MUST BE CLEARED, or the parent's
+   * submit gate stays satisfied by an id nothing is showing. The list refetches
+   * on window focus, so the ordinary path is: pick a form, tab to LinkedIn to
+   * look at it, come back to find it rejected — at which point this component
+   * renders "none of your forms is live" with no `<Select>` at all, while Boost
+   * stays enabled on the dead form. The server refuses it, but this component's
+   * whole job is to be the hint BEFORE the server has to.
+   */
+  const loaded = !!asks.data;
+  useEffect(() => {
+    if (!loaded) return;
+    if (value && !usable.some((a) => a._id === value)) onChange("");
+  }, [loaded, usable, value, onChange]);
 
   if (asks.isLoading) {
     return (
@@ -49,7 +74,11 @@ export function LeadFormPicker({
     );
   }
 
-  if (asks.isError) {
+  // ★ONLY WHEN THERE IS NOTHING TO SHOW. react-query keeps `data` through a
+  // failed background refetch, and replacing a populated, valid selector with
+  // an error paragraph over one transient 500 would take the choice away while
+  // leaving the parent's submit gate satisfied.
+  if (asks.isError && !asks.data) {
     return (
       <div className="space-y-1.5">
         <Label>Lead form</Label>

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -175,6 +175,102 @@ export type RunNowResult =
   | { created: false; reason: "already_ran" | "optimizer_disabled" | "no_data" }
   | { created: true; runId: string; proposalCount: number };
 
+
+// ── The Ask — lead capture, channel-neutral ───────────────────────────────
+
+/**
+ * ★NO LINKEDIN VOCABULARY IN THE DEFINITION HALF, deliberately. `identity`,
+ * `adButton` and `thankYou.ctaLabel` are ours; the api's adapter maps them to
+ * LinkedIn's own enums. The same Ask renders to WhatsApp and site forms later,
+ * and this type must not have to change when it does.
+ */
+export type AskIdentity =
+  | "first_name" | "last_name" | "email" | "work_email" | "phone" | "work_phone"
+  | "job_title" | "job_function" | "seniority" | "company_name" | "company_size"
+  | "industry" | "city" | "state" | "country" | "postal_code"
+  | "linkedin_profile" | "degree" | "field_of_study" | "school" | "gender" | "custom";
+
+/** Which downstream consumer justifies asking. A question that fits none of
+ *  these does not belong on the form — the discipline the whole surface is
+ *  built around. */
+export type AskQuestionPurpose = "contact" | "qualify" | "route" | "context";
+
+export type AskIntent =
+  | "demo_request" | "consultation" | "newsletter"
+  | "event_registration" | "recruitment" | "b2b_lead" | "custom";
+
+export interface AskQuestion {
+  key: string;
+  prompt: string;
+  hint?: string;
+  identity: AskIdentity;
+  kind: "text" | "choice";
+  options?: string[];
+  required: boolean;
+  purpose: AskQuestionPurpose;
+  /** One sentence the business owner would agree with. Shown beside the
+   *  question so the subtraction argument is visible, not merely claimed. */
+  whyAsked: string;
+  workEmailOnly?: boolean;
+}
+
+export interface Ask {
+  _id: string;
+  name: string;
+  intent: AskIntent;
+  status: "draft" | "published" | "archived";
+  locale: { country: string; language: string };
+  adButton: string;
+  content: {
+    headline: string;
+    description?: string;
+    questions: AskQuestion[];
+    consents?: Array<{ key: string; text: string; required: boolean }>;
+    privacyPolicyUrl?: string;
+    legalDisclaimer?: string;
+    thankYou: {
+      message: string;
+      ctaLabel: string;
+      ctaUrl?: string;
+      ctaKind?: "url" | "whatsapp";
+    };
+  };
+  channels?: {
+    linkedin?: {
+      formId: string;
+      formUrn: string;
+      adAccountId: string;
+      state: "DRAFT" | "PUBLISHED" | "ARCHIVED";
+      reviewStatus?: string;
+      rejectionReasons?: string[];
+      checkedAt?: string;
+    };
+  };
+  design?: { rationale?: string; editedByHuman?: boolean };
+  /**
+   * ★SERVED BY THE API, NOT DERIVED HERE. A rejected form leaves the campaign
+   * active and the budget intact while nothing delivers, so "is it actually
+   * working" has to read the same in every surface. Absent until the Ask has
+   * been published to a channel.
+   */
+  serving?: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+/**
+ * What happened to lead DELIVERY, which is a different question from whether
+ * the form exists.
+ *
+ * `blocked` means LinkedIn has not granted the Lead Sync permission: the form
+ * is live and will collect leads on LinkedIn, and none of them will reach the
+ * Inbox. Saying "published ✓" over that state is the thing this field exists
+ * to prevent.
+ */
+export type LeadDelivery =
+  | { status: "created" | "existing"; subscriptionId: string }
+  | { status: "blocked" | "unknown"; reason: string };
+
 export const growthApi = {
   /** Recent weekly optimizer runs (newest first, up to 12). */
   adjustments: () => api.get<{ runs: OptimizerRun[] }>("/v1/growth/adjustments"),
@@ -247,4 +343,38 @@ export const growthApi = {
       label: string;
     } | null;
   }) => api.patch<GrowthSettingsResponse>("/v1/growth/settings", patch),
+
+  // ── Asks ───────────────────────────────────────────────────────────────
+
+  listAsks: (includeArchived = false) =>
+    api.get<{ asks: Ask[] }>(
+      `/v1/growth/asks${includeArchived ? "?includeArchived=true" : ""}`,
+    ),
+
+  /** Design a new Ask. Runs the designer; NOTHING reaches LinkedIn. */
+  designAsk: (body: {
+    intent: AskIntent;
+    locale?: { country: string; language: string };
+    offer?: string;
+    followUp?: string;
+  }) => api.post<{ ask: Ask }>("/v1/growth/asks", body),
+
+  /**
+   * Create the form on LinkedIn.
+   *
+   * ★THE ONE IRREVERSIBLE STEP ON THIS SURFACE, and not because it spends
+   * anything — it cannot — but because LinkedIn freezes a published form's
+   * questions. Changing the field list afterwards means a new form and a new
+   * creative, so the UI asks before calling this.
+   */
+  publishAsk: (
+    id: string,
+    body: { whatsapp?: { phone: string; message: string }; ctaUrl?: string },
+  ) => api.post<{ ask: Ask; leadDelivery: LeadDelivery }>(`/v1/growth/asks/${id}/publish`, body),
+
+  /** Re-read the form from LinkedIn — the only way a rejection surfaces. */
+  syncAsk: (id: string) => api.post<{ ask: Ask }>(`/v1/growth/asks/${id}/sync`),
+
+  /** Stop the form collecting, on LinkedIn and here. */
+  archiveAsk: (id: string) => api.post<{ ask: Ask }>(`/v1/growth/asks/${id}/archive`),
 };

--- a/src/lib/api/growth.ts
+++ b/src/lib/api/growth.ts
@@ -244,6 +244,18 @@ export interface Ask {
       reviewStatus?: string;
       rejectionReasons?: string[];
       checkedAt?: string;
+      /**
+       * ★WHETHER THE LEADS ARRIVE, which is a different fact from the form
+       * being live and used to exist only as a toast. `blocked` means the Lead
+       * Sync permission has not been granted: the form collects on LinkedIn
+       * and nothing reaches the Inbox. Absent means nobody has established it
+       * either way — a third state, not a green one.
+       */
+      leadDelivery?: {
+        status: "created" | "existing" | "blocked" | "unknown";
+        reason?: string;
+        checkedAt?: string;
+      };
     };
   };
   design?: { rationale?: string; editedByHuman?: boolean };
@@ -371,6 +383,25 @@ export const growthApi = {
     id: string,
     body: { whatsapp?: { phone: string; message: string }; ctaUrl?: string },
   ) => api.post<{ ask: Ask; leadDelivery: LeadDelivery }>(`/v1/growth/asks/${id}/publish`, body),
+
+  /**
+   * Edit the WORDING.
+   *
+   * ★THE QUESTIONS ARE NOT IN THIS PAYLOAD, and that is LinkedIn's rule rather
+   * than a missing field: a live form's field list is frozen, so changing what
+   * you ask means a new form. The server refuses it by name
+   * (`QUESTIONS_FROZEN`) if a client ever tries.
+   */
+  editAsk: (
+    id: string,
+    body: {
+      name?: string;
+      headline?: string;
+      description?: string;
+      thankYouMessage?: string;
+      legalDisclaimer?: string;
+    },
+  ) => api.patch<{ ask: Ask }>(`/v1/growth/asks/${id}`, body),
 
   /** Re-read the form from LinkedIn — the only way a rejection surfaces. */
   syncAsk: (id: string) => api.post<{ ask: Ask }>(`/v1/growth/asks/${id}/sync`),

--- a/src/lib/api/linkedin-ads.ts
+++ b/src/lib/api/linkedin-ads.ts
@@ -226,6 +226,16 @@ export interface BoostCampaignInput {
    * "not political": that is a legal declaration the customer makes, not us.
    */
   notPolitical?: boolean;
+  /**
+   * The lead form (`growth_asks`) this campaign captures with.
+   *
+   * ★REQUIRED WHEN `objective` IS `lead_generation`, and that is LinkedIn's
+   * rule, not ours: every creative under a lead-gen campaign needs a lead gen
+   * form URN, and the refusal arrives only AFTER the campaign group and
+   * campaign exist. The server refuses up front (`ASK_REQUIRED`) so a missing
+   * form costs a message rather than two orphans in Campaign Manager.
+   */
+  askId?: string;
 }
 
 export const linkedInAdsApi = {


### PR DESCRIPTION
Third of three. Needs **peakhour-mongodb#511** then **peakhour-api#1072** merged first.

Adds the Lead forms surface to the Ads hub and puts `lead_generation` back in the Boost dialog, where it was removed after a spell of guaranteeing failure — LinkedIn requires a form URN on every lead-gen creative and nothing could produce one. It is **gated on a live form now rather than hidden**, so a business with none is told what to make instead of that the objective does not exist.

## Not a form builder

Campaign Manager already gives away templates, prefill and thank-you CTAs. What it cannot do is tell an advertiser a question is not worth its drop-off, because it optimises for submissions and never learns what became of the lead. So every question renders **beside the reason it exists and the consumer that reads its answer**, and the questions the designer dropped are shown next to the ones it kept.

## Two states deliberately refused as success

- **A form LinkedIn rejected** shows "Not delivering" with the reasons. The campaign stays active and the budget stays committed while nothing serves — the failure that looks healthy.
- **A live form whose leads cannot reach us** (Lead Sync not granted). Publishing reports lead *delivery* separately from the form going live, and the verdict is now persisted rather than living in a toast, so it survives a reload and is visible to a teammate who did not click Publish.

## Round 1

The publish dialog was mounted once for the life of the panel, so it kept whatever was typed for the previous form: publish form A over WhatsApp, open form B, and B's dialog was already on the WhatsApp branch with **A's number**, submit already enabled — one click from writing it onto a form LinkedIn then freezes. Every dialog mounts per Ask now.

The picker filtered its options but never cleared the parent's value, so picking a form and coming back to find it rejected left Boost enabled on the dead one. Plus per-row sync state (the shared mutation re-enabled the first row's button mid-request, and that disabled state is the double-fire guard), `aria-pressed` on the control that decides where a lead is sent, and `role="alert"` on the rejection callout.

Typecheck clean; 24 files / 379 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)