### PR TITLE
feat(inbox): saved replies in the reply box — insert, never send

### DIFF
--- a/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
@@ -126,8 +126,17 @@ export function ReplyBox({
             than replacing keeps a half-typed sentence. */}
         <SavedReplyPicker
           channel="linkedin"
+          draft={text}
           disabled={send.isPending}
-          onInsert={(body) => setText((cur) => appendReply(cur, body, COMMENT_MAX_LEN))}
+          onInsert={(body) => {
+            // ★Computed against the CURRENT text rather than inside a
+            // functional update, because the picker needs the answer
+            // synchronously to decide whether to count the insert — and
+            // a setState updater's return value is not available to it.
+            const next = appendReply(text, body, COMMENT_MAX_LEN);
+            if (next.fitted) setText(next.text);
+            return next.fitted;
+          }}
         />
         <Button
           type="button"

--- a/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
+++ b/src/app/(site)/dashboard/content/linkedin/_components/engage-shared.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { linkedInContentApi, type LinkedInAuthor } from "@/lib/api/linkedin-content";
 import { ApiError } from "@/lib/api";
+import { SavedReplyPicker, appendReply } from "@/components/inbox/saved-reply-picker";
 
 /** LinkedIn's own cap on comment text. */
 export const COMMENT_MAX_LEN = 1250;
@@ -119,6 +120,15 @@ export function ReplyBox({
         className="text-sm"
       />
       <div className="flex items-center gap-2">
+        {/* ★Inserts, never sends. The reply lands in the textarea above
+            and the person still presses Reply — see the picker's own
+            note on why that separation is load-bearing. Appending rather
+            than replacing keeps a half-typed sentence. */}
+        <SavedReplyPicker
+          channel="linkedin"
+          disabled={send.isPending}
+          onInsert={(body) => setText((cur) => appendReply(cur, body, COMMENT_MAX_LEN))}
+        />
         <Button
           type="button"
           size="sm"

--- a/src/components/inbox/saved-reply-picker.test.ts
+++ b/src/components/inbox/saved-reply-picker.test.ts
@@ -1,11 +1,16 @@
 /**
- * Inserting a saved reply, and the wrong version of it that looks right.
+ * Inserting a saved reply, and the two wrong versions of it that look
+ * right.
  *
  * "Insert" has an obvious implementation — set the textarea to the saved
  * reply — and it silently destroys work: someone half-way through typing
  * a personal sentence, who reaches for a saved reply to finish it, loses
- * the sentence. A convenience feature must never do that, so the append
- * behaviour is pinned rather than assumed.
+ * the sentence.
+ *
+ * The second-obvious implementation appends and then truncates to the
+ * channel cap, which is worse in a quieter way: a near-full draft gains
+ * half a word and the person posts it to a customer without noticing the
+ * button did that.
  */
 
 import { describe, it, expect } from "vitest";
@@ -15,22 +20,23 @@ const MAX = 1250;
 
 describe("★inserting must not destroy a draft", () => {
   it("keeps what the person already typed", () => {
-    expect(appendReply("Thanks for asking, Priya!", "Our plans start at ₹999.", MAX)).toBe(
-      "Thanks for asking, Priya!\n\nOur plans start at ₹999.",
-    );
+    const out = appendReply("Thanks for asking, Priya!", "Our plans start at ₹999.", MAX);
+    expect(out).toEqual({
+      text: "Thanks for asking, Priya!\n\nOur plans start at ₹999.",
+      fitted: true,
+    });
   });
 
   it("separates the two with a blank line, so the seam is editable", () => {
     // Jammed together, the saved reply reads as part of the person's own
     // sentence and they have to find the join before they can fix it.
-    const out = appendReply("Hi Sam", "Here are the details.", MAX);
-    expect(out).toContain("\n\n");
+    expect(appendReply("Hi Sam", "Here are the details.", MAX).text).toContain("\n\n");
   });
 
   it("does not add a leading blank line to an empty box", () => {
     // The common case: nothing typed yet. A reply starting with two
     // newlines looks like a mistake in the composer.
-    expect(appendReply("", "Our plans start at ₹999.", MAX)).toBe(
+    expect(appendReply("", "Our plans start at ₹999.", MAX).text).toBe(
       "Our plans start at ₹999.",
     );
   });
@@ -38,25 +44,48 @@ describe("★inserting must not destroy a draft", () => {
   it("treats a whitespace-only draft as empty", () => {
     // A stray space or newline from clicking around is not work worth
     // preserving, and preserving it produces the leading-blank-line bug.
-    expect(appendReply("   \n ", "Our plans start at ₹999.", MAX)).toBe(
+    expect(appendReply("   \n ", "Our plans start at ₹999.", MAX).text).toBe(
       "Our plans start at ₹999.",
     );
   });
 });
 
-describe("the channel cap", () => {
-  it("never returns more than the composer will accept", () => {
-    // The composer refuses over-length text on send. Handing it a value
-    // it will reject moves the failure to the moment the person presses
-    // the button, which is the worst possible time to discover it.
-    const long = "x".repeat(2000);
-    expect(appendReply("", long, MAX)).toHaveLength(MAX);
-    expect(appendReply("hello", long, MAX)).toHaveLength(MAX);
+describe("★when it does not fit, nothing happens", () => {
+  it("refuses rather than appending half a sentence", () => {
+    // The first cut sliced the joined string: a draft at 1,240 characters
+    // gained "\n\nOur pl" and the person posted it. Silent, and the half
+    // that gets cut is the end — where the call to action lives.
+    const draft = "x".repeat(1240);
+    const out = appendReply(draft, "Our plans start at ₹999 per month.", MAX);
+    expect(out.fitted).toBe(false);
+    expect(out.text).toBe(draft);
+  });
+
+  it("refuses rather than appending a bare newline", () => {
+    // At 1,249 the old version added exactly "\n" and nothing else.
+    const draft = "x".repeat(1249);
+    expect(appendReply(draft, "Anything at all", MAX)).toEqual({
+      text: draft,
+      fitted: false,
+    });
+  });
+
+  it("refuses a reply longer than the cap even into an empty box", () => {
+    expect(appendReply("", "y".repeat(2000), MAX).fitted).toBe(false);
+  });
+
+  it("fits exactly at the cap", () => {
+    // The boundary is inclusive — a reply that is precisely the limit is
+    // a reply the composer will accept.
+    const out = appendReply("", "z".repeat(MAX), MAX);
+    expect(out.fitted).toBe(true);
+    expect(out.text).toHaveLength(MAX);
   });
 
   it("respects a tighter cap than LinkedIn's", () => {
-    // X is 280. The picker is channel-neutral and the cap comes from the
-    // composer, which is the only thing that knows where the text is going.
-    expect(appendReply("", "y".repeat(500), 280)).toHaveLength(280);
+    // X is 280. The cap comes from the composer, which is the only thing
+    // that knows where the text is going.
+    expect(appendReply("", "y".repeat(500), 280).fitted).toBe(false);
+    expect(appendReply("", "y".repeat(200), 280).fitted).toBe(true);
   });
 });

--- a/src/components/inbox/saved-reply-picker.test.ts
+++ b/src/components/inbox/saved-reply-picker.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Inserting a saved reply, and the wrong version of it that looks right.
+ *
+ * "Insert" has an obvious implementation — set the textarea to the saved
+ * reply — and it silently destroys work: someone half-way through typing
+ * a personal sentence, who reaches for a saved reply to finish it, loses
+ * the sentence. A convenience feature must never do that, so the append
+ * behaviour is pinned rather than assumed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { appendReply } from "./saved-reply-picker";
+
+const MAX = 1250;
+
+describe("★inserting must not destroy a draft", () => {
+  it("keeps what the person already typed", () => {
+    expect(appendReply("Thanks for asking, Priya!", "Our plans start at ₹999.", MAX)).toBe(
+      "Thanks for asking, Priya!\n\nOur plans start at ₹999.",
+    );
+  });
+
+  it("separates the two with a blank line, so the seam is editable", () => {
+    // Jammed together, the saved reply reads as part of the person's own
+    // sentence and they have to find the join before they can fix it.
+    const out = appendReply("Hi Sam", "Here are the details.", MAX);
+    expect(out).toContain("\n\n");
+  });
+
+  it("does not add a leading blank line to an empty box", () => {
+    // The common case: nothing typed yet. A reply starting with two
+    // newlines looks like a mistake in the composer.
+    expect(appendReply("", "Our plans start at ₹999.", MAX)).toBe(
+      "Our plans start at ₹999.",
+    );
+  });
+
+  it("treats a whitespace-only draft as empty", () => {
+    // A stray space or newline from clicking around is not work worth
+    // preserving, and preserving it produces the leading-blank-line bug.
+    expect(appendReply("   \n ", "Our plans start at ₹999.", MAX)).toBe(
+      "Our plans start at ₹999.",
+    );
+  });
+});
+
+describe("the channel cap", () => {
+  it("never returns more than the composer will accept", () => {
+    // The composer refuses over-length text on send. Handing it a value
+    // it will reject moves the failure to the moment the person presses
+    // the button, which is the worst possible time to discover it.
+    const long = "x".repeat(2000);
+    expect(appendReply("", long, MAX)).toHaveLength(MAX);
+    expect(appendReply("hello", long, MAX)).toHaveLength(MAX);
+  });
+
+  it("respects a tighter cap than LinkedIn's", () => {
+    // X is 280. The picker is channel-neutral and the cap comes from the
+    // composer, which is the only thing that knows where the text is going.
+    expect(appendReply("", "y".repeat(500), 280)).toHaveLength(280);
+  });
+});

--- a/src/components/inbox/saved-reply-picker.tsx
+++ b/src/components/inbox/saved-reply-picker.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+/**
+ * The saved-reply picker — insert an answer you already wrote.
+ *
+ * ── ★IT INSERTS. IT NEVER SENDS. ─────────────────────────────────────
+ * Picking a reply puts text in the composer and closes. The person then
+ * reads it, edits it, and presses the send button that was always there.
+ * Nothing in this component can post anything, and the callback it takes
+ * is named `onInsert` rather than `onPick` so that stays obvious at every
+ * call site. An auto-reply bot is explicitly out of scope for this
+ * product; making the picker one click from sending would be how that
+ * line gets crossed by accident.
+ *
+ * ── ★AND IT APPENDS TO A DRAFT RATHER THAN REPLACING IT ──────────────
+ * If someone has already typed, their words are kept and the saved reply
+ * follows. Replacing would be tidier to implement and would silently
+ * destroy work — the one outcome a convenience feature must never have.
+ *
+ * ── CHANNEL-NEUTRAL BY CONSTRUCTION ──────────────────────────────────
+ * Lives in `components/inbox`, not under the LinkedIn dashboard: the
+ * library is shared by every surface that answers a customer, and the
+ * `channel` prop is what narrows it. Building it inside the LinkedIn
+ * folder would have guaranteed a second copy for WhatsApp.
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { MessageSquareQuote, Loader2, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  savedRepliesApi,
+  type SavedReply,
+  type SavedReplyChannel,
+} from "@/lib/api/saved-replies";
+
+export function SavedReplyPicker({
+  channel,
+  onInsert,
+  disabled,
+}: {
+  /** Narrows the list to replies scoped to this surface, plus every
+   *  reply with no scope at all — which is most of them. */
+  channel: SavedReplyChannel;
+  /** Receives the reply's text. The caller decides where it goes; this
+   *  component never sends anything. */
+  onInsert: (body: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState("");
+
+  const query = useQuery({
+    queryKey: ["saved-replies", channel],
+    queryFn: () => savedRepliesApi.list({ channel }),
+    // Only when the popover is open. The picker sits beside every reply
+    // box on a page that can render dozens of them — fetching per box on
+    // mount would be one request per comment on screen.
+    enabled: open,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const markUsed = useMutation({
+    mutationFn: (id: string) => savedRepliesApi.markUsed(id),
+    // ★Deliberately silent on failure. The text is already in the box;
+    // the person is mid-reply to a customer. A toast saying the usage
+    // counter did not increment is noise about a number that orders a
+    // list, interrupting the task it exists to speed up.
+    onError: () => {},
+  });
+
+  const replies = query.data?.replies ?? [];
+  const needle = filter.trim().toLowerCase();
+  const shown = needle
+    ? replies.filter(
+        (r) =>
+          r.title.toLowerCase().includes(needle) ||
+          r.body.toLowerCase().includes(needle) ||
+          r.tags?.some((t) => t.toLowerCase().includes(needle)),
+      )
+    : replies;
+
+  function insert(reply: SavedReply) {
+    onInsert(reply.body);
+    markUsed.mutate(reply.id);
+    setOpen(false);
+    setFilter("");
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-xs"
+          disabled={disabled}
+        >
+          <MessageSquareQuote className="size-3.5" />
+          Saved replies
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-0">
+        <div className="border-b p-2">
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Search saved replies…"
+              className="h-7 pl-7 text-xs"
+              autoFocus
+            />
+          </div>
+        </div>
+
+        <div className="max-h-72 overflow-y-auto">
+          {query.isLoading ? (
+            <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+              Loading…
+            </div>
+          ) : query.isError ? (
+            <p className="p-4 text-xs text-muted-foreground">
+              Couldn&apos;t load your saved replies. You can still write one by hand.
+            </p>
+          ) : replies.length === 0 ? (
+            <div className="p-4">
+              <p className="text-xs font-medium">No saved replies yet</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                When you answer the same question twice, save the answer here
+                and it&apos;ll be one click next time.
+              </p>
+            </div>
+          ) : shown.length === 0 ? (
+            <p className="p-4 text-xs text-muted-foreground">
+              Nothing matches &ldquo;{filter}&rdquo;.
+            </p>
+          ) : (
+            <ul>
+              {shown.map((r) => (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    onClick={() => insert(r)}
+                    className="w-full border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none"
+                  >
+                    <span className="block text-xs font-medium">{r.title}</span>
+                    {/* Two lines of the body, so someone can tell two
+                        similarly-titled replies apart before inserting
+                        one into a message to a customer. */}
+                    <span className="mt-0.5 block line-clamp-2 text-[11px] text-muted-foreground">
+                      {r.body}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {query.data?.truncated && (
+          <p className="border-t p-2 text-[10px] text-muted-foreground">
+            Showing the first 200. Archive the ones you no longer use.
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * Append a saved reply to whatever is already in the box.
+ *
+ * ★Exported and tested because "insert" has a wrong version that looks
+ * right: replacing the draft. Someone half-way through typing a personal
+ * sentence, who reaches for a saved reply to finish it, must not lose the
+ * sentence. Blank draft in, reply out; non-blank draft in, both, with one
+ * blank line between so the seam is visible and editable.
+ */
+export function appendReply(draft: string, reply: string, maxLen: number): string {
+  const base = draft.trimEnd();
+  const joined = base.length === 0 ? reply : `${base}\n\n${reply}`;
+  // The caller's channel cap wins. Truncating here is the lesser evil
+  // versus handing a composer a value it will refuse on send — but it is
+  // still a loss, which is why the picker shows the body before insert.
+  return joined.slice(0, maxLen);
+}

--- a/src/components/inbox/saved-reply-picker.tsx
+++ b/src/components/inbox/saved-reply-picker.tsx
@@ -25,8 +25,10 @@
  */
 
 import { useState } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { MessageSquareQuote, Loader2, Search } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { MessageSquareQuote, Loader2, Search, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -43,18 +45,32 @@ import {
 export function SavedReplyPicker({
   channel,
   onInsert,
+  draft,
   disabled,
 }: {
   /** Narrows the list to replies scoped to this surface, plus every
    *  reply with no scope at all — which is most of them. */
   channel: SavedReplyChannel;
-  /** Receives the reply's text. The caller decides where it goes; this
-   *  component never sends anything. */
-  onInsert: (body: string) => void;
+  /**
+   * Receives the reply's text. The caller decides where it goes; this
+   * component never sends anything.
+   *
+   * Returns whether the text actually landed — a composer at its
+   * character cap refuses rather than truncating, and a reply that did
+   * not go in must not be counted as used.
+   */
+  onInsert: (body: string) => boolean;
+  /** The composer's current text, so "save this answer" can offer it.
+   *  Without a create path the library stays permanently empty and the
+   *  picker's own empty state asks for something the product cannot do. */
+  draft?: string;
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const qc = useQueryClient();
 
   const query = useQuery({
     queryKey: ["saved-replies", channel],
@@ -88,14 +104,67 @@ export function SavedReplyPicker({
     : replies;
 
   function insert(reply: SavedReply) {
-    onInsert(reply.body);
+    // ★Counted only when it actually went in. `usageCount` is documented
+    // as "times inserted" and orders the list — counting a refused
+    // insert inflates the number and promotes a reply nobody could use.
+    if (!onInsert(reply.body)) {
+      toast.warning("That reply is too long to add to what you've already written.", {
+        description: "Shorten your draft, or clear it and insert the reply first.",
+      });
+      return;
+    }
     markUsed.mutate(reply.id);
     setOpen(false);
-    setFilter("");
   }
 
+  /**
+   * Save what is in the composer as a new reply.
+   *
+   * ★THE CREATE PATH LIVES HERE BECAUSE THIS IS WHERE THE ANSWER EXISTS.
+   * The picker shipped without one, so the library was permanently empty
+   * and its own empty state ("save the answer here") pointed at an
+   * affordance the product did not have. A settings page would work and
+   * would be the wrong first home: you learn a reply is worth saving at
+   * the moment you finish typing it for the second time, not later, in
+   * another tab.
+   */
+  const create = useMutation({
+    mutationFn: (title: string) =>
+      savedRepliesApi.create({ title, body: (draft ?? "").trim() }),
+    onSuccess: () => {
+      toast.success("Saved. It'll be here next time.");
+      setSaving(false);
+      setNewTitle("");
+      void qc.invalidateQueries({ queryKey: ["saved-replies"] });
+    },
+    onError: (err) => {
+      // The api answers 409 with a sentence about the existing title,
+      // which is the useful thing to show — a generic failure would send
+      // someone looking for a bug instead of at their own list.
+      toast.error(
+        err instanceof ApiError && err.code === "DUPLICATE_TITLE"
+          ? err.message
+          : "Couldn't save that reply. Please try again.",
+      );
+    },
+  });
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        // ★Reset on CLOSE, not only on insert. Escape or an outside click
+        // used to leave the search term behind, so the next open showed a
+        // filtered list — or "Nothing matches" — for a search the person
+        // had already abandoned and could not see.
+        if (!next) {
+          setFilter("");
+          setSaving(false);
+          setNewTitle("");
+        }
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -142,7 +211,15 @@ export function SavedReplyPicker({
             </div>
           ) : shown.length === 0 ? (
             <p className="p-4 text-xs text-muted-foreground">
-              Nothing matches &ldquo;{filter}&rdquo;.
+              Nothing matches &ldquo;{filter}&rdquo;
+              {/* ★Says WHY it might be lying. The filter runs over the
+                  rows already loaded, and the server caps that list — so
+                  on a large library a reply that exists can be absent
+                  from a search. Claiming a flat "nothing matches" there
+                  is the search telling the person their answer is gone. */}
+              {query.data?.truncated
+                ? " in the replies loaded so far. Archive ones you no longer use so the rest can load."
+                : "."}
             </p>
           ) : (
             <ul>
@@ -167,10 +244,67 @@ export function SavedReplyPicker({
           )}
         </div>
 
+        {/* ★No number. The cap is the api's (`LIST_LIMIT`) and nothing
+            ties the two files together, so a figure printed here is one
+            deploy away from being a confident lie. The flag is the fact;
+            the count is the server's business. */}
         {query.data?.truncated && (
           <p className="border-t p-2 text-[10px] text-muted-foreground">
-            Showing the first 200. Archive the ones you no longer use.
+            Not all of your saved replies are shown. Archive the ones you no
+            longer use.
           </p>
+        )}
+
+        {/* ── Save what is in the box ──────────────────────────────── */}
+        {(draft ?? "").trim().length > 0 && (
+          <div className="border-t p-2">
+            {saving ? (
+              <div className="space-y-1.5">
+                <Input
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value.slice(0, 80))}
+                  placeholder="Name it — e.g. Pricing"
+                  className="h-7 text-xs"
+                  autoFocus
+                />
+                <div className="flex items-center gap-1.5">
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="h-6 px-2 text-[11px]"
+                    disabled={!newTitle.trim() || create.isPending}
+                    aria-busy={create.isPending}
+                    onClick={() => create.mutate(newTitle.trim())}
+                  >
+                    {create.isPending && (
+                      <Loader2 className="mr-1 size-3 animate-spin motion-reduce:animate-none" />
+                    )}
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-[11px]"
+                    onClick={() => setSaving(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 w-full justify-start gap-1.5 px-1 text-[11px]"
+                onClick={() => setSaving(true)}
+              >
+                <Plus className="size-3" />
+                Save what you&apos;ve written as a reply
+              </Button>
+            )}
+          </div>
         )}
       </PopoverContent>
     </Popover>
@@ -186,11 +320,26 @@ export function SavedReplyPicker({
  * sentence. Blank draft in, reply out; non-blank draft in, both, with one
  * blank line between so the seam is visible and editable.
  */
-export function appendReply(draft: string, reply: string, maxLen: number): string {
+export function appendReply(
+  draft: string,
+  reply: string,
+  maxLen: number,
+): { text: string; fitted: boolean } {
   const base = draft.trimEnd();
   const joined = base.length === 0 ? reply : `${base}\n\n${reply}`;
-  // The caller's channel cap wins. Truncating here is the lesser evil
-  // versus handing a composer a value it will refuse on send — but it is
-  // still a loss, which is why the picker shows the body before insert.
-  return joined.slice(0, maxLen);
+
+  // ★IT REFUSES RATHER THAN TRUNCATING, and the first version did the
+  // opposite. `joined.slice(0, maxLen)` on a near-full draft appends a
+  // mid-word fragment — a draft at 1,240 characters gained "\n\nOur pl"
+  // — or, at 1,249, nothing but a stray newline. Both are silent, and
+  // both end up in a message to a customer if the person does not
+  // re-read what the button just did to their text.
+  //
+  // Cutting at a word boundary would be tidier and no more honest: half
+  // a saved reply is not the saved reply, and the half that gets cut is
+  // the end, where the call to action lives. So the draft is left
+  // untouched and the caller is told it did not fit — which is
+  // information the person can act on.
+  if (joined.length > maxLen) return { text: draft, fitted: false };
+  return { text: joined, fitted: true };
 }

--- a/src/lib/api/saved-replies.ts
+++ b/src/lib/api/saved-replies.ts
@@ -1,0 +1,84 @@
+import { api } from "@/lib/api";
+
+/**
+ * The saved-reply library — a business's canned answers, shared by every
+ * channel that lands in the Inbox.
+ *
+ * ★THERE IS NO SEND METHOD HERE, and that is deliberate rather than
+ * incidental. A saved reply is INSERTED into a composer for a human to
+ * edit and send; the sending is whatever that composer already does.
+ * Keeping the two apart in the client mirrors the api, where the library
+ * and the send path are separate files for the same reason.
+ */
+
+/** Mirrors `sup_inbox.source` — the channel an Inbox item arrived on, and
+ *  therefore the channel a reply can be scoped to. */
+export type SavedReplyChannel =
+  | "integration_fit"
+  | "in_app"
+  | "website"
+  | "email"
+  | "x"
+  | "facebook"
+  | "instagram"
+  | "whatsapp"
+  | "linkedin"
+  | "google_review"
+  | "other";
+
+export interface SavedReply {
+  id: string;
+  title: string;
+  body: string;
+  /** Absent means it fits every channel — the common case. */
+  channels?: SavedReplyChannel[];
+  tags?: string[];
+  status: "active" | "archived";
+  /** ★Times INSERTED, not times sent. We know a human put it in a box;
+   *  we cannot know whether they then rewrote it. The list is ordered by
+   *  this; nothing should report it as messages delivered. */
+  usageCount: number;
+  lastUsedAt?: string;
+}
+
+export interface SavedReplyList {
+  replies: SavedReply[];
+  /** The server caps the list rather than paginating — a business at the
+   *  cap has a curation problem the UI should name. */
+  truncated: boolean;
+}
+
+export const savedRepliesApi = {
+  list: (params?: { channel?: SavedReplyChannel; includeArchived?: boolean }) => {
+    const qs = new URLSearchParams();
+    if (params?.channel) qs.set("channel", params.channel);
+    if (params?.includeArchived) qs.set("includeArchived", "1");
+    const q = qs.toString();
+    return api.get<SavedReplyList>(`/v1/saved-replies${q ? `?${q}` : ""}`);
+  },
+
+  create: (body: {
+    title: string;
+    body: string;
+    channels?: SavedReplyChannel[];
+    tags?: string[];
+  }) => api.post<SavedReply>("/v1/saved-replies", body),
+
+  /** `null` on `channels`/`tags` CLEARS them — the only way to widen a
+   *  reply back to every channel after narrowing it. */
+  update: (
+    id: string,
+    body: {
+      title?: string;
+      body?: string;
+      channels?: SavedReplyChannel[] | null;
+      tags?: string[] | null;
+      status?: "active" | "archived";
+    },
+  ) => api.patch<SavedReply>(`/v1/saved-replies/${encodeURIComponent(id)}`, body),
+
+  /** Count an INSERT. Best-effort: the reply is already in the box, so a
+   *  failed counter must never surface to the person writing. */
+  markUsed: (id: string) =>
+    api.post<{ counted: boolean }>(`/v1/saved-replies/${encodeURIComponent(id)}/used`, {}),
+};


### PR DESCRIPTION
Plan §6.2, last of three. A picker beside every LinkedIn reply box, and the channel-neutral client behind it.

## ★ It inserts. It never sends.

Picking a reply puts text in the composer and closes. The person reads it, edits it, and presses the **Reply** button that was always there.

Nothing in the component can post anything, and the callback is named `onInsert` rather than `onPick` so that stays obvious at every call site. Auto-replying as a brand is out of scope for this product, and one-click-to-send is exactly how that line gets crossed by accident.

## ★ And it appends rather than replacing

"Insert" has an obvious wrong implementation that looks right — set the textarea to the saved reply — and it **silently destroys work**: someone half-way through typing a personal sentence, who reaches for a saved reply to finish it, loses the sentence. That is the one outcome a convenience feature must never have.

| draft | result |
|---|---|
| empty | the reply, with no leading blank line |
| whitespace only | same — a stray newline is not work worth preserving |
| `"Thanks for asking, Priya!"` | both, separated by a blank line so the seam is visible and editable |

All four pinned by tests, including the whitespace case that produces the leading-blank-line bug.

## ★ Lives in `components/inbox`, not under the LinkedIn dashboard

The library is shared by every surface that answers a customer, and `channel` is what narrows it. Building this inside the LinkedIn folder would have guaranteed a second copy the first time WhatsApp needed one — the same mistake the collection avoided by not being called `linkedin_saved_replies`.

## Three smaller decisions

- **The list is fetched only while the popover is open.** The picker sits beside every reply box on a page that renders dozens of them; fetching on mount would be one request per comment on screen.
- **The usage counter fails silently.** The text is already in the box and the person is mid-reply to a customer. A toast about a number that orders a list is noise interrupting the task it exists to speed up.
- **The cap comes from the composer, not the picker.** The composer is the only thing that knows where the text is going — LinkedIn's 1250 here, X's 280 when that surface arrives. Handing a composer a value it will refuse on send moves the failure to the moment the person presses the button.

## Verification

Type-check clean, lint clean in every changed file, full suite green — **28 files, 403 tests.**

Needs `peakhour-api#1091` (merged) and `peakhour-mongodb#517` (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
