### PR TITLE
feat(linkedin): Library — you can finally see the comments

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ThreadPanel } from "./thread-panel";
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
@@ -22,6 +23,9 @@ import {
   Share2,
   User,
   X,
+  MousePointerClick,
+  MessagesSquare,
+  TrendingUp,
 } from "lucide-react";
 import {
   linkedInContentApi,
@@ -55,7 +59,7 @@ const AUTHOR_FILTERS: { value: AuthorFilter; label: string }[] = [
   { value: "org", label: "Pages" },
 ];
 
-export function FeedPanel() {
+export function LibraryPanel() {
   const [authorFilter, setAuthorFilter] = useState<AuthorFilter>("all");
 
   const {
@@ -175,6 +179,25 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
   // on a resolvable author AND a real post URN.
   const author = postAuthor(post);
   const canComment = author !== null && !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
+  const [threadOpen, setThreadOpen] = useState(false);
+  // Reading a thread needs a real URN but NOT a resolvable author — you can
+  // look at engagement on a post you cannot currently comment as.
+  const canEngage = !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
+  // Opening a thread costs a LinkedIn call against a ~500/day app-wide
+  // budget, so the entry point is hidden when the counters say there is
+  // nothing in there to read.
+  const hasEngagement =
+    post.performance.comments > 0 || post.performance.likes > 0;
+  // Engagement over reach. Null rather than 0 when there are no
+  // impressions: a post nobody saw has no rate, and rendering "0.0%"
+  // would read as failure rather than as absence.
+  const engagementRate =
+    post.performance.impressions > 0
+      ? ((post.performance.likes + post.performance.comments + post.performance.shares +
+          post.performance.clicks) /
+          post.performance.impressions) *
+        100
+      : null;
 
   return (
     <li>
@@ -209,11 +232,44 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
             {post.content}
           </p>
 
+{/* ★Two lines, because they answer different questions. Reach is
+              what the post DID; engagement is what people did back, and it
+              is the half that can be acted on — so it carries the button.
+
+              `clicks` was already in the payload and simply never rendered.
+              The engagement RATE is the number worth leading on: a post
+              with 400 impressions and 20 comments is doing better than one
+              with 12,000 and 3, and the old strip made the second look
+              like the winner. */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
             <Metric icon={Eye} label="impressions" value={post.performance.impressions} />
-            <Metric icon={Heart} label="likes" value={post.performance.likes} />
+            <Metric icon={MousePointerClick} label="clicks" value={post.performance.clicks} />
+            {engagementRate !== null && (
+              <span
+                className="flex items-center gap-1"
+                title={`${engagementRate.toFixed(2)}% of people who saw this engaged with it`}
+              >
+                <TrendingUp className="size-3.5" aria-hidden />
+                {engagementRate.toFixed(1)}%
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <Metric icon={Heart} label="reactions" value={post.performance.likes} />
             <Metric icon={MessageSquare} label="comments" value={post.performance.comments} />
-            <Metric icon={Share2} label="shares" value={post.performance.shares} />
+            <Metric icon={Share2} label="reposts" value={post.performance.shares} />
+            {canEngage && hasEngagement && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="ml-auto h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setThreadOpen(true)}
+              >
+                <MessagesSquare className="size-3.5" /> View engagement
+              </Button>
+            )}
           </div>
 
           {canComment && (
@@ -239,6 +295,15 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
           )}
         </CardContent>
       </Card>
+
+      {canEngage && (
+        <ThreadPanel
+          postUrn={post.linkedInPostId as string}
+          author={author}
+          open={threadOpen}
+          onOpenChange={setThreadOpen}
+        />
+      )}
     </li>
   );
 }

--- a/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
@@ -255,7 +255,7 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
             )}
           </div>
 
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
             <Metric icon={Heart} label="reactions" value={post.performance.likes} />
             <Metric icon={MessageSquare} label="comments" value={post.performance.comments} />
             <Metric icon={Share2} label="reposts" value={post.performance.shares} />
@@ -300,6 +300,9 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
         <ThreadPanel
           postUrn={post.linkedInPostId as string}
           author={author}
+          // The URN that published this post IS us — the only sound test
+          // for "we wrote this comment", and available right here.
+          ourActorUrn={post.authorUrn}
           open={threadOpen}
           onOpenChange={setThreadOpen}
         />

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -38,6 +38,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ConfirmDialog } from "@/components/molecules";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   linkedInContentApi,
@@ -78,6 +80,7 @@ const COMMENT_MAX_LEN = 1250;
 export function ThreadPanel({
   postUrn,
   author,
+  ourActorUrn,
   open,
   onOpenChange,
 }: {
@@ -85,6 +88,14 @@ export function ThreadPanel({
   /** The post's own author — who we reply and react AS. Null when we
    *  cannot resolve one, in which case the panel reads but cannot write. */
   author: LinkedInAuthor | null;
+  /** The URN that published this post — i.e. us.
+   *
+   *  ★The ONLY sound test for "this is our comment". An earlier version
+   *  used `Boolean(comment.agent)`, which means "an ORGANIZATION authored
+   *  this" and is true of any other company's comment on the thread — so
+   *  another brand got a "You" badge and an Edit button whose save
+   *  LinkedIn would reject. */
+  ourActorUrn: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -109,7 +120,12 @@ export function ThreadPanel({
           </TabsList>
 
           <TabsContent value="comments" className="mt-3 min-h-0 flex-1 overflow-y-auto">
-            <CommentsTab postUrn={postUrn} author={author} open={open} />
+            <CommentsTab
+              postUrn={postUrn}
+              author={author}
+              ourActorUrn={ourActorUrn}
+              open={open}
+            />
           </TabsContent>
           <TabsContent value="reactions" className="mt-3 min-h-0 flex-1 overflow-y-auto">
             <ReactionsTab postUrn={postUrn} open={open} />
@@ -130,10 +146,12 @@ export function ThreadPanel({
 function CommentsTab({
   postUrn,
   author,
+  ourActorUrn,
   open,
 }: {
   postUrn: string;
   author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
   open: boolean;
 }) {
   const query = useInfiniteQuery({
@@ -183,7 +201,12 @@ function CommentsTab({
       <ul className="space-y-3">
         {comments.map((comment) => (
           <li key={comment.commentUrn ?? comment.id}>
-            <CommentRow comment={comment} postUrn={postUrn} author={author} />
+            <CommentRow
+              comment={comment}
+              postUrn={postUrn}
+              author={author}
+              ourActorUrn={ourActorUrn}
+            />
           </li>
         ))}
       </ul>
@@ -212,12 +235,17 @@ function CommentRow({
   comment,
   postUrn,
   author,
+  ourActorUrn,
   nested = false,
+  parentCommentUrn,
 }: {
   comment: LinkedInCommentDetail;
   postUrn: string;
   author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
   nested?: boolean;
+  /** Set on a reply, so a write can refresh the list it actually lives in. */
+  parentCommentUrn?: string;
 }) {
   const { formatRelativeTime } = useLocale();
   const qc = useQueryClient();
@@ -225,14 +253,32 @@ function CommentRow({
   const [editing, setEditing] = useState(false);
   const [showReplies, setShowReplies] = useState(false);
 
-  // An org `agent` means a member acted on a page's behalf — i.e. this is
-  // OUR comment. It is the only reliable "ours" signal on the payload, and
-  // it gates edit, which LinkedIn permits only on your own comment.
-  const isOurs = Boolean(comment.agent);
+  // ★Ours means the actor is the URN that published this post — not
+  // merely that SOME organization authored it. `comment.agent` is present
+  // on every org comment, including another brand's, so using it here put
+  // a "You" badge and an Edit button on comments we cannot edit.
+  const isOurs = Boolean(ourActorUrn) && comment.actor === ourActorUrn;
   // Actions that key on a comment need its composite URN. It is optional
   // because LinkedIn occasionally sends nothing to build one from — hide
   // the action rather than send a key that matches nothing.
   const canAct = Boolean(comment.commentUrn);
+
+  /**
+   * Refresh the list this comment is IN.
+   *
+   * ★A reply lives under `["linkedin-replies", parentCommentUrn]`, not
+   * under the thread key. Invalidating only the thread left a deleted
+   * reply on screen — and a row still on screen is a row that gets
+   * clicked again, re-sending a write LinkedIn has already applied.
+   */
+  function refreshOwnList() {
+    if (nested && parentCommentUrn) {
+      void qc.invalidateQueries({ queryKey: ["linkedin-replies", parentCommentUrn] });
+    }
+    // The thread is refreshed either way: a reply's deletion changes its
+    // parent's replyCount, which is rendered up there.
+    void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+  }
 
   const react = useMutation({
     mutationFn: (type: LinkedInReactionType) =>
@@ -240,7 +286,12 @@ function CommentRow({
         reactionType: type,
         author: author as LinkedInAuthor,
       }),
-    onSuccess: () => toast.success("Reaction added"),
+    onSuccess: () => {
+      toast.success("Reaction added");
+      // Without this the like count we just changed never moves, which
+      // reads as "it didn't work" and invites a second reaction.
+      refreshOwnList();
+    },
     onError: (err) => toast.error(engageErrorMessage(err)),
   });
 
@@ -253,7 +304,7 @@ function CommentRow({
       ),
     onSuccess: () => {
       toast.success("Comment deleted");
-      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+      refreshOwnList();
     },
     onError: (err) => toast.error(engageErrorMessage(err)),
   });
@@ -291,9 +342,9 @@ function CommentRow({
           {editing && comment.commentUrn ? (
             <EditBox
               commentUrn={comment.commentUrn}
-              postUrn={postUrn}
               initial={comment.message}
               author={author}
+              onSaved={refreshOwnList}
               onClose={() => setEditing(false)}
             />
           ) : (
@@ -342,23 +393,40 @@ function CommentRow({
               </Button>
             )}
 
+{/* ★Behind a confirm. Deleting is irreversible on LinkedIn, it is
+                offered on OTHER people's comments (that is the moderation
+                feature, not a bug), and one stray click on a member's
+                comment is a public act we cannot undo. Every other
+                destructive action in this dashboard asks first. */}
             {canAct && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
-                disabled={remove.isPending}
-                aria-busy={remove.isPending}
-                onClick={() => remove.mutate()}
-              >
-                {remove.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
-                ) : (
-                  <Trash2 className="size-3.5" />
-                )}
-                Delete
-              </Button>
+              <ConfirmDialog
+                variant="destructive"
+                title={isOurs ? "Delete your comment?" : "Delete this comment?"}
+                description={
+                  isOurs
+                    ? "This removes your comment from LinkedIn. It can't be undone."
+                    : "This removes someone else's comment from your post on LinkedIn. They aren't notified, and it can't be undone."
+                }
+                confirmLabel="Delete"
+                onConfirm={() => remove.mutate()}
+                trigger={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
+                    disabled={remove.isPending}
+                    aria-busy={remove.isPending}
+                  >
+                    {remove.isPending ? (
+                      <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+                    ) : (
+                      <Trash2 className="size-3.5" />
+                    )}
+                    Delete
+                  </Button>
+                }
+              />
             )}
 
             {comment.replyCount > 0 && !nested && (
@@ -389,6 +457,7 @@ function CommentRow({
               commentUrn={comment.commentUrn}
               postUrn={postUrn}
               author={author}
+              ourActorUrn={ourActorUrn}
             />
           )}
         </div>
@@ -403,10 +472,12 @@ function RepliesList({
   commentUrn,
   postUrn,
   author,
+  ourActorUrn,
 }: {
   commentUrn: string;
   postUrn: string;
   author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
 }) {
   const query = useInfiniteQuery({
     queryKey: ["linkedin-replies", commentUrn],
@@ -419,10 +490,24 @@ function RepliesList({
     getNextPageParam: (last) => last.nextStart ?? undefined,
     staleTime: 60_000,
     refetchOnWindowFocus: false,
+    // Same 403 gate as the sibling queries. A 403 here is a permanent no —
+    // retrying spends two more of a ~500/day app-wide budget to be told
+    // the same thing.
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
   });
 
   if (query.isLoading) {
     return <Skeleton className="mt-2 h-12 w-full" />;
+  }
+  // Rendering null on an error meant the user clicked "Show 3 replies" and
+  // watched nothing happen, with no way to tell a failure from an empty
+  // list. Say which it was.
+  if (query.isError) {
+    return (
+      <p className="mt-2 text-xs text-muted-foreground">
+        {engageErrorMessage(query.error)}
+      </p>
+    );
   }
   const replies = query.data?.pages.flatMap((p) => p.comments) ?? [];
   if (!replies.length) return null;
@@ -431,7 +516,14 @@ function RepliesList({
     <ul className="mt-2 space-y-3">
       {replies.map((reply) => (
         <li key={reply.commentUrn ?? reply.id}>
-          <CommentRow comment={reply} postUrn={postUrn} author={author} nested />
+          <CommentRow
+            comment={reply}
+            postUrn={postUrn}
+            author={author}
+            ourActorUrn={ourActorUrn}
+            nested
+            parentCommentUrn={commentUrn}
+          />
         </li>
       ))}
     </ul>
@@ -510,19 +602,22 @@ function ReplyBox({
 
 function EditBox({
   commentUrn,
-  postUrn,
   initial,
   author,
+  onSaved,
   onClose,
 }: {
   commentUrn: string;
-  postUrn: string;
   initial: string;
   author: LinkedInAuthor | null;
+  /** Refresh the list this comment lives in — the thread for a top-level
+   *  comment, the replies list for a reply. Edit is offered on both, and
+   *  invalidating only the thread showed a success toast beside the old
+   *  text still on screen. */
+  onSaved: () => void;
   onClose: () => void;
 }) {
   const [text, setText] = useState(initial);
-  const qc = useQueryClient();
   const save = useMutation({
     mutationFn: () =>
       linkedInContentApi.editComment(commentUrn, {
@@ -532,7 +627,7 @@ function EditBox({
     onSuccess: () => {
       toast.success("Comment updated");
       onClose();
-      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+      onSaved();
     },
     onError: (err) => toast.error(engageErrorMessage(err)),
   });
@@ -573,6 +668,12 @@ function EditBox({
   );
 }
 
+/** ★Radix Popover, not a hand-rolled absolute div. The hand-rolled one
+ *  had no outside-click or Escape handling, so it stayed floating over the
+ *  thread until you picked something — and opening a second one left two
+ *  on screen at once. Focus management and dismissal are exactly what the
+ *  primitive is for, and the repo already uses it for this same picker in
+ *  the Audience panel. */
 function ReactionPicker({
   pending,
   onPick,
@@ -582,44 +683,42 @@ function ReactionPicker({
 }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="relative">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 gap-1.5 px-2 text-xs"
-        disabled={pending}
-        aria-busy={pending}
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        {pending ? (
-          <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
-        ) : (
-          <Heart className="size-3.5" />
-        )}
-        React
-      </Button>
-      {open && (
-        <div className="absolute bottom-8 left-0 z-10 flex gap-0.5 rounded-md border bg-popover p-1 shadow-md">
-          {REACTIONS.map((r) => (
-            <button
-              key={r.type}
-              type="button"
-              title={r.label}
-              aria-label={r.label}
-              className="rounded px-1.5 py-0.5 text-base hover:bg-accent"
-              onClick={() => {
-                setOpen(false);
-                onPick(r.type);
-              }}
-            >
-              {r.emoji}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-xs"
+          disabled={pending}
+          aria-busy={pending}
+        >
+          {pending ? (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <Heart className="size-3.5" />
+          )}
+          React
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="flex w-auto gap-0.5 p-1">
+        {REACTIONS.map((r) => (
+          <button
+            key={r.type}
+            type="button"
+            title={r.label}
+            aria-label={r.label}
+            className="rounded px-1.5 py-0.5 text-base hover:bg-accent"
+            onClick={() => {
+              setOpen(false);
+              onPick(r.type);
+            }}
+          >
+            {r.emoji}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -1,0 +1,801 @@
+"use client";
+
+/**
+ * The thread panel — the surface that makes a comment visible.
+ *
+ * Until this shipped, LinkedIn Content could POST a comment it could not
+ * SHOW you: the write path landed with the engager panel and the read path
+ * never did. This is the read path, plus the actions that belong beside it.
+ *
+ * ★Everything here is fetched only when a person opens the sheet.
+ * Community Management Development tier allows ~500 requests/day for the
+ * whole app across every customer, so a thread is loaded on demand and
+ * never prefetched for a list of posts. `enabled: open` on both queries is
+ * the mechanism; do not replace it with an eager fetch.
+ */
+
+import { useState } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Loader2,
+  MessageSquare,
+  Heart,
+  Trash2,
+  CornerDownRight,
+  Pencil,
+  ExternalLink,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  linkedInContentApi,
+  type LinkedInActorProfile,
+  type LinkedInAuthor,
+  type LinkedInCommentDetail,
+  type LinkedInReaction,
+  type LinkedInReactionType,
+} from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+import { useLocale } from "@/hooks/use-locale";
+import { RetentionFootnote } from "./retention-footnote";
+
+/** Reaction types we may WRITE. `MAYBE` is deprecated by LinkedIn and 400s
+ *  on create, so it is absent here even though a read can surface it. */
+const REACTIONS: Array<{ type: LinkedInReactionType; emoji: string; label: string }> = [
+  { type: "LIKE", emoji: "👍", label: "Like" },
+  { type: "PRAISE", emoji: "🎉", label: "Celebrate" },
+  { type: "EMPATHY", emoji: "❤️", label: "Love" },
+  { type: "INTEREST", emoji: "💡", label: "Insightful" },
+  { type: "APPRECIATION", emoji: "🙌", label: "Support" },
+  { type: "ENTERTAINMENT", emoji: "😄", label: "Funny" },
+];
+
+/** Emoji for a reaction type we may not know — LinkedIn has added types
+ *  before, and an unrecognised one must render as something rather than
+ *  vanish from a list the user is counting. */
+function reactionEmoji(type: string): string {
+  return REACTIONS.find((r) => r.type === type)?.emoji ?? "•";
+}
+
+function reactionLabel(type: string): string {
+  return REACTIONS.find((r) => r.type === type)?.label ?? type;
+}
+
+const COMMENT_MAX_LEN = 1250;
+
+export function ThreadPanel({
+  postUrn,
+  author,
+  open,
+  onOpenChange,
+}: {
+  postUrn: string;
+  /** The post's own author — who we reply and react AS. Null when we
+   *  cannot resolve one, in which case the panel reads but cannot write. */
+  author: LinkedInAuthor | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Engagement</SheetTitle>
+          <SheetDescription>
+            Reply, react and moderate without leaving Peakhour.
+          </SheetDescription>
+        </SheetHeader>
+
+        <Tabs defaultValue="comments" className="mt-4 flex min-h-0 flex-1 flex-col">
+          <TabsList>
+            <TabsTrigger value="comments" className="gap-1.5">
+              <MessageSquare className="size-4" /> Comments
+            </TabsTrigger>
+            <TabsTrigger value="reactions" className="gap-1.5">
+              <Heart className="size-4" /> Reactions
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="comments" className="mt-3 min-h-0 flex-1 overflow-y-auto">
+            <CommentsTab postUrn={postUrn} author={author} open={open} />
+          </TabsContent>
+          <TabsContent value="reactions" className="mt-3 min-h-0 flex-1 overflow-y-auto">
+            <ReactionsTab postUrn={postUrn} open={open} />
+          </TabsContent>
+        </Tabs>
+
+        <RetentionFootnote>
+          Comment text is held for 48 hours and commenter names for 24, per
+          LinkedIn&apos;s data rules.
+        </RetentionFootnote>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ── Comments ──────────────────────────────────────────────
+
+function CommentsTab({
+  postUrn,
+  author,
+  open,
+}: {
+  postUrn: string;
+  author: LinkedInAuthor | null;
+  open: boolean;
+}) {
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-thread", postUrn],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.comments(postUrn, { count: 25, start: pageParam as number }),
+    getNextPageParam: (last) => last.nextStart ?? undefined,
+    // Loaded only while the sheet is open — see the file header on why.
+    enabled: open,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+
+  if (query.isLoading) return <ThreadSkeleton />;
+
+  if (query.isError) {
+    return <ErrorBody error={query.error} />;
+  }
+
+  const pages = query.data?.pages ?? [];
+  const comments = pages.flatMap((p) => p.comments);
+  // False means "we are not showing names", which is a different thing from
+  // "nobody has a name" — worth saying rather than leaving people to guess
+  // why every row says "A member".
+  const identityEnabled = pages[0]?.identityEnabled ?? true;
+
+  if (!comments.length) {
+    return (
+      <EmptyBody
+        title="No comments yet"
+        body="When someone comments on this post, it'll show up here and you can reply from Peakhour."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {!identityEnabled && (
+        <p className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          Commenter names are turned off right now, so everyone shows as
+          &ldquo;A member&rdquo;. Replies and reactions still work.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {comments.map((comment) => (
+          <li key={comment.commentUrn ?? comment.id}>
+            <CommentRow comment={comment} postUrn={postUrn} author={author} />
+          </li>
+        ))}
+      </ul>
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more comments
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function CommentRow({
+  comment,
+  postUrn,
+  author,
+  nested = false,
+}: {
+  comment: LinkedInCommentDetail;
+  postUrn: string;
+  author: LinkedInAuthor | null;
+  nested?: boolean;
+}) {
+  const { formatRelativeTime } = useLocale();
+  const qc = useQueryClient();
+  const [replying, setReplying] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [showReplies, setShowReplies] = useState(false);
+
+  // An org `agent` means a member acted on a page's behalf — i.e. this is
+  // OUR comment. It is the only reliable "ours" signal on the payload, and
+  // it gates edit, which LinkedIn permits only on your own comment.
+  const isOurs = Boolean(comment.agent);
+  // Actions that key on a comment need its composite URN. It is optional
+  // because LinkedIn occasionally sends nothing to build one from — hide
+  // the action rather than send a key that matches nothing.
+  const canAct = Boolean(comment.commentUrn);
+
+  const react = useMutation({
+    mutationFn: (type: LinkedInReactionType) =>
+      linkedInContentApi.createReaction(comment.commentUrn as string, {
+        reactionType: type,
+        author: author as LinkedInAuthor,
+      }),
+    onSuccess: () => toast.success("Reaction added"),
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  const remove = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.deleteComment(
+        postUrn,
+        comment.commentUrn ?? comment.id,
+        author ?? undefined,
+      ),
+    onSuccess: () => {
+      toast.success("Comment deleted");
+      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className={nested ? "border-l pl-3" : ""}>
+      <div className="flex gap-2.5">
+        <ActorAvatar profile={comment.actorProfile} />
+
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <span className="text-sm font-medium">
+              {comment.actorProfile?.displayName ?? "A member"}
+            </span>
+            {comment.actorProfile?.headline && (
+              <span className="truncate text-xs text-muted-foreground">
+                {comment.actorProfile.headline}
+              </span>
+            )}
+            {isOurs && (
+              <Badge variant="outline" className="text-[10px]">
+                You
+              </Badge>
+            )}
+            {comment.edited && (
+              <span className="text-[10px] text-muted-foreground">edited</span>
+            )}
+            {comment.createdAt && (
+              <span className="ml-auto text-xs text-muted-foreground">
+                {formatRelativeTime(new Date(comment.createdAt).toISOString())}
+              </span>
+            )}
+          </div>
+
+          {editing && comment.commentUrn ? (
+            <EditBox
+              commentUrn={comment.commentUrn}
+              postUrn={postUrn}
+              initial={comment.message}
+              author={author}
+              onClose={() => setEditing(false)}
+            />
+          ) : (
+            <p className="whitespace-pre-line text-sm leading-relaxed">
+              {comment.message || (
+                <span className="text-muted-foreground">(image only)</span>
+              )}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-1">
+            {comment.likeCount > 0 && (
+              <span className="mr-1 text-xs tabular-nums text-muted-foreground">
+                {comment.likeCount} {comment.likeCount === 1 ? "like" : "likes"}
+              </span>
+            )}
+
+            {author && canAct && !nested && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setReplying((v) => !v)}
+              >
+                <CornerDownRight className="size-3.5" /> Reply
+              </Button>
+            )}
+
+            {author && canAct && (
+              <ReactionPicker
+                pending={react.isPending}
+                onPick={(type) => react.mutate(type)}
+              />
+            )}
+
+            {isOurs && canAct && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setEditing((v) => !v)}
+              >
+                <Pencil className="size-3.5" /> Edit
+              </Button>
+            )}
+
+            {canAct && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
+                disabled={remove.isPending}
+                aria-busy={remove.isPending}
+                onClick={() => remove.mutate()}
+              >
+                {remove.isPending ? (
+                  <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+                ) : (
+                  <Trash2 className="size-3.5" />
+                )}
+                Delete
+              </Button>
+            )}
+
+            {comment.replyCount > 0 && !nested && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setShowReplies((v) => !v)}
+              >
+                {showReplies ? "Hide" : "Show"} {comment.replyCount}{" "}
+                {comment.replyCount === 1 ? "reply" : "replies"}
+              </Button>
+            )}
+          </div>
+
+          {replying && comment.commentUrn && author && (
+            <ReplyBox
+              postUrn={postUrn}
+              parentCommentUrn={comment.commentUrn}
+              author={author}
+              onClose={() => setReplying(false)}
+            />
+          )}
+
+          {showReplies && comment.commentUrn && (
+            <RepliesList
+              commentUrn={comment.commentUrn}
+              postUrn={postUrn}
+              author={author}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Replies load only when expanded — LinkedIn nests exactly one level, so
+ *  this never recurses. */
+function RepliesList({
+  commentUrn,
+  postUrn,
+  author,
+}: {
+  commentUrn: string;
+  postUrn: string;
+  author: LinkedInAuthor | null;
+}) {
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-replies", commentUrn],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.commentReplies(commentUrn, {
+        count: 25,
+        start: pageParam as number,
+      }),
+    getNextPageParam: (last) => last.nextStart ?? undefined,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (query.isLoading) {
+    return <Skeleton className="mt-2 h-12 w-full" />;
+  }
+  const replies = query.data?.pages.flatMap((p) => p.comments) ?? [];
+  if (!replies.length) return null;
+
+  return (
+    <ul className="mt-2 space-y-3">
+      {replies.map((reply) => (
+        <li key={reply.commentUrn ?? reply.id}>
+          <CommentRow comment={reply} postUrn={postUrn} author={author} nested />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ReplyBox({
+  postUrn,
+  parentCommentUrn,
+  author,
+  onClose,
+}: {
+  postUrn: string;
+  parentCommentUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState("");
+  const qc = useQueryClient();
+  const send = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, {
+        text: text.trim(),
+        author,
+        parentCommentUrn,
+      }),
+    onSuccess: () => {
+      toast.success("Reply posted");
+      setText("");
+      onClose();
+      void qc.invalidateQueries({ queryKey: ["linkedin-replies", parentCommentUrn] });
+      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        placeholder="Write a reply…"
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || send.isPending}
+          aria-busy={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {send.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Reply
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function EditBox({
+  commentUrn,
+  postUrn,
+  initial,
+  author,
+  onClose,
+}: {
+  commentUrn: string;
+  postUrn: string;
+  initial: string;
+  author: LinkedInAuthor | null;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState(initial);
+  const qc = useQueryClient();
+  const save = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.editComment(commentUrn, {
+        text: text.trim(),
+        ...(author ? { author } : {}),
+      }),
+    onSuccess: () => {
+      toast.success("Comment updated");
+      onClose();
+      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className="space-y-1.5">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || text.trim() === initial || save.isPending}
+          aria-busy={save.isPending}
+          onClick={() => save.mutate()}
+        >
+          {save.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Save
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ReactionPicker({
+  pending,
+  onPick,
+}: {
+  pending: boolean;
+  onPick: (type: LinkedInReactionType) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 gap-1.5 px-2 text-xs"
+        disabled={pending}
+        aria-busy={pending}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {pending ? (
+          <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+        ) : (
+          <Heart className="size-3.5" />
+        )}
+        React
+      </Button>
+      {open && (
+        <div className="absolute bottom-8 left-0 z-10 flex gap-0.5 rounded-md border bg-popover p-1 shadow-md">
+          {REACTIONS.map((r) => (
+            <button
+              key={r.type}
+              type="button"
+              title={r.label}
+              aria-label={r.label}
+              className="rounded px-1.5 py-0.5 text-base hover:bg-accent"
+              onClick={() => {
+                setOpen(false);
+                onPick(r.type);
+              }}
+            >
+              {r.emoji}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Reactions ─────────────────────────────────────────────
+
+function ReactionsTab({ postUrn, open }: { postUrn: string; open: boolean }) {
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-reactions", postUrn],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.reactions(postUrn, { count: 25, start: pageParam as number }),
+    getNextPageParam: (last) => last.nextStart ?? undefined,
+    enabled: open,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+
+  if (query.isLoading) return <ThreadSkeleton />;
+  if (query.isError) return <ErrorBody error={query.error} />;
+
+  const reactions = query.data?.pages.flatMap((p) => p.reactions) ?? [];
+  if (!reactions.length) {
+    return (
+      <EmptyBody
+        title="No reactions yet"
+        body="Reactions on this post will show up here, grouped by type."
+      />
+    );
+  }
+
+  // Grouped by type for scanning. This is the reactors we have LOADED, not
+  // the post's totals — the authoritative per-type counts live on the
+  // metric strip, which reads them from LinkedIn in one call.
+  const groups = new Map<string, LinkedInReaction[]>();
+  for (const r of reactions) {
+    const list = groups.get(r.reactionType) ?? [];
+    list.push(r);
+    groups.set(r.reactionType, list);
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Most people who only react stay anonymous — LinkedIn shares names for
+        commenters, not reactors.
+      </p>
+
+      {[...groups.entries()].map(([type, list]) => (
+        <div key={type} className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <span className="text-base" aria-hidden>
+              {reactionEmoji(type)}
+            </span>
+            <span className="text-xs font-medium">{reactionLabel(type)}</span>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {list.length}
+            </span>
+          </div>
+          <ul className="space-y-2">
+            {list.map((r) => (
+              <li key={r.id} className="flex items-center gap-2.5">
+                <ActorAvatar profile={r.actorProfile} />
+                <span className="text-sm">
+                  {r.actorProfile?.displayName ?? "A member"}
+                </span>
+                {r.actorProfile?.vanityName && (
+                  <a
+                    href={`https://www.linkedin.com/in/${r.actorProfile.vanityName}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label="View profile on LinkedIn"
+                  >
+                    <ExternalLink className="size-3" />
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ── Shared ────────────────────────────────────────────────
+
+function ActorAvatar({ profile }: { profile?: LinkedInActorProfile }) {
+  const name = profile?.displayName ?? "";
+  const initials =
+    name
+      .split(" ")
+      .map((p) => p[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "—";
+  return (
+    <Avatar className="size-8 shrink-0">
+      {/* LinkedIn's image URLs carry their own expiry, often shorter than
+          our cache — a broken image is normal, and AvatarFallback covers
+          it without a retry. */}
+      {profile?.pictureUrl && <AvatarImage src={profile.pictureUrl} alt="" />}
+      <AvatarFallback className="text-[10px]">{initials}</AvatarFallback>
+    </Avatar>
+  );
+}
+
+/** Map an engagement failure to something a person can act on. Never
+ *  surfaces the raw provider string — it carries LinkedIn JSON and URNs.
+ *
+ *  ★A 403 does NOT promise a reconnect helps: an org post 403s on the
+ *  pre-`_feed` grant, which reconnecting fixes, but a member-authored post
+ *  403s on a permission LinkedIn grants to select developers only. The
+ *  server already words this carefully; pass it through. */
+function engageErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === "NOT_CONNECTED") return "Reconnect LinkedIn to continue.";
+    if (err.code === "CONFIRMATION_REQUIRED" || err.code === "VALIDATION_ERROR") {
+      return err.message;
+    }
+    if (err.status === 403 || err.status === 404 || err.status === 429) {
+      return err.message;
+    }
+  }
+  return "That didn't work. Please try again.";
+}
+
+function ErrorBody({ error }: { error: unknown }) {
+  return (
+    <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center">
+      <p className="text-sm text-muted-foreground">{engageErrorMessage(error)}</p>
+    </div>
+  );
+}
+
+function EmptyBody({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-6 text-center">
+      <p className="text-sm font-medium">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+function ThreadSkeleton() {
+  return (
+    <div className="space-y-4">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex gap-2.5">
+          <Skeleton className="size-8 shrink-0 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-40" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { MessageSquare, Newspaper, RefreshCw, Rocket, Send, Users } from "lucide-react";
+import { MessageSquare, Newspaper, RefreshCw, Rocket, Users } from "lucide-react";
 import {
   PostComposer,
   PostComposerSkeleton,
@@ -18,7 +18,7 @@ import {
 } from "./_components/post-composer";
 import { AudiencePanel } from "./_components/audience-panel";
 import { BoostCandidatesPanel } from "./_components/boost-candidates-panel";
-import { FeedPanel } from "./_components/feed-panel";
+import { LibraryPanel } from "./_components/library-panel";
 import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
 
 /** Reconnect round trips come back to this hub, not to Settings. */
@@ -142,8 +142,12 @@ function LinkedInTabs({
   identity: ReturnType<typeof useLinkedInIdentity>;
   enabledIdentity: ReturnType<typeof useLinkedInIdentity> | null;
 }) {
-  const [tab, setTab] = useState<"compose" | "feed" | "audience" | "boost">("compose");
-  const [feedOpened, setFeedOpened] = useState(false);
+  // ★Library · Feed · Audience · Boost is the settled shape. Library holds
+  // drafting AND the published archive — you write the next post from how
+  // the last one did, and splitting those across tabs meant navigating in
+  // order to learn. The new Feed (incoming community activity) arrives
+  // with the webhook work, so this hub has three tabs today, not four.
+  const [tab, setTab] = useState<"library" | "audience" | "boost">("library");
   const [audienceOpened, setAudienceOpened] = useState(false);
   const [boostOpened, setBoostOpened] = useState(false);
   // Composer seed text — set when the user clicks "Use this draft" on
@@ -153,9 +157,12 @@ function LinkedInTabs({
   const [composerSeed, setComposerSeed] = useState<string | undefined>(undefined);
 
   function handleTabChange(value: string) {
-    if (value === "compose" || value === "feed" || value === "audience" || value === "boost") {
+    if (value === "library" || value === "audience" || value === "boost") {
       setTab(value);
-      if (value === "feed") setFeedOpened(true);
+      // Radix TabsContent mounts eagerly, so each non-default tab stays
+      // gated on having been opened once. A tab that skips this fires its
+      // query on every page load — which, against a ~500-requests/day
+      // app-wide LinkedIn budget, is not a style preference.
       if (value === "audience") setAudienceOpened(true);
       if (value === "boost") setBoostOpened(true);
     }
@@ -164,11 +171,8 @@ function LinkedInTabs({
   return (
     <Tabs value={tab} onValueChange={handleTabChange}>
       <TabsList>
-        <TabsTrigger value="compose" className="gap-1.5">
-          <Send className="size-4" /> Compose
-        </TabsTrigger>
-        <TabsTrigger value="feed" className="gap-1.5">
-          <Newspaper className="size-4" /> Feed
+        <TabsTrigger value="library" className="gap-1.5">
+          <Newspaper className="size-4" /> Library
         </TabsTrigger>
         <TabsTrigger value="audience" className="gap-1.5">
           <Users className="size-4" /> Audience
@@ -178,7 +182,7 @@ function LinkedInTabs({
         </TabsTrigger>
       </TabsList>
 
-      <TabsContent value="compose" className="mt-4 space-y-4">
+      <TabsContent value="library" className="mt-4 space-y-4">
         <SuggestedDraftsPanel onUseDraft={setComposerSeed} />
         <Card>
           <CardContent className="p-5">
@@ -195,10 +199,14 @@ function LinkedInTabs({
         <p className="text-xs text-muted-foreground">
           Compose with AI, schedule for later, publish now, or turn a longer write-up into a swipeable carousel. Image attachments are coming.
         </p>
-      </TabsContent>
 
-      <TabsContent value="feed" className="mt-4">
-        {feedOpened ? <FeedPanel /> : null}
+        {/* The published archive sits directly under the composer, because
+            what you write next is informed by how the last one landed and
+            that only works if both are on one screen. Mounted with the tab
+            rather than gated: it reads from Mongo (the post-sync cron's
+            output), so it costs no LinkedIn budget. The per-post threads
+            are the on-demand part. */}
+        <LibraryPanel />
       </TabsContent>
 
       <TabsContent value="audience" className="mt-4">

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -400,6 +400,87 @@ export const linkedInContentApi = {
     ),
 
   /**
+   * Comments on a post — or, when `target` is a comment URN, that comment's
+   * replies. LinkedIn serves both from one resource and nests exactly one
+   * level, so there is no recursion to write in the UI.
+   *
+   * ★ON-DEMAND ONLY. Community Management Development tier allows ~500
+   * requests/day for the whole app across every customer, so this is called
+   * when a person opens a thread and never to pre-fill a list of posts.
+   */
+  comments: (target: string, params?: { count?: number; start?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.count === "number") qs.set("count", String(params.count));
+    if (typeof params?.start === "number") qs.set("start", String(params.start));
+    const q = qs.toString();
+    return api.get<LinkedInCommentPage>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(target)}/comments${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /** Replies on one comment. */
+  commentReplies: (commentUrn: string, params?: { count?: number; start?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.count === "number") qs.set("count", String(params.count));
+    if (typeof params?.start === "number") qs.set("start", String(params.start));
+    const q = qs.toString();
+    return api.get<LinkedInCommentPage>(
+      `/v1/linkedin/content/comments/${encodeURIComponent(commentUrn)}/replies${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /**
+   * Who reacted to a post or comment, and with what.
+   *
+   * ★Reactor NAMES are best-effort. LinkedIn returns actor URNs here and
+   * exposes no profile lookup for other members — identity arrives only
+   * alongside a comments read — so a reactor is named only if they also
+   * commented recently. Render a nameless reactor as normal, not as a gap.
+   */
+  reactions: (entityUrn: string, params?: { count?: number; start?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.count === "number") qs.set("count", String(params.count));
+    if (typeof params?.start === "number") qs.set("start", String(params.start));
+    const q = qs.toString();
+    return api.get<LinkedInReactionPage>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(entityUrn)}/reactions${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /** Per-reaction-type counts + comment summary for a post. The AUTHORITATIVE
+   *  reaction breakdown — `reactions` above only returns the current page. */
+  socialMetadata: (postUrn: string) =>
+    api.get<LinkedInSocialMetadata>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(postUrn)}/social-metadata`,
+    ),
+
+  /** Edit a comment we authored. `author` picks the page to edit as; omit to
+   *  edit as the signed-in member. */
+  editComment: (commentUrn: string, body: { text: string; author?: LinkedInAuthor }) =>
+    api.patch<{ commentUrn: string }>(
+      `/v1/linkedin/content/comments/${encodeURIComponent(commentUrn)}`,
+      body,
+    ),
+
+  /** Delete a comment.
+   *
+   *  `commentRef` may be the bare numeric id OR the composite comment URN —
+   *  the server unpacks the thread from the URN when given one, which is
+   *  what the thread panel has to hand. The author is a QUERY pair
+   *  (`authorType`/`pageId`) rather than a body because DELETE carries none. */
+  deleteComment: (postUrn: string, commentRef: string, author?: LinkedInAuthor) => {
+    const qs = new URLSearchParams();
+    if (author?.type === "org") {
+      qs.set("authorType", "org");
+      qs.set("pageId", author.pageId);
+    }
+    const q = qs.toString();
+    return api.delete<{ deleted: boolean }>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(postUrn)}/comments/${encodeURIComponent(commentRef)}${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /**
    * React to a post OR a comment as the member or an org page. `entityUrn` is
    * the target's full URN — a post (`urn:li:share:*` / `urn:li:ugcPost:*`) or a
    * comment (`urn:li:comment:(...)`). Same `RECONNECT_REQUIRED` (403) contract
@@ -502,6 +583,83 @@ export interface CarouselResult {
   /** False when the document upload didn't confirm AVAILABLE before posting
    *  (best-effort path) — the post may still be processing on LinkedIn. */
   documentAvailable: boolean;
+}
+
+
+/** A commenter's public profile, when LinkedIn decorated it.
+ *
+ *  ★24-hour data on the server, and OPTIONAL here. It is absent whenever
+ *  identity is switched off or LinkedIn declined the decoration, so render
+ *  its absence as "A member" — never as an error state. */
+export interface LinkedInActorProfile {
+  actorUrn: string;
+  displayName?: string;
+  headline?: string;
+  pictureUrl?: string;
+  vanityName?: string;
+}
+
+/** One comment in a thread. */
+export interface LinkedInCommentDetail {
+  /** LinkedIn's numeric comment id — what the delete path wants. */
+  id: string;
+  /** The composite `urn:li:comment:(...)`. Absent only when LinkedIn sent
+   *  nothing to build it from; actions that key on a comment are hidden
+   *  in that case rather than sending a URN that matches nothing. */
+  commentUrn?: string;
+  actor: string;
+  /** Present when an org authored it — i.e. this is OUR page's comment. */
+  agent?: string;
+  /** May be empty for an image-only comment. */
+  message: string;
+  createdAt?: number;
+  lastModifiedAt?: number;
+  edited: boolean;
+  likeCount: number;
+  likedByUs: boolean;
+  replyCount: number;
+  parentCommentUrn?: string;
+  objectUrn?: string;
+  imageUrns: string[];
+  actorProfile?: LinkedInActorProfile;
+}
+
+export interface LinkedInCommentPage {
+  comments: LinkedInCommentDetail[];
+  total?: number;
+  /** Pass as `start` for the next page; absent = end of thread. */
+  nextStart?: number;
+  /** Whether names were actually fetched. False means "we are not showing
+   *  names", which is different from "nobody has one". */
+  identityEnabled: boolean;
+}
+
+export interface LinkedInReaction {
+  id: string;
+  actor: string;
+  reactionType: string;
+  createdAt?: number;
+  root?: string;
+  actorProfile?: LinkedInActorProfile;
+}
+
+export interface LinkedInReactionPage {
+  reactions: LinkedInReaction[];
+  total?: number;
+  nextStart?: number;
+  identityEnabled: boolean;
+  /** Always true — see `reactions` above on why most reactors are nameless. */
+  reactorNamesAreBestEffort?: boolean;
+}
+
+/** Authoritative per-type reaction counts for a post. */
+export interface LinkedInSocialMetadata {
+  entity: string;
+  commentsState?: string;
+  reactions: Record<string, number>;
+  totalReactions: number;
+  commentCount: number;
+  topLevelCommentCount: number;
 }
 
 /** One published post in the LinkedIn Feed tab (GET /feed). */


### PR DESCRIPTION
**PR 4 of 11.** Depends on peakhour-api #1077 → #1078 → #1079 → #1080; merge those first.

The first PR in this series anyone can *see*. Until now LinkedIn Content could post a comment it could not **show** you — the write path shipped with the engager panel, the read path never did.

## Tabs, settled

**Library · Audience · Boost** today; **Feed** joins when the webhook work lands.

**Library absorbs Compose** — you write the next post from how the last one landed, and splitting those across tabs meant navigating in order to learn. The composer, suggested drafts and the published archive are now one screen.

**Boost stays its own tab.** Folding it into Library was proposed earlier in this plan and rejected: paid promotion is a different job with a different risk profile, and burying it in a list of posts makes spending money a side effect of browsing.

## The metric strip

Two lines, because they answer different questions:

```
Impressions 12.4k · Clicks 78 · 2.3%
♥ 42   💬 24   🔁 5            [View engagement]
```

Reach is what the post **did**; engagement is what people did **back** — and that's the half you can act on, so it carries the button.

`clicks` was already in the payload and simply never rendered. **Engagement rate now leads**: a post with 400 impressions and 20 comments is doing better than one with 12,000 and 3, and the old single-line strip made the second look like the winner. It's `null` rather than `0%` when nothing was seen — a post nobody saw has no rate, and "0.0%" reads as failure rather than absence.

## The thread panel

A Sheet with the comment tree, replies nested one level (LinkedIn allows exactly one), and inline **Reply / React / Edit / Delete**.

- Edit shows only on comments we authored — the `agent` field is the only reliable "ours" signal on the payload.
- Actions that key on a comment are hidden when its composite URN is missing, rather than sending a key that matches nothing.
- A Reactions tab groups reactors by type.

## Budget is a design constraint, not a footnote

Development tier allows **~500 requests/day for the whole app across every customer**. So:

- `enabled: open` on both panel queries — nothing fetches until someone opens a thread.
- "View engagement" is **hidden entirely** when the synced counters say the thread is empty.
- The post list reads Mongo (the post-sync cron's output), so browsing the Library costs no LinkedIn budget at all.

## Two things the UI says out loud

**Most reactors stay anonymous.** LinkedIn returns actor URNs on the Reactions API and exposes no profile lookup for other members — identity arrives only alongside a *comments* read. So a reactor is named only if they also commented within the 24-hour cache. The tab says so, because otherwise it reads as our bug.

**"We're not showing names" ≠ "nobody has a name".** When identity is switched off, the comments tab says that explicitly rather than leaving people to wonder why every row reads "A member".

## Verification

`tsc` clean, `eslint` clean on every touched file, 35 LinkedIn b2c tests pass. One pre-existing eslint error in `post-composer.tsx:780` is untouched by this PR.

**Not verified against a live LinkedIn account** — I have no token. Worth a manual pass on a real thread before merge, particularly the `actor~` projection from #1080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
