### PR TITLE
feat(linkedin): the Feed — is anyone waiting on us?

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
@@ -15,7 +15,7 @@
  * left open. The thread panel is where on-demand API calls happen.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Loader2,
@@ -31,7 +31,6 @@ import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   linkedInContentApi,
@@ -42,6 +41,11 @@ import {
 import { ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { RetentionFootnote } from "./retention-footnote";
+import {
+  ReplyBox,
+  engageErrorMessage,
+  linkedInPostUrl,
+} from "./engage-shared";
 
 const FILTERS = [
   { key: "needs_reply", label: "Needs reply" },
@@ -53,10 +57,62 @@ const FILTERS = [
 
 type FilterKey = (typeof FILTERS)[number]["key"];
 
-const COMMENT_MAX_LEN = 1250;
+/**
+ * Collects interactions a person has actually LOOKED at, and reports them
+ * in one call.
+ *
+ * ★Three problems this replaces. The old version fired on every rendered
+ * row — so opening the Feed cleared "New" for 25 rows nobody had scrolled
+ * to, and a background refetch marked things seen while the tab was not
+ * even on screen. It also sent one POST per row against an endpoint that
+ * accepts a hundred, and, because the cache is never updated with
+ * `seenAt`, re-sent all of them on the next remount.
+ *
+ * So: only rows that entered the viewport, only while the document is
+ * visible, flushed once on a short debounce, and remembered for the
+ * lifetime of the panel so a remount does not repeat them.
+ */
+function useMarkSeen() {
+  const pending = useRef(new Set<string>());
+  const sent = useRef(new Set<string>());
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    const urns = [...pending.current].filter((u) => !sent.current.has(u));
+    pending.current.clear();
+    if (!urns.length) return;
+    urns.forEach((u) => sent.current.add(u));
+    // A missed "seen" costs a badge, not data — and an error toast on a
+    // page somebody is only scrolling is worse than the badge.
+    linkedInContentApi.markInteractionsSeen(urns.slice(0, 100)).catch(() => {
+      urns.forEach((u) => sent.current.delete(u));
+    });
+  }, []);
+
+  const observe = useCallback(
+    (urn: string) => {
+      if (sent.current.has(urn) || pending.current.has(urn)) return;
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+      pending.current.add(urn);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(flush, 800);
+    },
+    [flush],
+  );
+
+  useEffect(() => {
+    const t = timer;
+    return () => {
+      if (t.current) clearTimeout(t.current);
+    };
+  }, []);
+
+  return observe;
+}
 
 export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }) {
   const [filter, setFilter] = useState<FilterKey>("needs_reply");
+  const markSeen = useMarkSeen();
 
   const query = useInfiniteQuery({
     queryKey: ["linkedin-interactions", filter],
@@ -76,17 +132,59 @@ export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }
   const rows = query.data?.pages.flatMap((p) => p.rows) ?? [];
   const counts = query.data?.pages[0]?.counts;
 
-  if (query.isLoading) return <FeedSkeleton />;
+  // ★The chips stay mounted through loading AND error. Unmounting them
+  // blanked the toolbar on every filter switch, and turned any error into
+  // a dead end with no way back to a filter that works — LibraryPanel
+  // renders its own filter row above these branches for the same reason.
+  const chips = (
+    <div className="flex flex-wrap gap-1.5">
+      {FILTERS.map((f) => (
+        <Button
+          key={f.key}
+          type="button"
+          size="sm"
+          variant={filter === f.key ? "default" : "outline"}
+          className="h-7 px-2.5 text-xs"
+          onClick={() => setFilter(f.key)}
+        >
+          {f.label}
+          {countFor(f.key, counts) !== null && (
+            <span className="ml-1.5 tabular-nums opacity-70">
+              {countFor(f.key, counts)}
+            </span>
+          )}
+        </Button>
+      ))}
+    </div>
+  );
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-3">
+        {chips}
+        <FeedSkeleton />
+      </div>
+    );
+  }
+
   if (query.isError) {
     return (
-      <EmptyBody
-        title="Couldn't load your community activity"
-        body={
-          query.error instanceof ApiError
-            ? query.error.message
-            : "Please try again in a moment."
-        }
-      />
+      <div className="space-y-3">
+        {chips}
+        <EmptyBody
+          title="Couldn't load your community activity"
+          body={engageErrorMessage(query.error)}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => void query.refetch()}
+        >
+          Try again
+        </Button>
+      </div>
     );
   }
 
@@ -94,25 +192,7 @@ export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }
     <div className="space-y-3">
       <FeedHeader counts={counts} />
 
-      <div className="flex flex-wrap gap-1.5">
-        {FILTERS.map((f) => (
-          <Button
-            key={f.key}
-            type="button"
-            size="sm"
-            variant={filter === f.key ? "default" : "outline"}
-            className="h-7 px-2.5 text-xs"
-            onClick={() => setFilter(f.key)}
-          >
-            {f.label}
-            {countFor(f.key, counts) !== null && (
-              <span className="ml-1.5 tabular-nums opacity-70">
-                {countFor(f.key, counts)}
-              </span>
-            )}
-          </Button>
-        ))}
-      </div>
+      {chips}
 
       {rows.length === 0 ? (
         <EmptyBody
@@ -127,7 +207,12 @@ export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }
         <ul className="space-y-3">
           {rows.map((row) => (
             <li key={row.id}>
-              <InteractionRow row={row} author={author} filter={filter} />
+              <InteractionRow
+              row={row}
+              author={author}
+              filter={filter}
+              onSeen={markSeen}
+            />
             </li>
           ))}
         </ul>
@@ -192,46 +277,59 @@ function InteractionRow({
   row,
   author,
   filter,
+  onSeen,
 }: {
   row: LinkedInInteraction;
   author: LinkedInAuthor | null;
   filter: FilterKey;
+  onSeen: (interactionUrn: string) => void;
 }) {
   const { formatRelativeTime } = useLocale();
   const qc = useQueryClient();
   const [replying, setReplying] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
 
-  // Marked seen when the row renders, not when it is clicked. The badge
-  // asks "has anyone here looked at this", and it is on screen — but this
-  // is deliberately NOT a status change, so it can never empty the reply
-  // queue by scrolling.
+  // ★Seen when it ENTERS THE VIEWPORT, not when it renders. "New" means
+  // nobody here has looked at it, and a row below the fold has not been
+  // looked at — marking on render cleared the badge for a whole page
+  // somebody scrolled past the top of. Still deliberately NOT a status
+  // change, so no amount of scrolling can empty the reply queue.
   useEffect(() => {
-    if (row.seenAt) return;
-    const t = setTimeout(() => {
-      linkedInContentApi.markInteractionsSeen([row.interactionUrn]).catch(() => {
-        // A missed "seen" costs a badge, not data. Failing loudly here
-        // would put an error toast on a page the user is only scrolling.
-      });
-    }, 1200);
-    return () => clearTimeout(t);
-  }, [row.interactionUrn, row.seenAt]);
+    if (row.seenAt || !ref.current) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const el = ref.current;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            onSeen(row.interactionUrn);
+            io.unobserve(el);
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [row.interactionUrn, row.seenAt, onSeen]);
+
+  const snoozed = Boolean(row.snoozedUntil && new Date(row.snoozedUntil) > new Date());
 
   const snooze = useMutation({
-    mutationFn: () =>
-      linkedInContentApi.updateInteraction(row.interactionUrn, {
-        snoozedUntil: new Date(Date.now() + 24 * 3600 * 1000).toISOString(),
-      }),
-    onSuccess: () => {
-      toast.success("Snoozed for a day");
+    mutationFn: (until: string | null) =>
+      linkedInContentApi.updateInteraction(row.interactionUrn, { snoozedUntil: until }),
+    onSuccess: (_d, until) => {
+      toast.success(until ? "Snoozed for a day" : "Back in your queue");
       void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
     },
-    onError: () => toast.error("Couldn't snooze that. Please try again."),
+    onError: (err) => toast.error(engageErrorMessage(err)),
   });
 
   const canReply = author !== null && row.kind === "comment" && !row.redacted;
+  const postUrl = linkedInPostUrl(row.parentPostUrn);
 
   return (
-    <Card>
+    <Card ref={ref}>
       <CardContent className="space-y-2 p-4">
         <div className="flex flex-wrap items-center gap-1.5">
           <KindBadge kind={row.kind} />
@@ -256,14 +354,20 @@ function InteractionRow({
         )}
 
         <div className="flex flex-wrap items-center gap-1">
-          <a
-            href={`https://www.linkedin.com/feed/update/${row.parentPostUrn}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-          >
-            View post <ExternalLink className="size-3" />
-          </a>
+{/* Guarded, not interpolated: the ingest can put a comment URN in
+              `parentPostUrn`, and a comment URN in a /feed/update/ path is
+              a dead link. No link reads as "no link"; a broken one reads
+              as our bug. */}
+          {postUrl && (
+            <a
+              href={postUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              View post <ExternalLink className="size-3" />
+            </a>
+          )}
 
           {canReply && (
             <Button
@@ -277,7 +381,12 @@ function InteractionRow({
             </Button>
           )}
 
-          {filter === "needs_reply" && (
+{/* ★Snoozing has a way back. The button only appeared on the
+              needs_reply filter, which the server excludes snoozed rows
+              from — so once snoozed, an item could not be found again from
+              this surface at all. It shows up under "All" with an
+              un-snooze, which is where someone would go looking. */}
+          {filter === "needs_reply" && !snoozed && (
             <Button
               type="button"
               variant="ghost"
@@ -285,7 +394,7 @@ function InteractionRow({
               className="h-7 gap-1.5 px-2 text-xs"
               disabled={snooze.isPending}
               aria-busy={snooze.isPending}
-              onClick={() => snooze.mutate()}
+              onClick={() => snooze.mutate(new Date(Date.now() + 24 * 3600 * 1000).toISOString())}
             >
               {snooze.isPending ? (
                 <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
@@ -293,6 +402,25 @@ function InteractionRow({
                 <BellOff className="size-3.5" />
               )}
               Snooze a day
+            </Button>
+          )}
+
+          {snoozed && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              disabled={snooze.isPending}
+              aria-busy={snooze.isPending}
+              onClick={() => snooze.mutate(null)}
+            >
+              {snooze.isPending ? (
+                <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+              ) : (
+                <BellOff className="size-3.5" />
+              )}
+              Un-snooze
             </Button>
           )}
         </div>
@@ -303,83 +431,15 @@ function InteractionRow({
             parentCommentUrn={row.interactionUrn}
             author={author}
             onClose={() => setReplying(false)}
+            // The server marks the interaction replied in the same call,
+            // so refetching is what moves it out of the queue.
+            onReplied={() =>
+              void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] })
+            }
           />
         )}
       </CardContent>
     </Card>
-  );
-}
-
-function ReplyBox({
-  postUrn,
-  parentCommentUrn,
-  author,
-  onClose,
-}: {
-  postUrn: string;
-  parentCommentUrn: string;
-  author: LinkedInAuthor;
-  onClose: () => void;
-}) {
-  const [text, setText] = useState("");
-  const qc = useQueryClient();
-  const send = useMutation({
-    mutationFn: () =>
-      linkedInContentApi.createComment(postUrn, {
-        text: text.trim(),
-        author,
-        parentCommentUrn,
-      }),
-    onSuccess: () => {
-      toast.success("Reply posted");
-      onClose();
-      // The server marks the interaction replied as part of the same
-      // call, so refetching is what moves it out of the queue.
-      void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
-    },
-    onError: (err) =>
-      toast.error(
-        err instanceof ApiError ? err.message : "Couldn't post that reply.",
-      ),
-  });
-
-  return (
-    <div className="space-y-1.5 border-t pt-2">
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
-        placeholder="Write a reply…"
-        rows={2}
-        className="text-sm"
-      />
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          disabled={!text.trim() || send.isPending}
-          aria-busy={send.isPending}
-          onClick={() => send.mutate()}
-        >
-          {send.isPending && (
-            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
-          )}
-          Reply
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
-          {text.length}/{COMMENT_MAX_LEN}
-        </span>
-      </div>
-    </div>
   );
 }
 

--- a/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+/**
+ * The Community Feed — one queue for everything that happened to the brand.
+ *
+ * ★WHY A QUEUE AND NOT MORE NUMBERS ON EACH POST. The engagement itself
+ * already lives under every post in Library. What was missing is the
+ * question a person actually opens the dashboard to answer: is anyone
+ * waiting on us? Spreading that across fifty post cards means it can only
+ * be answered by reading all fifty. One reverse-chronological list makes
+ * the dashboard simpler while showing considerably more.
+ *
+ * ★And it is CHEAP. Every row arrived over the webhook and is read from
+ * our own database, so this costs no LinkedIn budget and can be polled and
+ * left open. The thread panel is where on-demand API calls happen.
+ */
+
+import { useEffect, useState } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Loader2,
+  MessageSquare,
+  AtSign,
+  Repeat2,
+  Clock,
+  CornerDownRight,
+  BellOff,
+  ExternalLink,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  linkedInContentApi,
+  type LinkedInAuthor,
+  type LinkedInFeedCounts,
+  type LinkedInInteraction,
+} from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+import { useLocale } from "@/hooks/use-locale";
+import { RetentionFootnote } from "./retention-footnote";
+
+const FILTERS = [
+  { key: "needs_reply", label: "Needs reply" },
+  { key: "new", label: "New" },
+  { key: "mentions", label: "Mentions" },
+  { key: "reposts", label: "Reposts" },
+  { key: "all", label: "All" },
+] as const;
+
+type FilterKey = (typeof FILTERS)[number]["key"];
+
+const COMMENT_MAX_LEN = 1250;
+
+export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }) {
+  const [filter, setFilter] = useState<FilterKey>("needs_reply");
+
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-interactions", filter],
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.interactions({
+        filter,
+        ...(pageParam ? { cursor: pageParam } : {}),
+        limit: 25,
+      }),
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+
+  const rows = query.data?.pages.flatMap((p) => p.rows) ?? [];
+  const counts = query.data?.pages[0]?.counts;
+
+  if (query.isLoading) return <FeedSkeleton />;
+  if (query.isError) {
+    return (
+      <EmptyBody
+        title="Couldn't load your community activity"
+        body={
+          query.error instanceof ApiError
+            ? query.error.message
+            : "Please try again in a moment."
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <FeedHeader counts={counts} />
+
+      <div className="flex flex-wrap gap-1.5">
+        {FILTERS.map((f) => (
+          <Button
+            key={f.key}
+            type="button"
+            size="sm"
+            variant={filter === f.key ? "default" : "outline"}
+            className="h-7 px-2.5 text-xs"
+            onClick={() => setFilter(f.key)}
+          >
+            {f.label}
+            {countFor(f.key, counts) !== null && (
+              <span className="ml-1.5 tabular-nums opacity-70">
+                {countFor(f.key, counts)}
+              </span>
+            )}
+          </Button>
+        ))}
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyBody
+          title={filter === "needs_reply" ? "Nothing waiting on you" : "Nothing here yet"}
+          body={
+            filter === "needs_reply"
+              ? "Every comment on your posts has been answered."
+              : "Comments, mentions and reposts of your Page will land here."
+          }
+        />
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <InteractionRow row={row} author={author} filter={filter} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more
+        </Button>
+      )}
+
+      <RetentionFootnote>
+        LinkedIn lets us keep a comment&apos;s text for 48 hours. After that the
+        item stays here — along with whether you replied — but the words are
+        gone.
+      </RetentionFootnote>
+    </div>
+  );
+}
+
+/**
+ * The one number worth leading on.
+ *
+ * ★"Oldest unanswered: 14h" beats "5 need a reply". A count says how much
+ * work there is; a duration says whether anyone is being let down, which
+ * is the thing a business actually needs to know and the thing no other
+ * dashboard tells them.
+ */
+function FeedHeader({ counts }: { counts?: LinkedInFeedCounts }) {
+  if (!counts) return null;
+  const waiting = counts.oldestUnansweredMs;
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border bg-muted/30 px-3 py-2 text-xs">
+      {waiting === null ? (
+        <span className="text-muted-foreground">Nothing is waiting on a reply.</span>
+      ) : (
+        <span className="flex items-center gap-1.5">
+          <Clock className="size-3.5 text-muted-foreground" aria-hidden />
+          <span className="text-muted-foreground">Oldest unanswered</span>
+          <span className="font-medium tabular-nums">{formatDuration(waiting)}</span>
+        </span>
+      )}
+      <span className="ml-auto text-muted-foreground tabular-nums">
+        {counts.needsReply} awaiting reply
+      </span>
+    </div>
+  );
+}
+
+function InteractionRow({
+  row,
+  author,
+  filter,
+}: {
+  row: LinkedInInteraction;
+  author: LinkedInAuthor | null;
+  filter: FilterKey;
+}) {
+  const { formatRelativeTime } = useLocale();
+  const qc = useQueryClient();
+  const [replying, setReplying] = useState(false);
+
+  // Marked seen when the row renders, not when it is clicked. The badge
+  // asks "has anyone here looked at this", and it is on screen — but this
+  // is deliberately NOT a status change, so it can never empty the reply
+  // queue by scrolling.
+  useEffect(() => {
+    if (row.seenAt) return;
+    const t = setTimeout(() => {
+      linkedInContentApi.markInteractionsSeen([row.interactionUrn]).catch(() => {
+        // A missed "seen" costs a badge, not data. Failing loudly here
+        // would put an error toast on a page the user is only scrolling.
+      });
+    }, 1200);
+    return () => clearTimeout(t);
+  }, [row.interactionUrn, row.seenAt]);
+
+  const snooze = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.updateInteraction(row.interactionUrn, {
+        snoozedUntil: new Date(Date.now() + 24 * 3600 * 1000).toISOString(),
+      }),
+    onSuccess: () => {
+      toast.success("Snoozed for a day");
+      void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
+    },
+    onError: () => toast.error("Couldn't snooze that. Please try again."),
+  });
+
+  const canReply = author !== null && row.kind === "comment" && !row.redacted;
+
+  return (
+    <Card>
+      <CardContent className="space-y-2 p-4">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <KindBadge kind={row.kind} />
+          <StatusBadges row={row} />
+          <span className="ml-auto text-xs text-muted-foreground">
+            {formatRelativeTime(row.occurredAt ?? row.receivedAt)}
+          </span>
+        </div>
+
+        {row.redacted ? (
+          // The row survives its content on purpose: what we DID about it
+          // is ours to keep, and is exactly what the response-time metrics
+          // are built on. Saying so is better than showing a blank.
+          <p className="text-sm italic text-muted-foreground">
+            The text of this {row.kind} is no longer available — LinkedIn only
+            lets us keep it for 48 hours.
+          </p>
+        ) : (
+          <p className="whitespace-pre-line text-sm leading-relaxed line-clamp-4">
+            {row.text || <span className="text-muted-foreground">(no text)</span>}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-1">
+          <a
+            href={`https://www.linkedin.com/feed/update/${row.parentPostUrn}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            View post <ExternalLink className="size-3" />
+          </a>
+
+          {canReply && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              onClick={() => setReplying((v) => !v)}
+            >
+              <CornerDownRight className="size-3.5" /> Reply
+            </Button>
+          )}
+
+          {filter === "needs_reply" && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              disabled={snooze.isPending}
+              aria-busy={snooze.isPending}
+              onClick={() => snooze.mutate()}
+            >
+              {snooze.isPending ? (
+                <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+              ) : (
+                <BellOff className="size-3.5" />
+              )}
+              Snooze a day
+            </Button>
+          )}
+        </div>
+
+        {replying && author && (
+          <ReplyBox
+            postUrn={row.parentPostUrn}
+            parentCommentUrn={row.interactionUrn}
+            author={author}
+            onClose={() => setReplying(false)}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReplyBox({
+  postUrn,
+  parentCommentUrn,
+  author,
+  onClose,
+}: {
+  postUrn: string;
+  parentCommentUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState("");
+  const qc = useQueryClient();
+  const send = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, {
+        text: text.trim(),
+        author,
+        parentCommentUrn,
+      }),
+    onSuccess: () => {
+      toast.success("Reply posted");
+      onClose();
+      // The server marks the interaction replied as part of the same
+      // call, so refetching is what moves it out of the queue.
+      void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
+    },
+    onError: (err) =>
+      toast.error(
+        err instanceof ApiError ? err.message : "Couldn't post that reply.",
+      ),
+  });
+
+  return (
+    <div className="space-y-1.5 border-t pt-2">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        placeholder="Write a reply…"
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || send.isPending}
+          aria-busy={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {send.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Reply
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function KindBadge({ kind }: { kind: LinkedInInteraction["kind"] }) {
+  const map = {
+    comment: { icon: MessageSquare, label: "Comment" },
+    mention: { icon: AtSign, label: "Mention" },
+    repost: { icon: Repeat2, label: "Repost" },
+    reaction: { icon: MessageSquare, label: "Reaction" },
+  } as const;
+  const { icon: Icon, label } = map[kind];
+  return (
+    <Badge variant="outline" className="gap-1 text-[10px]">
+      <Icon className="size-3" /> {label}
+    </Badge>
+  );
+}
+
+function StatusBadges({ row }: { row: LinkedInInteraction }) {
+  return (
+    <>
+      {!row.seenAt && (
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          New
+        </Badge>
+      )}
+      {row.status === "needs_reply" && (
+        <Badge
+          variant="outline"
+          className="border-warning text-[10px] uppercase tracking-wide text-warning-on-tint"
+        >
+          Needs reply
+        </Badge>
+      )}
+      {row.status === "replied" && (
+        <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+          Replied
+          {typeof row.firstResponseMs === "number" && (
+            <span className="ml-1 tabular-nums opacity-70">
+              in {formatDuration(row.firstResponseMs)}
+            </span>
+          )}
+        </Badge>
+      )}
+      {row.snoozedUntil && new Date(row.snoozedUntil) > new Date() && (
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          Snoozed
+        </Badge>
+      )}
+    </>
+  );
+}
+
+function countFor(key: FilterKey, counts?: LinkedInFeedCounts): number | null {
+  if (!counts) return null;
+  if (key === "needs_reply") return counts.needsReply;
+  if (key === "new") return counts.unseen;
+  if (key === "mentions") return counts.mentions;
+  if (key === "reposts") return counts.reposts;
+  return null;
+}
+
+/** Coarse on purpose. "14h" is the answer; "13h 47m" is noise, and a
+ *  duration that changes every minute reads as a timer rather than a
+ *  measure of how long someone has been kept waiting. */
+function formatDuration(ms: number): string {
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${Math.max(mins, 1)}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+function EmptyBody({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-6 text-center">
+      <p className="text-sm font-medium">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-9 w-full" />
+      <Skeleton className="h-7 w-64" />
+      {[0, 1, 2].map((i) => (
+        <Card key={i}>
+          <CardContent className="space-y-2 p-4">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * Pieces shared by the two places a LinkedIn comment can be answered:
+ * Library's thread panel, and the Feed's queue.
+ *
+ * They are the same action with the same rules — LinkedIn's 1,250-character
+ * limit, the same author resolution, the same error wording — and keeping
+ * two copies meant a fix to one silently left the other wrong. The reply
+ * box in particular had already been written twice.
+ */
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { linkedInContentApi, type LinkedInAuthor } from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+
+/** LinkedIn's own cap on comment text. */
+export const COMMENT_MAX_LEN = 1250;
+
+/**
+ * Turn an engagement failure into something a person can act on.
+ *
+ * ★A 403 does NOT promise that reconnecting helps. An org post 403s on a
+ * grant predating the `_feed` scopes, which reconnecting fixes; a
+ * member-authored post 403s on a permission LinkedIn grants to select
+ * developers only, which it never will. The server already words this
+ * carefully — pass its message through rather than inventing a cheerier
+ * one that sends someone round a loop ending where it started.
+ *
+ * What we do NOT pass through is a raw transport string: it carries
+ * LinkedIn JSON and URNs, and "Active business required" is a sentence
+ * written for a log, not a person.
+ */
+export function engageErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === "NOT_CONNECTED") return "Reconnect LinkedIn to continue.";
+    if (err.code === "FORBIDDEN" && err.message.includes("business")) {
+      return "Pick a business to see your community activity.";
+    }
+    if (
+      err.code === "CONFIRMATION_REQUIRED" ||
+      err.code === "VALIDATION_ERROR" ||
+      err.code === "INVALID_REQUEST" ||
+      err.code === "NOT_FOUND"
+    ) {
+      return err.message;
+    }
+    if (err.status === 403 || err.status === 404 || err.status === 429) {
+      return err.message;
+    }
+  }
+  return "That didn't work. Please try again.";
+}
+
+/**
+ * A permalink, or null.
+ *
+ * ★Guarded rather than interpolated. `parentPostUrn` can hold a comment
+ * URN — the ingest falls back to a decorated payload's `object` when
+ * LinkedIn sends no `sourcePost` — and a comment URN in a
+ * `/feed/update/` path is a dead link. A missing link reads as "no link";
+ * a broken one reads as a bug.
+ *
+ * Raw colons, no `encodeURIComponent`, no trailing slash: matches the
+ * backend's permalink convention, and encoding produces `%3A%3A` URLs
+ * some browser caches mishandle.
+ */
+export function linkedInPostUrl(urn: string | null | undefined): string | null {
+  if (!urn || !urn.includes("urn:li:")) return null;
+  if (urn.startsWith("urn:li:comment:")) return null;
+  return `https://www.linkedin.com/feed/update/${urn}`;
+}
+
+/** Post a reply to one comment, as a given author. */
+export function ReplyBox({
+  postUrn,
+  parentCommentUrn,
+  author,
+  onClose,
+  onReplied,
+}: {
+  postUrn: string;
+  parentCommentUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+  /** Refresh whichever list this reply belongs to — the thread, the
+   *  replies under a comment, or the Feed queue. */
+  onReplied: () => void;
+}) {
+  const [text, setText] = useState("");
+  const send = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, {
+        text: text.trim(),
+        author,
+        parentCommentUrn,
+      }),
+    onSuccess: () => {
+      toast.success("Reply posted");
+      setText("");
+      onClose();
+      onReplied();
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        placeholder="Write a reply…"
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || send.isPending}
+          aria-busy={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {send.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Reply
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ThreadPanel } from "./thread-panel";
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
@@ -22,6 +23,9 @@ import {
   Share2,
   User,
   X,
+  MousePointerClick,
+  MessagesSquare,
+  TrendingUp,
 } from "lucide-react";
 import {
   linkedInContentApi,
@@ -55,7 +59,7 @@ const AUTHOR_FILTERS: { value: AuthorFilter; label: string }[] = [
   { value: "org", label: "Pages" },
 ];
 
-export function FeedPanel() {
+export function LibraryPanel() {
   const [authorFilter, setAuthorFilter] = useState<AuthorFilter>("all");
 
   const {
@@ -175,6 +179,25 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
   // on a resolvable author AND a real post URN.
   const author = postAuthor(post);
   const canComment = author !== null && !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
+  const [threadOpen, setThreadOpen] = useState(false);
+  // Reading a thread needs a real URN but NOT a resolvable author — you can
+  // look at engagement on a post you cannot currently comment as.
+  const canEngage = !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
+  // Opening a thread costs a LinkedIn call against a ~500/day app-wide
+  // budget, so the entry point is hidden when the counters say there is
+  // nothing in there to read.
+  const hasEngagement =
+    post.performance.comments > 0 || post.performance.likes > 0;
+  // Engagement over reach. Null rather than 0 when there are no
+  // impressions: a post nobody saw has no rate, and rendering "0.0%"
+  // would read as failure rather than as absence.
+  const engagementRate =
+    post.performance.impressions > 0
+      ? ((post.performance.likes + post.performance.comments + post.performance.shares +
+          post.performance.clicks) /
+          post.performance.impressions) *
+        100
+      : null;
 
   return (
     <li>
@@ -209,11 +232,44 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
             {post.content}
           </p>
 
+{/* ★Two lines, because they answer different questions. Reach is
+              what the post DID; engagement is what people did back, and it
+              is the half that can be acted on — so it carries the button.
+
+              `clicks` was already in the payload and simply never rendered.
+              The engagement RATE is the number worth leading on: a post
+              with 400 impressions and 20 comments is doing better than one
+              with 12,000 and 3, and the old strip made the second look
+              like the winner. */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
             <Metric icon={Eye} label="impressions" value={post.performance.impressions} />
-            <Metric icon={Heart} label="likes" value={post.performance.likes} />
+            <Metric icon={MousePointerClick} label="clicks" value={post.performance.clicks} />
+            {engagementRate !== null && (
+              <span
+                className="flex items-center gap-1"
+                title={`${engagementRate.toFixed(2)}% of people who saw this engaged with it`}
+              >
+                <TrendingUp className="size-3.5" aria-hidden />
+                {engagementRate.toFixed(1)}%
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <Metric icon={Heart} label="reactions" value={post.performance.likes} />
             <Metric icon={MessageSquare} label="comments" value={post.performance.comments} />
-            <Metric icon={Share2} label="shares" value={post.performance.shares} />
+            <Metric icon={Share2} label="reposts" value={post.performance.shares} />
+            {canEngage && hasEngagement && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="ml-auto h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setThreadOpen(true)}
+              >
+                <MessagesSquare className="size-3.5" /> View engagement
+              </Button>
+            )}
           </div>
 
           {canComment && (
@@ -239,6 +295,15 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
           )}
         </CardContent>
       </Card>
+
+      {canEngage && (
+        <ThreadPanel
+          postUrn={post.linkedInPostId as string}
+          author={author}
+          open={threadOpen}
+          onOpenChange={setThreadOpen}
+        />
+      )}
     </li>
   );
 }

--- a/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
@@ -255,7 +255,7 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
             )}
           </div>
 
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
             <Metric icon={Heart} label="reactions" value={post.performance.likes} />
             <Metric icon={MessageSquare} label="comments" value={post.performance.comments} />
             <Metric icon={Share2} label="reposts" value={post.performance.shares} />
@@ -300,6 +300,9 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
         <ThreadPanel
           postUrn={post.linkedInPostId as string}
           author={author}
+          // The URN that published this post IS us — the only sound test
+          // for "we wrote this comment", and available right here.
+          ourActorUrn={post.authorUrn}
           open={threadOpen}
           onOpenChange={setThreadOpen}
         />

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -38,6 +38,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ConfirmDialog } from "@/components/molecules";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   linkedInContentApi,
@@ -78,6 +80,7 @@ const COMMENT_MAX_LEN = 1250;
 export function ThreadPanel({
   postUrn,
   author,
+  ourActorUrn,
   open,
   onOpenChange,
 }: {
@@ -85,6 +88,14 @@ export function ThreadPanel({
   /** The post's own author — who we reply and react AS. Null when we
    *  cannot resolve one, in which case the panel reads but cannot write. */
   author: LinkedInAuthor | null;
+  /** The URN that published this post — i.e. us.
+   *
+   *  ★The ONLY sound test for "this is our comment". An earlier version
+   *  used `Boolean(comment.agent)`, which means "an ORGANIZATION authored
+   *  this" and is true of any other company's comment on the thread — so
+   *  another brand got a "You" badge and an Edit button whose save
+   *  LinkedIn would reject. */
+  ourActorUrn: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -109,7 +120,12 @@ export function ThreadPanel({
           </TabsList>
 
           <TabsContent value="comments" className="mt-3 min-h-0 flex-1 overflow-y-auto">
-            <CommentsTab postUrn={postUrn} author={author} open={open} />
+            <CommentsTab
+              postUrn={postUrn}
+              author={author}
+              ourActorUrn={ourActorUrn}
+              open={open}
+            />
           </TabsContent>
           <TabsContent value="reactions" className="mt-3 min-h-0 flex-1 overflow-y-auto">
             <ReactionsTab postUrn={postUrn} open={open} />
@@ -130,10 +146,12 @@ export function ThreadPanel({
 function CommentsTab({
   postUrn,
   author,
+  ourActorUrn,
   open,
 }: {
   postUrn: string;
   author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
   open: boolean;
 }) {
   const query = useInfiniteQuery({
@@ -183,7 +201,12 @@ function CommentsTab({
       <ul className="space-y-3">
         {comments.map((comment) => (
           <li key={comment.commentUrn ?? comment.id}>
-            <CommentRow comment={comment} postUrn={postUrn} author={author} />
+            <CommentRow
+              comment={comment}
+              postUrn={postUrn}
+              author={author}
+              ourActorUrn={ourActorUrn}
+            />
           </li>
         ))}
       </ul>
@@ -212,12 +235,17 @@ function CommentRow({
   comment,
   postUrn,
   author,
+  ourActorUrn,
   nested = false,
+  parentCommentUrn,
 }: {
   comment: LinkedInCommentDetail;
   postUrn: string;
   author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
   nested?: boolean;
+  /** Set on a reply, so a write can refresh the list it actually lives in. */
+  parentCommentUrn?: string;
 }) {
   const { formatRelativeTime } = useLocale();
   const qc = useQueryClient();
@@ -225,14 +253,32 @@ function CommentRow({
   const [editing, setEditing] = useState(false);
   const [showReplies, setShowReplies] = useState(false);
 
-  // An org `agent` means a member acted on a page's behalf — i.e. this is
-  // OUR comment. It is the only reliable "ours" signal on the payload, and
-  // it gates edit, which LinkedIn permits only on your own comment.
-  const isOurs = Boolean(comment.agent);
+  // ★Ours means the actor is the URN that published this post — not
+  // merely that SOME organization authored it. `comment.agent` is present
+  // on every org comment, including another brand's, so using it here put
+  // a "You" badge and an Edit button on comments we cannot edit.
+  const isOurs = Boolean(ourActorUrn) && comment.actor === ourActorUrn;
   // Actions that key on a comment need its composite URN. It is optional
   // because LinkedIn occasionally sends nothing to build one from — hide
   // the action rather than send a key that matches nothing.
   const canAct = Boolean(comment.commentUrn);
+
+  /**
+   * Refresh the list this comment is IN.
+   *
+   * ★A reply lives under `["linkedin-replies", parentCommentUrn]`, not
+   * under the thread key. Invalidating only the thread left a deleted
+   * reply on screen — and a row still on screen is a row that gets
+   * clicked again, re-sending a write LinkedIn has already applied.
+   */
+  function refreshOwnList() {
+    if (nested && parentCommentUrn) {
+      void qc.invalidateQueries({ queryKey: ["linkedin-replies", parentCommentUrn] });
+    }
+    // The thread is refreshed either way: a reply's deletion changes its
+    // parent's replyCount, which is rendered up there.
+    void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+  }
 
   const react = useMutation({
     mutationFn: (type: LinkedInReactionType) =>
@@ -240,7 +286,12 @@ function CommentRow({
         reactionType: type,
         author: author as LinkedInAuthor,
       }),
-    onSuccess: () => toast.success("Reaction added"),
+    onSuccess: () => {
+      toast.success("Reaction added");
+      // Without this the like count we just changed never moves, which
+      // reads as "it didn't work" and invites a second reaction.
+      refreshOwnList();
+    },
     onError: (err) => toast.error(engageErrorMessage(err)),
   });
 
@@ -253,7 +304,7 @@ function CommentRow({
       ),
     onSuccess: () => {
       toast.success("Comment deleted");
-      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+      refreshOwnList();
     },
     onError: (err) => toast.error(engageErrorMessage(err)),
   });
@@ -291,9 +342,9 @@ function CommentRow({
           {editing && comment.commentUrn ? (
             <EditBox
               commentUrn={comment.commentUrn}
-              postUrn={postUrn}
               initial={comment.message}
               author={author}
+              onSaved={refreshOwnList}
               onClose={() => setEditing(false)}
             />
           ) : (
@@ -342,23 +393,40 @@ function CommentRow({
               </Button>
             )}
 
+{/* ★Behind a confirm. Deleting is irreversible on LinkedIn, it is
+                offered on OTHER people's comments (that is the moderation
+                feature, not a bug), and one stray click on a member's
+                comment is a public act we cannot undo. Every other
+                destructive action in this dashboard asks first. */}
             {canAct && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
-                disabled={remove.isPending}
-                aria-busy={remove.isPending}
-                onClick={() => remove.mutate()}
-              >
-                {remove.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
-                ) : (
-                  <Trash2 className="size-3.5" />
-                )}
-                Delete
-              </Button>
+              <ConfirmDialog
+                variant="destructive"
+                title={isOurs ? "Delete your comment?" : "Delete this comment?"}
+                description={
+                  isOurs
+                    ? "This removes your comment from LinkedIn. It can't be undone."
+                    : "This removes someone else's comment from your post on LinkedIn. They aren't notified, and it can't be undone."
+                }
+                confirmLabel="Delete"
+                onConfirm={() => remove.mutate()}
+                trigger={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
+                    disabled={remove.isPending}
+                    aria-busy={remove.isPending}
+                  >
+                    {remove.isPending ? (
+                      <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+                    ) : (
+                      <Trash2 className="size-3.5" />
+                    )}
+                    Delete
+                  </Button>
+                }
+              />
             )}
 
             {comment.replyCount > 0 && !nested && (
@@ -389,6 +457,7 @@ function CommentRow({
               commentUrn={comment.commentUrn}
               postUrn={postUrn}
               author={author}
+              ourActorUrn={ourActorUrn}
             />
           )}
         </div>
@@ -403,10 +472,12 @@ function RepliesList({
   commentUrn,
   postUrn,
   author,
+  ourActorUrn,
 }: {
   commentUrn: string;
   postUrn: string;
   author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
 }) {
   const query = useInfiniteQuery({
     queryKey: ["linkedin-replies", commentUrn],
@@ -419,10 +490,24 @@ function RepliesList({
     getNextPageParam: (last) => last.nextStart ?? undefined,
     staleTime: 60_000,
     refetchOnWindowFocus: false,
+    // Same 403 gate as the sibling queries. A 403 here is a permanent no —
+    // retrying spends two more of a ~500/day app-wide budget to be told
+    // the same thing.
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
   });
 
   if (query.isLoading) {
     return <Skeleton className="mt-2 h-12 w-full" />;
+  }
+  // Rendering null on an error meant the user clicked "Show 3 replies" and
+  // watched nothing happen, with no way to tell a failure from an empty
+  // list. Say which it was.
+  if (query.isError) {
+    return (
+      <p className="mt-2 text-xs text-muted-foreground">
+        {engageErrorMessage(query.error)}
+      </p>
+    );
   }
   const replies = query.data?.pages.flatMap((p) => p.comments) ?? [];
   if (!replies.length) return null;
@@ -431,7 +516,14 @@ function RepliesList({
     <ul className="mt-2 space-y-3">
       {replies.map((reply) => (
         <li key={reply.commentUrn ?? reply.id}>
-          <CommentRow comment={reply} postUrn={postUrn} author={author} nested />
+          <CommentRow
+            comment={reply}
+            postUrn={postUrn}
+            author={author}
+            ourActorUrn={ourActorUrn}
+            nested
+            parentCommentUrn={commentUrn}
+          />
         </li>
       ))}
     </ul>
@@ -510,19 +602,22 @@ function ReplyBox({
 
 function EditBox({
   commentUrn,
-  postUrn,
   initial,
   author,
+  onSaved,
   onClose,
 }: {
   commentUrn: string;
-  postUrn: string;
   initial: string;
   author: LinkedInAuthor | null;
+  /** Refresh the list this comment lives in — the thread for a top-level
+   *  comment, the replies list for a reply. Edit is offered on both, and
+   *  invalidating only the thread showed a success toast beside the old
+   *  text still on screen. */
+  onSaved: () => void;
   onClose: () => void;
 }) {
   const [text, setText] = useState(initial);
-  const qc = useQueryClient();
   const save = useMutation({
     mutationFn: () =>
       linkedInContentApi.editComment(commentUrn, {
@@ -532,7 +627,7 @@ function EditBox({
     onSuccess: () => {
       toast.success("Comment updated");
       onClose();
-      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+      onSaved();
     },
     onError: (err) => toast.error(engageErrorMessage(err)),
   });
@@ -573,6 +668,12 @@ function EditBox({
   );
 }
 
+/** ★Radix Popover, not a hand-rolled absolute div. The hand-rolled one
+ *  had no outside-click or Escape handling, so it stayed floating over the
+ *  thread until you picked something — and opening a second one left two
+ *  on screen at once. Focus management and dismissal are exactly what the
+ *  primitive is for, and the repo already uses it for this same picker in
+ *  the Audience panel. */
 function ReactionPicker({
   pending,
   onPick,
@@ -582,44 +683,42 @@ function ReactionPicker({
 }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="relative">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 gap-1.5 px-2 text-xs"
-        disabled={pending}
-        aria-busy={pending}
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        {pending ? (
-          <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
-        ) : (
-          <Heart className="size-3.5" />
-        )}
-        React
-      </Button>
-      {open && (
-        <div className="absolute bottom-8 left-0 z-10 flex gap-0.5 rounded-md border bg-popover p-1 shadow-md">
-          {REACTIONS.map((r) => (
-            <button
-              key={r.type}
-              type="button"
-              title={r.label}
-              aria-label={r.label}
-              className="rounded px-1.5 py-0.5 text-base hover:bg-accent"
-              onClick={() => {
-                setOpen(false);
-                onPick(r.type);
-              }}
-            >
-              {r.emoji}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-xs"
+          disabled={pending}
+          aria-busy={pending}
+        >
+          {pending ? (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <Heart className="size-3.5" />
+          )}
+          React
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="flex w-auto gap-0.5 p-1">
+        {REACTIONS.map((r) => (
+          <button
+            key={r.type}
+            type="button"
+            title={r.label}
+            aria-label={r.label}
+            className="rounded px-1.5 py-0.5 text-base hover:bg-accent"
+            onClick={() => {
+              setOpen(false);
+              onPick(r.type);
+            }}
+          >
+            {r.emoji}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -52,6 +52,7 @@ import {
 import { ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { RetentionFootnote } from "./retention-footnote";
+import { COMMENT_MAX_LEN, ReplyBox, engageErrorMessage } from "./engage-shared";
 
 /** Reaction types we may WRITE. `MAYBE` is deprecated by LinkedIn and 400s
  *  on create, so it is absent here even though a read can surface it. */
@@ -74,8 +75,6 @@ function reactionEmoji(type: string): string {
 function reactionLabel(type: string): string {
   return REACTIONS.find((r) => r.type === type)?.label ?? type;
 }
-
-const COMMENT_MAX_LEN = 1250;
 
 export function ThreadPanel({
   postUrn,
@@ -449,6 +448,7 @@ function CommentRow({
               parentCommentUrn={comment.commentUrn}
               author={author}
               onClose={() => setReplying(false)}
+              onReplied={refreshOwnList}
             />
           )}
 
@@ -527,76 +527,6 @@ function RepliesList({
         </li>
       ))}
     </ul>
-  );
-}
-
-function ReplyBox({
-  postUrn,
-  parentCommentUrn,
-  author,
-  onClose,
-}: {
-  postUrn: string;
-  parentCommentUrn: string;
-  author: LinkedInAuthor;
-  onClose: () => void;
-}) {
-  const [text, setText] = useState("");
-  const qc = useQueryClient();
-  const send = useMutation({
-    mutationFn: () =>
-      linkedInContentApi.createComment(postUrn, {
-        text: text.trim(),
-        author,
-        parentCommentUrn,
-      }),
-    onSuccess: () => {
-      toast.success("Reply posted");
-      setText("");
-      onClose();
-      void qc.invalidateQueries({ queryKey: ["linkedin-replies", parentCommentUrn] });
-      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
-    },
-    onError: (err) => toast.error(engageErrorMessage(err)),
-  });
-
-  return (
-    <div className="mt-2 space-y-1.5">
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
-        placeholder="Write a reply…"
-        rows={2}
-        className="text-sm"
-      />
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          disabled={!text.trim() || send.isPending}
-          aria-busy={send.isPending}
-          onClick={() => send.mutate()}
-        >
-          {send.isPending && (
-            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
-          )}
-          Reply
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
-          {text.length}/{COMMENT_MAX_LEN}
-        </span>
-      </div>
-    </div>
   );
 }
 
@@ -843,26 +773,6 @@ function ActorAvatar({ profile }: { profile?: LinkedInActorProfile }) {
       <AvatarFallback className="text-[10px]">{initials}</AvatarFallback>
     </Avatar>
   );
-}
-
-/** Map an engagement failure to something a person can act on. Never
- *  surfaces the raw provider string — it carries LinkedIn JSON and URNs.
- *
- *  ★A 403 does NOT promise a reconnect helps: an org post 403s on the
- *  pre-`_feed` grant, which reconnecting fixes, but a member-authored post
- *  403s on a permission LinkedIn grants to select developers only. The
- *  server already words this carefully; pass it through. */
-function engageErrorMessage(err: unknown): string {
-  if (err instanceof ApiError) {
-    if (err.code === "NOT_CONNECTED") return "Reconnect LinkedIn to continue.";
-    if (err.code === "CONFIRMATION_REQUIRED" || err.code === "VALIDATION_ERROR") {
-      return err.message;
-    }
-    if (err.status === 403 || err.status === 404 || err.status === 429) {
-      return err.message;
-    }
-  }
-  return "That didn't work. Please try again.";
 }
 
 function ErrorBody({ error }: { error: unknown }) {

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -1,0 +1,801 @@
+"use client";
+
+/**
+ * The thread panel — the surface that makes a comment visible.
+ *
+ * Until this shipped, LinkedIn Content could POST a comment it could not
+ * SHOW you: the write path landed with the engager panel and the read path
+ * never did. This is the read path, plus the actions that belong beside it.
+ *
+ * ★Everything here is fetched only when a person opens the sheet.
+ * Community Management Development tier allows ~500 requests/day for the
+ * whole app across every customer, so a thread is loaded on demand and
+ * never prefetched for a list of posts. `enabled: open` on both queries is
+ * the mechanism; do not replace it with an eager fetch.
+ */
+
+import { useState } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Loader2,
+  MessageSquare,
+  Heart,
+  Trash2,
+  CornerDownRight,
+  Pencil,
+  ExternalLink,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  linkedInContentApi,
+  type LinkedInActorProfile,
+  type LinkedInAuthor,
+  type LinkedInCommentDetail,
+  type LinkedInReaction,
+  type LinkedInReactionType,
+} from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+import { useLocale } from "@/hooks/use-locale";
+import { RetentionFootnote } from "./retention-footnote";
+
+/** Reaction types we may WRITE. `MAYBE` is deprecated by LinkedIn and 400s
+ *  on create, so it is absent here even though a read can surface it. */
+const REACTIONS: Array<{ type: LinkedInReactionType; emoji: string; label: string }> = [
+  { type: "LIKE", emoji: "👍", label: "Like" },
+  { type: "PRAISE", emoji: "🎉", label: "Celebrate" },
+  { type: "EMPATHY", emoji: "❤️", label: "Love" },
+  { type: "INTEREST", emoji: "💡", label: "Insightful" },
+  { type: "APPRECIATION", emoji: "🙌", label: "Support" },
+  { type: "ENTERTAINMENT", emoji: "😄", label: "Funny" },
+];
+
+/** Emoji for a reaction type we may not know — LinkedIn has added types
+ *  before, and an unrecognised one must render as something rather than
+ *  vanish from a list the user is counting. */
+function reactionEmoji(type: string): string {
+  return REACTIONS.find((r) => r.type === type)?.emoji ?? "•";
+}
+
+function reactionLabel(type: string): string {
+  return REACTIONS.find((r) => r.type === type)?.label ?? type;
+}
+
+const COMMENT_MAX_LEN = 1250;
+
+export function ThreadPanel({
+  postUrn,
+  author,
+  open,
+  onOpenChange,
+}: {
+  postUrn: string;
+  /** The post's own author — who we reply and react AS. Null when we
+   *  cannot resolve one, in which case the panel reads but cannot write. */
+  author: LinkedInAuthor | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Engagement</SheetTitle>
+          <SheetDescription>
+            Reply, react and moderate without leaving Peakhour.
+          </SheetDescription>
+        </SheetHeader>
+
+        <Tabs defaultValue="comments" className="mt-4 flex min-h-0 flex-1 flex-col">
+          <TabsList>
+            <TabsTrigger value="comments" className="gap-1.5">
+              <MessageSquare className="size-4" /> Comments
+            </TabsTrigger>
+            <TabsTrigger value="reactions" className="gap-1.5">
+              <Heart className="size-4" /> Reactions
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="comments" className="mt-3 min-h-0 flex-1 overflow-y-auto">
+            <CommentsTab postUrn={postUrn} author={author} open={open} />
+          </TabsContent>
+          <TabsContent value="reactions" className="mt-3 min-h-0 flex-1 overflow-y-auto">
+            <ReactionsTab postUrn={postUrn} open={open} />
+          </TabsContent>
+        </Tabs>
+
+        <RetentionFootnote>
+          Comment text is held for 48 hours and commenter names for 24, per
+          LinkedIn&apos;s data rules.
+        </RetentionFootnote>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ── Comments ──────────────────────────────────────────────
+
+function CommentsTab({
+  postUrn,
+  author,
+  open,
+}: {
+  postUrn: string;
+  author: LinkedInAuthor | null;
+  open: boolean;
+}) {
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-thread", postUrn],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.comments(postUrn, { count: 25, start: pageParam as number }),
+    getNextPageParam: (last) => last.nextStart ?? undefined,
+    // Loaded only while the sheet is open — see the file header on why.
+    enabled: open,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+
+  if (query.isLoading) return <ThreadSkeleton />;
+
+  if (query.isError) {
+    return <ErrorBody error={query.error} />;
+  }
+
+  const pages = query.data?.pages ?? [];
+  const comments = pages.flatMap((p) => p.comments);
+  // False means "we are not showing names", which is a different thing from
+  // "nobody has a name" — worth saying rather than leaving people to guess
+  // why every row says "A member".
+  const identityEnabled = pages[0]?.identityEnabled ?? true;
+
+  if (!comments.length) {
+    return (
+      <EmptyBody
+        title="No comments yet"
+        body="When someone comments on this post, it'll show up here and you can reply from Peakhour."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {!identityEnabled && (
+        <p className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          Commenter names are turned off right now, so everyone shows as
+          &ldquo;A member&rdquo;. Replies and reactions still work.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {comments.map((comment) => (
+          <li key={comment.commentUrn ?? comment.id}>
+            <CommentRow comment={comment} postUrn={postUrn} author={author} />
+          </li>
+        ))}
+      </ul>
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more comments
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function CommentRow({
+  comment,
+  postUrn,
+  author,
+  nested = false,
+}: {
+  comment: LinkedInCommentDetail;
+  postUrn: string;
+  author: LinkedInAuthor | null;
+  nested?: boolean;
+}) {
+  const { formatRelativeTime } = useLocale();
+  const qc = useQueryClient();
+  const [replying, setReplying] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [showReplies, setShowReplies] = useState(false);
+
+  // An org `agent` means a member acted on a page's behalf — i.e. this is
+  // OUR comment. It is the only reliable "ours" signal on the payload, and
+  // it gates edit, which LinkedIn permits only on your own comment.
+  const isOurs = Boolean(comment.agent);
+  // Actions that key on a comment need its composite URN. It is optional
+  // because LinkedIn occasionally sends nothing to build one from — hide
+  // the action rather than send a key that matches nothing.
+  const canAct = Boolean(comment.commentUrn);
+
+  const react = useMutation({
+    mutationFn: (type: LinkedInReactionType) =>
+      linkedInContentApi.createReaction(comment.commentUrn as string, {
+        reactionType: type,
+        author: author as LinkedInAuthor,
+      }),
+    onSuccess: () => toast.success("Reaction added"),
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  const remove = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.deleteComment(
+        postUrn,
+        comment.commentUrn ?? comment.id,
+        author ?? undefined,
+      ),
+    onSuccess: () => {
+      toast.success("Comment deleted");
+      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className={nested ? "border-l pl-3" : ""}>
+      <div className="flex gap-2.5">
+        <ActorAvatar profile={comment.actorProfile} />
+
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <span className="text-sm font-medium">
+              {comment.actorProfile?.displayName ?? "A member"}
+            </span>
+            {comment.actorProfile?.headline && (
+              <span className="truncate text-xs text-muted-foreground">
+                {comment.actorProfile.headline}
+              </span>
+            )}
+            {isOurs && (
+              <Badge variant="outline" className="text-[10px]">
+                You
+              </Badge>
+            )}
+            {comment.edited && (
+              <span className="text-[10px] text-muted-foreground">edited</span>
+            )}
+            {comment.createdAt && (
+              <span className="ml-auto text-xs text-muted-foreground">
+                {formatRelativeTime(new Date(comment.createdAt).toISOString())}
+              </span>
+            )}
+          </div>
+
+          {editing && comment.commentUrn ? (
+            <EditBox
+              commentUrn={comment.commentUrn}
+              postUrn={postUrn}
+              initial={comment.message}
+              author={author}
+              onClose={() => setEditing(false)}
+            />
+          ) : (
+            <p className="whitespace-pre-line text-sm leading-relaxed">
+              {comment.message || (
+                <span className="text-muted-foreground">(image only)</span>
+              )}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-1">
+            {comment.likeCount > 0 && (
+              <span className="mr-1 text-xs tabular-nums text-muted-foreground">
+                {comment.likeCount} {comment.likeCount === 1 ? "like" : "likes"}
+              </span>
+            )}
+
+            {author && canAct && !nested && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setReplying((v) => !v)}
+              >
+                <CornerDownRight className="size-3.5" /> Reply
+              </Button>
+            )}
+
+            {author && canAct && (
+              <ReactionPicker
+                pending={react.isPending}
+                onPick={(type) => react.mutate(type)}
+              />
+            )}
+
+            {isOurs && canAct && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setEditing((v) => !v)}
+              >
+                <Pencil className="size-3.5" /> Edit
+              </Button>
+            )}
+
+            {canAct && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs text-destructive hover:text-destructive"
+                disabled={remove.isPending}
+                aria-busy={remove.isPending}
+                onClick={() => remove.mutate()}
+              >
+                {remove.isPending ? (
+                  <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+                ) : (
+                  <Trash2 className="size-3.5" />
+                )}
+                Delete
+              </Button>
+            )}
+
+            {comment.replyCount > 0 && !nested && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                onClick={() => setShowReplies((v) => !v)}
+              >
+                {showReplies ? "Hide" : "Show"} {comment.replyCount}{" "}
+                {comment.replyCount === 1 ? "reply" : "replies"}
+              </Button>
+            )}
+          </div>
+
+          {replying && comment.commentUrn && author && (
+            <ReplyBox
+              postUrn={postUrn}
+              parentCommentUrn={comment.commentUrn}
+              author={author}
+              onClose={() => setReplying(false)}
+            />
+          )}
+
+          {showReplies && comment.commentUrn && (
+            <RepliesList
+              commentUrn={comment.commentUrn}
+              postUrn={postUrn}
+              author={author}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Replies load only when expanded — LinkedIn nests exactly one level, so
+ *  this never recurses. */
+function RepliesList({
+  commentUrn,
+  postUrn,
+  author,
+}: {
+  commentUrn: string;
+  postUrn: string;
+  author: LinkedInAuthor | null;
+}) {
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-replies", commentUrn],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.commentReplies(commentUrn, {
+        count: 25,
+        start: pageParam as number,
+      }),
+    getNextPageParam: (last) => last.nextStart ?? undefined,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (query.isLoading) {
+    return <Skeleton className="mt-2 h-12 w-full" />;
+  }
+  const replies = query.data?.pages.flatMap((p) => p.comments) ?? [];
+  if (!replies.length) return null;
+
+  return (
+    <ul className="mt-2 space-y-3">
+      {replies.map((reply) => (
+        <li key={reply.commentUrn ?? reply.id}>
+          <CommentRow comment={reply} postUrn={postUrn} author={author} nested />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ReplyBox({
+  postUrn,
+  parentCommentUrn,
+  author,
+  onClose,
+}: {
+  postUrn: string;
+  parentCommentUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState("");
+  const qc = useQueryClient();
+  const send = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, {
+        text: text.trim(),
+        author,
+        parentCommentUrn,
+      }),
+    onSuccess: () => {
+      toast.success("Reply posted");
+      setText("");
+      onClose();
+      void qc.invalidateQueries({ queryKey: ["linkedin-replies", parentCommentUrn] });
+      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        placeholder="Write a reply…"
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || send.isPending}
+          aria-busy={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {send.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Reply
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function EditBox({
+  commentUrn,
+  postUrn,
+  initial,
+  author,
+  onClose,
+}: {
+  commentUrn: string;
+  postUrn: string;
+  initial: string;
+  author: LinkedInAuthor | null;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState(initial);
+  const qc = useQueryClient();
+  const save = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.editComment(commentUrn, {
+        text: text.trim(),
+        ...(author ? { author } : {}),
+      }),
+    onSuccess: () => {
+      toast.success("Comment updated");
+      onClose();
+      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className="space-y-1.5">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || text.trim() === initial || save.isPending}
+          aria-busy={save.isPending}
+          onClick={() => save.mutate()}
+        >
+          {save.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Save
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ReactionPicker({
+  pending,
+  onPick,
+}: {
+  pending: boolean;
+  onPick: (type: LinkedInReactionType) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 gap-1.5 px-2 text-xs"
+        disabled={pending}
+        aria-busy={pending}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {pending ? (
+          <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+        ) : (
+          <Heart className="size-3.5" />
+        )}
+        React
+      </Button>
+      {open && (
+        <div className="absolute bottom-8 left-0 z-10 flex gap-0.5 rounded-md border bg-popover p-1 shadow-md">
+          {REACTIONS.map((r) => (
+            <button
+              key={r.type}
+              type="button"
+              title={r.label}
+              aria-label={r.label}
+              className="rounded px-1.5 py-0.5 text-base hover:bg-accent"
+              onClick={() => {
+                setOpen(false);
+                onPick(r.type);
+              }}
+            >
+              {r.emoji}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Reactions ─────────────────────────────────────────────
+
+function ReactionsTab({ postUrn, open }: { postUrn: string; open: boolean }) {
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-reactions", postUrn],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.reactions(postUrn, { count: 25, start: pageParam as number }),
+    getNextPageParam: (last) => last.nextStart ?? undefined,
+    enabled: open,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+
+  if (query.isLoading) return <ThreadSkeleton />;
+  if (query.isError) return <ErrorBody error={query.error} />;
+
+  const reactions = query.data?.pages.flatMap((p) => p.reactions) ?? [];
+  if (!reactions.length) {
+    return (
+      <EmptyBody
+        title="No reactions yet"
+        body="Reactions on this post will show up here, grouped by type."
+      />
+    );
+  }
+
+  // Grouped by type for scanning. This is the reactors we have LOADED, not
+  // the post's totals — the authoritative per-type counts live on the
+  // metric strip, which reads them from LinkedIn in one call.
+  const groups = new Map<string, LinkedInReaction[]>();
+  for (const r of reactions) {
+    const list = groups.get(r.reactionType) ?? [];
+    list.push(r);
+    groups.set(r.reactionType, list);
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Most people who only react stay anonymous — LinkedIn shares names for
+        commenters, not reactors.
+      </p>
+
+      {[...groups.entries()].map(([type, list]) => (
+        <div key={type} className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <span className="text-base" aria-hidden>
+              {reactionEmoji(type)}
+            </span>
+            <span className="text-xs font-medium">{reactionLabel(type)}</span>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {list.length}
+            </span>
+          </div>
+          <ul className="space-y-2">
+            {list.map((r) => (
+              <li key={r.id} className="flex items-center gap-2.5">
+                <ActorAvatar profile={r.actorProfile} />
+                <span className="text-sm">
+                  {r.actorProfile?.displayName ?? "A member"}
+                </span>
+                {r.actorProfile?.vanityName && (
+                  <a
+                    href={`https://www.linkedin.com/in/${r.actorProfile.vanityName}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label="View profile on LinkedIn"
+                  >
+                    <ExternalLink className="size-3" />
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ── Shared ────────────────────────────────────────────────
+
+function ActorAvatar({ profile }: { profile?: LinkedInActorProfile }) {
+  const name = profile?.displayName ?? "";
+  const initials =
+    name
+      .split(" ")
+      .map((p) => p[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "—";
+  return (
+    <Avatar className="size-8 shrink-0">
+      {/* LinkedIn's image URLs carry their own expiry, often shorter than
+          our cache — a broken image is normal, and AvatarFallback covers
+          it without a retry. */}
+      {profile?.pictureUrl && <AvatarImage src={profile.pictureUrl} alt="" />}
+      <AvatarFallback className="text-[10px]">{initials}</AvatarFallback>
+    </Avatar>
+  );
+}
+
+/** Map an engagement failure to something a person can act on. Never
+ *  surfaces the raw provider string — it carries LinkedIn JSON and URNs.
+ *
+ *  ★A 403 does NOT promise a reconnect helps: an org post 403s on the
+ *  pre-`_feed` grant, which reconnecting fixes, but a member-authored post
+ *  403s on a permission LinkedIn grants to select developers only. The
+ *  server already words this carefully; pass it through. */
+function engageErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === "NOT_CONNECTED") return "Reconnect LinkedIn to continue.";
+    if (err.code === "CONFIRMATION_REQUIRED" || err.code === "VALIDATION_ERROR") {
+      return err.message;
+    }
+    if (err.status === 403 || err.status === 404 || err.status === 429) {
+      return err.message;
+    }
+  }
+  return "That didn't work. Please try again.";
+}
+
+function ErrorBody({ error }: { error: unknown }) {
+  return (
+    <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center">
+      <p className="text-sm text-muted-foreground">{engageErrorMessage(error)}</p>
+    </div>
+  );
+}
+
+function EmptyBody({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-6 text-center">
+      <p className="text-sm font-medium">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+function ThreadSkeleton() {
+  return (
+    <div className="space-y-4">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex gap-2.5">
+          <Skeleton className="size-8 shrink-0 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-40" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -19,7 +19,34 @@ import {
 import { AudiencePanel } from "./_components/audience-panel";
 import { BoostCandidatesPanel } from "./_components/boost-candidates-panel";
 import { LibraryPanel } from "./_components/library-panel";
+import { CommunityFeedPanel } from "./_components/community-feed-panel";
+import type {
+  LinkedInAuthor,
+  LinkedInIdentity,
+} from "@/lib/api/linkedin-content";
 import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
+
+/**
+ * Who the Feed replies AS.
+ *
+ * A Feed row spans every Page a business administers, so unlike the
+ * thread panel — which knows the post it belongs to — there is no
+ * per-row author to infer. Defaults to the first enabled Company Page,
+ * falling back to the member.
+ *
+ * ★A known simplification, and worth stating: replying to a comment on
+ * the SECOND Page currently replies as the first. The server rejects an
+ * author the business has not enabled, so this cannot post as a Page
+ * nobody authorised — but it can post as the wrong one. The fix is to
+ * carry the post's author on each interaction row, which needs the
+ * ingest to record it; until then the thread panel in Library is the
+ * correct surface for a multi-Page business.
+ */
+function feedAuthor(identity?: LinkedInIdentity): LinkedInAuthor | null {
+  const page = identity?.pages?.[0];
+  if (page) return { type: "org", pageId: page.id };
+  return identity ? { type: "person" } : null;
+}
 
 /** Reconnect round trips come back to this hub, not to Settings. */
 const RECONNECT_HREF = reconnectHref("/dashboard/content/linkedin", LINKEDIN_CONTENT_PROVIDER);
@@ -147,7 +174,8 @@ function LinkedInTabs({
   // the last one did, and splitting those across tabs meant navigating in
   // order to learn. The new Feed (incoming community activity) arrives
   // with the webhook work, so this hub has three tabs today, not four.
-  const [tab, setTab] = useState<"library" | "audience" | "boost">("library");
+  const [tab, setTab] = useState<"library" | "feed" | "audience" | "boost">("library");
+  const [feedOpened, setFeedOpened] = useState(false);
   const [audienceOpened, setAudienceOpened] = useState(false);
   const [boostOpened, setBoostOpened] = useState(false);
   // Composer seed text — set when the user clicks "Use this draft" on
@@ -157,8 +185,14 @@ function LinkedInTabs({
   const [composerSeed, setComposerSeed] = useState<string | undefined>(undefined);
 
   function handleTabChange(value: string) {
-    if (value === "library" || value === "audience" || value === "boost") {
+    if (
+      value === "library" ||
+      value === "feed" ||
+      value === "audience" ||
+      value === "boost"
+    ) {
       setTab(value);
+      if (value === "feed") setFeedOpened(true);
       // Radix TabsContent mounts eagerly, so each non-default tab stays
       // gated on having been opened once. A tab that skips this fires its
       // query on every page load — which, against a ~500-requests/day
@@ -173,6 +207,9 @@ function LinkedInTabs({
       <TabsList>
         <TabsTrigger value="library" className="gap-1.5">
           <Newspaper className="size-4" /> Library
+        </TabsTrigger>
+        <TabsTrigger value="feed" className="gap-1.5">
+          <MessageSquare className="size-4" /> Feed
         </TabsTrigger>
         <TabsTrigger value="audience" className="gap-1.5">
           <Users className="size-4" /> Audience
@@ -207,6 +244,19 @@ function LinkedInTabs({
             output), so it costs no LinkedIn budget. The per-post threads
             are the on-demand part. */}
         <LibraryPanel />
+      </TabsContent>
+
+      <TabsContent value="feed" className="mt-4">
+        {/* Lazy-mounted like every other non-default tab. This one reads
+            Mongo rather than LinkedIn so it costs no API budget — but it
+            still costs a round trip on a page nobody may open. */}
+        {feedOpened ? (
+          <CommunityFeedPanel author={feedAuthor(enabledIdentity?.data)} />
+        ) : null}
+        <p className="mt-3 text-xs text-muted-foreground">
+          Comments, mentions and reposts across your Pages, newest first. Replies
+          you send here post straight to LinkedIn.
+        </p>
       </TabsContent>
 
       <TabsContent value="audience" className="mt-4">

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/molecules/empty-state";
-import { MessageSquare, Newspaper, RefreshCw, Rocket, Send, Users } from "lucide-react";
+import { MessageSquare, Newspaper, RefreshCw, Rocket, Users } from "lucide-react";
 import {
   PostComposer,
   PostComposerSkeleton,
@@ -18,7 +18,7 @@ import {
 } from "./_components/post-composer";
 import { AudiencePanel } from "./_components/audience-panel";
 import { BoostCandidatesPanel } from "./_components/boost-candidates-panel";
-import { FeedPanel } from "./_components/feed-panel";
+import { LibraryPanel } from "./_components/library-panel";
 import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
 
 /** Reconnect round trips come back to this hub, not to Settings. */
@@ -142,8 +142,12 @@ function LinkedInTabs({
   identity: ReturnType<typeof useLinkedInIdentity>;
   enabledIdentity: ReturnType<typeof useLinkedInIdentity> | null;
 }) {
-  const [tab, setTab] = useState<"compose" | "feed" | "audience" | "boost">("compose");
-  const [feedOpened, setFeedOpened] = useState(false);
+  // ★Library · Feed · Audience · Boost is the settled shape. Library holds
+  // drafting AND the published archive — you write the next post from how
+  // the last one did, and splitting those across tabs meant navigating in
+  // order to learn. The new Feed (incoming community activity) arrives
+  // with the webhook work, so this hub has three tabs today, not four.
+  const [tab, setTab] = useState<"library" | "audience" | "boost">("library");
   const [audienceOpened, setAudienceOpened] = useState(false);
   const [boostOpened, setBoostOpened] = useState(false);
   // Composer seed text — set when the user clicks "Use this draft" on
@@ -153,9 +157,12 @@ function LinkedInTabs({
   const [composerSeed, setComposerSeed] = useState<string | undefined>(undefined);
 
   function handleTabChange(value: string) {
-    if (value === "compose" || value === "feed" || value === "audience" || value === "boost") {
+    if (value === "library" || value === "audience" || value === "boost") {
       setTab(value);
-      if (value === "feed") setFeedOpened(true);
+      // Radix TabsContent mounts eagerly, so each non-default tab stays
+      // gated on having been opened once. A tab that skips this fires its
+      // query on every page load — which, against a ~500-requests/day
+      // app-wide LinkedIn budget, is not a style preference.
       if (value === "audience") setAudienceOpened(true);
       if (value === "boost") setBoostOpened(true);
     }
@@ -164,11 +171,8 @@ function LinkedInTabs({
   return (
     <Tabs value={tab} onValueChange={handleTabChange}>
       <TabsList>
-        <TabsTrigger value="compose" className="gap-1.5">
-          <Send className="size-4" /> Compose
-        </TabsTrigger>
-        <TabsTrigger value="feed" className="gap-1.5">
-          <Newspaper className="size-4" /> Feed
+        <TabsTrigger value="library" className="gap-1.5">
+          <Newspaper className="size-4" /> Library
         </TabsTrigger>
         <TabsTrigger value="audience" className="gap-1.5">
           <Users className="size-4" /> Audience
@@ -178,7 +182,7 @@ function LinkedInTabs({
         </TabsTrigger>
       </TabsList>
 
-      <TabsContent value="compose" className="mt-4 space-y-4">
+      <TabsContent value="library" className="mt-4 space-y-4">
         <SuggestedDraftsPanel onUseDraft={setComposerSeed} />
         <Card>
           <CardContent className="p-5">
@@ -195,10 +199,14 @@ function LinkedInTabs({
         <p className="text-xs text-muted-foreground">
           Compose with AI, schedule for later, publish now, or turn a longer write-up into a swipeable carousel. Image attachments are coming.
         </p>
-      </TabsContent>
 
-      <TabsContent value="feed" className="mt-4">
-        {feedOpened ? <FeedPanel /> : null}
+        {/* The published archive sits directly under the composer, because
+            what you write next is informed by how the last one landed and
+            that only works if both are on one screen. Mounted with the tab
+            rather than gated: it reads from Mongo (the post-sync cron's
+            output), so it costs no LinkedIn budget. The per-post threads
+            are the on-demand part. */}
+        <LibraryPanel />
       </TabsContent>
 
       <TabsContent value="audience" className="mt-4">

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -400,6 +400,87 @@ export const linkedInContentApi = {
     ),
 
   /**
+   * Comments on a post — or, when `target` is a comment URN, that comment's
+   * replies. LinkedIn serves both from one resource and nests exactly one
+   * level, so there is no recursion to write in the UI.
+   *
+   * ★ON-DEMAND ONLY. Community Management Development tier allows ~500
+   * requests/day for the whole app across every customer, so this is called
+   * when a person opens a thread and never to pre-fill a list of posts.
+   */
+  comments: (target: string, params?: { count?: number; start?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.count === "number") qs.set("count", String(params.count));
+    if (typeof params?.start === "number") qs.set("start", String(params.start));
+    const q = qs.toString();
+    return api.get<LinkedInCommentPage>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(target)}/comments${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /** Replies on one comment. */
+  commentReplies: (commentUrn: string, params?: { count?: number; start?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.count === "number") qs.set("count", String(params.count));
+    if (typeof params?.start === "number") qs.set("start", String(params.start));
+    const q = qs.toString();
+    return api.get<LinkedInCommentPage>(
+      `/v1/linkedin/content/comments/${encodeURIComponent(commentUrn)}/replies${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /**
+   * Who reacted to a post or comment, and with what.
+   *
+   * ★Reactor NAMES are best-effort. LinkedIn returns actor URNs here and
+   * exposes no profile lookup for other members — identity arrives only
+   * alongside a comments read — so a reactor is named only if they also
+   * commented recently. Render a nameless reactor as normal, not as a gap.
+   */
+  reactions: (entityUrn: string, params?: { count?: number; start?: number }) => {
+    const qs = new URLSearchParams();
+    if (typeof params?.count === "number") qs.set("count", String(params.count));
+    if (typeof params?.start === "number") qs.set("start", String(params.start));
+    const q = qs.toString();
+    return api.get<LinkedInReactionPage>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(entityUrn)}/reactions${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /** Per-reaction-type counts + comment summary for a post. The AUTHORITATIVE
+   *  reaction breakdown — `reactions` above only returns the current page. */
+  socialMetadata: (postUrn: string) =>
+    api.get<LinkedInSocialMetadata>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(postUrn)}/social-metadata`,
+    ),
+
+  /** Edit a comment we authored. `author` picks the page to edit as; omit to
+   *  edit as the signed-in member. */
+  editComment: (commentUrn: string, body: { text: string; author?: LinkedInAuthor }) =>
+    api.patch<{ commentUrn: string }>(
+      `/v1/linkedin/content/comments/${encodeURIComponent(commentUrn)}`,
+      body,
+    ),
+
+  /** Delete a comment.
+   *
+   *  `commentRef` may be the bare numeric id OR the composite comment URN —
+   *  the server unpacks the thread from the URN when given one, which is
+   *  what the thread panel has to hand. The author is a QUERY pair
+   *  (`authorType`/`pageId`) rather than a body because DELETE carries none. */
+  deleteComment: (postUrn: string, commentRef: string, author?: LinkedInAuthor) => {
+    const qs = new URLSearchParams();
+    if (author?.type === "org") {
+      qs.set("authorType", "org");
+      qs.set("pageId", author.pageId);
+    }
+    const q = qs.toString();
+    return api.delete<{ deleted: boolean }>(
+      `/v1/linkedin/content/posts/${encodeURIComponent(postUrn)}/comments/${encodeURIComponent(commentRef)}${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /**
    * React to a post OR a comment as the member or an org page. `entityUrn` is
    * the target's full URN — a post (`urn:li:share:*` / `urn:li:ugcPost:*`) or a
    * comment (`urn:li:comment:(...)`). Same `RECONNECT_REQUIRED` (403) contract
@@ -502,6 +583,83 @@ export interface CarouselResult {
   /** False when the document upload didn't confirm AVAILABLE before posting
    *  (best-effort path) — the post may still be processing on LinkedIn. */
   documentAvailable: boolean;
+}
+
+
+/** A commenter's public profile, when LinkedIn decorated it.
+ *
+ *  ★24-hour data on the server, and OPTIONAL here. It is absent whenever
+ *  identity is switched off or LinkedIn declined the decoration, so render
+ *  its absence as "A member" — never as an error state. */
+export interface LinkedInActorProfile {
+  actorUrn: string;
+  displayName?: string;
+  headline?: string;
+  pictureUrl?: string;
+  vanityName?: string;
+}
+
+/** One comment in a thread. */
+export interface LinkedInCommentDetail {
+  /** LinkedIn's numeric comment id — what the delete path wants. */
+  id: string;
+  /** The composite `urn:li:comment:(...)`. Absent only when LinkedIn sent
+   *  nothing to build it from; actions that key on a comment are hidden
+   *  in that case rather than sending a URN that matches nothing. */
+  commentUrn?: string;
+  actor: string;
+  /** Present when an org authored it — i.e. this is OUR page's comment. */
+  agent?: string;
+  /** May be empty for an image-only comment. */
+  message: string;
+  createdAt?: number;
+  lastModifiedAt?: number;
+  edited: boolean;
+  likeCount: number;
+  likedByUs: boolean;
+  replyCount: number;
+  parentCommentUrn?: string;
+  objectUrn?: string;
+  imageUrns: string[];
+  actorProfile?: LinkedInActorProfile;
+}
+
+export interface LinkedInCommentPage {
+  comments: LinkedInCommentDetail[];
+  total?: number;
+  /** Pass as `start` for the next page; absent = end of thread. */
+  nextStart?: number;
+  /** Whether names were actually fetched. False means "we are not showing
+   *  names", which is different from "nobody has one". */
+  identityEnabled: boolean;
+}
+
+export interface LinkedInReaction {
+  id: string;
+  actor: string;
+  reactionType: string;
+  createdAt?: number;
+  root?: string;
+  actorProfile?: LinkedInActorProfile;
+}
+
+export interface LinkedInReactionPage {
+  reactions: LinkedInReaction[];
+  total?: number;
+  nextStart?: number;
+  identityEnabled: boolean;
+  /** Always true — see `reactions` above on why most reactors are nameless. */
+  reactorNamesAreBestEffort?: boolean;
+}
+
+/** Authoritative per-type reaction counts for a post. */
+export interface LinkedInSocialMetadata {
+  entity: string;
+  commentsState?: string;
+  reactions: Record<string, number>;
+  totalReactions: number;
+  commentCount: number;
+  topLevelCommentCount: number;
 }
 
 /** One published post in the LinkedIn Feed tab (GET /feed). */

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -447,6 +447,41 @@ export const linkedInContentApi = {
     );
   },
 
+  /**
+   * The Community Feed — incoming comments, mentions and reposts.
+   *
+   * ★Reads Mongo on the server, never LinkedIn: every row arrived over
+   * the webhook. So this is cheap to poll and cheap to leave open, unlike
+   * the thread panel, which spends real API budget per call.
+   */
+  interactions: (params?: { filter?: string; cursor?: string; limit?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.filter) qs.set("filter", params.filter);
+    if (params?.cursor) qs.set("cursor", params.cursor);
+    if (typeof params?.limit === "number") qs.set("limit", String(params.limit));
+    const q = qs.toString();
+    return api.get<LinkedInFeedPage>(
+      `/v1/linkedin/content/interactions${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /** Mark a screenful as seen. Batched, and deliberately does NOT change
+   *  reply status — reading a comment is not answering it. */
+  markInteractionsSeen: (interactionUrns: string[]) =>
+    api.post<{ marked: number }>("/v1/linkedin/content/interactions/seen", {
+      interactionUrns,
+    }),
+
+  /** Snooze, assign or dismiss one interaction. */
+  updateInteraction: (
+    interactionUrn: string,
+    body: { snoozedUntil?: string | null; assignedToId?: string | null; ignored?: boolean },
+  ) =>
+    api.patch<{ interactionUrn: string }>(
+      `/v1/linkedin/content/interactions/${encodeURIComponent(interactionUrn)}`,
+      body,
+    ),
+
   /** Per-reaction-type counts + comment summary for a post. The AUTHORITATIVE
    *  reaction breakdown — `reactions` above only returns the current page. */
   socialMetadata: (postUrn: string) =>
@@ -660,6 +695,48 @@ export interface LinkedInSocialMetadata {
   totalReactions: number;
   commentCount: number;
   topLevelCommentCount: number;
+}
+
+
+/** One row in the Community Feed. */
+export interface LinkedInInteraction {
+  id: string;
+  kind: "comment" | "reaction" | "repost" | "mention";
+  interactionUrn: string;
+  parentPostUrn: string;
+  parentCommentUrn?: string;
+  actorUrn?: string;
+  actorType?: "person" | "org";
+  /** Absent once the 48h sweep has taken it — see `redacted`. */
+  text?: string;
+  occurredAt?: string;
+  receivedAt: string;
+  status: "new" | "needs_reply" | "replied" | "ignored";
+  seenAt?: string;
+  repliedAt?: string;
+  replyCommentUrn?: string;
+  firstResponseMs?: number;
+  assignedToId?: string;
+  snoozedUntil?: string;
+  /** LinkedIn's 48-hour cap has passed and the member's words are gone.
+   *  The row remains, and still records what we did about it. */
+  redacted: boolean;
+}
+
+export interface LinkedInFeedCounts {
+  needsReply: number;
+  unseen: number;
+  mentions: number;
+  reposts: number;
+  /** How long the oldest unanswered comment has waited, ms. Null when
+   *  nothing is waiting. */
+  oldestUnansweredMs: number | null;
+}
+
+export interface LinkedInFeedPage {
+  rows: LinkedInInteraction[];
+  nextCursor: string | null;
+  counts: LinkedInFeedCounts;
 }
 
 /** One published post in the LinkedIn Feed tab (GET /feed). */


### PR DESCRIPTION
**PR 7 of 11.** Stacked on b2c#501; depends on peakhour-api #1083 → #1082 → #1081 → #1080 → #1079 → #1078 → #1077.

The fourth tab, and the one that answers the question a person actually opens this dashboard for. Tabs are now **Library · Feed · Audience · Boost**, as settled.

## Why a queue, not more numbers on each post

The engagement itself already sits under every post in Library. What was missing is *"is anyone waiting on us?"* — and spreading that across fifty post cards means it can only be answered by reading all fifty.

One reverse-chronological list makes the dashboard **simpler** while showing considerably more.

## The header leads on a duration, not a count

**"Oldest unanswered: 14h"** beats "5 need a reply". A count says how much work there is; a duration says whether somebody is being *let down* — which is the thing no other dashboard tells a business.

Formatted coarsely on purpose: a number that ticks every minute reads as a timer rather than as how long someone has been kept waiting.

## Three decisions worth reviewing

**Rows are marked seen on render**, after a short delay — and that is deliberately **not** a status change. The badge asks "has anyone here looked at this", and it's on screen. But seeing isn't answering, so no amount of scrolling can empty the reply queue. A failed mark is swallowed: it costs a badge, not data, and an error toast on a page someone is only scrolling is worse than the badge.

**A redacted row says so rather than showing a blank.** After 48 hours LinkedIn's rules take the member's words — but the row, and whether we replied, and how fast, is ours to keep, and is exactly what the response-time metrics are built on. *"The text is no longer available"* is a truer empty state than nothing.

**Replies go straight to LinkedIn**, and the server marks the interaction replied in the same call — so the row leaves the queue on refetch rather than needing its own write.

## ⚠️ Known simplification, stated at the call site

A Feed row spans **every Page** a business administers, so unlike the thread panel there's no per-row author to infer — replying currently uses the first Page.

The server rejects an author the business hasn't enabled, so this **cannot** post as a Page nobody authorised. But it *can* post as the wrong one. The fix is carrying the post's author on each interaction row, which needs the ingest to record it. Until then, Library's thread panel is the correct surface for a multi-Page business.

Happy to do that now if you'd rather not merge with it — it's a small ingest change plus a schema field.

`tsc` clean, `eslint` clean on new files, 35 LinkedIn b2c tests pass.

**Not verified against a live LinkedIn account** — no token here. The webhook path in particular has never received a real event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
