### PR TITLE
feat(linkedin): the Audience tab stops being a 48-hour list

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-blocks.test.ts
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-blocks.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The one thing the Audience blocks must never do: report "not measured"
+ * as "nothing happened".
+ *
+ * These numbers begin the day the hourly rollup first ran, and there is
+ * no backfill — LinkedIn does not serve this history and the raw rows are
+ * gone at 48 hours. So a 90-day view holding four days of data is a young
+ * rollup, not a dead community, and the difference is invisible unless
+ * something says so.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatDuration } from "./audience-blocks";
+
+describe("★how long someone has been waiting", () => {
+  it("rounds DOWN to the leading unit", () => {
+    // "3h" for 3h59m understates the wait. This number exists to prompt
+    // action, and an overstatement that turned out to be rounding costs
+    // more trust than the precision is worth.
+    expect(formatDuration(3 * 3_600_000 + 59 * 60_000)).toBe("3h");
+    expect(formatDuration(47 * 3_600_000)).toBe("1d");
+  });
+
+  it("does not render a sub-minute wait as 0m", () => {
+    // "0m waiting" reads as a bug, or as nobody waiting at all.
+    expect(formatDuration(20_000)).toBe("under a minute");
+  });
+
+  it("uses minutes below an hour and hours below a day", () => {
+    expect(formatDuration(45 * 60_000)).toBe("45m");
+    expect(formatDuration(5 * 3_600_000)).toBe("5h");
+  });
+
+  it("handles zero without producing a negative or empty string", () => {
+    expect(formatDuration(0)).toBe("under a minute");
+  });
+});

--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-blocks.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-blocks.tsx
@@ -50,6 +50,10 @@ const REACTION_LABEL: Record<string, string> = {
   MAYBE: "Curious",
 };
 
+/** How many buckets a facet card shows. Past the top few the counts are
+ *  single digits and the question the block answers is already answered. */
+const MAX_BUCKETS_PER_FACET = 8;
+
 /** The demographic facets worth showing, in the order a person reads
  *  them: who they are, then what they do, then where. */
 const DEMOGRAPHIC_BLOCKS: Array<{ field: string; title: string }> = [
@@ -59,6 +63,36 @@ const DEMOGRAPHIC_BLOCKS: Array<{ field: string; title: string }> = [
   { field: "followerCountsByStaffCountRange", title: "By company size" },
   { field: "followerCountsByGeoCountry", title: "By country" },
 ];
+
+/**
+ * What a block shows when it cannot show numbers.
+ *
+ * ★NOT `null`. Returning nothing on error deletes the block silently and
+ * leaves the window buttons above it looking inert — the user clicks 90d,
+ * nothing happens, and there is no way to tell a broken tab from an empty
+ * community. A 403 here means no business is selected, which is a thing
+ * the person can fix, so it is named rather than absorbed.
+ */
+function BlockError({ title, error }: { title: string; error: unknown }) {
+  const noBusiness = error instanceof ApiError && error.status === 403;
+  return (
+    <section className="space-y-3">
+      <BlockHeading title={title} />
+      <Card>
+        <CardContent className="p-6 text-center">
+          <p className="text-sm font-medium">
+            {noBusiness ? "Pick a business to see this" : `Couldn't load ${title.toLowerCase()}`}
+          </p>
+          <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+            {noBusiness
+              ? "Once a business is selected, we'll show how its community has been engaging."
+              : "Try again in a moment. Your LinkedIn connection is unaffected — these numbers come from Peakhour, not LinkedIn."}
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
 
 export function useAudienceSummary(days: number) {
   return useQuery({
@@ -83,11 +117,14 @@ export function useAudienceSummary(days: number) {
 export function CommunityPulse({
   summary,
   loading,
+  error,
 }: {
   summary?: LinkedInAudienceSummary;
   loading: boolean;
+  error?: unknown;
 }) {
   if (loading) return <BlockSkeleton rows={2} />;
+  if (error) return <BlockError title="Community pulse" error={error} />;
   if (!summary) return null;
 
   const t = summary.totals;
@@ -132,17 +169,29 @@ export function CommunityPulse({
 export function ResponseHealth({
   summary,
   loading,
+  error,
 }: {
   summary?: LinkedInAudienceSummary;
   loading: boolean;
+  error?: unknown;
 }) {
   if (loading) return <BlockSkeleton rows={1} />;
+  if (error) return <BlockError title="Response health" error={error} />;
   if (!summary) return null;
   const h = summary.responseHealth;
 
   return (
     <section className="space-y-3">
-      <BlockHeading title="Response health" />
+      {/* ★The badge belongs here as much as on the pulse. Reply rate,
+          median first reply and replies-sent are all rollup-derived and
+          all window-scoped — a 90-day view backed by three days reports
+          an uncaveated reply rate, which is exactly the "not measured
+          read as nothing happened" failure this file exists to prevent. */}
+      <BlockHeading
+        title="Response health"
+        coverageDays={summary.coverageDays}
+        days={summary.days}
+      />
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <KpiCard
           title="Reply rate"
@@ -191,14 +240,42 @@ export function ResponseHealth({
  * here it DOES cost a LinkedIn request, against a ~500/day app-wide
  * budget shared with the thread panel and the reactions list.
  */
-export function WhoFollows() {
+export function WhoFollows({ orgPageId }: { orgPageId?: string }) {
   const query = useQuery({
-    queryKey: ["linkedin-follower-stats"],
-    queryFn: () => linkedInContentApi.followerStats(),
+    // ★The Page is part of the key, not just the request. Demographics
+    // are per Page; a key that omitted it would serve the first Page's
+    // breakdown for the second one from cache.
+    queryKey: ["linkedin-follower-stats", orgPageId],
+    queryFn: () => linkedInContentApi.followerStats(orgPageId as string),
+    // ★REQUIRED by the route, which 400s without it before doing anything
+    // else. Firing anyway would render the "you publish only to a
+    // personal feed" fallback for every Company Page on the platform —
+    // a confident wrong answer rather than an error.
+    enabled: Boolean(orgPageId),
     staleTime: 60 * 60_000,
     refetchOnWindowFocus: false,
     retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 1,
   });
+
+  if (!orgPageId) {
+    // Genuinely pageless: the member publishes to their own feed, and
+    // LinkedIn has no follower breakdown to give. This is the ONLY
+    // situation in which that sentence is true.
+    return (
+      <section className="space-y-3">
+        <BlockHeading title="Who follows" />
+        <Card>
+          <CardContent className="p-6 text-center">
+            <p className="text-sm font-medium">No Company Page connected</p>
+            <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+              LinkedIn reports follower demographics for Company Pages you
+              administer. Personal-feed followers have no breakdown.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
 
   if (query.isLoading) return <BlockSkeleton rows={2} />;
 
@@ -211,9 +288,9 @@ export function WhoFollows() {
           <CardContent className="p-6 text-center">
             <p className="text-sm font-medium">Follower demographics unavailable</p>
             <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
-              LinkedIn provides this for Company Pages you administer. If you
-              publish only to your personal feed, there is nothing to break
-              down here.
+              We couldn&apos;t read this Page&apos;s follower breakdown from
+              LinkedIn. It needs the page-admin permission, and LinkedIn only
+              reports demographics once a Page has enough followers.
             </p>
           </CardContent>
         </Card>
@@ -221,9 +298,19 @@ export function WhoFollows() {
     );
   }
 
+  // ★SORTED AND CAPPED. LinkedIn returns these in its own order, which is
+  // not by size — a Page spanning sixty industries rendered a sixty-row
+  // card with the dominant bucket somewhere in the middle. The reaction
+  // mix above was already sorted; these were the same kind of list and
+  // were not. The tail is dropped rather than scrolled: past the top few
+  // the counts are single digits and the question ("who follows us?")
+  // is answered by the head.
   const blocks = DEMOGRAPHIC_BLOCKS.map(({ field, title }) => ({
     title,
-    buckets: (byDemographic[field] ?? []).filter((b) => b.organic > 0),
+    buckets: (byDemographic[field] ?? [])
+      .filter((b) => b.organic > 0)
+      .sort((a, b) => b.organic - a.organic)
+      .slice(0, MAX_BUCKETS_PER_FACET),
   })).filter((b) => b.buckets.length > 0);
 
   return (

--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-blocks.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-blocks.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+/**
+ * The Audience tab's first, second and fourth blocks. The third — who
+ * engages — is the existing AQS list in `audience-panel.tsx`.
+ *
+ * ── ★THESE NUMBERS BEGIN WHEN THE ROLLUP DID ─────────────────────────
+ * Everything here comes from `ana_linkedin_community_daily`, written
+ * hourly before the 48-hour sweep can reach the rows it is computed
+ * from. There is no backfill and there cannot be one: LinkedIn does not
+ * serve this history, and the raw rows are gone. So a short series means
+ * a young rollup, not a quiet Page — and every block that could be read
+ * either way says which it is, from `coverageDays`. Getting that wrong
+ * is not a cosmetic problem: it is the difference between "nobody is
+ * engaging with us" and "we started measuring on Tuesday".
+ *
+ * ── ★AND WHY THERE IS NO CHART LIBRARY HERE ──────────────────────────
+ * Every one of these is a ranked or proportional list, which the repo
+ * already has molecules for. A hand-rolled chart would add a rendering
+ * surface, a colour decision and an axis to get wrong, for data whose
+ * whole shape is "these categories, these counts".
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { KpiCard } from "@/components/molecules";
+// Not re-exported from the barrel — imported directly, like its other
+// call sites, rather than widening the barrel as a side effect of this
+// change.
+import { ProportionListCard } from "@/components/molecules/proportion-list-card";
+import { Clock, Heart, MessageSquare, Repeat2, AtSign, Users } from "lucide-react";
+import {
+  linkedInContentApi,
+  type LinkedInAudienceSummary,
+  type LinkedInDemographicBucket,
+} from "@/lib/api/linkedin-content";
+import { ApiError } from "@/lib/api";
+
+/** Reaction type → the word LinkedIn shows for it. An unknown type keeps
+ *  its own name rather than vanishing from a list someone is counting. */
+const REACTION_LABEL: Record<string, string> = {
+  LIKE: "Like",
+  PRAISE: "Celebrate",
+  EMPATHY: "Love",
+  INTEREST: "Insightful",
+  APPRECIATION: "Support",
+  ENTERTAINMENT: "Funny",
+  MAYBE: "Curious",
+};
+
+/** The demographic facets worth showing, in the order a person reads
+ *  them: who they are, then what they do, then where. */
+const DEMOGRAPHIC_BLOCKS: Array<{ field: string; title: string }> = [
+  { field: "followerCountsBySeniority", title: "By seniority" },
+  { field: "followerCountsByFunction", title: "By function" },
+  { field: "followerCountsByIndustry", title: "By industry" },
+  { field: "followerCountsByStaffCountRange", title: "By company size" },
+  { field: "followerCountsByGeoCountry", title: "By country" },
+];
+
+export function useAudienceSummary(days: number) {
+  return useQuery({
+    queryKey: ["linkedin-audience-summary", days],
+    queryFn: () => linkedInContentApi.audienceSummary(days),
+    // Our own Mongo, not LinkedIn — cheap to refetch, unlike everything
+    // else on this pillar.
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 2,
+  });
+}
+
+/**
+ * Block 1 — community pulse.
+ *
+ * Totals plus the reaction mix. The per-day series is deliberately not
+ * plotted: with `coverageDays` frequently in single digits, a line chart
+ * would draw a trend from three points and imply a precision the data
+ * does not have.
+ */
+export function CommunityPulse({
+  summary,
+  loading,
+}: {
+  summary?: LinkedInAudienceSummary;
+  loading: boolean;
+}) {
+  if (loading) return <BlockSkeleton rows={2} />;
+  if (!summary) return null;
+
+  const t = summary.totals;
+  const reactionItems = Object.entries(t.reactionsByType)
+    .map(([type, count]) => ({
+      id: type,
+      label: REACTION_LABEL[type] ?? type,
+      count,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  return (
+    <section className="space-y-3">
+      <BlockHeading
+        title="Community pulse"
+        coverageDays={summary.coverageDays}
+        days={summary.days}
+      />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard title="Reactions" value={t.reactions} icon={Heart} />
+        <KpiCard title="Comments" value={t.comments} icon={MessageSquare} />
+        <KpiCard title="Reposts" value={t.reposts} icon={Repeat2} />
+        <KpiCard title="Mentions" value={t.mentions} icon={AtSign} />
+      </div>
+      <ProportionListCard
+        title="Reaction mix"
+        items={reactionItems}
+        total={t.reactions}
+        emptyMessage="No reactions recorded in this window yet."
+      />
+    </section>
+  );
+}
+
+/**
+ * Block 2 — response health.
+ *
+ * ★The block nobody else builds, and the only one with an obligation in
+ * it. Everything above says how the community behaved; this says whether
+ * the business answered.
+ */
+export function ResponseHealth({
+  summary,
+  loading,
+}: {
+  summary?: LinkedInAudienceSummary;
+  loading: boolean;
+}) {
+  if (loading) return <BlockSkeleton rows={1} />;
+  if (!summary) return null;
+  const h = summary.responseHealth;
+
+  return (
+    <section className="space-y-3">
+      <BlockHeading title="Response health" />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard
+          title="Reply rate"
+          // ★"—", not "0%". Null means nothing arrived to answer, which
+          // is not a failure to answer it, and this is the number most
+          // likely to be screenshotted.
+          value={h.replyRate === null ? "—" : `${Math.round(h.replyRate * 100)}%`}
+          description={
+            h.replyRate === null
+              ? "No comments in this window"
+              : "Of top-level comments"
+          }
+        />
+        <KpiCard
+          title="Median first reply"
+          value={h.medianFirstResponseMs === null ? "—" : formatDuration(h.medianFirstResponseMs)}
+          description={h.medianFirstResponseMs === null ? "Nothing answered yet" : undefined}
+          icon={Clock}
+        />
+        <KpiCard title="Replies sent" value={h.repliesSent} icon={MessageSquare} />
+        <KpiCard
+          title="Waiting now"
+          value={h.needsReplyOpen}
+          // ★The one number this whole surface exists to make impossible
+          // to ignore, and it is read live rather than from the rollup.
+          description={
+            h.oldestUnansweredMs !== null
+              ? `Oldest ${formatDuration(h.oldestUnansweredMs)}`
+              : "Nothing waiting"
+          }
+          icon={Users}
+        />
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Block 4 — who follows.
+ *
+ * ★The largest free win in the plan: this data has been retainable for a
+ * year and completely unused. It answers the question the other three
+ * blocks cannot — "are the people following us the people we sell to?"
+ *
+ * Fetched once per tab open and never polled: unlike everything else
+ * here it DOES cost a LinkedIn request, against a ~500/day app-wide
+ * budget shared with the thread panel and the reactions list.
+ */
+export function WhoFollows() {
+  const query = useQuery({
+    queryKey: ["linkedin-follower-stats"],
+    queryFn: () => linkedInContentApi.followerStats(),
+    staleTime: 60 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 403) && count < 1,
+  });
+
+  if (query.isLoading) return <BlockSkeleton rows={2} />;
+
+  const byDemographic = query.data?.byDemographic;
+  if (query.isError || !byDemographic) {
+    return (
+      <section className="space-y-3">
+        <BlockHeading title="Who follows" />
+        <Card>
+          <CardContent className="p-6 text-center">
+            <p className="text-sm font-medium">Follower demographics unavailable</p>
+            <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+              LinkedIn provides this for Company Pages you administer. If you
+              publish only to your personal feed, there is nothing to break
+              down here.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  const blocks = DEMOGRAPHIC_BLOCKS.map(({ field, title }) => ({
+    title,
+    buckets: (byDemographic[field] ?? []).filter((b) => b.organic > 0),
+  })).filter((b) => b.buckets.length > 0);
+
+  return (
+    <section className="space-y-3">
+      <BlockHeading title="Who follows" />
+      {blocks.length === 0 ? (
+        <Card>
+          <CardContent className="p-6 text-center">
+            <p className="text-sm font-medium">No follower breakdown yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              LinkedIn reports demographics once a Page has enough followers.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {blocks.map(({ title, buckets }) => (
+            <ProportionListCard
+              key={title}
+              title={title}
+              items={buckets.map(toItem)}
+              total={buckets.reduce((a, b) => a + b.organic, 0)}
+              emptyMessage="Nothing reported."
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** A bucket as the proportion card wants it.
+ *
+ *  ★`label` is what the api resolved from LinkedIn's taxonomy, and it
+ *  falls back to the raw id when that lookup failed. Rendering the URN
+ *  would be worse than either — unreadable AND indistinguishable from a
+ *  bug. */
+function toItem(b: LinkedInDemographicBucket) {
+  return { id: b.key, label: b.label ?? b.key, count: b.organic };
+}
+
+function BlockHeading({
+  title,
+  coverageDays,
+  days,
+}: {
+  title: string;
+  coverageDays?: number;
+  days?: number;
+}) {
+  // ★Shown whenever the window is wider than the data. Without it, a
+  // 90-day view holding four days reads as a dead community rather than
+  // as a rollup that started on Tuesday — and there is no backfill that
+  // will ever close the gap, so the caveat is permanent, not transitional.
+  const partial =
+    typeof coverageDays === "number" &&
+    typeof days === "number" &&
+    coverageDays < days;
+
+  return (
+    <div className="flex items-center gap-2">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      {partial && (
+        <Badge variant="outline" className="text-[10px] font-normal">
+          {coverageDays} {coverageDays === 1 ? "day" : "days"} measured
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function BlockSkeleton({ rows }: { rows: number }) {
+  return (
+    <section className="space-y-3">
+      <Skeleton className="h-4 w-32" />
+      {Array.from({ length: rows }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-4 w-24" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </CardContent>
+        </Card>
+      ))}
+    </section>
+  );
+}
+
+/**
+ * A duration a person can read at a glance.
+ *
+ * ★Rounded DOWN to the leading unit on purpose. "2h" for 2h59m
+ * understates the wait, and this number exists to prompt action — an
+ * overstatement that turned out to be rounding would cost more trust
+ * than the precision is worth.
+ */
+export function formatDuration(ms: number): string {
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return "under a minute";
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}

--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -154,6 +154,11 @@ const WINDOWS = [7, 30, 90] as const;
 export function AudiencePanel() {
   const [days, setDays] = useState<number>(30);
   const summary = useAudienceSummary(days);
+  // Follower demographics are per Company Page and the route requires the
+  // id. Shares the cached ["linkedin-me"] query with the composer, so this
+  // costs no extra round trip.
+  const { data: identity } = useLinkedInIdentity();
+  const orgPageId = identity?.pages?.[0]?.id;
 
   return (
     <div className="space-y-6">
@@ -172,10 +177,18 @@ export function AudiencePanel() {
         ))}
       </div>
 
-      <CommunityPulse summary={summary.data} loading={summary.isLoading} />
-      <ResponseHealth summary={summary.data} loading={summary.isLoading} />
+      <CommunityPulse
+        summary={summary.data}
+        loading={summary.isLoading}
+        error={summary.error}
+      />
+      <ResponseHealth
+        summary={summary.data}
+        loading={summary.isLoading}
+        error={summary.error}
+      />
       <TopEngagersBlock />
-      <WhoFollows />
+      <WhoFollows orgPageId={orgPageId} />
     </div>
   );
 }

--- a/src/app/(site)/dashboard/content/linkedin/_components/audience-panel.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/audience-panel.tsx
@@ -27,6 +27,12 @@ import {
 } from "@/lib/api/linkedin-content";
 import { useLinkedInIdentity } from "./post-composer";
 import { RetentionFootnote } from "./retention-footnote";
+import {
+  CommunityPulse,
+  ResponseHealth,
+  WhoFollows,
+  useAudienceSummary,
+} from "./audience-blocks";
 
 const COMMENT_MAX = 1250; // LinkedIn comment cap (mirrors the api route)
 const HAS_ORG_SCOPE = "w_organization_social";
@@ -125,7 +131,56 @@ export function engageErrorMessage(err: unknown): string {
  * enrichment (which returns the public profile URL alongside the
  * name).
  */
+/** How much history the pulse and response-health blocks cover. Capped at
+ *  the rollup collection's own one-year TTL — asking for more cannot
+ *  return more. */
+const WINDOWS = [7, 30, 90] as const;
+
+/**
+ * The Audience tab — four blocks, replacing what used to be a single
+ * 48-hour engager list.
+ *
+ * ── ★THREE OF THEM COST NOTHING, AND ONE DOES ────────────────────────
+ * Pulse, response health and the engager ranking all read our own Mongo.
+ * "Who follows" is a live LinkedIn call against a ~500/day app-wide
+ * budget shared with the thread panel and the reactions list, which is
+ * why it is fetched once per tab open and never polled.
+ *
+ * The window selector applies only to the first two: the engager
+ * ranking has its own retention-bound lookback, and follower
+ * demographics are a lifetime snapshot with no window at all. Wiring one
+ * control to all three would imply a consistency the data does not have.
+ */
 export function AudiencePanel() {
+  const [days, setDays] = useState<number>(30);
+  const summary = useAudienceSummary(days);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-1">
+        {WINDOWS.map((w) => (
+          <Button
+            key={w}
+            type="button"
+            size="sm"
+            variant={days === w ? "secondary" : "ghost"}
+            className="h-7 px-2.5 text-xs"
+            onClick={() => setDays(w)}
+          >
+            {w}d
+          </Button>
+        ))}
+      </div>
+
+      <CommunityPulse summary={summary.data} loading={summary.isLoading} />
+      <ResponseHealth summary={summary.data} loading={summary.isLoading} />
+      <TopEngagersBlock />
+      <WhoFollows />
+    </div>
+  );
+}
+
+function TopEngagersBlock() {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["linkedin-engagers"],
     queryFn: () => linkedInContentApi.engagers(),

--- a/src/app/(site)/dashboard/content/linkedin/page.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/page.tsx
@@ -306,6 +306,12 @@ function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; 
           "jobs-runner",
           "performance-sync",
           "linkedin-subscription-reconcile",
+          // ★Must be pressed BEFORE retention-cleanup, always. The rollup
+          // is what turns 48-hour member activity into the year-retainable
+          // daily numbers the Audience tab reads; the cleanup is what
+          // deletes the source. Run them the other way round on dev and
+          // those days are gone for good.
+          "linkedin-community-rollup",
           "linkedin-retention-cleanup",
         ]}
         onTriggered={() => {
@@ -327,6 +333,9 @@ function LinkedInPageShell({ children, loading }: { children?: React.ReactNode; 
           // serving the empty result they cached.
           queryClient.invalidateQueries({ queryKey: ["linkedin-interactions"] });
           queryClient.invalidateQueries({ queryKey: ["linkedin-post-reposts"] });
+          // The rollup writes exactly what the Audience tab's pulse and
+          // response-health blocks read.
+          queryClient.invalidateQueries({ queryKey: ["linkedin-audience-summary"] });
         }}
       />
       <div>

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -324,10 +324,15 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       // the one outcome here that loses data permanently, and it arrives
       // inside an HTTP 200.
       if (num(d.truncatedBuckets) > 0) {
+        const n = num(d.truncatedBuckets);
         return {
           level: "warning",
+          // ★A bucket is one (Page, day), NOT one day. Three Pages
+          // truncated on a single day is three buckets — calling them
+          // "3 days" overstates the loss and, worse, sends someone
+          // looking for two days that were never affected.
           message:
-            `Rollup hit its cap — ${num(d.truncatedBuckets)} day${plural(num(d.truncatedBuckets), "")} were NOT written and cannot be recovered later.`,
+            `Rollup hit its cap — ${n} Page-${plural(n, "day")} ${n === 1 ? "was" : "were"} NOT written and cannot be recovered later.`,
         };
       }
       // Rows carrying no Page are grouped out of every Page's totals. A

--- a/src/components/dev/cron-metadata.ts
+++ b/src/components/dev/cron-metadata.ts
@@ -311,6 +311,39 @@ export const CRON_METADATA: Record<string, CronMetadata> = {
       return `LinkedIn data cleaned — ${total} ${plural(total, "row")} removed.`;
     },
   },
+  "linkedin-community-rollup": {
+    label: "Roll up LinkedIn community",
+    frequency: "Runs hourly (at :20 past)",
+    description:
+      "Folds comments, reactions, reposts and mentions into the daily numbers the Audience tab reads. ★Hourly because it is racing the 48-hour retention sweep: once the raw rows are redacted those days cannot be reconstructed, from us or from LinkedIn.",
+    summarize: (data) => {
+      const d = asRecord(data);
+      if (!d) return "Community rollup complete.";
+      // ★A capped run is a WARNING, not a success. The buckets it refused
+      // to write are redacted before a later run can reach them — this is
+      // the one outcome here that loses data permanently, and it arrives
+      // inside an HTTP 200.
+      if (num(d.truncatedBuckets) > 0) {
+        return {
+          level: "warning",
+          message:
+            `Rollup hit its cap — ${num(d.truncatedBuckets)} day${plural(num(d.truncatedBuckets), "")} were NOT written and cannot be recovered later.`,
+        };
+      }
+      // Rows carrying no Page are grouped out of every Page's totals. A
+      // number that stays high means the ingest stopped recording it,
+      // which is invisible on every other surface.
+      if (num(d.skippedNoPage) > 0 && num(d.daysRolled) === 0) {
+        return {
+          level: "warning",
+          message: `Nothing rolled up — ${num(d.skippedNoPage)} interactions have no Page recorded.`,
+        };
+      }
+      const days = num(d.daysRolled);
+      if (days === 0) return { level: "warning", message: "Nothing to roll up yet — no LinkedIn community activity received." };
+      return `Rolled up ${days} ${plural(days, "day")} across ${num(d.pages)} ${plural(num(d.pages), "Page")}.`;
+    },
+  },
   "linkedin-subscription-reconcile": {
     label: "Reconnect LinkedIn comment alerts",
     frequency: "Runs daily at 4:30 AM UTC",

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -490,6 +490,22 @@ export const linkedInContentApi = {
       body,
     ),
 
+  /**
+   * The Audience tab's four blocks.
+   *
+   * ★Reads our own rollup, never LinkedIn — so unlike the thread panel
+   * this is cheap to poll and cheap to leave open.
+   */
+  audienceSummary: (days?: number) =>
+    api.get<LinkedInAudienceSummary>(
+      `/v1/linkedin/content/audience/summary${days ? `?days=${days}` : ""}`,
+    ),
+
+  /** Follower demographics (lifetime mode — omit the interval). ★This one
+   *  DOES hit LinkedIn, so it is fetched once per tab open, never polled. */
+  followerStats: () =>
+    api.get<LinkedInFollowerStats>("/v1/linkedin/content/analytics/followers"),
+
   /** Per-reaction-type counts + comment summary for a post. The AUTHORITATIVE
    *  reaction breakdown — `reactions` above only returns the current page. */
   socialMetadata: (postUrn: string) =>
@@ -707,6 +723,62 @@ export interface LinkedInSocialMetadata {
 
 
 /** One row in the Community Feed. */
+
+/** One day of the Audience pulse. Days with no rollup row are ABSENT
+ *  rather than zero — a day that was not measured is not a quiet day. */
+export interface LinkedInPulsePoint {
+  date: string;
+  reactions: number;
+  comments: number;
+  reposts: number;
+  mentions: number;
+}
+
+/**
+ * The Audience tab's four blocks, from `ana_linkedin_community_daily`.
+ *
+ * ★Costs no LinkedIn requests — the hourly rollup wrote all of it before
+ * the 48h sweep could reach the rows it came from. The consequence worth
+ * rendering: the series begins the day the rollup first ran and cannot be
+ * backfilled, which is what `coverageDays` is for.
+ */
+export interface LinkedInAudienceSummary {
+  days: number;
+  /** Distinct days in the window that actually have data. A 90-day chart
+   *  holding 3 days is a young rollup, not a quiet Page. */
+  coverageDays: number;
+  pulse: LinkedInPulsePoint[];
+  totals: {
+    reactions: number;
+    comments: number;
+    reposts: number;
+    mentions: number;
+    reactionsByType: Record<string, number>;
+  };
+  responseHealth: {
+    /** Null — not 0 — when nothing arrived to answer. */
+    replyRate: number | null;
+    medianFirstResponseMs: number | null;
+    repliesSent: number;
+    needsReplyOpen: number;
+    oldestUnansweredMs: number | null;
+  };
+  engagers: { unique: number; new: number; returning: number };
+}
+
+/** One demographic bucket, with the label the api resolved for its URN.
+ *  `label` falls back to the id when LinkedIn's taxonomy is unreachable. */
+export interface LinkedInDemographicBucket {
+  key: string;
+  organic: number;
+  label?: string;
+}
+
+export interface LinkedInFollowerStats {
+  byDemographic: Record<string, LinkedInDemographicBucket[]> | null;
+  series: Array<{ start: number; end?: number; organicGain: number; paidGain: number }> | null;
+}
+
 export interface LinkedInInteraction {
   id: string;
   kind: "comment" | "reaction" | "repost" | "mention";

--- a/src/lib/api/linkedin-content.ts
+++ b/src/lib/api/linkedin-content.ts
@@ -501,10 +501,23 @@ export const linkedInContentApi = {
       `/v1/linkedin/content/audience/summary${days ? `?days=${days}` : ""}`,
     ),
 
-  /** Follower demographics (lifetime mode — omit the interval). ★This one
-   *  DOES hit LinkedIn, so it is fetched once per tab open, never polled. */
-  followerStats: () =>
-    api.get<LinkedInFollowerStats>("/v1/linkedin/content/analytics/followers"),
+  /**
+   * Follower demographics for one Company Page, lifetime mode (no interval).
+   *
+   * ★`orgPageId` IS REQUIRED. The route validates it before doing anything
+   * else and 400s without it — so omitting it does not degrade the block,
+   * it kills it: the fallback shown would read "you publish only to your
+   * personal feed", which is a confident wrong answer rather than an
+   * error. Demographics are per Page by construction; there is no
+   * business-wide breakdown to fall back to.
+   *
+   * ★This one DOES hit LinkedIn, so it is fetched once per tab open and
+   * never polled.
+   */
+  followerStats: (orgPageId: string) =>
+    api.get<LinkedInFollowerStats>(
+      `/v1/linkedin/content/analytics/followers?orgPageId=${encodeURIComponent(orgPageId)}`,
+    ),
 
   /** Per-reaction-type counts + comment summary for a post. The AUTHORITATIVE
    *  reaction breakdown — `reactions` above only returns the current page. */
@@ -722,8 +735,6 @@ export interface LinkedInSocialMetadata {
 }
 
 
-/** One row in the Community Feed. */
-
 /** One day of the Audience pulse. Days with no rollup row are ABSENT
  *  rather than zero — a day that was not measured is not a quiet day. */
 export interface LinkedInPulsePoint {
@@ -779,6 +790,7 @@ export interface LinkedInFollowerStats {
   series: Array<{ start: number; end?: number; organicGain: number; paidGain: number }> | null;
 }
 
+/** One row in the Community Feed. */
 export interface LinkedInInteraction {
   id: string;
   kind: "comment" | "reaction" | "repost" | "mention";


### PR DESCRIPTION
Plan §9. Four blocks replacing what was a single 48-hour engager list — and the tab's whole problem was that it could only ever show two days, because two days is all the raw substrate is allowed to hold.

| # | Block | What it answers |
|---|---|---|
| 1 | **Community pulse** | Reactions, comments, reposts, mentions over 7/30/90 days, plus the reaction mix |
| 2 | **Response health** | Reply rate, median first reply, replies sent, and what is waiting **right now** with the age of the oldest |
| 3 | **Who engages** | The existing AQS ranking, unchanged |
| 4 | **Who follows** | Seniority, function, industry, company size, country |

Block 2 is the only one with an obligation in it: everything else says how the community behaved, this says whether the business answered. Block 4 is the largest free win in the plan — retainable for a year, and completely unused until now.

## ★ Every block says when it started measuring

These numbers begin the day the hourly rollup first ran, and **cannot be backfilled** — LinkedIn does not serve this history and the raw rows are gone at 48h.

So a 90-day view holding four days is a **young rollup**, not a dead community, and the two are indistinguishable unless something says so. `coverageDays` drives a *"4 days measured"* badge whenever the window is wider than the data. The caveat is permanent, not transitional.

## Three smaller decisions that are decisions

- **"—", never "0%"**, for a reply rate with nothing to answer. A business with no comments has no reply rate, and this is the number most likely to be screenshotted.
- **Durations round down.** "3h" for 3h59m understates a wait, and this number exists to prompt action — an overstatement that turned out to be rounding costs more trust than the precision is worth.
- **The window selector drives blocks 1 and 2 only.** The engager ranking has its own retention-bound lookback, and follower demographics are a lifetime snapshot with no window at all. Wiring one control to all three would imply a consistency the data does not have.

## No chart library

Every one of these is a ranked or proportional list, and the repo already has `KpiCard` and `ProportionListCard`. A hand-rolled chart would add a rendering surface, a colour decision and an axis to get wrong, for data whose whole shape is *"these categories, these counts"*.

The per-day series is also deliberately **not** plotted: with `coverageDays` frequently in single digits, a line would draw a trend from three points.

## Cost

Three of the four blocks read our own Mongo and cost nothing. **Who follows** is a live LinkedIn call against the ~500/day app-wide budget, so it is fetched once per tab open and never polled.

## The cross-repo cron rule, both halves

- A `CRON_METADATA` entry for `linkedin-community-rollup` whose summarizer treats a **capped run as a WARNING** — the buckets it refused to write get redacted before a later run can reach them, and that arrives inside an HTTP 200.
- The button mounted on the LinkedIn page, ordered deliberately **before** `linkedin-retention-cleanup`: the rollup makes the durable copy, the cleanup deletes the source, and pressing them the other way round on dev loses those days for good.

## Verification

Type-check clean, lint clean in every changed file, full b2c suite green — **27 files, 397 tests.**

## Needs

`peakhour-api#1089` (merged) for `GET /audience/summary` and the labelled follower demographics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
