### PR TITLE
feat(linkedin): the Feed — is anyone waiting on us?

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
@@ -15,7 +15,7 @@
  * left open. The thread panel is where on-demand API calls happen.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Loader2,
@@ -31,7 +31,6 @@ import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   linkedInContentApi,
@@ -42,6 +41,11 @@ import {
 import { ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { RetentionFootnote } from "./retention-footnote";
+import {
+  ReplyBox,
+  engageErrorMessage,
+  linkedInPostUrl,
+} from "./engage-shared";
 
 const FILTERS = [
   { key: "needs_reply", label: "Needs reply" },
@@ -53,10 +57,62 @@ const FILTERS = [
 
 type FilterKey = (typeof FILTERS)[number]["key"];
 
-const COMMENT_MAX_LEN = 1250;
+/**
+ * Collects interactions a person has actually LOOKED at, and reports them
+ * in one call.
+ *
+ * ★Three problems this replaces. The old version fired on every rendered
+ * row — so opening the Feed cleared "New" for 25 rows nobody had scrolled
+ * to, and a background refetch marked things seen while the tab was not
+ * even on screen. It also sent one POST per row against an endpoint that
+ * accepts a hundred, and, because the cache is never updated with
+ * `seenAt`, re-sent all of them on the next remount.
+ *
+ * So: only rows that entered the viewport, only while the document is
+ * visible, flushed once on a short debounce, and remembered for the
+ * lifetime of the panel so a remount does not repeat them.
+ */
+function useMarkSeen() {
+  const pending = useRef(new Set<string>());
+  const sent = useRef(new Set<string>());
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    const urns = [...pending.current].filter((u) => !sent.current.has(u));
+    pending.current.clear();
+    if (!urns.length) return;
+    urns.forEach((u) => sent.current.add(u));
+    // A missed "seen" costs a badge, not data — and an error toast on a
+    // page somebody is only scrolling is worse than the badge.
+    linkedInContentApi.markInteractionsSeen(urns.slice(0, 100)).catch(() => {
+      urns.forEach((u) => sent.current.delete(u));
+    });
+  }, []);
+
+  const observe = useCallback(
+    (urn: string) => {
+      if (sent.current.has(urn) || pending.current.has(urn)) return;
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+      pending.current.add(urn);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(flush, 800);
+    },
+    [flush],
+  );
+
+  useEffect(() => {
+    const t = timer;
+    return () => {
+      if (t.current) clearTimeout(t.current);
+    };
+  }, []);
+
+  return observe;
+}
 
 export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }) {
   const [filter, setFilter] = useState<FilterKey>("needs_reply");
+  const markSeen = useMarkSeen();
 
   const query = useInfiniteQuery({
     queryKey: ["linkedin-interactions", filter],
@@ -76,17 +132,59 @@ export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }
   const rows = query.data?.pages.flatMap((p) => p.rows) ?? [];
   const counts = query.data?.pages[0]?.counts;
 
-  if (query.isLoading) return <FeedSkeleton />;
+  // ★The chips stay mounted through loading AND error. Unmounting them
+  // blanked the toolbar on every filter switch, and turned any error into
+  // a dead end with no way back to a filter that works — LibraryPanel
+  // renders its own filter row above these branches for the same reason.
+  const chips = (
+    <div className="flex flex-wrap gap-1.5">
+      {FILTERS.map((f) => (
+        <Button
+          key={f.key}
+          type="button"
+          size="sm"
+          variant={filter === f.key ? "default" : "outline"}
+          className="h-7 px-2.5 text-xs"
+          onClick={() => setFilter(f.key)}
+        >
+          {f.label}
+          {countFor(f.key, counts) !== null && (
+            <span className="ml-1.5 tabular-nums opacity-70">
+              {countFor(f.key, counts)}
+            </span>
+          )}
+        </Button>
+      ))}
+    </div>
+  );
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-3">
+        {chips}
+        <FeedSkeleton />
+      </div>
+    );
+  }
+
   if (query.isError) {
     return (
-      <EmptyBody
-        title="Couldn't load your community activity"
-        body={
-          query.error instanceof ApiError
-            ? query.error.message
-            : "Please try again in a moment."
-        }
-      />
+      <div className="space-y-3">
+        {chips}
+        <EmptyBody
+          title="Couldn't load your community activity"
+          body={engageErrorMessage(query.error)}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => void query.refetch()}
+        >
+          Try again
+        </Button>
+      </div>
     );
   }
 
@@ -94,25 +192,7 @@ export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }
     <div className="space-y-3">
       <FeedHeader counts={counts} />
 
-      <div className="flex flex-wrap gap-1.5">
-        {FILTERS.map((f) => (
-          <Button
-            key={f.key}
-            type="button"
-            size="sm"
-            variant={filter === f.key ? "default" : "outline"}
-            className="h-7 px-2.5 text-xs"
-            onClick={() => setFilter(f.key)}
-          >
-            {f.label}
-            {countFor(f.key, counts) !== null && (
-              <span className="ml-1.5 tabular-nums opacity-70">
-                {countFor(f.key, counts)}
-              </span>
-            )}
-          </Button>
-        ))}
-      </div>
+      {chips}
 
       {rows.length === 0 ? (
         <EmptyBody
@@ -127,7 +207,12 @@ export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }
         <ul className="space-y-3">
           {rows.map((row) => (
             <li key={row.id}>
-              <InteractionRow row={row} author={author} filter={filter} />
+              <InteractionRow
+              row={row}
+              author={author}
+              filter={filter}
+              onSeen={markSeen}
+            />
             </li>
           ))}
         </ul>
@@ -192,46 +277,59 @@ function InteractionRow({
   row,
   author,
   filter,
+  onSeen,
 }: {
   row: LinkedInInteraction;
   author: LinkedInAuthor | null;
   filter: FilterKey;
+  onSeen: (interactionUrn: string) => void;
 }) {
   const { formatRelativeTime } = useLocale();
   const qc = useQueryClient();
   const [replying, setReplying] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
 
-  // Marked seen when the row renders, not when it is clicked. The badge
-  // asks "has anyone here looked at this", and it is on screen — but this
-  // is deliberately NOT a status change, so it can never empty the reply
-  // queue by scrolling.
+  // ★Seen when it ENTERS THE VIEWPORT, not when it renders. "New" means
+  // nobody here has looked at it, and a row below the fold has not been
+  // looked at — marking on render cleared the badge for a whole page
+  // somebody scrolled past the top of. Still deliberately NOT a status
+  // change, so no amount of scrolling can empty the reply queue.
   useEffect(() => {
-    if (row.seenAt) return;
-    const t = setTimeout(() => {
-      linkedInContentApi.markInteractionsSeen([row.interactionUrn]).catch(() => {
-        // A missed "seen" costs a badge, not data. Failing loudly here
-        // would put an error toast on a page the user is only scrolling.
-      });
-    }, 1200);
-    return () => clearTimeout(t);
-  }, [row.interactionUrn, row.seenAt]);
+    if (row.seenAt || !ref.current) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const el = ref.current;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            onSeen(row.interactionUrn);
+            io.unobserve(el);
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [row.interactionUrn, row.seenAt, onSeen]);
+
+  const snoozed = Boolean(row.snoozedUntil && new Date(row.snoozedUntil) > new Date());
 
   const snooze = useMutation({
-    mutationFn: () =>
-      linkedInContentApi.updateInteraction(row.interactionUrn, {
-        snoozedUntil: new Date(Date.now() + 24 * 3600 * 1000).toISOString(),
-      }),
-    onSuccess: () => {
-      toast.success("Snoozed for a day");
+    mutationFn: (until: string | null) =>
+      linkedInContentApi.updateInteraction(row.interactionUrn, { snoozedUntil: until }),
+    onSuccess: (_d, until) => {
+      toast.success(until ? "Snoozed for a day" : "Back in your queue");
       void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
     },
-    onError: () => toast.error("Couldn't snooze that. Please try again."),
+    onError: (err) => toast.error(engageErrorMessage(err)),
   });
 
   const canReply = author !== null && row.kind === "comment" && !row.redacted;
+  const postUrl = linkedInPostUrl(row.parentPostUrn);
 
   return (
-    <Card>
+    <Card ref={ref}>
       <CardContent className="space-y-2 p-4">
         <div className="flex flex-wrap items-center gap-1.5">
           <KindBadge kind={row.kind} />
@@ -256,14 +354,20 @@ function InteractionRow({
         )}
 
         <div className="flex flex-wrap items-center gap-1">
-          <a
-            href={`https://www.linkedin.com/feed/update/${row.parentPostUrn}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-          >
-            View post <ExternalLink className="size-3" />
-          </a>
+{/* Guarded, not interpolated: the ingest can put a comment URN in
+              `parentPostUrn`, and a comment URN in a /feed/update/ path is
+              a dead link. No link reads as "no link"; a broken one reads
+              as our bug. */}
+          {postUrl && (
+            <a
+              href={postUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              View post <ExternalLink className="size-3" />
+            </a>
+          )}
 
           {canReply && (
             <Button
@@ -277,7 +381,12 @@ function InteractionRow({
             </Button>
           )}
 
-          {filter === "needs_reply" && (
+{/* ★Snoozing has a way back. The button only appeared on the
+              needs_reply filter, which the server excludes snoozed rows
+              from — so once snoozed, an item could not be found again from
+              this surface at all. It shows up under "All" with an
+              un-snooze, which is where someone would go looking. */}
+          {filter === "needs_reply" && !snoozed && (
             <Button
               type="button"
               variant="ghost"
@@ -285,7 +394,7 @@ function InteractionRow({
               className="h-7 gap-1.5 px-2 text-xs"
               disabled={snooze.isPending}
               aria-busy={snooze.isPending}
-              onClick={() => snooze.mutate()}
+              onClick={() => snooze.mutate(new Date(Date.now() + 24 * 3600 * 1000).toISOString())}
             >
               {snooze.isPending ? (
                 <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
@@ -293,6 +402,25 @@ function InteractionRow({
                 <BellOff className="size-3.5" />
               )}
               Snooze a day
+            </Button>
+          )}
+
+          {snoozed && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              disabled={snooze.isPending}
+              aria-busy={snooze.isPending}
+              onClick={() => snooze.mutate(null)}
+            >
+              {snooze.isPending ? (
+                <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+              ) : (
+                <BellOff className="size-3.5" />
+              )}
+              Un-snooze
             </Button>
           )}
         </div>
@@ -303,83 +431,15 @@ function InteractionRow({
             parentCommentUrn={row.interactionUrn}
             author={author}
             onClose={() => setReplying(false)}
+            // The server marks the interaction replied in the same call,
+            // so refetching is what moves it out of the queue.
+            onReplied={() =>
+              void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] })
+            }
           />
         )}
       </CardContent>
     </Card>
-  );
-}
-
-function ReplyBox({
-  postUrn,
-  parentCommentUrn,
-  author,
-  onClose,
-}: {
-  postUrn: string;
-  parentCommentUrn: string;
-  author: LinkedInAuthor;
-  onClose: () => void;
-}) {
-  const [text, setText] = useState("");
-  const qc = useQueryClient();
-  const send = useMutation({
-    mutationFn: () =>
-      linkedInContentApi.createComment(postUrn, {
-        text: text.trim(),
-        author,
-        parentCommentUrn,
-      }),
-    onSuccess: () => {
-      toast.success("Reply posted");
-      onClose();
-      // The server marks the interaction replied as part of the same
-      // call, so refetching is what moves it out of the queue.
-      void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
-    },
-    onError: (err) =>
-      toast.error(
-        err instanceof ApiError ? err.message : "Couldn't post that reply.",
-      ),
-  });
-
-  return (
-    <div className="space-y-1.5 border-t pt-2">
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
-        placeholder="Write a reply…"
-        rows={2}
-        className="text-sm"
-      />
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          disabled={!text.trim() || send.isPending}
-          aria-busy={send.isPending}
-          onClick={() => send.mutate()}
-        >
-          {send.isPending && (
-            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
-          )}
-          Reply
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
-          {text.length}/{COMMENT_MAX_LEN}
-        </span>
-      </div>
-    </div>
   );
 }
 

--- a/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/community-feed-panel.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+/**
+ * The Community Feed — one queue for everything that happened to the brand.
+ *
+ * ★WHY A QUEUE AND NOT MORE NUMBERS ON EACH POST. The engagement itself
+ * already lives under every post in Library. What was missing is the
+ * question a person actually opens the dashboard to answer: is anyone
+ * waiting on us? Spreading that across fifty post cards means it can only
+ * be answered by reading all fifty. One reverse-chronological list makes
+ * the dashboard simpler while showing considerably more.
+ *
+ * ★And it is CHEAP. Every row arrived over the webhook and is read from
+ * our own database, so this costs no LinkedIn budget and can be polled and
+ * left open. The thread panel is where on-demand API calls happen.
+ */
+
+import { useEffect, useState } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Loader2,
+  MessageSquare,
+  AtSign,
+  Repeat2,
+  Clock,
+  CornerDownRight,
+  BellOff,
+  ExternalLink,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  linkedInContentApi,
+  type LinkedInAuthor,
+  type LinkedInFeedCounts,
+  type LinkedInInteraction,
+} from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+import { useLocale } from "@/hooks/use-locale";
+import { RetentionFootnote } from "./retention-footnote";
+
+const FILTERS = [
+  { key: "needs_reply", label: "Needs reply" },
+  { key: "new", label: "New" },
+  { key: "mentions", label: "Mentions" },
+  { key: "reposts", label: "Reposts" },
+  { key: "all", label: "All" },
+] as const;
+
+type FilterKey = (typeof FILTERS)[number]["key"];
+
+const COMMENT_MAX_LEN = 1250;
+
+export function CommunityFeedPanel({ author }: { author: LinkedInAuthor | null }) {
+  const [filter, setFilter] = useState<FilterKey>("needs_reply");
+
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-interactions", filter],
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.interactions({
+        filter,
+        ...(pageParam ? { cursor: pageParam } : {}),
+        limit: 25,
+      }),
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+
+  const rows = query.data?.pages.flatMap((p) => p.rows) ?? [];
+  const counts = query.data?.pages[0]?.counts;
+
+  if (query.isLoading) return <FeedSkeleton />;
+  if (query.isError) {
+    return (
+      <EmptyBody
+        title="Couldn't load your community activity"
+        body={
+          query.error instanceof ApiError
+            ? query.error.message
+            : "Please try again in a moment."
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <FeedHeader counts={counts} />
+
+      <div className="flex flex-wrap gap-1.5">
+        {FILTERS.map((f) => (
+          <Button
+            key={f.key}
+            type="button"
+            size="sm"
+            variant={filter === f.key ? "default" : "outline"}
+            className="h-7 px-2.5 text-xs"
+            onClick={() => setFilter(f.key)}
+          >
+            {f.label}
+            {countFor(f.key, counts) !== null && (
+              <span className="ml-1.5 tabular-nums opacity-70">
+                {countFor(f.key, counts)}
+              </span>
+            )}
+          </Button>
+        ))}
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyBody
+          title={filter === "needs_reply" ? "Nothing waiting on you" : "Nothing here yet"}
+          body={
+            filter === "needs_reply"
+              ? "Every comment on your posts has been answered."
+              : "Comments, mentions and reposts of your Page will land here."
+          }
+        />
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <InteractionRow row={row} author={author} filter={filter} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more
+        </Button>
+      )}
+
+      <RetentionFootnote>
+        LinkedIn lets us keep a comment&apos;s text for 48 hours. After that the
+        item stays here — along with whether you replied — but the words are
+        gone.
+      </RetentionFootnote>
+    </div>
+  );
+}
+
+/**
+ * The one number worth leading on.
+ *
+ * ★"Oldest unanswered: 14h" beats "5 need a reply". A count says how much
+ * work there is; a duration says whether anyone is being let down, which
+ * is the thing a business actually needs to know and the thing no other
+ * dashboard tells them.
+ */
+function FeedHeader({ counts }: { counts?: LinkedInFeedCounts }) {
+  if (!counts) return null;
+  const waiting = counts.oldestUnansweredMs;
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border bg-muted/30 px-3 py-2 text-xs">
+      {waiting === null ? (
+        <span className="text-muted-foreground">Nothing is waiting on a reply.</span>
+      ) : (
+        <span className="flex items-center gap-1.5">
+          <Clock className="size-3.5 text-muted-foreground" aria-hidden />
+          <span className="text-muted-foreground">Oldest unanswered</span>
+          <span className="font-medium tabular-nums">{formatDuration(waiting)}</span>
+        </span>
+      )}
+      <span className="ml-auto text-muted-foreground tabular-nums">
+        {counts.needsReply} awaiting reply
+      </span>
+    </div>
+  );
+}
+
+function InteractionRow({
+  row,
+  author,
+  filter,
+}: {
+  row: LinkedInInteraction;
+  author: LinkedInAuthor | null;
+  filter: FilterKey;
+}) {
+  const { formatRelativeTime } = useLocale();
+  const qc = useQueryClient();
+  const [replying, setReplying] = useState(false);
+
+  // Marked seen when the row renders, not when it is clicked. The badge
+  // asks "has anyone here looked at this", and it is on screen — but this
+  // is deliberately NOT a status change, so it can never empty the reply
+  // queue by scrolling.
+  useEffect(() => {
+    if (row.seenAt) return;
+    const t = setTimeout(() => {
+      linkedInContentApi.markInteractionsSeen([row.interactionUrn]).catch(() => {
+        // A missed "seen" costs a badge, not data. Failing loudly here
+        // would put an error toast on a page the user is only scrolling.
+      });
+    }, 1200);
+    return () => clearTimeout(t);
+  }, [row.interactionUrn, row.seenAt]);
+
+  const snooze = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.updateInteraction(row.interactionUrn, {
+        snoozedUntil: new Date(Date.now() + 24 * 3600 * 1000).toISOString(),
+      }),
+    onSuccess: () => {
+      toast.success("Snoozed for a day");
+      void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
+    },
+    onError: () => toast.error("Couldn't snooze that. Please try again."),
+  });
+
+  const canReply = author !== null && row.kind === "comment" && !row.redacted;
+
+  return (
+    <Card>
+      <CardContent className="space-y-2 p-4">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <KindBadge kind={row.kind} />
+          <StatusBadges row={row} />
+          <span className="ml-auto text-xs text-muted-foreground">
+            {formatRelativeTime(row.occurredAt ?? row.receivedAt)}
+          </span>
+        </div>
+
+        {row.redacted ? (
+          // The row survives its content on purpose: what we DID about it
+          // is ours to keep, and is exactly what the response-time metrics
+          // are built on. Saying so is better than showing a blank.
+          <p className="text-sm italic text-muted-foreground">
+            The text of this {row.kind} is no longer available — LinkedIn only
+            lets us keep it for 48 hours.
+          </p>
+        ) : (
+          <p className="whitespace-pre-line text-sm leading-relaxed line-clamp-4">
+            {row.text || <span className="text-muted-foreground">(no text)</span>}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-1">
+          <a
+            href={`https://www.linkedin.com/feed/update/${row.parentPostUrn}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            View post <ExternalLink className="size-3" />
+          </a>
+
+          {canReply && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              onClick={() => setReplying((v) => !v)}
+            >
+              <CornerDownRight className="size-3.5" /> Reply
+            </Button>
+          )}
+
+          {filter === "needs_reply" && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2 text-xs"
+              disabled={snooze.isPending}
+              aria-busy={snooze.isPending}
+              onClick={() => snooze.mutate()}
+            >
+              {snooze.isPending ? (
+                <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+              ) : (
+                <BellOff className="size-3.5" />
+              )}
+              Snooze a day
+            </Button>
+          )}
+        </div>
+
+        {replying && author && (
+          <ReplyBox
+            postUrn={row.parentPostUrn}
+            parentCommentUrn={row.interactionUrn}
+            author={author}
+            onClose={() => setReplying(false)}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReplyBox({
+  postUrn,
+  parentCommentUrn,
+  author,
+  onClose,
+}: {
+  postUrn: string;
+  parentCommentUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState("");
+  const qc = useQueryClient();
+  const send = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, {
+        text: text.trim(),
+        author,
+        parentCommentUrn,
+      }),
+    onSuccess: () => {
+      toast.success("Reply posted");
+      onClose();
+      // The server marks the interaction replied as part of the same
+      // call, so refetching is what moves it out of the queue.
+      void qc.invalidateQueries({ queryKey: ["linkedin-interactions"] });
+    },
+    onError: (err) =>
+      toast.error(
+        err instanceof ApiError ? err.message : "Couldn't post that reply.",
+      ),
+  });
+
+  return (
+    <div className="space-y-1.5 border-t pt-2">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        placeholder="Write a reply…"
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || send.isPending}
+          aria-busy={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {send.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Reply
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function KindBadge({ kind }: { kind: LinkedInInteraction["kind"] }) {
+  const map = {
+    comment: { icon: MessageSquare, label: "Comment" },
+    mention: { icon: AtSign, label: "Mention" },
+    repost: { icon: Repeat2, label: "Repost" },
+    reaction: { icon: MessageSquare, label: "Reaction" },
+  } as const;
+  const { icon: Icon, label } = map[kind];
+  return (
+    <Badge variant="outline" className="gap-1 text-[10px]">
+      <Icon className="size-3" /> {label}
+    </Badge>
+  );
+}
+
+function StatusBadges({ row }: { row: LinkedInInteraction }) {
+  return (
+    <>
+      {!row.seenAt && (
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          New
+        </Badge>
+      )}
+      {row.status === "needs_reply" && (
+        <Badge
+          variant="outline"
+          className="border-warning text-[10px] uppercase tracking-wide text-warning-on-tint"
+        >
+          Needs reply
+        </Badge>
+      )}
+      {row.status === "replied" && (
+        <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+          Replied
+          {typeof row.firstResponseMs === "number" && (
+            <span className="ml-1 tabular-nums opacity-70">
+              in {formatDuration(row.firstResponseMs)}
+            </span>
+          )}
+        </Badge>
+      )}
+      {row.snoozedUntil && new Date(row.snoozedUntil) > new Date() && (
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          Snoozed
+        </Badge>
+      )}
+    </>
+  );
+}
+
+function countFor(key: FilterKey, counts?: LinkedInFeedCounts): number | null {
+  if (!counts) return null;
+  if (key === "needs_reply") return counts.needsReply;
+  if (key === "new") return counts.unseen;
+  if (key === "mentions") return counts.mentions;
+  if (key === "reposts") return counts.reposts;
+  return null;
+}
+
+/** Coarse on purpose. "14h" is the answer; "13h 47m" is noise, and a
+ *  duration that changes every minute reads as a timer rather than a
+ *  measure of how long someone has been kept waiting. */
+function formatDuration(ms: number): string {
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${Math.max(mins, 1)}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+function EmptyBody({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-6 text-center">
+      <p className="text-sm font-medium">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-9 w-full" />
+      <Skeleton className="h-7 w-64" />
+      {[0, 1, 2].map((i) => (
+        <Card key={i}>
+          <CardContent className="space-y-2 p-4">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * Pieces shared by the two places a LinkedIn comment can be answered:
+ * Library's thread panel, and the Feed's queue.
+ *
+ * They are the same action with the same rules — LinkedIn's 1,250-character
+ * limit, the same author resolution, the same error wording — and keeping
+ * two copies meant a fix to one silently left the other wrong. The reply
+ * box in particular had already been written twice.
+ */
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { linkedInContentApi, type LinkedInAuthor } from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+
+/** LinkedIn's own cap on comment text. */
+export const COMMENT_MAX_LEN = 1250;
+
+/**
+ * Turn an engagement failure into something a person can act on.
+ *
+ * ★A 403 does NOT promise that reconnecting helps. An org post 403s on a
+ * grant predating the `_feed` scopes, which reconnecting fixes; a
+ * member-authored post 403s on a permission LinkedIn grants to select
+ * developers only, which it never will. The server already words this
+ * carefully — pass its message through rather than inventing a cheerier
+ * one that sends someone round a loop ending where it started.
+ *
+ * What we do NOT pass through is a raw transport string: it carries
+ * LinkedIn JSON and URNs, and "Active business required" is a sentence
+ * written for a log, not a person.
+ */
+export function engageErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === "NOT_CONNECTED") return "Reconnect LinkedIn to continue.";
+    if (err.code === "FORBIDDEN" && err.message.includes("business")) {
+      return "Pick a business to see your community activity.";
+    }
+    if (
+      err.code === "CONFIRMATION_REQUIRED" ||
+      err.code === "VALIDATION_ERROR" ||
+      err.code === "INVALID_REQUEST" ||
+      err.code === "NOT_FOUND"
+    ) {
+      return err.message;
+    }
+    if (err.status === 403 || err.status === 404 || err.status === 429) {
+      return err.message;
+    }
+  }
+  return "That didn't work. Please try again.";
+}
+
+/**
+ * A permalink, or null.
+ *
+ * ★Guarded rather than interpolated. `parentPostUrn` can hold a comment
+ * URN — the ingest falls back to a decorated payload's `object` when
+ * LinkedIn sends no `sourcePost` — and a comment URN in a
+ * `/feed/update/` path is a dead link. A missing link reads as "no link";
+ * a broken one reads as a bug.
+ *
+ * Raw colons, no `encodeURIComponent`, no trailing slash: matches the
+ * backend's permalink convention, and encoding produces `%3A%3A` URLs
+ * some browser caches mishandle.
+ */
+export function linkedInPostUrl(urn: string | null | undefined): string | null {
+  if (!urn || !urn.includes("urn:li:")) return null;
+  if (urn.startsWith("urn:li:comment:")) return null;
+  return `https://www.linkedin.com/feed/update/${urn}`;
+}
+
+/** Post a reply to one comment, as a given author. */
+export function ReplyBox({
+  postUrn,
+  parentCommentUrn,
+  author,
+  onClose,
+  onReplied,
+}: {
+  postUrn: string;
+  parentCommentUrn: string;
+  author: LinkedInAuthor;
+  onClose: () => void;
+  /** Refresh whichever list this reply belongs to — the thread, the
+   *  replies under a comment, or the Feed queue. */
+  onReplied: () => void;
+}) {
+  const [text, setText] = useState("");
+  const send = useMutation({
+    mutationFn: () =>
+      linkedInContentApi.createComment(postUrn, {
+        text: text.trim(),
+        author,
+        parentCommentUrn,
+      }),
+    onSuccess: () => {
+      toast.success("Reply posted");
+      setText("");
+      onClose();
+      onReplied();
+    },
+    onError: (err) => toast.error(engageErrorMessage(err)),
+  });
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
+        placeholder="Write a reply…"
+        rows={2}
+        className="text-sm"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={!text.trim() || send.isPending}
+          aria-busy={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {send.isPending && (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Reply
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
+          {text.length}/{COMMENT_MAX_LEN}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -52,6 +52,7 @@ import {
 import { ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
 import { RetentionFootnote } from "./retention-footnote";
+import { COMMENT_MAX_LEN, ReplyBox, engageErrorMessage } from "./engage-shared";
 
 /** Reaction types we may WRITE. `MAYBE` is deprecated by LinkedIn and 400s
  *  on create, so it is absent here even though a read can surface it. */
@@ -74,8 +75,6 @@ function reactionEmoji(type: string): string {
 function reactionLabel(type: string): string {
   return REACTIONS.find((r) => r.type === type)?.label ?? type;
 }
-
-const COMMENT_MAX_LEN = 1250;
 
 export function ThreadPanel({
   postUrn,
@@ -449,6 +448,7 @@ function CommentRow({
               parentCommentUrn={comment.commentUrn}
               author={author}
               onClose={() => setReplying(false)}
+              onReplied={refreshOwnList}
             />
           )}
 
@@ -527,76 +527,6 @@ function RepliesList({
         </li>
       ))}
     </ul>
-  );
-}
-
-function ReplyBox({
-  postUrn,
-  parentCommentUrn,
-  author,
-  onClose,
-}: {
-  postUrn: string;
-  parentCommentUrn: string;
-  author: LinkedInAuthor;
-  onClose: () => void;
-}) {
-  const [text, setText] = useState("");
-  const qc = useQueryClient();
-  const send = useMutation({
-    mutationFn: () =>
-      linkedInContentApi.createComment(postUrn, {
-        text: text.trim(),
-        author,
-        parentCommentUrn,
-      }),
-    onSuccess: () => {
-      toast.success("Reply posted");
-      setText("");
-      onClose();
-      void qc.invalidateQueries({ queryKey: ["linkedin-replies", parentCommentUrn] });
-      void qc.invalidateQueries({ queryKey: ["linkedin-thread", postUrn] });
-    },
-    onError: (err) => toast.error(engageErrorMessage(err)),
-  });
-
-  return (
-    <div className="mt-2 space-y-1.5">
-      <Textarea
-        value={text}
-        onChange={(e) => setText(e.target.value.slice(0, COMMENT_MAX_LEN))}
-        placeholder="Write a reply…"
-        rows={2}
-        className="text-sm"
-      />
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          disabled={!text.trim() || send.isPending}
-          aria-busy={send.isPending}
-          onClick={() => send.mutate()}
-        >
-          {send.isPending && (
-            <Loader2 className="mr-1.5 size-3.5 animate-spin motion-reduce:animate-none" />
-          )}
-          Reply
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground">
-          {text.length}/{COMMENT_MAX_LEN}
-        </span>
-      </div>
-    </div>
   );
 }
 
@@ -843,26 +773,6 @@ function ActorAvatar({ profile }: { profile?: LinkedInActorProfile }) {
       <AvatarFallback className="text-[10px]">{initials}</AvatarFallback>
     </Avatar>
   );
-}
-
-/** Map an engagement failure to something a person can act on. Never
- *  surfaces the raw provider string — it carries LinkedIn JSON and URNs.
- *
- *  ★A 403 does NOT promise a reconnect helps: an org post 403s on the
- *  pre-`_feed` grant, which reconnecting fixes, but a member-authored post
- *  403s on a permission LinkedIn grants to select developers only. The
- *  server already words this carefully; pass it through. */
-function engageErrorMessage(err: unknown): string {
-  if (err instanceof ApiError) {
-    if (err.code === "NOT_CONNECTED") return "Reconnect LinkedIn to continue.";
-    if (err.code === "CONFIRMATION_REQUIRED" || err.code === "VALIDATION_ERROR") {
-      return err.message;
-    }
-    if (err.status === 403 || err.status === 404 || err.status === 429) {
-      return err.message;
-    }
-  }
-  return "That didn't work. Please try again.";
 }
 
 function ErrorBody({ error }: { error: unknown }) {

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -19,7 +19,34 @@ import {
 import { AudiencePanel } from "./_components/audience-panel";
 import { BoostCandidatesPanel } from "./_components/boost-candidates-panel";
 import { LibraryPanel } from "./_components/library-panel";
+import { CommunityFeedPanel } from "./_components/community-feed-panel";
+import type {
+  LinkedInAuthor,
+  LinkedInIdentity,
+} from "@/lib/api/linkedin-content";
 import { SuggestedDraftsPanel } from "./_components/suggested-drafts-panel";
+
+/**
+ * Who the Feed replies AS.
+ *
+ * A Feed row spans every Page a business administers, so unlike the
+ * thread panel — which knows the post it belongs to — there is no
+ * per-row author to infer. Defaults to the first enabled Company Page,
+ * falling back to the member.
+ *
+ * ★A known simplification, and worth stating: replying to a comment on
+ * the SECOND Page currently replies as the first. The server rejects an
+ * author the business has not enabled, so this cannot post as a Page
+ * nobody authorised — but it can post as the wrong one. The fix is to
+ * carry the post's author on each interaction row, which needs the
+ * ingest to record it; until then the thread panel in Library is the
+ * correct surface for a multi-Page business.
+ */
+function feedAuthor(identity?: LinkedInIdentity): LinkedInAuthor | null {
+  const page = identity?.pages?.[0];
+  if (page) return { type: "org", pageId: page.id };
+  return identity ? { type: "person" } : null;
+}
 
 /** Reconnect round trips come back to this hub, not to Settings. */
 const RECONNECT_HREF = reconnectHref("/dashboard/content/linkedin", LINKEDIN_CONTENT_PROVIDER);
@@ -147,7 +174,8 @@ function LinkedInTabs({
   // the last one did, and splitting those across tabs meant navigating in
   // order to learn. The new Feed (incoming community activity) arrives
   // with the webhook work, so this hub has three tabs today, not four.
-  const [tab, setTab] = useState<"library" | "audience" | "boost">("library");
+  const [tab, setTab] = useState<"library" | "feed" | "audience" | "boost">("library");
+  const [feedOpened, setFeedOpened] = useState(false);
   const [audienceOpened, setAudienceOpened] = useState(false);
   const [boostOpened, setBoostOpened] = useState(false);
   // Composer seed text — set when the user clicks "Use this draft" on
@@ -157,8 +185,14 @@ function LinkedInTabs({
   const [composerSeed, setComposerSeed] = useState<string | undefined>(undefined);
 
   function handleTabChange(value: string) {
-    if (value === "library" || value === "audience" || value === "boost") {
+    if (
+      value === "library" ||
+      value === "feed" ||
+      value === "audience" ||
+      value === "boost"
+    ) {
       setTab(value);
+      if (value === "feed") setFeedOpened(true);
       // Radix TabsContent mounts eagerly, so each non-default tab stays
       // gated on having been opened once. A tab that skips this fires its
       // query on every page load — which, against a ~500-requests/day
@@ -173,6 +207,9 @@ function LinkedInTabs({
       <TabsList>
         <TabsTrigger value="library" className="gap-1.5">
           <Newspaper className="size-4" /> Library
+        </TabsTrigger>
+        <TabsTrigger value="feed" className="gap-1.5">
+          <MessageSquare className="size-4" /> Feed
         </TabsTrigger>
         <TabsTrigger value="audience" className="gap-1.5">
           <Users className="size-4" /> Audience
@@ -207,6 +244,19 @@ function LinkedInTabs({
             output), so it costs no LinkedIn budget. The per-post threads
             are the on-demand part. */}
         <LibraryPanel />
+      </TabsContent>
+
+      <TabsContent value="feed" className="mt-4">
+        {/* Lazy-mounted like every other non-default tab. This one reads
+            Mongo rather than LinkedIn so it costs no API budget — but it
+            still costs a round trip on a page nobody may open. */}
+        {feedOpened ? (
+          <CommunityFeedPanel author={feedAuthor(enabledIdentity?.data)} />
+        ) : null}
+        <p className="mt-3 text-xs text-muted-foreground">
+          Comments, mentions and reposts across your Pages, newest first. Replies
+          you send here post straight to LinkedIn.
+        </p>
       </TabsContent>
 
       <TabsContent value="audience" className="mt-4">

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -447,6 +447,41 @@ export const linkedInContentApi = {
     );
   },
 
+  /**
+   * The Community Feed — incoming comments, mentions and reposts.
+   *
+   * ★Reads Mongo on the server, never LinkedIn: every row arrived over
+   * the webhook. So this is cheap to poll and cheap to leave open, unlike
+   * the thread panel, which spends real API budget per call.
+   */
+  interactions: (params?: { filter?: string; cursor?: string; limit?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.filter) qs.set("filter", params.filter);
+    if (params?.cursor) qs.set("cursor", params.cursor);
+    if (typeof params?.limit === "number") qs.set("limit", String(params.limit));
+    const q = qs.toString();
+    return api.get<LinkedInFeedPage>(
+      `/v1/linkedin/content/interactions${q ? `?${q}` : ""}`,
+    );
+  },
+
+  /** Mark a screenful as seen. Batched, and deliberately does NOT change
+   *  reply status — reading a comment is not answering it. */
+  markInteractionsSeen: (interactionUrns: string[]) =>
+    api.post<{ marked: number }>("/v1/linkedin/content/interactions/seen", {
+      interactionUrns,
+    }),
+
+  /** Snooze, assign or dismiss one interaction. */
+  updateInteraction: (
+    interactionUrn: string,
+    body: { snoozedUntil?: string | null; assignedToId?: string | null; ignored?: boolean },
+  ) =>
+    api.patch<{ interactionUrn: string }>(
+      `/v1/linkedin/content/interactions/${encodeURIComponent(interactionUrn)}`,
+      body,
+    ),
+
   /** Per-reaction-type counts + comment summary for a post. The AUTHORITATIVE
    *  reaction breakdown — `reactions` above only returns the current page. */
   socialMetadata: (postUrn: string) =>
@@ -660,6 +695,48 @@ export interface LinkedInSocialMetadata {
   totalReactions: number;
   commentCount: number;
   topLevelCommentCount: number;
+}
+
+
+/** One row in the Community Feed. */
+export interface LinkedInInteraction {
+  id: string;
+  kind: "comment" | "reaction" | "repost" | "mention";
+  interactionUrn: string;
+  parentPostUrn: string;
+  parentCommentUrn?: string;
+  actorUrn?: string;
+  actorType?: "person" | "org";
+  /** Absent once the 48h sweep has taken it — see `redacted`. */
+  text?: string;
+  occurredAt?: string;
+  receivedAt: string;
+  status: "new" | "needs_reply" | "replied" | "ignored";
+  seenAt?: string;
+  repliedAt?: string;
+  replyCommentUrn?: string;
+  firstResponseMs?: number;
+  assignedToId?: string;
+  snoozedUntil?: string;
+  /** LinkedIn's 48-hour cap has passed and the member's words are gone.
+   *  The row remains, and still records what we did about it. */
+  redacted: boolean;
+}
+
+export interface LinkedInFeedCounts {
+  needsReply: number;
+  unseen: number;
+  mentions: number;
+  reposts: number;
+  /** How long the oldest unanswered comment has waited, ms. Null when
+   *  nothing is waiting. */
+  oldestUnansweredMs: number | null;
+}
+
+export interface LinkedInFeedPage {
+  rows: LinkedInInteraction[];
+  nextCursor: string | null;
+  counts: LinkedInFeedCounts;
 }
 
 /** One published post in the LinkedIn Feed tab (GET /feed). */


### PR DESCRIPTION
Reopens **#502**, which GitHub auto-closed when its stacked base branch was deleted on the #501 merge. Same branch, same commits, plus the round-1 review fixes. All prior review discussion is on #502.

The fourth tab, and the one that answers the question a person actually opens this dashboard for. Tabs are now **Library · Feed · Audience · Boost**, as settled.

## Why a queue, not more numbers on each post

The engagement itself already sits under every post in Library. What was missing is *"is anyone waiting on us?"* — and spreading that across fifty post cards means it can only be answered by reading all fifty. One reverse-chronological list makes the dashboard **simpler** while showing considerably more.

## The header leads on a duration, not a count

**"Oldest unanswered: 14h"** beats "5 need a reply". A count says how much work there is; a duration says whether somebody is being *let down*.

## Round-1 review fixes included

**Mark-seen fired on render, for every row on the page** — so opening the Feed cleared "New" for 25 items nobody had scrolled to, and a background refetch marked things seen while the tab wasn't on screen. Now driven by `IntersectionObserver` at 50% visibility, gated on `document.visibilityState`, batched into one call, and remembered for the life of the panel.

**Snoozing was one-way.** The button only appeared on the `needs_reply` filter, which the server excludes snoozed rows from — so once snoozed, an item couldn't be reached from this surface at all. It now appears under "All" with an Un-snooze.

Also: the loading/error branches unmounted the filter chips (blanking the toolbar on every switch, and turning any error into a dead end); raw `ApiError.message` reached users; and "View post" was interpolated without the guard that stops a comment URN becoming a dead permalink.

`ReplyBox`, `COMMENT_MAX_LEN`, the error mapper and the permalink guard now live in one module used by **both** the thread panel and the Feed — they're the same action with the same rules, and two copies meant a fix to one silently left the other wrong.

## ⚠️ Known simplification

A Feed row spans **every Page** a business administers, so replying uses the first Page. The server rejects an author the business hasn't enabled, so this **cannot** post as an unauthorised Page — but it can post as the wrong one. Library's thread panel is correct for multi-Page until the ingest records each post's author.

`tsc` clean, `eslint` clean on touched files, 35 LinkedIn b2c tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
