### PR TITLE
fix(dev): the subscription cron shipped without the half that makes it usable

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -295,8 +295,19 @@ function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; 
           ENQUEUES a linkedin_post_sync job (it doesn't drain inline), so click
           linkedin-post-sync first, then jobs-runner to actually run it and
           populate posts + KPIs. */}
+      {/* ★`linkedin-subscription-reconcile` is the only way a LinkedIn
+          subscription gets CREATED on dev — its seed phase arms connections
+          that have none, and Vercel Cron fires only on production. Without
+          it the Feed tab is permanently empty here, and empty is exactly
+          what a quiet week looks like. */}
       <CronToolbar
-        crons={["linkedin-post-sync", "jobs-runner", "performance-sync", "linkedin-retention-cleanup"]}
+        crons={[
+          "linkedin-post-sync",
+          "jobs-runner",
+          "performance-sync",
+          "linkedin-subscription-reconcile",
+          "linkedin-retention-cleanup",
+        ]}
         onTriggered={() => {
           queryClient.invalidateQueries({ queryKey: ["content-hub-integrations"] });
           queryClient.invalidateQueries({ queryKey: ["linkedin-me"] });
@@ -310,6 +321,12 @@ function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; 
           queryClient.invalidateQueries({ queryKey: ["linkedin-engagers"] });
           // post-sync writes the feed rows too — refresh the Feed tab.
           queryClient.invalidateQueries({ queryKey: ["linkedin-feed"] });
+          // The subscription cron's backfill writes soc_linkedin_interactions
+          // — the Feed tab's own rows, and the per-post Reposts dialog's.
+          // Without these the cron reports events replayed and both keep
+          // serving the empty result they cached.
+          queryClient.invalidateQueries({ queryKey: ["linkedin-interactions"] });
+          queryClient.invalidateQueries({ queryKey: ["linkedin-post-reposts"] });
         }}
       />
       <div>

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -311,6 +311,46 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       return `LinkedIn data cleaned — ${total} ${plural(total, "row")} removed.`;
     },
   },
+  "linkedin-subscription-reconcile": {
+    label: "Reconnect LinkedIn comment alerts",
+    frequency: "Runs daily at 4:30 AM UTC",
+    description:
+      "Subscribes your Company Pages to LinkedIn's activity alerts, renews the ones that lapsed, and replays anything that failed to arrive. Nothing else notices when LinkedIn quietly stops sending — the symptom is a Feed that looks like a quiet week.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return "LinkedIn alerts reconnected.";
+      const seed = asRecord(d.seed);
+      const armed = seed ? num(seed.subscribed) : 0;
+      const renewed = num(d.resubscribed);
+      const replayed = num(d.interactionsWritten);
+      // ★A run that touched nothing is reported as a warning, not a
+      // success. On dev this cron is the only way a subscription gets
+      // created at all, so "0 checked, 0 armed" is the state someone is
+      // trying to leave — and a green toast for it is how you conclude
+      // the pipeline works when nothing has been connected.
+      if (armed === 0 && renewed === 0 && num(d.checked) === 0) {
+        return {
+          level: "warning",
+          message:
+            "No LinkedIn Pages to reconnect — connect LinkedIn and enable a Page first.",
+        };
+      }
+      const parts: string[] = [];
+      if (armed > 0) parts.push(`${armed} ${plural(armed, "Page")} newly subscribed`);
+      if (renewed > 0) parts.push(`${renewed} renewed`);
+      if (num(d.revoked) > 0) parts.push(`${num(d.revoked)} need a reconnect`);
+      // Kept distinct from `revoked`: a member who is no longer a Page
+      // admin CANNOT fix this by reconnecting, and telling them to is a
+      // loop that ends where it started.
+      if (num(d.forbidden) > 0) {
+        parts.push(`${num(d.forbidden)} lost admin rights`);
+      }
+      if (replayed > 0) parts.push(`${replayed} missed ${plural(replayed, "event")} replayed`);
+      return parts.length
+        ? `LinkedIn alerts: ${parts.join(", ")}.`
+        : "LinkedIn alerts checked — everything already up to date.";
+    },
+  },
   "voice-card-refresh": {
     label: "Refresh brand voice",
     frequency: "Runs weekly (Sunday 5 AM UTC)",


### PR DESCRIPTION
## ★ A cron the api schedules, with no button and no name

`cron-metadata`'s own guard test reads `peakhour-api`'s `vercel.json` and fails when a scheduled cron has no friendly label. It went red the moment `linkedin-subscription-reconcile` became dev-triggerable in api#1087 — which is exactly what that test exists for.

Both halves of the cross-repo rule, not just the one the test checks:

- **A `CRON_METADATA` entry**, so the button reads *"Reconnect LinkedIn comment alerts"* rather than the fallback `Run linkedin-subscription-reconcile` stub, and the tooltip explains that nothing else notices when LinkedIn quietly stops sending.
- **Mounted on `/dashboard/content/linkedin`**, the page whose data it produces. ★It is the **only** way a LinkedIn subscription gets created on dev — Vercel Cron fires only on production — so without this button the Feed tab is permanently empty here. And empty is precisely what a quiet week looks like.

## The summarizer warns rather than congratulates

A run that touched nothing reports as a **warning**. On dev, "0 checked, 0 armed" is the state someone is trying to leave; a green toast for it is how you conclude the pipeline works when nothing has been connected.

`revoked` and `forbidden` stay separate in the message, too — a member who has lost Page admin rights **cannot** fix it by reconnecting, and telling them to is a loop that ends where it started.

## Invalidation

Adds `linkedin-interactions` and `linkedin-post-reposts` to the trigger's invalidation set. The cron's backfill writes those very rows, so without it the toast reports events replayed while the Feed tab and the per-post Reposts dialog keep serving the empty result they cached.

## Verification

Full b2c suite green — 26 files, 393 tests (was 1 failing). Type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
