### PR TITLE
feat(linkedin): the count is the way in — six metrics on one row, three of them doors

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/engagement-dialogs.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/engagement-dialogs.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+/**
+ * Engagement, opened from the number it belongs to.
+ *
+ * ── ★WHY THREE DIALOGS AND NOT ONE PANEL ─────────────────────────────
+ * The first version of this put every kind of engagement behind a single
+ * "View engagement" button beside the counts. That made the counts
+ * decoration: you read "24 comments", then hunted for a separate control,
+ * then picked a tab to get back to the thing you had already pointed at.
+ * The number IS the affordance — clicking 24 comments opens the comments,
+ * and nothing else has to be found first.
+ *
+ * Three separate dialogs rather than one with tabs, for the same reason:
+ * a tab strip re-asks the question the click already answered.
+ *
+ * ── ★AND WHY EACH ONE COSTS SOMETHING TO OPEN ────────────────────────
+ * Community Management Development tier allows ~500 requests/day for the
+ * WHOLE app across every customer. Every dialog here fetches on open and
+ * never before — `enabled: open` on each query is the mechanism. Do not
+ * "warm" these on hover or on render: a Library page of 25 cards would
+ * spend the entire day's budget on a scroll.
+ *
+ * The exception is Reposts, which reads our own Mongo (rows the webhook
+ * delivered) and costs LinkedIn nothing.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Loader2, ExternalLink, Repeat2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  linkedInContentApi,
+  type LinkedInAuthor,
+  type LinkedInInteraction,
+} from "@/lib/api/linkedin-content";
+import { useLocale } from "@/hooks/use-locale";
+import { CommentsTab, ReactionsTab } from "./thread-panel";
+import { RetentionFootnote } from "./retention-footnote";
+import { engageErrorMessage } from "./engage-shared";
+
+/** One dialog frame, so the three below cannot drift in size, scroll
+ *  behaviour or footnote placement. */
+function EngagementDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footnote,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+  footnote: React.ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] w-full flex-col gap-0 sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="mt-4 min-h-0 flex-1 overflow-y-auto">{children}</div>
+        <RetentionFootnote>{footnote}</RetentionFootnote>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Who reacted, and with which reaction.
+ *
+ * ★Reaction TYPE is always known; the PERSON usually is not, and that is
+ * LinkedIn's limit rather than ours. Decorations arrive only as the
+ * `actor~` expansion on a COMMENTS read — the reactions finder offers no
+ * equivalent and there is no profile lookup for another member — so a
+ * reactor has a name here only if they also commented recently enough to
+ * still be in the 24-hour cache. `ReactionsTab` says so in the body; the
+ * description says it before the list, so nobody reads a screen of
+ * "A member" as something being broken.
+ */
+export function ReactionsDialog({
+  postUrn,
+  open,
+  onOpenChange,
+}: {
+  postUrn: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <EngagementDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Reactions"
+      description="Everyone who reacted to this post, grouped by reaction."
+      footnote="Reactor names come from LinkedIn's 24-hour profile cache, so most people who only reacted show as “A member”."
+    >
+      <ReactionsTab postUrn={postUrn} open={open} />
+    </EngagementDialog>
+  );
+}
+
+/**
+ * Who commented, who they are, and the reply box.
+ *
+ * The whole of `CommentsTab` — reply as the page or as you, six reaction
+ * types, edit, delete, one level of nested replies, permissions and the
+ * plain-language 403 — is reused rather than re-implemented. See the note
+ * on its export.
+ */
+export function CommentsDialog({
+  postUrn,
+  author,
+  ourActorUrn,
+  open,
+  onOpenChange,
+}: {
+  postUrn: string;
+  /** Who we reply and react AS. Null when unresolvable — the dialog then
+   *  reads but cannot write, which is better than guessing an author. */
+  author: LinkedInAuthor | null;
+  ourActorUrn: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <EngagementDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Comments"
+      description="Reply, react and moderate without leaving Peakhour."
+      footnote="Comment text is held for 48 hours and commenter names for 24, per LinkedIn's data rules."
+    >
+      <CommentsTab
+        postUrn={postUrn}
+        author={author}
+        ourActorUrn={ourActorUrn}
+        open={open}
+      />
+    </EngagementDialog>
+  );
+}
+
+/**
+ * Who reposted this, and anyone who mentioned it.
+ *
+ * ── ★THIS ONE READS OUR OWN DATABASE, NOT LINKEDIN ───────────────────
+ * There is no "who reposted" endpoint. Reposts reach us exactly one way:
+ * an `ORGANIZATION_SOCIAL_ACTION_NOTIFICATIONS` webhook with
+ * `action:"SHARE"`, ingested into `soc_linkedin_interactions`. So this
+ * dialog is a filtered read of the Feed's own rows, costs no LinkedIn
+ * budget, and — importantly — shows nothing at all until webhook delivery
+ * is live. The empty state says which of those it is, because "no reposts
+ * yet" and "reposts cannot reach us yet" look identical and mean opposite
+ * things.
+ */
+export function RepostsDialog({
+  postUrn,
+  open,
+  onOpenChange,
+}: {
+  postUrn: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { formatRelativeTime } = useLocale();
+  const query = useInfiniteQuery({
+    queryKey: ["linkedin-post-reposts", postUrn],
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      linkedInContentApi.interactions({
+        postUrn,
+        filter: "reposts",
+        limit: 25,
+        ...(pageParam ? { cursor: pageParam } : {}),
+      }),
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    // Cheap (our Mongo, not LinkedIn) but still on-demand — there is no
+    // reason to hold a subscription open for a dialog nobody opened.
+    enabled: open,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const rows = query.data?.pages.flatMap((p) => p.rows) ?? [];
+
+  return (
+    <EngagementDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Reposts"
+      description="People who shared this post with their own network."
+      footnote="Reposts arrive over LinkedIn's notification webhook. The member's words are held for 48 hours; that this happened is kept."
+    >
+      {query.isLoading ? (
+        <RepostSkeleton />
+      ) : query.isError ? (
+        <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center">
+          <p className="text-sm text-muted-foreground">
+            {engageErrorMessage(query.error)}
+          </p>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-md border bg-muted/30 p-6 text-center">
+          <p className="text-sm font-medium">No reposts recorded</p>
+          <p className="mx-auto mt-1 max-w-sm text-xs text-muted-foreground">
+            Reposts reach Peakhour over LinkedIn&apos;s notification webhook.
+            If the counter above shows reposts but this list is empty, the
+            webhook has not delivered them — reposts from before it was
+            connected cannot be recovered beyond LinkedIn&apos;s 60-day
+            replay window.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((row) => (
+            <li key={row.id} className="flex gap-2.5">
+              <span
+                className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted"
+                aria-hidden
+              >
+                <Repeat2 className="size-4 text-muted-foreground" />
+              </span>
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex flex-wrap items-center gap-x-2">
+                  <span className="text-sm font-medium">
+                    {repostActorLabel(row)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {row.kind === "mention" ? "mentioned this" : "reposted this"}
+                  </span>
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {formatRelativeTime(row.occurredAt ?? row.receivedAt)}
+                  </span>
+                </div>
+                {/* Redacted is the NORMAL end state, not a failure: at 48h
+                    the sweep takes the member's words and keeps the row. */}
+                {row.redacted ? (
+                  <p className="text-xs italic text-muted-foreground">
+                    Their commentary is past LinkedIn&apos;s 48-hour window.
+                  </p>
+                ) : row.text ? (
+                  <p className="whitespace-pre-line text-sm text-muted-foreground">
+                    {row.text}
+                  </p>
+                ) : null}
+                {row.actorUrn && (
+                  <a
+                    href={`https://www.linkedin.com/feed/update/${row.interactionUrn}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    View on LinkedIn <ExternalLink className="size-3" />
+                  </a>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="mt-3 h-7 w-full gap-1.5 text-xs"
+          disabled={query.isFetchingNextPage}
+          aria-busy={query.isFetchingNextPage}
+          onClick={() => void query.fetchNextPage()}
+        >
+          {query.isFetchingNextPage && (
+            <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+          )}
+          Load more
+        </Button>
+      )}
+    </EngagementDialog>
+  );
+}
+
+/** A reposter's name, when we have one.
+ *
+ *  ★Reposts carry no `actor~` decoration — the notification gives a URN
+ *  and nothing else — so this is "A member" far more often than a comment
+ *  is. Rendering the raw URN instead would be worse than anonymous: it is
+ *  unreadable AND it looks like a bug. */
+function repostActorLabel(row: LinkedInInteraction): string {
+  return row.actorProfile?.displayName ?? "A member";
+}
+
+function RepostSkeleton() {
+  return (
+    <div className="space-y-3">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex gap-2.5">
+          <Skeleton className="size-8 shrink-0 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-40" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/library-panel.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { ThreadPanel } from "./thread-panel";
+import {
+  ReactionsDialog,
+  CommentsDialog,
+  RepostsDialog,
+} from "./engagement-dialogs";
+import { MetricStrip } from "./metric-strip";
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api";
@@ -14,18 +19,11 @@ import { Textarea } from "@/components/ui/textarea";
 import {
   Building2,
   ExternalLink,
-  Eye,
-  Heart,
   Loader2,
-  MessageSquare,
   MessageSquarePlus,
   Send,
-  Share2,
   User,
   X,
-  MousePointerClick,
-  MessagesSquare,
-  TrendingUp,
 } from "lucide-react";
 import {
   linkedInContentApi,
@@ -179,25 +177,15 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
   // on a resolvable author AND a real post URN.
   const author = postAuthor(post);
   const canComment = author !== null && !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
-  const [threadOpen, setThreadOpen] = useState(false);
-  // Reading a thread needs a real URN but NOT a resolvable author — you can
-  // look at engagement on a post you cannot currently comment as.
+  // One piece of state per dialog rather than one "which tab" value: the
+  // metric you clicked decides what opens, and there is no tab strip left
+  // to re-ask the question.
+  const [reactionsOpen, setReactionsOpen] = useState(false);
+  const [commentsOpen, setCommentsOpen] = useState(false);
+  const [repostsOpen, setRepostsOpen] = useState(false);
+  // Reading engagement needs a real URN but NOT a resolvable author — you
+  // can look at a post you cannot currently comment as.
   const canEngage = !!post.linkedInPostId && post.linkedInPostId.includes("urn:li:");
-  // Opening a thread costs a LinkedIn call against a ~500/day app-wide
-  // budget, so the entry point is hidden when the counters say there is
-  // nothing in there to read.
-  const hasEngagement =
-    post.performance.comments > 0 || post.performance.likes > 0;
-  // Engagement over reach. Null rather than 0 when there are no
-  // impressions: a post nobody saw has no rate, and rendering "0.0%"
-  // would read as failure rather than as absence.
-  const engagementRate =
-    post.performance.impressions > 0
-      ? ((post.performance.likes + post.performance.comments + post.performance.shares +
-          post.performance.clicks) /
-          post.performance.impressions) *
-        100
-      : null;
 
   return (
     <li>
@@ -232,45 +220,22 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
             {post.content}
           </p>
 
-{/* ★Two lines, because they answer different questions. Reach is
-              what the post DID; engagement is what people did back, and it
-              is the half that can be acted on — so it carries the button.
+{/* ★ONE ROW, AND THE COUNTS ARE THE CONTROLS. These six were split
+              across two lines under a reach/engagement taxonomy the viewer
+              had to learn before comparing anything — and the wrap moved
+              with the container, so the grouping was not even stable.
 
-              `clicks` was already in the payload and simply never rendered.
-              The engagement RATE is the number worth leading on: a post
-              with 400 impressions and 20 comments is doing better than one
-              with 12,000 and 3, and the old strip made the second look
-              like the winner. */}
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
-            <Metric icon={Eye} label="impressions" value={post.performance.impressions} />
-            <Metric icon={MousePointerClick} label="clicks" value={post.performance.clicks} />
-            {engagementRate !== null && (
-              <span
-                className="flex items-center gap-1"
-                title={`${engagementRate.toFixed(2)}% of people who saw this engaged with it`}
-              >
-                <TrendingUp className="size-3.5" aria-hidden />
-                {engagementRate.toFixed(1)}%
-              </span>
-            )}
-          </div>
-
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
-            <Metric icon={Heart} label="reactions" value={post.performance.likes} />
-            <Metric icon={MessageSquare} label="comments" value={post.performance.comments} />
-            <Metric icon={Share2} label="reposts" value={post.performance.shares} />
-            {canEngage && hasEngagement && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="ml-auto h-7 gap-1.5 px-2 text-xs"
-                onClick={() => setThreadOpen(true)}
-              >
-                <MessagesSquare className="size-3.5" /> View engagement
-              </Button>
-            )}
-          </div>
+              The "View engagement" button that used to sit here is gone:
+              it made the numbers decoration, sending you off to find a
+              separate control and then a tab to get back to the thing you
+              had already pointed at. See metric-strip.tsx. */}
+          <MetricStrip
+            values={post.performance}
+            canOpen={canEngage}
+            onOpenReactions={() => setReactionsOpen(true)}
+            onOpenComments={() => setCommentsOpen(true)}
+            onOpenReposts={() => setRepostsOpen(true)}
+          />
 
           {canComment && (
             <div className="border-t pt-2">
@@ -297,15 +262,27 @@ function FeedRow({ post }: { post: LinkedInFeedPost }) {
       </Card>
 
       {canEngage && (
-        <ThreadPanel
-          postUrn={post.linkedInPostId as string}
-          author={author}
-          // The URN that published this post IS us — the only sound test
-          // for "we wrote this comment", and available right here.
-          ourActorUrn={post.authorUrn}
-          open={threadOpen}
-          onOpenChange={setThreadOpen}
-        />
+        <>
+          <ReactionsDialog
+            postUrn={post.linkedInPostId as string}
+            open={reactionsOpen}
+            onOpenChange={setReactionsOpen}
+          />
+          <CommentsDialog
+            postUrn={post.linkedInPostId as string}
+            author={author}
+            // The URN that published this post IS us — the only sound test
+            // for "we wrote this comment", and available right here.
+            ourActorUrn={post.authorUrn}
+            open={commentsOpen}
+            onOpenChange={setCommentsOpen}
+          />
+          <RepostsDialog
+            postUrn={post.linkedInPostId as string}
+            open={repostsOpen}
+            onOpenChange={setRepostsOpen}
+          />
+        </>
       )}
     </li>
   );
@@ -426,27 +403,6 @@ function CommentBox({
   );
 }
 
-function Metric({
-  icon: Icon,
-  label,
-  value,
-}: {
-  icon: typeof Eye;
-  label: string;
-  value: number;
-}) {
-  return (
-    <span
-      className="flex items-center gap-1"
-      aria-label={`${value.toLocaleString()} ${label}`}
-      title={`${value.toLocaleString()} ${label}`}
-    >
-      <Icon className="size-3.5" aria-hidden />
-      {formatCount(value)}
-    </span>
-  );
-}
-
 // ── Helpers ───────────────────────────────────────────────
 
 /** Build a "View on LinkedIn" URL only when we have a real URN — a bare
@@ -460,12 +416,6 @@ function linkedInPostUrl(linkedInPostId: string | null): string | null {
   // linkedin.ts): encoding produces %3A%3A URLs some browser caches
   // mishandle.
   return `https://www.linkedin.com/feed/update/${linkedInPostId}`;
-}
-
-function formatCount(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
 }
 
 // ── Sub-components ────────────────────────────────────────

--- a/src/app/(site)/dashboard/content/linkedin/_components/metric-strip.test.ts
+++ b/src/app/(site)/dashboard/content/linkedin/_components/metric-strip.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The two decisions the metric strip makes that are worth pinning.
+ *
+ * Both are about NOT doing something: not turning a zero into a door
+ * nobody wants opened (and which costs a LinkedIn request against a
+ * ~500/day app-wide budget to discover is empty), and not rendering a
+ * rate for a post that has no denominator.
+ */
+
+import { describe, it, expect } from "vitest";
+import { engagementRate, opensDialog, formatCount } from "./metric-strip";
+
+describe("which counts are clickable", () => {
+  it("★a zero count never opens a dialog", () => {
+    // An empty dialog is a wasted click, and on reactions and comments it
+    // is a wasted LinkedIn request from a budget shared by every customer.
+    expect(opensDialog(0, true)).toBe(false);
+  });
+
+  it("a real count opens one", () => {
+    expect(opensDialog(1, true)).toBe(true);
+  });
+
+  it("★nothing opens without a real post URN", () => {
+    // A post with no `urn:li:` id cannot be read from LinkedIn at all, so
+    // the count still renders — it just is not a control whose only
+    // possible outcome is an error.
+    expect(opensDialog(24, false)).toBe(false);
+  });
+});
+
+describe("the engagement rate", () => {
+  it("★is null, not zero, when nobody saw the post", () => {
+    // "0.0%" reads as failure. A post with no impressions has no rate —
+    // that is absence, and the strip omits it rather than asserting it.
+    expect(
+      engagementRate({ impressions: 0, clicks: 0, likes: 0, comments: 0, shares: 0 }),
+    ).toBeNull();
+  });
+
+  it("counts every interaction over reach", () => {
+    // 400 impressions, 20 interactions → 5%.
+    expect(
+      engagementRate({ impressions: 400, clicks: 5, likes: 10, comments: 3, shares: 2 }),
+    ).toBeCloseTo(5);
+  });
+
+  it("★a small post can out-rate a big one", () => {
+    // The reason the rate leads: the old two-line strip showed raw
+    // impressions first and made the second of these look like the winner.
+    const small = engagementRate({ impressions: 400, clicks: 0, likes: 0, comments: 20, shares: 0 });
+    const big = engagementRate({ impressions: 12_000, clicks: 0, likes: 0, comments: 3, shares: 0 });
+    expect(small!).toBeGreaterThan(big!);
+  });
+});
+
+describe("count formatting", () => {
+  it("abbreviates thousands and millions", () => {
+    expect(formatCount(999)).toBe("999");
+    expect(formatCount(1_200)).toBe("1.2k");
+    expect(formatCount(2_500_000)).toBe("2.5M");
+  });
+});

--- a/src/app/(site)/dashboard/content/linkedin/_components/metric-strip.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/metric-strip.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+/**
+ * The six numbers a post has, on one line, each one explained on hover —
+ * and three of them are doors.
+ *
+ * ── ★ONE ROW, NOT TWO ────────────────────────────────────────────────
+ * The previous strip split these across two lines, "reach" above and
+ * "engagement" below. It reads as a taxonomy the viewer has to learn
+ * before they can compare anything, and the wrap point moved with the
+ * container, so the grouping it was meant to communicate was not even
+ * stable. Six figures fit on one line at every width we support; below
+ * that they wrap as a single flowing row, which is the honest behaviour
+ * for a list of peers.
+ *
+ * ── ★ICONS NEED WORDS, AND A `title=` IS NOT THEM ────────────────────
+ * A row of six glyphs is unreadable until you already know it. The old
+ * strip leaned on the native `title` attribute, which does not appear on
+ * keyboard focus, does not appear on touch at all, and takes about a
+ * second to show — so for most people the icons were simply unlabelled.
+ * Each metric now carries a real tooltip from the shared component, keyed
+ * to the trigger, so it is reachable by keyboard and says what the number
+ * MEANS rather than restating it.
+ *
+ * ── ★AND THE COUNT IS THE BUTTON ─────────────────────────────────────
+ * Reactions, comments and reposts open their own dialog. There used to be
+ * a separate "View engagement" control beside these numbers, which made
+ * the numbers decoration: you read "24 comments", then looked elsewhere
+ * for the way in, then chose a tab to get back to what you had already
+ * pointed at. Pointing at it IS the way in now.
+ *
+ * A count of zero stays rendered but is not a button — an empty dialog is
+ * a wasted click, and on reactions and comments it is a wasted LinkedIn
+ * request against a ~500/day app-wide budget.
+ */
+
+import {
+  Eye,
+  MousePointerClick,
+  TrendingUp,
+  Heart,
+  MessageSquare,
+  Repeat2,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export interface MetricStripValues {
+  impressions: number;
+  clicks: number;
+  likes: number;
+  comments: number;
+  shares: number;
+}
+
+/** What each icon means, in the words a person would use. Kept beside the
+ *  icons rather than at the call site so the six explanations cannot drift
+ *  apart, and so a seventh metric has an obvious home. */
+const EXPLANATIONS = {
+  impressions: "How many times this post appeared on someone's screen.",
+  clicks: "Clicks on the post — links, images, “see more”, your page name.",
+  engagement:
+    "Reactions, comments, reposts and clicks as a share of impressions. A post seen 400 times with 20 comments is doing better than one seen 12,000 times with 3.",
+  likes: "Reactions of every kind — Like, Celebrate, Love, Insightful, Support, Funny.",
+  comments: "Comments and replies from people who saw this.",
+  shares: "People who reposted this to their own network.",
+} as const;
+
+/**
+ * Engagement over reach, or null when there is no reach to divide by.
+ *
+ * ★Null rather than 0. A post nobody saw has no rate — rendering "0.0%"
+ * asserts a measured failure where there is only absence, and those are
+ * different things to a person deciding what to write next.
+ */
+export function engagementRate(v: MetricStripValues): number | null {
+  if (v.impressions <= 0) return null;
+  return ((v.likes + v.comments + v.shares + v.clicks) / v.impressions) * 100;
+}
+
+/**
+ * Whether a count is a door.
+ *
+ * A zero is not: an empty dialog is a wasted click, and on reactions and
+ * comments it is a wasted LinkedIn request against a ~500/day budget
+ * shared by every customer. Nor is anything on a post with no real URN,
+ * where the only possible outcome is an error.
+ */
+export function opensDialog(count: number, canOpen: boolean): boolean {
+  return canOpen && count > 0;
+}
+
+export function MetricStrip({
+  values,
+  onOpenReactions,
+  onOpenComments,
+  onOpenReposts,
+  /** False when we cannot read engagement for this post — a post with no
+   *  real URN. The counts still render; they just do not open anything,
+   *  which is better than a dialog that can only fail. */
+  canOpen,
+}: {
+  values: MetricStripValues;
+  onOpenReactions: () => void;
+  onOpenComments: () => void;
+  onOpenReposts: () => void;
+  canOpen: boolean;
+}) {
+  const rate = engagementRate(values);
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted-foreground tabular-nums">
+        <Metric icon={Eye} label="impressions" value={values.impressions} explain={EXPLANATIONS.impressions} />
+        <Metric icon={MousePointerClick} label="clicks" value={values.clicks} explain={EXPLANATIONS.clicks} />
+        {rate !== null && (
+          <Metric
+            icon={TrendingUp}
+            label="engagement rate"
+            display={`${rate.toFixed(1)}%`}
+            // The precise figure belongs in the tooltip; the strip shows one
+            // decimal so six numbers stay scannable.
+            explain={`${rate.toFixed(2)}% — ${EXPLANATIONS.engagement}`}
+          />
+        )}
+        <Metric
+          icon={Heart}
+          label="reactions"
+          value={values.likes}
+          explain={EXPLANATIONS.likes}
+          {...(opensDialog(values.likes, canOpen) ? { onClick: onOpenReactions, action: "See who reacted" } : {})}
+        />
+        <Metric
+          icon={MessageSquare}
+          label="comments"
+          value={values.comments}
+          explain={EXPLANATIONS.comments}
+          {...(opensDialog(values.comments, canOpen) ? { onClick: onOpenComments, action: "Read and reply" } : {})}
+        />
+        <Metric
+          icon={Repeat2}
+          label="reposts"
+          value={values.shares}
+          explain={EXPLANATIONS.shares}
+          {...(opensDialog(values.shares, canOpen) ? { onClick: onOpenReposts, action: "See who reposted" } : {})}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * One metric — a span, or a button when it opens something.
+ *
+ * ★The element TYPE changes with the behaviour rather than a span
+ * carrying an onClick. A clickable count has to be reachable by keyboard
+ * and announced as a control, and `<button>` is the only thing that gets
+ * all of that without re-implementing it.
+ */
+function Metric({
+  icon: Icon,
+  label,
+  value,
+  display,
+  explain,
+  onClick,
+  action,
+}: {
+  icon: LucideIcon;
+  label: string;
+  /** Omitted for a derived metric that has no count of its own. */
+  value?: number;
+  /** Pre-formatted text, when the value is not a plain count. */
+  display?: string;
+  explain: string;
+  onClick?: () => void;
+  /** What the click does — appended to the tooltip so the affordance is
+   *  stated rather than left to be discovered by hovering. */
+  action?: string;
+}) {
+  const text = display ?? formatCount(value ?? 0);
+  // The accessible name carries the FULL number; the visible text may be
+  // abbreviated to "1.2k", which is not something to read out.
+  const name = display ? `${display} ${label}` : `${(value ?? 0).toLocaleString()} ${label}`;
+
+  const body = (
+    <>
+      <Icon className="size-3.5" aria-hidden />
+      {text}
+    </>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {onClick ? (
+          <button
+            type="button"
+            onClick={onClick}
+            aria-label={`${name} — ${action ?? "open"}`}
+            className="flex items-center gap-1 rounded-sm underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {body}
+          </button>
+        ) : (
+          <span className="flex items-center gap-1" aria-label={name}>
+            {body}
+          </span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">
+        <p className="font-medium capitalize">{label}</p>
+        <p className="mt-0.5 text-xs">{explain}</p>
+        {action && <p className="mt-1 text-xs font-medium">{action} →</p>}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/thread-panel.tsx
@@ -1,24 +1,34 @@
 "use client";
 
 /**
- * The thread panel — the surface that makes a comment visible.
+ * The comment and reaction lists — the surface that makes engagement
+ * visible, and the actions that belong beside it.
  *
  * Until this shipped, LinkedIn Content could POST a comment it could not
  * SHOW you: the write path landed with the engager panel and the read path
- * never did. This is the read path, plus the actions that belong beside it.
+ * never did. This is the read path.
  *
- * ★Everything here is fetched only when a person opens the sheet.
- * Community Management Development tier allows ~500 requests/day for the
- * whole app across every customer, so a thread is loaded on demand and
- * never prefetched for a list of posts. `enabled: open` on both queries is
- * the mechanism; do not replace it with an eager fetch.
+ * ── ★NO LONGER A PANEL OF ITS OWN ────────────────────────────────────
+ * These were a two-tab sheet behind a "View engagement" button beside the
+ * counts, which made the counts decoration — you read "24 comments", found
+ * a separate control, then picked a tab to get back to what you had
+ * already pointed at. The counts are the controls now, and each opens the
+ * one list it names (`engagement-dialogs.tsx`). What survived is
+ * everything below: it is where reply, react, edit, delete, nested
+ * replies, the "is this ours" test and the 403 mapping live, and a second
+ * surface re-implementing any of it would drift.
+ *
+ * ★Everything here is fetched only when a dialog is OPEN. Community
+ * Management Development tier allows ~500 requests/day for the whole app
+ * across every customer, so a thread is loaded on demand and never
+ * prefetched for a list of posts. `enabled: open` on both queries is the
+ * mechanism; do not replace it with an eager fetch.
  */
 
 import { useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Loader2,
-  MessageSquare,
   Heart,
   Trash2,
   CornerDownRight,
@@ -26,14 +36,6 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { toast } from "sonner";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
@@ -51,7 +53,6 @@ import {
 } from "@/lib/api/linkedin-content";
 import { ApiError } from "@/lib/api";
 import { useLocale } from "@/hooks/use-locale";
-import { RetentionFootnote } from "./retention-footnote";
 import { COMMENT_MAX_LEN, ReplyBox, engageErrorMessage } from "./engage-shared";
 
 /** Reaction types we may WRITE. `MAYBE` is deprecated by LinkedIn and 400s
@@ -76,73 +77,18 @@ function reactionLabel(type: string): string {
   return REACTIONS.find((r) => r.type === type)?.label ?? type;
 }
 
-export function ThreadPanel({
-  postUrn,
-  author,
-  ourActorUrn,
-  open,
-  onOpenChange,
-}: {
-  postUrn: string;
-  /** The post's own author — who we reply and react AS. Null when we
-   *  cannot resolve one, in which case the panel reads but cannot write. */
-  author: LinkedInAuthor | null;
-  /** The URN that published this post — i.e. us.
-   *
-   *  ★The ONLY sound test for "this is our comment". An earlier version
-   *  used `Boolean(comment.agent)`, which means "an ORGANIZATION authored
-   *  this" and is true of any other company's comment on the thread — so
-   *  another brand got a "You" badge and an Edit button whose save
-   *  LinkedIn would reject. */
-  ourActorUrn: string | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="flex w-full flex-col gap-0 sm:max-w-xl">
-        <SheetHeader>
-          <SheetTitle>Engagement</SheetTitle>
-          <SheetDescription>
-            Reply, react and moderate without leaving Peakhour.
-          </SheetDescription>
-        </SheetHeader>
-
-        <Tabs defaultValue="comments" className="mt-4 flex min-h-0 flex-1 flex-col">
-          <TabsList>
-            <TabsTrigger value="comments" className="gap-1.5">
-              <MessageSquare className="size-4" /> Comments
-            </TabsTrigger>
-            <TabsTrigger value="reactions" className="gap-1.5">
-              <Heart className="size-4" /> Reactions
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="comments" className="mt-3 min-h-0 flex-1 overflow-y-auto">
-            <CommentsTab
-              postUrn={postUrn}
-              author={author}
-              ourActorUrn={ourActorUrn}
-              open={open}
-            />
-          </TabsContent>
-          <TabsContent value="reactions" className="mt-3 min-h-0 flex-1 overflow-y-auto">
-            <ReactionsTab postUrn={postUrn} open={open} />
-          </TabsContent>
-        </Tabs>
-
-        <RetentionFootnote>
-          Comment text is held for 48 hours and commenter names for 24, per
-          LinkedIn&apos;s data rules.
-        </RetentionFootnote>
-      </SheetContent>
-    </Sheet>
-  );
-}
-
 // ── Comments ──────────────────────────────────────────────
 
-function CommentsTab({
+/**
+ * ★EXPORTED so the Library's Comments dialog is this list, not a copy of
+ * it. Everything that makes a comment actionable — the reply box, the
+ * six-way reaction picker, edit, delete, the one-level reply thread, the
+ * "is this ours" test and the 403 mapping — lives in `CommentRow` below.
+ * A second surface re-implementing even part of that would drift, and the
+ * half it dropped would be the half nobody notices until a customer
+ * cannot answer someone.
+ */
+export function CommentsTab({
   postUrn,
   author,
   ourActorUrn,
@@ -159,7 +105,7 @@ function CommentsTab({
     queryFn: ({ pageParam }) =>
       linkedInContentApi.comments(postUrn, { count: 25, start: pageParam as number }),
     getNextPageParam: (last) => last.nextStart ?? undefined,
-    // Loaded only while the sheet is open — see the file header on why.
+    // Loaded only while the dialog is open — see the file header on why.
     enabled: open,
     staleTime: 60_000,
     refetchOnWindowFocus: false,
@@ -654,7 +600,8 @@ function ReactionPicker({
 
 // ── Reactions ─────────────────────────────────────────────
 
-function ReactionsTab({ postUrn, open }: { postUrn: string; open: boolean }) {
+/** Exported for the Library's Reactions dialog — see `CommentsTab`. */
+export function ReactionsTab({ postUrn, open }: { postUrn: string; open: boolean }) {
   const query = useInfiniteQuery({
     queryKey: ["linkedin-reactions", postUrn],
     initialPageParam: 0,

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -454,10 +454,18 @@ export const linkedInContentApi = {
    * the webhook. So this is cheap to poll and cheap to leave open, unlike
    * the thread panel, which spends real API budget per call.
    */
-  interactions: (params?: { filter?: string; cursor?: string; limit?: number }) => {
+  interactions: (params?: {
+    filter?: string;
+    cursor?: string;
+    limit?: number;
+    /** Narrow to one post — what the Library's per-card Reposts dialog asks.
+     *  The Feed tab omits it and gets the whole-brand queue. */
+    postUrn?: string;
+  }) => {
     const qs = new URLSearchParams();
     if (params?.filter) qs.set("filter", params.filter);
     if (params?.cursor) qs.set("cursor", params.cursor);
+    if (params?.postUrn) qs.set("postUrn", params.postUrn);
     if (typeof params?.limit === "number") qs.set("limit", String(params.limit));
     const q = qs.toString();
     return api.get<LinkedInFeedPage>(
@@ -721,6 +729,13 @@ export interface LinkedInInteraction {
   /** LinkedIn's 48-hour cap has passed and the member's words are gone.
    *  The row remains, and still records what we did about it. */
   redacted: boolean;
+  /** Who did it, when we still have them in the 24-hour cache.
+   *
+   *  ★Absent is the ORDINARY case, not an error — the cache is filled only
+   *  by comments reads, so a reposter (whose notification carries a URN
+   *  and nothing else) usually has no decoration at all. Render the
+   *  fallback, never an error state. */
+  actorProfile?: LinkedInActorProfile;
 }
 
 export interface LinkedInFeedCounts {


### PR DESCRIPTION
Follows the design in the LinkedIn Community Management plan, with one revision to §5.1 agreed in this round: the engagement panel is gone, and the metrics themselves are the way in.

## ★ The numbers were decoration

A post card showed "24 comments". To read those comments you looked away to a separate **View engagement** button, opened a two-tab sheet, and picked the tab for the thing you had already pointed at. Three steps to arrive where the first click was.

Reactions, comments and reposts are buttons now. Each opens the one list it names — no tab strip, because a tab strip re-asks the question the click already answered.

| Click | Opens |
|---|---|
| ❤️ reactions | everyone who reacted, grouped by reaction type |
| 💬 comments | commenters with identity, headline, photo — and reply, react, edit, delete |
| 🔁 reposts | who reposted, and mentions of the post |

## ★ Six figures were split across two lines

Under a reach-above / engagement-below taxonomy you had to learn before you could compare anything — and the wrap point moved with the container, so the grouping it was meant to communicate was not even stable.

One row now: **impressions · clicks · engagement rate · reactions · comments · reposts**. Below the breakpoint they wrap as one flowing row, which is the honest behaviour for a list of peers.

## ★ Each icon says what it means

From the shared `Tooltip`. The old strip used the native `title` attribute, which never appears on keyboard focus, never appears on touch, and takes about a second on hover — so for most people a row of six glyphs was simply unlabelled. The tooltips explain the metric rather than restating the number, and on the three clickable ones they name the action ("Read and reply →").

## Details that are decisions, not styling

- **A zero count renders but is not a button.** An empty dialog is a wasted click, and on reactions and comments a wasted LinkedIn request against a ~500/day budget shared by every customer.
- **The element type changes with the behaviour** — `<button>`, not a `<span>` with an `onClick` — so a clickable count is reachable by keyboard and announced as a control.
- **The accessible name carries the full number**; the visible text may read "1.2k", which is not something to read out.
- **The engagement rate stays `null`, not `0`,** when a post has no impressions. "0.0%" asserts a measured failure where there is only absence.

## What was reused, and what was deleted

The comment list is **reused, not reimplemented**. Reply as the page or as you, six reaction types, edit, delete, one level of nested replies, the "is this ours" test and the plain-language 403 all still live in `CommentRow`. A second surface re-implementing even part of that would drift, and the half it dropped would be the half nobody notices until a customer cannot answer someone.

`ThreadPanel` — the two-tab sheet — is **deleted**. Nothing referenced it once the counts took over.

## Reposts is a new surface, and reads our own database

There is no "who reposted" endpoint. Reposts reach us only as an `ORGANIZATION_SOCIAL_ACTION_NOTIFICATIONS` webhook with `action:"SHARE"`, so this is a per-post filter over `soc_linkedin_interactions` — no LinkedIn budget spent.

Its empty state says which emptiness it is: *"no reposts yet"* and *"reposts cannot reach us yet"* look identical on screen and mean opposite things.

## ★ On commenter identity, and the one limit that is LinkedIn's

Commenter identity was approved on 2026-08-14 and is already wired: name, headline and photo from the `actor~` expansion, cached 24 hours behind a TTL index, kill switch `LINKEDIN_ACTOR_DECORATION` shipping **enabled**. If you are seeing "A member" on comments, check that flag is not set to `false` — the UI also renders an explicit banner when identity is switched off, so it never reads as a bug.

**Reactors are different, and no amount of wiring changes it.** Reaction *type* is always known. The *person* usually is not: decorations arrive only as the `actor~` expansion on a **comments** read, the reactions finder offers no equivalent, and LinkedIn exposes no profile lookup for another member. So a reactor is named only if they also commented recently enough to still be in the 24-hour cache. The dialog says this above the list rather than letting a screen of "A member" read as something broken.

## Verification

Type-check clean. Lint clean in every changed file. LinkedIn component tests green — 4 files, 42 tests, 7 of them new (which counts open a dialog, and the rate's null-vs-zero rule).

## Needs

`peakhour-api#1088` for the `postUrn` filter and actor decoration on interaction rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
